### PR TITLE
fix: remove url validation from DNF baseurl to allow $releasever variables

### DIFF
--- a/gen/go/pm/v1/actions.pb.go
+++ b/gen/go/pm/v1/actions.pb.go
@@ -1855,9 +1855,9 @@ func (x *DnfRepository) GetDisabled() bool {
 // PacmanRepository configures an Arch Linux pacman repository.
 type PacmanRepository struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Server URL (can include $repo and $arch variables)
-	// @gotags: validate:"required_without=Disabled,omitempty,url"
-	Server string `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty" validate:"required_without=Disabled,omitempty,url"`
+	// Server URL (supports pacman variables like $repo and $arch)
+	// @gotags: validate:"required_without=Disabled,omitempty"
+	Server string `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty" validate:"required_without=Disabled,omitempty"`
 	// SigLevel (e.g., "Optional TrustAll", "Required DatabaseOptional")
 	// @gotags: validate:"omitempty,max=128"
 	SigLevel string `protobuf:"bytes,2,opt,name=sig_level,json=sigLevel,proto3" json:"sig_level,omitempty" validate:"omitempty,max=128"`

--- a/gen/ts/pm/v1/actions_pb.ts
+++ b/gen/ts/pm/v1/actions_pb.ts
@@ -865,8 +865,8 @@ export const DnfRepositorySchema: GenMessage<DnfRepository> = /*@__PURE__*/
  */
 export type PacmanRepository = Message<"pm.v1.PacmanRepository"> & {
   /**
-   * Server URL (can include $repo and $arch variables)
-   * @gotags: validate:"required_without=Disabled,omitempty,url"
+   * Server URL (supports pacman variables like $repo and $arch)
+   * @gotags: validate:"required_without=Disabled,omitempty"
    *
    * @generated from field: string server = 1;
    */

--- a/proto/pm/v1/actions.proto
+++ b/proto/pm/v1/actions.proto
@@ -367,8 +367,8 @@ message DnfRepository {
 
 // PacmanRepository configures an Arch Linux pacman repository.
 message PacmanRepository {
-  // Server URL (can include $repo and $arch variables)
-  // @gotags: validate:"required_without=Disabled,omitempty,url"
+  // Server URL (supports pacman variables like $repo and $arch)
+  // @gotags: validate:"required_without=Disabled,omitempty"
   string server = 1;
 
   // SigLevel (e.g., "Optional TrustAll", "Required DatabaseOptional")


### PR DESCRIPTION
## Summary

Remove the `url` validation tag from `DnfRepository.baseurl` in the proto definition. DNF repository URLs commonly use `$releasever` and `$basearch` variables which are resolved at runtime by dnf but fail strict URL validation.

Fixes manchtools/power-manage-server#19

## Test plan

- [ ] Create a repository action with DNF baseurl containing `$releasever` — should succeed
- [ ] Existing apt repository validation unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed repository URL validation to allow package-manager variable expansion in DNF and Pacman repository entries (e.g., $releasever, $basearch, $repo, $arch).

* **Documentation**
  * Clarified that repository base/server fields support package-manager variable expansion in repository configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->