### PR TITLE
feat: reboot detection and scheduling utility

### DIFF
--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -3,6 +3,7 @@ package reboot
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 
@@ -35,7 +36,8 @@ func IsRequired() bool {
 	if path, err := lookPathFunc("needs-restarting"); err == nil {
 		if err := runCmdFunc(path, "-r"); err != nil {
 			// needs-restarting exits 1 when reboot is needed
-			if exitErr, ok := err.(*exec.ExitError); ok {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
 				return exitErr.ExitCode() == 1
 			}
 		}

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -9,6 +9,15 @@ import (
 	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
+// Injectable seams for testing. Production code uses the defaults.
+var (
+	statFunc     = os.Stat
+	lookPathFunc = exec.LookPath
+	runCmdFunc   = func(name string, args ...string) error {
+		return exec.Command(name, args...).Run()
+	}
+)
+
 // IsRequired checks if the system requires a reboot after updates.
 //
 // Detection methods:
@@ -18,14 +27,13 @@ import (
 // Returns false on unsupported systems or if detection fails.
 func IsRequired() bool {
 	// Debian/Ubuntu: file-based detection
-	if _, err := os.Stat("/var/run/reboot-required"); err == nil {
+	if _, err := statFunc("/var/run/reboot-required"); err == nil {
 		return true
 	}
 
 	// Fedora/RHEL: needs-restarting (from dnf-utils/yum-utils)
-	if path, err := exec.LookPath("needs-restarting"); err == nil {
-		cmd := exec.Command(path, "-r")
-		if err := cmd.Run(); err != nil {
+	if path, err := lookPathFunc("needs-restarting"); err == nil {
+		if err := runCmdFunc(path, "-r"); err != nil {
 			// needs-restarting exits 1 when reboot is needed
 			if exitErr, ok := err.(*exec.ExitError); ok {
 				return exitErr.ExitCode() == 1

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -4,6 +4,8 @@ package reboot
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 
@@ -25,25 +27,40 @@ var (
 //   - Debian/Ubuntu: checks /var/run/reboot-required (created by update-notifier)
 //   - Fedora/RHEL: runs needs-restarting -r (exit 1 = reboot needed)
 //
-// Returns false on unsupported systems or if detection fails.
+// Returns false on unsupported systems or if detection fails. Unexpected
+// errors (permission denied on stat, exec failure on needs-restarting) are
+// logged via slog.Debug rather than returned, since callers treat this as a
+// best-effort hint.
 func IsRequired() bool {
-	// Debian/Ubuntu: file-based detection
+	// Debian/Ubuntu: file-based detection. A successful stat means the
+	// file exists and reboot is required. ErrNotExist is the expected
+	// "no reboot needed" path; any other error is unexpected and logged.
 	if _, err := statFunc("/var/run/reboot-required"); err == nil {
 		return true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		slog.Debug("stat /var/run/reboot-required failed", "error", err)
 	}
 
-	// Fedora/RHEL: needs-restarting (from dnf-utils/yum-utils)
-	if path, err := lookPathFunc("needs-restarting"); err == nil {
-		if err := runCmdFunc(path, "-r"); err != nil {
-			// needs-restarting exits 1 when reboot is needed
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
-				return exitErr.ExitCode() == 1
-			}
-		}
+	// Fedora/RHEL: needs-restarting (from dnf-utils/yum-utils).
+	// Look up the binary; if absent, we silently fall through (no detection
+	// available on this system).
+	path, err := lookPathFunc("needs-restarting")
+	if err != nil {
+		return false
+	}
+
+	runErr := runCmdFunc(path, "-r")
+	if runErr == nil {
 		return false // exit 0 = no reboot needed
 	}
-
+	// needs-restarting exits 1 when a reboot IS needed.
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode() == 1
+	}
+	// Couldn't even run needs-restarting (e.g. *exec.Error wrapping ENOENT
+	// or a permission error). Log and report no reboot rather than guess.
+	slog.Debug("needs-restarting -r failed to run", "error", runErr)
 	return false
 }
 
@@ -52,14 +69,27 @@ func IsRequired() bool {
 // Parameters:
 //   - ctx: context for the sudo command
 //   - delay: shutdown delay (e.g. "+1" for 1 minute, "+5" for 5 minutes, "now" for immediate)
-//   - message: broadcast message shown to logged-in users
+//   - message: broadcast message shown to logged-in users (omitted when empty)
+//
+// An empty delay defaults to "+1" since shutdown(8) requires a time argument.
 func Schedule(ctx context.Context, delay, message string) error {
-	_, err := sysexec.Sudo(ctx, "shutdown", "-r", delay, message)
-	return err
+	if delay == "" {
+		delay = "+1"
+	}
+	args := []string{"-r", delay}
+	if message != "" {
+		args = append(args, message)
+	}
+	if _, err := sysexec.Sudo(ctx, "shutdown", args...); err != nil {
+		return fmt.Errorf("schedule reboot: %w", err)
+	}
+	return nil
 }
 
 // Cancel cancels a pending scheduled reboot.
 func Cancel(ctx context.Context) error {
-	_, err := sysexec.Sudo(ctx, "shutdown", "-c")
-	return err
+	if _, err := sysexec.Sudo(ctx, "shutdown", "-c"); err != nil {
+		return fmt.Errorf("cancel reboot: %w", err)
+	}
+	return nil
 }

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -1,0 +1,55 @@
+// Package reboot provides system reboot detection and scheduling utilities.
+package reboot
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// IsRequired checks if the system requires a reboot after updates.
+//
+// Detection methods:
+//   - Debian/Ubuntu: checks /var/run/reboot-required (created by update-notifier)
+//   - Fedora/RHEL: runs needs-restarting -r (exit 1 = reboot needed)
+//
+// Returns false on unsupported systems or if detection fails.
+func IsRequired() bool {
+	// Debian/Ubuntu: file-based detection
+	if _, err := os.Stat("/var/run/reboot-required"); err == nil {
+		return true
+	}
+
+	// Fedora/RHEL: needs-restarting (from dnf-utils/yum-utils)
+	if path, err := exec.LookPath("needs-restarting"); err == nil {
+		cmd := exec.Command(path, "-r")
+		if err := cmd.Run(); err != nil {
+			// needs-restarting exits 1 when reboot is needed
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				return exitErr.ExitCode() == 1
+			}
+		}
+		return false // exit 0 = no reboot needed
+	}
+
+	return false
+}
+
+// Schedule schedules a system reboot via shutdown -r.
+//
+// Parameters:
+//   - ctx: context for the sudo command
+//   - delay: shutdown delay (e.g. "+1" for 1 minute, "+5" for 5 minutes, "now" for immediate)
+//   - message: broadcast message shown to logged-in users
+func Schedule(ctx context.Context, delay, message string) error {
+	_, err := sysexec.Sudo(ctx, "shutdown", "-r", delay, message)
+	return err
+}
+
+// Cancel cancels a pending scheduled reboot.
+func Cancel(ctx context.Context) error {
+	_, err := sysexec.Sudo(ctx, "shutdown", "-c")
+	return err
+}

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -36,15 +36,20 @@ func assertNeedsRestartingArgs(t *testing.T, name string, args []string) {
 
 // exitErrCode returns an *exec.ExitError that reports the given exit code,
 // produced by actually running a tiny shell command. Constructing one
-// directly isn't portable since ProcessState is OS-specific.
+// directly isn't portable since ProcessState is OS-specific. Skips the test
+// if /bin/sh is not available in PATH (e.g. minimal containers).
 func exitErrCode(t *testing.T, code int) error {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", "exit "+itoa(code))
-	err := cmd.Run()
-	if err == nil {
-		t.Fatalf("expected exit %d to produce an error", code)
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("skipping test: sh not found in PATH: %v", err)
 	}
-	return err
+	cmd := exec.Command(shPath, "-c", "exit "+itoa(code))
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	t.Fatalf("expected exit %d to produce an error", code)
+	return nil
 }
 
 func itoa(n int) string {

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -1,0 +1,28 @@
+package reboot
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestIsRequired_DoesNotPanic(t *testing.T) {
+	// Just verify it runs without panicking — actual result depends on system state
+	result := IsRequired()
+	t.Logf("IsRequired() = %v", result)
+}
+
+func TestIsRequired_DebianDetection(t *testing.T) {
+	// On Debian/Ubuntu, /var/run/reboot-required indicates a reboot is needed.
+	// We can't create this file without root, so just verify the path is checked.
+	// If the file happens to exist, IsRequired should return true.
+	t.Logf("Debian reboot-required detection: checked /var/run/reboot-required")
+}
+
+func TestIsRequired_FedoraDetection(t *testing.T) {
+	if _, err := exec.LookPath("needs-restarting"); err != nil {
+		t.Skip("needs-restarting not available")
+	}
+
+	result := IsRequired()
+	t.Logf("IsRequired() via needs-restarting = %v", result)
+}

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -1,28 +1,101 @@
 package reboot
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
-func TestIsRequired_DoesNotPanic(t *testing.T) {
-	// Just verify it runs without panicking — actual result depends on system state
-	result := IsRequired()
-	t.Logf("IsRequired() = %v", result)
-}
+func TestIsRequired_DebianFileExists(t *testing.T) {
+	dir := t.TempDir()
+	fakeFile := filepath.Join(dir, "reboot-required")
+	os.WriteFile(fakeFile, []byte("*** System restart required ***\n"), 0644)
 
-func TestIsRequired_DebianDetection(t *testing.T) {
-	// On Debian/Ubuntu, /var/run/reboot-required indicates a reboot is needed.
-	// We can't create this file without root, so just verify the path is checked.
-	// If the file happens to exist, IsRequired should return true.
-	t.Logf("Debian reboot-required detection: checked /var/run/reboot-required")
-}
-
-func TestIsRequired_FedoraDetection(t *testing.T) {
-	if _, err := exec.LookPath("needs-restarting"); err != nil {
-		t.Skip("needs-restarting not available")
+	origStat := statFunc
+	statFunc = func(name string) (os.FileInfo, error) {
+		if name == "/var/run/reboot-required" {
+			return os.Stat(fakeFile)
+		}
+		return os.Stat(name)
 	}
+	defer func() { statFunc = origStat }()
 
-	result := IsRequired()
-	t.Logf("IsRequired() via needs-restarting = %v", result)
+	if !IsRequired() {
+		t.Error("expected IsRequired() = true when reboot-required file exists")
+	}
 }
+
+func TestIsRequired_DebianFileAbsent(t *testing.T) {
+	origStat := statFunc
+	origLookPath := lookPathFunc
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	lookPathFunc = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	defer func() { statFunc = origStat; lookPathFunc = origLookPath }()
+
+	if IsRequired() {
+		t.Error("expected IsRequired() = false when no detection method available")
+	}
+}
+
+func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
+	origStat := statFunc
+	origLookPath := lookPathFunc
+	origRunCmd := runCmdFunc
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	lookPathFunc = func(file string) (string, error) {
+		if file == "needs-restarting" {
+			return "/usr/bin/needs-restarting", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	runCmdFunc = func(name string, args ...string) error {
+		// Simulate needs-restarting exit code 1 (reboot needed)
+		cmd := exec.Command("sh", "-c", "exit 1")
+		cmd.Run()
+		return &exec.ExitError{ProcessState: cmd.ProcessState}
+	}
+	defer func() { statFunc = origStat; lookPathFunc = origLookPath; runCmdFunc = origRunCmd }()
+
+	if !IsRequired() {
+		t.Error("expected IsRequired() = true when needs-restarting exits 1")
+	}
+}
+
+func TestIsRequired_FedoraNoReboot(t *testing.T) {
+	origStat := statFunc
+	origLookPath := lookPathFunc
+	origRunCmd := runCmdFunc
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	lookPathFunc = func(file string) (string, error) {
+		if file == "needs-restarting" {
+			return "/usr/bin/needs-restarting", nil
+		}
+		return "", exec.ErrNotFound
+	}
+	runCmdFunc = func(name string, args ...string) error {
+		return nil // exit 0 = no reboot needed
+	}
+	defer func() { statFunc = origStat; lookPathFunc = origLookPath; runCmdFunc = origRunCmd }()
+
+	if IsRequired() {
+		t.Error("expected IsRequired() = false when needs-restarting exits 0")
+	}
+}
+
+func TestIsRequired_LiveSystem(t *testing.T) {
+	result := IsRequired()
+	t.Logf("IsRequired() = %v (live system)", result)
+}
+
+// Unused but kept for reference — fmt is used indirectly
+var _ = fmt.Sprintf

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -1,7 +1,6 @@
 package reboot
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,6 +95,3 @@ func TestIsRequired_LiveSystem(t *testing.T) {
 	result := IsRequired()
 	t.Logf("IsRequired() = %v (live system)", result)
 }
-
-// Unused but kept for reference — fmt is used indirectly
-var _ = fmt.Sprintf

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -20,6 +20,20 @@ func withSeams(t *testing.T) {
 	})
 }
 
+// assertNeedsRestartingArgs fails the test if the runCmdFunc invocation does
+// not match the expected `needs-restarting -r` call. Used by Fedora-path
+// tests to catch regressions that would invoke the wrong binary or drop the
+// -r flag.
+func assertNeedsRestartingArgs(t *testing.T, name string, args []string) {
+	t.Helper()
+	if name != "/usr/bin/needs-restarting" {
+		t.Errorf("runCmd called with name=%q, want %q", name, "/usr/bin/needs-restarting")
+	}
+	if len(args) != 1 || args[0] != "-r" {
+		t.Errorf("runCmd called with args=%v, want [-r]", args)
+	}
+}
+
 // exitErrCode returns an *exec.ExitError that reports the given exit code,
 // produced by actually running a tiny shell command. Constructing one
 // directly isn't portable since ProcessState is OS-specific.
@@ -117,6 +131,7 @@ func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
 		return "", exec.ErrNotFound
 	}
 	runCmdFunc = func(name string, args ...string) error {
+		assertNeedsRestartingArgs(t, name, args)
 		return exitErrCode(t, 1)
 	}
 
@@ -134,6 +149,7 @@ func TestIsRequired_FedoraNoReboot(t *testing.T) {
 		return "/usr/bin/needs-restarting", nil
 	}
 	runCmdFunc = func(name string, args ...string) error {
+		assertNeedsRestartingArgs(t, name, args)
 		return nil // exit 0
 	}
 
@@ -153,6 +169,7 @@ func TestIsRequired_FedoraOtherExitCode(t *testing.T) {
 		return "/usr/bin/needs-restarting", nil
 	}
 	runCmdFunc = func(name string, args ...string) error {
+		assertNeedsRestartingArgs(t, name, args)
 		return exitErrCode(t, 2)
 	}
 
@@ -172,6 +189,7 @@ func TestIsRequired_FedoraRunCmdNonExitError(t *testing.T) {
 		return "/usr/bin/needs-restarting", nil
 	}
 	runCmdFunc = func(name string, args ...string) error {
+		assertNeedsRestartingArgs(t, name, args)
 		return &exec.Error{Name: name, Err: errors.New("permission denied")}
 	}
 

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -1,25 +1,74 @@
 package reboot
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 )
 
+// withSeams snapshots and restores the package-level injection points so
+// tests can override them safely.
+func withSeams(t *testing.T) {
+	t.Helper()
+	origStat, origLookPath, origRunCmd := statFunc, lookPathFunc, runCmdFunc
+	t.Cleanup(func() {
+		statFunc = origStat
+		lookPathFunc = origLookPath
+		runCmdFunc = origRunCmd
+	})
+}
+
+// exitErrCode returns an *exec.ExitError that reports the given exit code,
+// produced by actually running a tiny shell command. Constructing one
+// directly isn't portable since ProcessState is OS-specific.
+func exitErrCode(t *testing.T, code int) error {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "exit "+itoa(code))
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected exit %d to produce an error", code)
+	}
+	return err
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
 func TestIsRequired_DebianFileExists(t *testing.T) {
+	withSeams(t)
 	dir := t.TempDir()
 	fakeFile := filepath.Join(dir, "reboot-required")
-	os.WriteFile(fakeFile, []byte("*** System restart required ***\n"), 0644)
+	if err := os.WriteFile(fakeFile, []byte("*** System restart required ***\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	origStat := statFunc
 	statFunc = func(name string) (os.FileInfo, error) {
 		if name == "/var/run/reboot-required" {
 			return os.Stat(fakeFile)
 		}
 		return os.Stat(name)
 	}
-	defer func() { statFunc = origStat }()
 
 	if !IsRequired() {
 		t.Error("expected IsRequired() = true when reboot-required file exists")
@@ -27,25 +76,37 @@ func TestIsRequired_DebianFileExists(t *testing.T) {
 }
 
 func TestIsRequired_DebianFileAbsent(t *testing.T) {
-	origStat := statFunc
-	origLookPath := lookPathFunc
+	withSeams(t)
 	statFunc = func(name string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	}
 	lookPathFunc = func(file string) (string, error) {
 		return "", exec.ErrNotFound
 	}
-	defer func() { statFunc = origStat; lookPathFunc = origLookPath }()
 
 	if IsRequired() {
 		t.Error("expected IsRequired() = false when no detection method available")
 	}
 }
 
+// An unexpected stat error (e.g. EACCES) must NOT short-circuit to true and
+// must fall through to the needs-restarting branch.
+func TestIsRequired_DebianStatUnexpectedError(t *testing.T) {
+	withSeams(t)
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrPermission
+	}
+	lookPathFunc = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	if IsRequired() {
+		t.Error("expected IsRequired() = false when stat fails with permission error and no fallback")
+	}
+}
+
 func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
-	origStat := statFunc
-	origLookPath := lookPathFunc
-	origRunCmd := runCmdFunc
+	withSeams(t)
 	statFunc = func(name string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	}
@@ -56,12 +117,8 @@ func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
 		return "", exec.ErrNotFound
 	}
 	runCmdFunc = func(name string, args ...string) error {
-		// Simulate needs-restarting exit code 1 (reboot needed)
-		cmd := exec.Command("sh", "-c", "exit 1")
-		cmd.Run()
-		return &exec.ExitError{ProcessState: cmd.ProcessState}
+		return exitErrCode(t, 1)
 	}
-	defer func() { statFunc = origStat; lookPathFunc = origLookPath; runCmdFunc = origRunCmd }()
 
 	if !IsRequired() {
 		t.Error("expected IsRequired() = true when needs-restarting exits 1")
@@ -69,25 +126,57 @@ func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
 }
 
 func TestIsRequired_FedoraNoReboot(t *testing.T) {
-	origStat := statFunc
-	origLookPath := lookPathFunc
-	origRunCmd := runCmdFunc
+	withSeams(t)
 	statFunc = func(name string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	}
 	lookPathFunc = func(file string) (string, error) {
-		if file == "needs-restarting" {
-			return "/usr/bin/needs-restarting", nil
-		}
-		return "", exec.ErrNotFound
+		return "/usr/bin/needs-restarting", nil
 	}
 	runCmdFunc = func(name string, args ...string) error {
-		return nil // exit 0 = no reboot needed
+		return nil // exit 0
 	}
-	defer func() { statFunc = origStat; lookPathFunc = origLookPath; runCmdFunc = origRunCmd }()
 
 	if IsRequired() {
 		t.Error("expected IsRequired() = false when needs-restarting exits 0")
+	}
+}
+
+// needs-restarting exit codes other than 0 and 1 must NOT be interpreted as
+// "reboot needed" — only exit 1 means that.
+func TestIsRequired_FedoraOtherExitCode(t *testing.T) {
+	withSeams(t)
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	lookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/needs-restarting", nil
+	}
+	runCmdFunc = func(name string, args ...string) error {
+		return exitErrCode(t, 2)
+	}
+
+	if IsRequired() {
+		t.Error("expected IsRequired() = false when needs-restarting exits with code 2")
+	}
+}
+
+// If runCmd returns a non-ExitError (e.g. *exec.Error wrapping ENOENT), we
+// must NOT report a reboot — log and return false.
+func TestIsRequired_FedoraRunCmdNonExitError(t *testing.T) {
+	withSeams(t)
+	statFunc = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	lookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/needs-restarting", nil
+	}
+	runCmdFunc = func(name string, args ...string) error {
+		return &exec.Error{Name: name, Err: errors.New("permission denied")}
+	}
+
+	if IsRequired() {
+		t.Error("expected IsRequired() = false when needs-restarting fails to execute")
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `sdk/go/sys/reboot/` package for detecting pending reboots and scheduling them.

### API

- `IsRequired() bool` — detects pending reboot
  - Debian/Ubuntu: `/var/run/reboot-required`
  - Fedora/RHEL: `needs-restarting -r` (exit 1 = needed)
- `Schedule(ctx, delay, message) error` — `sudo shutdown -r <delay> <message>`
- `Cancel(ctx) error` — `sudo shutdown -c`

## Test plan

- [x] `go test ./go/sys/reboot/...` passes
- [ ] Fedora detection test runs in Fedora CI (skipped here — no needs-restarting)

Closes manchtools/power-manage-sdk#13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system reboot detection plus schedule and cancel actions. Apps can check whether a reboot is required and request or cancel a system reboot with a customizable delay and optional message. Detection uses platform-appropriate heuristics and fails safely without surfacing internal errors.

* **Tests**
  * Added comprehensive tests covering detection paths, error handling, command-exit interpretations, and live-system sanity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->