### PR TITLE
refactor: propagate caller ctx through pkg run() methods

### DIFF
--- a/go/pkg/apt.go
+++ b/go/pkg/apt.go
@@ -61,7 +61,7 @@ func (a *Apt) Install(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"install", "-y", "--fix-broken"}, packages...)
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // InstallVersion installs a package with specific version options.
@@ -78,7 +78,7 @@ func (a *Apt) InstallVersion(name string, opts InstallOptions) (*CommandResult, 
 	}
 	args = append(args, pkgSpec)
 
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // Remove removes packages.
@@ -87,7 +87,7 @@ func (a *Apt) Remove(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"remove", "-y"}, packages...)
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // Purge removes packages including configuration files.
@@ -96,12 +96,12 @@ func (a *Apt) Purge(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"purge", "-y"}, packages...)
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // Update updates the package database.
 func (a *Apt) Update() (*CommandResult, error) {
-	return a.run("apt", "update")
+	return a.run(a.ctx, "apt", "update")
 }
 
 // dpkgConfOptions are passed to apt commands that may trigger dpkg config file
@@ -118,28 +118,33 @@ var dpkgConfOptions = []string{
 func (a *Apt) Upgrade(packages ...string) (*CommandResult, error) {
 	if len(packages) == 0 {
 		args := append([]string{"upgrade", "-y"}, dpkgConfOptions...)
-		return a.run("apt", args...)
+		return a.run(a.ctx, "apt", args...)
 	}
 	args := append([]string{"install", "-y", "--only-upgrade"}, dpkgConfOptions...)
 	args = append(args, packages...)
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // DistUpgrade runs apt dist-upgrade -y for packages with held-back dependencies.
 func (a *Apt) DistUpgrade() (*CommandResult, error) {
 	args := append([]string{"dist-upgrade", "-y"}, dpkgConfOptions...)
-	return a.run("apt", args...)
+	return a.run(a.ctx, "apt", args...)
 }
 
 // FixBroken runs apt --fix-broken install -y to repair broken dependencies.
 func (a *Apt) FixBroken() (*CommandResult, error) {
+	return a.fixBroken(a.ctx)
+}
+
+// fixBroken is the context-aware variant used internally by Repair.
+func (a *Apt) fixBroken(ctx context.Context) (*CommandResult, error) {
 	args := append([]string{"--fix-broken", "install", "-y"}, dpkgConfOptions...)
-	return a.run("apt", args...)
+	return a.run(ctx, "apt", args...)
 }
 
 // Autoremove runs apt autoremove -y to remove unused packages.
 func (a *Apt) Autoremove() (*CommandResult, error) {
-	return a.run("apt", "autoremove", "-y")
+	return a.run(a.ctx, "apt", "autoremove", "-y")
 }
 
 // Search searches for packages.
@@ -349,7 +354,7 @@ func (a *Apt) Pin(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"hold"}, packages...)
-	return a.run("apt-mark", args...)
+	return a.run(a.ctx, "apt-mark", args...)
 }
 
 // Unpin allows a package to be upgraded again (apt-mark unhold).
@@ -358,7 +363,7 @@ func (a *Apt) Unpin(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"unhold"}, packages...)
-	return a.run("apt-mark", args...)
+	return a.run(a.ctx, "apt-mark", args...)
 }
 
 // ListPinned lists all pinned (held) packages.
@@ -430,7 +435,7 @@ func (a *Apt) hasApt() bool {
 	return a.getAptCmd() == "apt"
 }
 
-func (a *Apt) run(cmd string, args ...string) (*CommandResult, error) {
+func (a *Apt) run(ctx context.Context, cmd string, args ...string) (*CommandResult, error) {
 	start := time.Now()
 
 	// Use preferred apt command for apt/apt-get operations
@@ -442,9 +447,9 @@ func (a *Apt) run(cmd string, args ...string) (*CommandResult, error) {
 	if a.useSudo {
 		// Prepend sudo -n (non-interactive) to avoid password prompts
 		sudoArgs := append([]string{"-n", cmd}, args...)
-		c = exec.CommandContext(a.ctx, "sudo", sudoArgs...)
+		c = exec.CommandContext(ctx, "sudo", sudoArgs...)
 	} else {
-		c = exec.CommandContext(a.ctx, cmd, args...)
+		c = exec.CommandContext(ctx, cmd, args...)
 	}
 
 	// Prevent debconf from trying interactive frontends when there is no terminal.

--- a/go/pkg/dnf.go
+++ b/go/pkg/dnf.go
@@ -72,7 +72,7 @@ func (d *Dnf) Install(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"install", "-y"}, packages...)
-	return d.run(args...)
+	return d.run(d.ctx, args...)
 }
 
 // InstallVersion installs a package with specific version options.
@@ -88,11 +88,11 @@ func (d *Dnf) InstallVersion(name string, opts InstallOptions) (*CommandResult, 
 	}
 	args = append(args, pkgSpec)
 
-	result, err := d.run(args...)
+	result, err := d.run(d.ctx, args...)
 
 	// If downgrade is allowed and install failed, try explicit downgrade
 	if opts.AllowDowngrade && err != nil && opts.Version != "" {
-		return d.run("downgrade", "-y", pkgSpec)
+		return d.run(d.ctx, "downgrade", "-y", pkgSpec)
 	}
 
 	return result, err
@@ -104,14 +104,14 @@ func (d *Dnf) Remove(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"remove", "-y"}, packages...)
-	return d.run(args...)
+	return d.run(d.ctx, args...)
 }
 
 // Update updates the package database (dnf check-update).
 // dnf check-update returns exit code 100 when updates are available,
 // which is a success case, not an error.
 func (d *Dnf) Update() (*CommandResult, error) {
-	result, err := d.run("check-update")
+	result, err := d.run(d.ctx, "check-update")
 	if err != nil && result != nil && result.ExitCode == 100 {
 		result.Success = true
 		return result, nil
@@ -122,10 +122,10 @@ func (d *Dnf) Update() (*CommandResult, error) {
 // Upgrade upgrades packages.
 func (d *Dnf) Upgrade(packages ...string) (*CommandResult, error) {
 	if len(packages) == 0 {
-		return d.run("upgrade", "-y")
+		return d.run(d.ctx, "upgrade", "-y")
 	}
 	args := append([]string{"upgrade", "-y"}, packages...)
-	return d.run(args...)
+	return d.run(d.ctx, args...)
 }
 
 // Search searches for packages.
@@ -343,7 +343,7 @@ func (d *Dnf) ensureVersionLock() error {
 	}
 
 	// Install the plugin
-	_, err = d.run("install", "-y", "python3-dnf-plugin-versionlock")
+	_, err = d.run(d.ctx, "install", "-y", "python3-dnf-plugin-versionlock")
 	return err
 }
 
@@ -357,7 +357,7 @@ func (d *Dnf) Pin(packages ...string) (*CommandResult, error) {
 		return nil, err
 	}
 	args := append([]string{"versionlock", "add"}, packages...)
-	return d.run(args...)
+	return d.run(d.ctx, args...)
 }
 
 // Unpin allows a package to be upgraded again (dnf versionlock delete).
@@ -370,7 +370,7 @@ func (d *Dnf) Unpin(packages ...string) (*CommandResult, error) {
 		return nil, err
 	}
 	args := append([]string{"versionlock", "delete"}, packages...)
-	return d.run(args...)
+	return d.run(d.ctx, args...)
 }
 
 // ListPinned lists all pinned (versionlocked) packages.
@@ -437,16 +437,16 @@ func (d *Dnf) getPinnedSet() (map[string]bool, error) {
 	return pinned, nil
 }
 
-func (d *Dnf) run(args ...string) (*CommandResult, error) {
+func (d *Dnf) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	start := time.Now()
 
 	var c *exec.Cmd
 	if d.useSudo {
 		// Prepend sudo -n (non-interactive) to avoid password prompts
 		sudoArgs := append([]string{"-n", "dnf"}, args...)
-		c = exec.CommandContext(d.ctx, "sudo", sudoArgs...)
+		c = exec.CommandContext(ctx, "sudo", sudoArgs...)
 	} else {
-		c = exec.CommandContext(d.ctx, "dnf", args...)
+		c = exec.CommandContext(ctx, "dnf", args...)
 	}
 
 	// Force English locale for reliable output parsing.

--- a/go/pkg/flatpak.go
+++ b/go/pkg/flatpak.go
@@ -68,7 +68,7 @@ func (f *Flatpak) Install(packages ...string) (*CommandResult, error) {
 		args = append(args, "--user")
 	}
 	args = append(args, packages...)
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // InstallVersion installs a package with specific version options.
@@ -92,7 +92,7 @@ func (f *Flatpak) Remove(packages ...string) (*CommandResult, error) {
 		args = append(args, "--user")
 	}
 	args = append(args, packages...)
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // Purge removes packages and their data.
@@ -107,7 +107,7 @@ func (f *Flatpak) Purge(packages ...string) (*CommandResult, error) {
 		args = append(args, "--user")
 	}
 	args = append(args, packages...)
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // Update updates the Flatpak remote metadata.
@@ -118,7 +118,7 @@ func (f *Flatpak) Update() (*CommandResult, error) {
 	} else {
 		args = append(args, "--user")
 	}
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // Upgrade upgrades packages.
@@ -132,7 +132,7 @@ func (f *Flatpak) Upgrade(packages ...string) (*CommandResult, error) {
 	if len(packages) > 0 {
 		args = append(args, packages...)
 	}
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // Search searches for packages in configured remotes.
@@ -400,7 +400,7 @@ func (f *Flatpak) Pin(packages ...string) (*CommandResult, error) {
 		} else {
 			args = append(args, "--user")
 		}
-		result, err := f.run(args...)
+		result, err := f.run(f.ctx, args...)
 		if result != nil {
 			allOutput.WriteString(result.Stdout)
 			allOutput.WriteString(result.Stderr)
@@ -432,7 +432,7 @@ func (f *Flatpak) Unpin(packages ...string) (*CommandResult, error) {
 		} else {
 			args = append(args, "--user")
 		}
-		result, err := f.run(args...)
+		result, err := f.run(f.ctx, args...)
 		if result != nil {
 			allOutput.WriteString(result.Stdout)
 			allOutput.WriteString(result.Stderr)
@@ -535,7 +535,7 @@ func (f *Flatpak) AddRemote(name, url string) (*CommandResult, error) {
 	} else {
 		args = append(args, "--user")
 	}
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // RemoveRemote removes a Flatpak remote repository.
@@ -546,7 +546,7 @@ func (f *Flatpak) RemoveRemote(name string) (*CommandResult, error) {
 	} else {
 		args = append(args, "--user")
 	}
-	return f.run(args...)
+	return f.run(f.ctx, args...)
 }
 
 // ListRemotes lists configured Flatpak remotes.
@@ -574,15 +574,15 @@ func (f *Flatpak) ListRemotes() ([]string, error) {
 	return remotes, nil
 }
 
-func (f *Flatpak) run(args ...string) (*CommandResult, error) {
+func (f *Flatpak) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	start := time.Now()
 
 	var c *exec.Cmd
 	if f.useSudo {
 		sudoArgs := append([]string{"-n", "flatpak"}, args...)
-		c = exec.CommandContext(f.ctx, "sudo", sudoArgs...)
+		c = exec.CommandContext(ctx, "sudo", sudoArgs...)
 	} else {
-		c = exec.CommandContext(f.ctx, "flatpak", args...)
+		c = exec.CommandContext(ctx, "flatpak", args...)
 	}
 
 	// Force English locale for reliable output parsing.

--- a/go/pkg/pacman.go
+++ b/go/pkg/pacman.go
@@ -70,7 +70,7 @@ func (p *Pacman) Install(packages ...string) (*CommandResult, error) {
 	}
 	// -S: sync, --noconfirm: non-interactive, --needed: don't reinstall if up to date
 	args := append([]string{"-S", "--noconfirm", "--needed"}, packages...)
-	return p.run(args...)
+	return p.run(p.ctx, args...)
 }
 
 // InstallVersion installs a package with specific version options.
@@ -91,7 +91,7 @@ func (p *Pacman) InstallVersion(name string, opts InstallOptions) (*CommandResul
 	}
 	args = append(args, pkgSpec)
 
-	return p.run(args...)
+	return p.run(p.ctx, args...)
 }
 
 // Remove removes packages.
@@ -101,7 +101,7 @@ func (p *Pacman) Remove(packages ...string) (*CommandResult, error) {
 	}
 	// -R: remove, --noconfirm: non-interactive
 	args := append([]string{"-R", "--noconfirm"}, packages...)
-	return p.run(args...)
+	return p.run(p.ctx, args...)
 }
 
 // Purge removes packages including configuration files.
@@ -111,24 +111,24 @@ func (p *Pacman) Purge(packages ...string) (*CommandResult, error) {
 	}
 	// -Rns: remove with dependencies and config files
 	args := append([]string{"-Rns", "--noconfirm"}, packages...)
-	return p.run(args...)
+	return p.run(p.ctx, args...)
 }
 
 // Update updates the package database.
 func (p *Pacman) Update() (*CommandResult, error) {
 	// -Sy: sync database
-	return p.run("-Sy", "--noconfirm")
+	return p.run(p.ctx, "-Sy", "--noconfirm")
 }
 
 // Upgrade upgrades packages.
 func (p *Pacman) Upgrade(packages ...string) (*CommandResult, error) {
 	if len(packages) == 0 {
 		// -Syu: sync, refresh, upgrade all
-		return p.run("-Syu", "--noconfirm")
+		return p.run(p.ctx, "-Syu", "--noconfirm")
 	}
 	// Upgrade specific packages
 	args := append([]string{"-S", "--noconfirm"}, packages...)
-	return p.run(args...)
+	return p.run(p.ctx, args...)
 }
 
 // Search searches for packages.
@@ -512,15 +512,15 @@ func (p *Pacman) updateIgnorePkg(confContent string, ignoredPkgs []string) (*Com
 	return p.runWithStdin("tee", "/etc/pacman.conf", newConf.String())
 }
 
-func (p *Pacman) run(args ...string) (*CommandResult, error) {
+func (p *Pacman) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	start := time.Now()
 
 	var c *exec.Cmd
 	if p.useSudo {
 		sudoArgs := append([]string{"-n", "pacman"}, args...)
-		c = exec.CommandContext(p.ctx, "sudo", sudoArgs...)
+		c = exec.CommandContext(ctx, "sudo", sudoArgs...)
 	} else {
-		c = exec.CommandContext(p.ctx, "pacman", args...)
+		c = exec.CommandContext(ctx, "pacman", args...)
 	}
 
 	// Force English locale for reliable output parsing.

--- a/go/pkg/repair.go
+++ b/go/pkg/repair.go
@@ -38,26 +38,37 @@ func (a *Apt) Repair(ctx context.Context) error {
 		"/var/cache/apt/archives/lock",
 	}
 	for _, lf := range lockFiles {
-		removeStaleLock(lf)
+		if err := removeStaleLock(ctx, lf); err != nil {
+			return err
+		}
 	}
 
 	// dpkg --configure -a
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := a.run(ctx, "dpkg", "--configure", "-a"); err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		slog.Warn("dpkg --configure -a failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt --fix-broken install -y
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := a.fixBroken(ctx); err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		slog.Warn("apt --fix-broken install failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt update
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := a.run(ctx, "apt", "update"); err != nil {
 		return repairErr(ctx, "apt update failed", result.Stderr, err)
 	}
@@ -68,27 +79,36 @@ func (a *Apt) Repair(ctx context.Context) error {
 // Repair for Dnf: runs dnf history redo last, dnf remove --duplicates, rpm --verifydb.
 func (d *Dnf) Repair(ctx context.Context) error {
 	// dnf -y history redo last
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := d.run(ctx, "history", "redo", "last", "-y"); err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		slog.Warn("dnf history redo last failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// dnf -y remove --duplicates
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := d.run(ctx, "remove", "--duplicates", "-y"); err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		slog.Warn("dnf remove --duplicates failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// rpm --verifydb (read-only, no sudo needed)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	c := exec.CommandContext(ctx, "rpm", "--verifydb")
 	c.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 	if out, err := c.CombinedOutput(); err != nil {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
 		slog.Warn("rpm --verifydb failed", "error", err, "output", string(out))
 	}
@@ -99,9 +119,14 @@ func (d *Dnf) Repair(ctx context.Context) error {
 // Repair for Pacman: removes stale db.lck, runs pacman -Syy --noconfirm.
 func (p *Pacman) Repair(ctx context.Context) error {
 	// Remove stale lock file
-	removeStaleLock("/var/lib/pacman/db.lck")
+	if err := removeStaleLock(ctx, "/var/lib/pacman/db.lck"); err != nil {
+		return err
+	}
 
 	// pacman -Syy --noconfirm (force refresh all databases)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := p.run(ctx, "-Syy", "--noconfirm"); err != nil {
 		return repairErr(ctx, "pacman -Syy failed", result.Stderr, err)
 	}
@@ -112,9 +137,14 @@ func (p *Pacman) Repair(ctx context.Context) error {
 // Repair for Zypper: removes stale zypp.pid, runs zypper refresh.
 func (z *Zypper) Repair(ctx context.Context) error {
 	// Remove stale lock file
-	removeStaleLock("/run/zypp.pid")
+	if err := removeStaleLock(ctx, "/run/zypp.pid"); err != nil {
+		return err
+	}
 
 	// zypper --non-interactive refresh
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := z.run(ctx, "--non-interactive", "refresh"); err != nil {
 		return repairErr(ctx, "zypper refresh failed", result.Stderr, err)
 	}
@@ -130,6 +160,9 @@ func (f *Flatpak) Repair(ctx context.Context) error {
 	} else {
 		args = append(args, "--user")
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if result, err := f.run(ctx, args...); err != nil {
 		return repairErr(ctx, "flatpak repair failed", result.Stderr, err)
 	}
@@ -140,19 +173,36 @@ func (f *Flatpak) Repair(ctx context.Context) error {
 // removeStaleLock removes a lock file if the owning package manager process
 // is not running. Uses fuser to check if any process has the file open,
 // which is more reliable than pgrep for detecting active locks.
-func removeStaleLock(path string) {
+//
+// Returns ctx.Err() if the context is cancelled at any point so callers
+// can short-circuit cleanly. A failure to actually remove the file is
+// logged via slog.Warn (best-effort) and does not return an error, but
+// a context cancellation always wins over the warning path.
+func removeStaleLock(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if _, err := os.Stat(path); err != nil {
-		return // file doesn't exist
+		return nil // file doesn't exist
 	}
 
 	// Check if any process has this specific file open.
 	// fuser exits 0 if processes are using the file, 1 if not.
-	if err := exec.Command("fuser", path).Run(); err == nil {
-		return // file is actively in use
+	if err := exec.CommandContext(ctx, "fuser", path).Run(); err == nil {
+		return nil // file is actively in use
+	} else if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 
 	// No process has the file open — lock is stale. Remove it.
-	if err := exec.Command("sudo", "-n", "rm", "-f", path).Run(); err != nil {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := exec.CommandContext(ctx, "sudo", "-n", "rm", "-f", path).Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		slog.Warn("failed to remove stale lock", "path", path, "error", err)
 	}
+	return nil
 }

--- a/go/pkg/repair.go
+++ b/go/pkg/repair.go
@@ -10,9 +10,8 @@ import (
 
 // Repair attempts to fix common package manager issues.
 //
-// NOTE: The ctx parameter is accepted for API consistency but the underlying
-// run() method uses the manager's stored context (from NewXxxWithContext).
-// For proper context propagation, construct the manager with the desired context.
+// The ctx parameter is propagated through to the underlying subprocess
+// invocations, so deadlines and cancellations from the caller are honored.
 
 // Repair for Apt: removes stale lock files, runs dpkg --configure -a,
 // apt --fix-broken install -y, and apt update.
@@ -29,17 +28,17 @@ func (a *Apt) Repair(ctx context.Context) error {
 	}
 
 	// dpkg --configure -a
-	if result, err := a.run("dpkg", "--configure", "-a"); err != nil {
+	if result, err := a.run(ctx, "dpkg", "--configure", "-a"); err != nil {
 		slog.Warn("dpkg --configure -a failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt --fix-broken install -y
-	if result, err := a.FixBroken(); err != nil {
+	if result, err := a.fixBroken(ctx); err != nil {
 		slog.Warn("apt --fix-broken install failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt update
-	if result, err := a.run("apt", "update"); err != nil {
+	if result, err := a.run(ctx, "apt", "update"); err != nil {
 		return fmt.Errorf("apt update failed: %s", result.Stderr)
 	}
 
@@ -49,12 +48,12 @@ func (a *Apt) Repair(ctx context.Context) error {
 // Repair for Dnf: runs dnf history redo last, dnf remove --duplicates, rpm --verifydb.
 func (d *Dnf) Repair(ctx context.Context) error {
 	// dnf -y history redo last
-	if result, err := d.run("history", "redo", "last", "-y"); err != nil {
+	if result, err := d.run(ctx, "history", "redo", "last", "-y"); err != nil {
 		slog.Warn("dnf history redo last failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// dnf -y remove --duplicates
-	if result, err := d.run("remove", "--duplicates", "-y"); err != nil {
+	if result, err := d.run(ctx, "remove", "--duplicates", "-y"); err != nil {
 		slog.Warn("dnf remove --duplicates failed", "error", err, "stderr", result.Stderr)
 	}
 
@@ -74,7 +73,7 @@ func (p *Pacman) Repair(ctx context.Context) error {
 	removeStaleLock("/var/lib/pacman/db.lck")
 
 	// pacman -Syy --noconfirm (force refresh all databases)
-	if result, err := p.run("-Syy", "--noconfirm"); err != nil {
+	if result, err := p.run(ctx, "-Syy", "--noconfirm"); err != nil {
 		return fmt.Errorf("pacman -Syy failed: %s", result.Stderr)
 	}
 
@@ -87,7 +86,7 @@ func (z *Zypper) Repair(ctx context.Context) error {
 	removeStaleLock("/run/zypp.pid")
 
 	// zypper --non-interactive refresh
-	if result, err := z.run("--non-interactive", "refresh"); err != nil {
+	if result, err := z.run(ctx, "--non-interactive", "refresh"); err != nil {
 		return fmt.Errorf("zypper refresh failed: %s", result.Stderr)
 	}
 
@@ -102,7 +101,7 @@ func (f *Flatpak) Repair(ctx context.Context) error {
 	} else {
 		args = append(args, "--user")
 	}
-	if result, err := f.run(args...); err != nil {
+	if result, err := f.run(ctx, args...); err != nil {
 		return fmt.Errorf("flatpak repair failed: %s", result.Stderr)
 	}
 

--- a/go/pkg/repair.go
+++ b/go/pkg/repair.go
@@ -12,6 +12,20 @@ import (
 //
 // The ctx parameter is propagated through to the underlying subprocess
 // invocations, so deadlines and cancellations from the caller are honored.
+// Repair methods short-circuit and return ctx.Err() the moment ctx is
+// cancelled, so a cancelled caller does not cause additional sudo
+// subprocesses to be spawned.
+
+// repairErr returns ctx.Err() if the context has been cancelled, otherwise
+// it wraps err with the given message and the subprocess stderr. The
+// returned error is detectable via errors.Is(err, context.Canceled) /
+// errors.Is(err, context.DeadlineExceeded).
+func repairErr(ctx context.Context, msg, stderr string, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return fmt.Errorf("%s: %s: %w", msg, stderr, err)
+}
 
 // Repair for Apt: removes stale lock files, runs dpkg --configure -a,
 // apt --fix-broken install -y, and apt update.
@@ -29,17 +43,23 @@ func (a *Apt) Repair(ctx context.Context) error {
 
 	// dpkg --configure -a
 	if result, err := a.run(ctx, "dpkg", "--configure", "-a"); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		slog.Warn("dpkg --configure -a failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt --fix-broken install -y
 	if result, err := a.fixBroken(ctx); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		slog.Warn("apt --fix-broken install failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// apt update
 	if result, err := a.run(ctx, "apt", "update"); err != nil {
-		return fmt.Errorf("apt update failed: %s", result.Stderr)
+		return repairErr(ctx, "apt update failed", result.Stderr, err)
 	}
 
 	return nil
@@ -49,11 +69,17 @@ func (a *Apt) Repair(ctx context.Context) error {
 func (d *Dnf) Repair(ctx context.Context) error {
 	// dnf -y history redo last
 	if result, err := d.run(ctx, "history", "redo", "last", "-y"); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		slog.Warn("dnf history redo last failed", "error", err, "stderr", result.Stderr)
 	}
 
 	// dnf -y remove --duplicates
 	if result, err := d.run(ctx, "remove", "--duplicates", "-y"); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		slog.Warn("dnf remove --duplicates failed", "error", err, "stderr", result.Stderr)
 	}
 
@@ -61,6 +87,9 @@ func (d *Dnf) Repair(ctx context.Context) error {
 	c := exec.CommandContext(ctx, "rpm", "--verifydb")
 	c.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 	if out, err := c.CombinedOutput(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		slog.Warn("rpm --verifydb failed", "error", err, "output", string(out))
 	}
 
@@ -74,7 +103,7 @@ func (p *Pacman) Repair(ctx context.Context) error {
 
 	// pacman -Syy --noconfirm (force refresh all databases)
 	if result, err := p.run(ctx, "-Syy", "--noconfirm"); err != nil {
-		return fmt.Errorf("pacman -Syy failed: %s", result.Stderr)
+		return repairErr(ctx, "pacman -Syy failed", result.Stderr, err)
 	}
 
 	return nil
@@ -87,7 +116,7 @@ func (z *Zypper) Repair(ctx context.Context) error {
 
 	// zypper --non-interactive refresh
 	if result, err := z.run(ctx, "--non-interactive", "refresh"); err != nil {
-		return fmt.Errorf("zypper refresh failed: %s", result.Stderr)
+		return repairErr(ctx, "zypper refresh failed", result.Stderr, err)
 	}
 
 	return nil
@@ -102,7 +131,7 @@ func (f *Flatpak) Repair(ctx context.Context) error {
 		args = append(args, "--user")
 	}
 	if result, err := f.run(ctx, args...); err != nil {
-		return fmt.Errorf("flatpak repair failed: %s", result.Stderr)
+		return repairErr(ctx, "flatpak repair failed", result.Stderr, err)
 	}
 
 	return nil

--- a/go/pkg/repair_test.go
+++ b/go/pkg/repair_test.go
@@ -1,0 +1,68 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRepairErr_PassesThroughCtxErr verifies that when the context is
+// cancelled, repairErr returns the raw ctx.Err() so callers can detect
+// it via errors.Is, instead of wrapping the subprocess error.
+func TestRepairErr_PassesThroughCtxErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	subErr := errors.New("sudo: command timed out")
+	got := repairErr(ctx, "apt update failed", "stderr output", subErr)
+
+	if !errors.Is(got, context.Canceled) {
+		t.Errorf("expected errors.Is(err, context.Canceled) = true, got err = %v", got)
+	}
+	// Must be the raw ctx.Err() — not wrapped — so the message stays clean.
+	if got.Error() != context.Canceled.Error() {
+		t.Errorf("expected raw context.Canceled, got %q", got.Error())
+	}
+}
+
+// TestRepairErr_PassesThroughDeadlineExceeded verifies the same for
+// DeadlineExceeded so callers using errors.Is can match either form.
+func TestRepairErr_PassesThroughDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+	defer cancel()
+
+	subErr := errors.New("sudo: command timed out")
+	got := repairErr(ctx, "apt update failed", "stderr output", subErr)
+
+	if !errors.Is(got, context.DeadlineExceeded) {
+		t.Errorf("expected errors.Is(err, context.DeadlineExceeded) = true, got err = %v", got)
+	}
+}
+
+// TestRepairErr_WrapsSubprocessError verifies that when the context is
+// healthy, repairErr wraps the subprocess error with the message and
+// stderr, AND keeps the original error reachable via errors.Is.
+func TestRepairErr_WrapsSubprocessError(t *testing.T) {
+	ctx := context.Background()
+	subErr := errors.New("exit status 100")
+
+	got := repairErr(ctx, "apt update failed", "E: Could not get lock", subErr)
+
+	if got == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// The original error must remain reachable for callers using errors.Is.
+	if !errors.Is(got, subErr) {
+		t.Errorf("expected errors.Is(err, subErr) = true, got err = %v", got)
+	}
+	// The message and stderr must appear for debuggability.
+	msg := got.Error()
+	if !strings.Contains(msg, "apt update failed") {
+		t.Errorf("expected error message to contain 'apt update failed', got %q", msg)
+	}
+	if !strings.Contains(msg, "E: Could not get lock") {
+		t.Errorf("expected error message to contain stderr, got %q", msg)
+	}
+}

--- a/go/pkg/repair_test.go
+++ b/go/pkg/repair_test.go
@@ -66,3 +66,45 @@ func TestRepairErr_WrapsSubprocessError(t *testing.T) {
 		t.Errorf("expected error message to contain stderr, got %q", msg)
 	}
 }
+
+// TestRemoveStaleLock_CancelledCtx verifies that removeStaleLock returns
+// ctx.Err() immediately on a pre-cancelled context, before stat'ing the
+// path or spawning fuser/sudo subprocesses.
+func TestRemoveStaleLock_CancelledCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Use a path that definitely exists so we know the early return is
+	// from the ctx check, not from the os.Stat ENOENT branch.
+	err := removeStaleLock(ctx, "/etc/hostname")
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected errors.Is(err, context.Canceled) = true, got err = %v", err)
+	}
+}
+
+// TestRemoveStaleLock_NonExistentPathHealthyCtx verifies the happy path:
+// a healthy context plus a non-existent path returns nil silently
+// (preserving the pre-existing best-effort behavior).
+func TestRemoveStaleLock_NonExistentPathHealthyCtx(t *testing.T) {
+	err := removeStaleLock(context.Background(), "/nonexistent/path/does/not/exist")
+	if err != nil {
+		t.Errorf("expected nil for non-existent path, got %v", err)
+	}
+}
+
+// TestAptRepair_PreflightCancellation verifies that Apt.Repair short-circuits
+// on a pre-cancelled context without spawning any subprocesses. The very
+// first thing it does is iterate lockFiles calling removeStaleLock, which
+// itself preflights ctx.Err().
+func TestAptRepair_PreflightCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	a := NewAptWithContext(context.Background())
+	err := a.Repair(ctx)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected errors.Is(err, context.Canceled) = true, got err = %v", err)
+	}
+}

--- a/go/pkg/zypper.go
+++ b/go/pkg/zypper.go
@@ -59,7 +59,7 @@ func (z *Zypper) Install(packages ...string) (*CommandResult, error) {
 	}
 	// --non-interactive: non-interactive mode
 	args := append([]string{"--non-interactive", "install"}, packages...)
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // InstallVersion installs a package with specific version options.
@@ -76,7 +76,7 @@ func (z *Zypper) InstallVersion(name string, opts InstallOptions) (*CommandResul
 	}
 	args = append(args, pkgSpec)
 
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // Remove removes packages.
@@ -85,7 +85,7 @@ func (z *Zypper) Remove(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"--non-interactive", "remove"}, packages...)
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // Purge removes packages (zypper doesn't distinguish purge from remove).
@@ -95,23 +95,23 @@ func (z *Zypper) Purge(packages ...string) (*CommandResult, error) {
 
 // Update updates the package database (refresh repositories).
 func (z *Zypper) Update() (*CommandResult, error) {
-	return z.run("--non-interactive", "refresh")
+	return z.run(z.ctx, "--non-interactive", "refresh")
 }
 
 // Upgrade upgrades packages.
 func (z *Zypper) Upgrade(packages ...string) (*CommandResult, error) {
 	if len(packages) == 0 {
 		// Upgrade all packages
-		return z.run("--non-interactive", "update")
+		return z.run(z.ctx, "--non-interactive", "update")
 	}
 	// Upgrade specific packages
 	args := append([]string{"--non-interactive", "update"}, packages...)
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // DistUpgrade performs a distribution upgrade.
 func (z *Zypper) DistUpgrade() (*CommandResult, error) {
-	return z.run("--non-interactive", "dist-upgrade")
+	return z.run(z.ctx, "--non-interactive", "dist-upgrade")
 }
 
 // Search searches for packages.
@@ -372,7 +372,7 @@ func (z *Zypper) Pin(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"--non-interactive", "addlock"}, packages...)
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // Unpin allows a package to be upgraded again by removing the lock.
@@ -381,7 +381,7 @@ func (z *Zypper) Unpin(packages ...string) (*CommandResult, error) {
 		return &CommandResult{Success: true}, nil
 	}
 	args := append([]string{"--non-interactive", "removelock"}, packages...)
-	return z.run(args...)
+	return z.run(z.ctx, args...)
 }
 
 // ListPinned lists all pinned (locked) packages.
@@ -461,15 +461,15 @@ func (z *Zypper) getPinnedSet() (map[string]bool, error) {
 	return pinned, nil
 }
 
-func (z *Zypper) run(args ...string) (*CommandResult, error) {
+func (z *Zypper) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	start := time.Now()
 
 	var c *exec.Cmd
 	if z.useSudo {
 		sudoArgs := append([]string{"-n", "zypper"}, args...)
-		c = exec.CommandContext(z.ctx, "sudo", sudoArgs...)
+		c = exec.CommandContext(ctx, "sudo", sudoArgs...)
 	} else {
-		c = exec.CommandContext(z.ctx, "zypper", args...)
+		c = exec.CommandContext(ctx, "zypper", args...)
 	}
 
 	// Force English locale for reliable output parsing.


### PR DESCRIPTION
## Summary

Resolves manchtools/power-manage-sdk#21.

The `Repair(ctx)` methods on `Apt`/`Dnf`/`Pacman`/`Zypper`/`Flatpak` accepted a `context.Context` argument, but the underlying `run()` helper used the manager's *stored* context (from `NewXxxWithContext`). Deadlines and cancellations passed to `Repair(ctx)` never reached the spawned subprocesses.

This PR takes the "more invasive but cleaner" option called out in the issue and changes `run()` to accept `context.Context` as its first parameter.

### What changed
- `(a *Apt) run(ctx, cmd, args...)` and the equivalents on `Dnf`, `Pacman`, `Zypper`, `Flatpak` now take an explicit `ctx`.
- All `Manager`-interface methods that don't accept `ctx` (Install, Remove, Upgrade, etc.) pass `m.ctx` — public signatures and behavior are unchanged.
- All `Repair(ctx)` methods now propagate their argument through to every spawned command.
- For `Apt.FixBroken` (public API, no `ctx` parameter), an internal `a.fixBroken(ctx)` helper does the work; the public method delegates with `a.ctx`, while `Repair` calls it with the caller-supplied `ctx`.

### Out of scope
- `HasUpdates(ctx, ...)` already passes `ctx` directly via `exec.CommandContext` in `updates.go` — no change needed.
- Manager-interface methods (Install/Remove/Upgrade/etc.) keep the stored-ctx pattern. Changing those would be a breaking API change and is not what the issue asks for.

## Test plan

- [x] `go build ./...` (sdk, agent, server)
- [x] `go vet ./...` (sdk, agent, server)
- [x] `go test ./go/pkg/... -count=1`
- [x] No call sites missed: `grep '\.run(' go/pkg/*.go` shows every invocation now has a `ctx` argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cancellation and timeout handling across package managers and repair flows so caller deadlines/cancellations reliably stop ongoing operations, prevent further subprocess/sudo spawns, and produce more consistent error reporting.
* **Tests**
  * Added unit tests covering canceled, deadline-exceeded, and subprocess-failure repair scenarios.
* **Documentation**
  * Updated top-level notes describing propagation of caller deadlines and cancellation to subprocess invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->