### PR TITLE
feat: TerminalHandler interface and dispatch in SDK Client

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -329,6 +329,43 @@ type InventoryHandler interface {
 	CollectInventory(ctx context.Context) *pm.DeviceInventory
 }
 
+// TerminalHandler extends StreamHandler with remote terminal (PTY) session
+// support. Handlers that implement this interface receive the four
+// server-initiated session control messages from manchtools/power-manage-sdk#16
+// and are responsible for allocating PTYs, relaying I/O, and reporting
+// state back via Client.SendTerminalOutput / Client.SendTerminalStateChange.
+//
+// All four methods MUST return promptly: the SDK invokes them on the
+// receive loop, so a slow handler will stall delivery of every other
+// ServerMessage variant. Implementations should hand off to a per-session
+// goroutine for any blocking I/O.
+//
+// A nil error from these methods means the request was accepted; the
+// handler is expected to surface terminal-level failures via
+// SendTerminalStateChange with a TERMINAL_SESSION_STATE_ERROR payload.
+// Returning a non-nil error from OnTerminalStart/Input/Resize/Stop is
+// treated as a fatal stream error and tears down the agent connection.
+type TerminalHandler interface {
+	StreamHandler
+	// OnTerminalStart is called when the server requests a new PTY.
+	// The handler should validate tty_user, allocate the PTY, kick off
+	// I/O goroutines, and send a TERMINAL_SESSION_STATE_STARTED state
+	// change. If allocation fails, it MUST send a STATE_ERROR instead.
+	OnTerminalStart(ctx context.Context, req *pm.TerminalStart) error
+	// OnTerminalInput is called for every stdin frame from the server.
+	// The handler should write the bytes to the PTY of the matching
+	// session_id and ignore (with a debug log) frames for unknown
+	// sessions.
+	OnTerminalInput(ctx context.Context, req *pm.TerminalInput) error
+	// OnTerminalResize forwards a TIOCSWINSZ to the session's PTY.
+	// Unknown sessions are ignored.
+	OnTerminalResize(ctx context.Context, req *pm.TerminalResize) error
+	// OnTerminalStop terminates the session and reverts any side effects
+	// (shell unmask, temp home cleanup, etc.). Unknown sessions are
+	// idempotent no-ops so the server can fire and forget on disconnect.
+	OnTerminalStop(ctx context.Context, req *pm.TerminalStop) error
+}
+
 // Connect establishes a bidirectional stream with the server.
 func (c *Client) Connect(ctx context.Context) error {
 	c.mu.Lock()
@@ -452,6 +489,32 @@ func (c *Client) SendInventory(ctx context.Context, inventory *pm.DeviceInventor
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_Inventory{
 			Inventory: inventory,
+		},
+	})
+}
+
+// SendTerminalOutput sends a stdout/stderr chunk from a remote terminal
+// session back to the server. The TerminalHandler is responsible for
+// chunking PTY reads to fit the proto's 64KB max data size.
+func (c *Client) SendTerminalOutput(ctx context.Context, out *pm.TerminalOutput) error {
+	return c.send(&pm.AgentMessage{
+		Id: NewULID(),
+		Payload: &pm.AgentMessage_TerminalOutput{
+			TerminalOutput: out,
+		},
+	})
+}
+
+// SendTerminalStateChange reports a terminal session lifecycle event
+// (started, exited with code, error). Send STARTED immediately after
+// the PTY is allocated, EXITED when the shell process exits cleanly,
+// and ERROR for any failure that ends the session before STARTED or
+// in flight.
+func (c *Client) SendTerminalStateChange(ctx context.Context, change *pm.TerminalStateChange) error {
+	return c.send(&pm.AgentMessage{
+		Id: NewULID(),
+		Payload: &pm.AgentMessage_TerminalStateChange{
+			TerminalStateChange: change,
 		},
 	})
 }
@@ -728,97 +791,140 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 			if result.err != nil {
 				return fmt.Errorf("receive: %w", result.err)
 			}
-
-			switch p := result.msg.Payload.(type) {
-			case *pm.ServerMessage_Welcome:
-				if err := handler.OnWelcome(ctx, p.Welcome); err != nil {
-					return fmt.Errorf("handle welcome: %w", err)
-				}
-
-			case *pm.ServerMessage_Action:
-				var actionResult *pm.ActionResult
-				var err error
-
-				// Check if handler supports streaming
-				if streamingHandler, ok := handler.(StreamingHandler); ok {
-					// Create a callback that sends output chunks
-					sendChunk := func(chunk *pm.OutputChunk) error {
-						return c.SendOutputChunk(ctx, chunk)
-					}
-					actionResult, err = streamingHandler.OnActionWithStreaming(ctx, p.Action.Action, sendChunk)
-				} else {
-					actionResult, err = handler.OnAction(ctx, p.Action.Action)
-				}
-
-				if err != nil {
-					return fmt.Errorf("handle action: %w", err)
-				}
-				if actionResult != nil {
-					if err := c.SendActionResult(ctx, actionResult); err != nil {
-						return fmt.Errorf("send action result: %w", err)
-					}
-				}
-
-			case *pm.ServerMessage_Query:
-				queryResult, err := handler.OnQuery(ctx, p.Query)
-				if err != nil {
-					return fmt.Errorf("handle query: %w", err)
-				}
-				if queryResult != nil {
-					if err := c.SendQueryResult(ctx, queryResult); err != nil {
-						return fmt.Errorf("send query result: %w", err)
-					}
-				}
-
-			case *pm.ServerMessage_Error:
-				if err := handler.OnError(ctx, p.Error); err != nil {
-					return fmt.Errorf("handle error: %w", err)
-				}
-
-			case *pm.ServerMessage_GetLuksKey, *pm.ServerMessage_StoreLuksKey:
-				// LUKS request-response: deliver to pending request by message ID.
-				c.deliverPending(result.msg)
-
-			case *pm.ServerMessage_RequestInventory:
-				if invHandler, ok := handler.(InventoryHandler); ok {
-					go func() {
-						if inv := invHandler.CollectInventory(ctx); inv != nil {
-							if err := c.SendInventory(ctx, inv); err != nil {
-								c.logger.Warn("failed to send inventory", "error", err)
-							}
-						}
-					}()
-				}
-
-			case *pm.ServerMessage_LogQuery:
-				if lqHandler, ok := handler.(LogQueryHandler); ok {
-					result, err := lqHandler.OnLogQuery(ctx, p.LogQuery)
-					if err != nil {
-						return fmt.Errorf("handle log query: %w", err)
-					}
-					if result != nil {
-						if err := c.SendLogQueryResult(ctx, result); err != nil {
-							return fmt.Errorf("send log query result: %w", err)
-						}
-					}
-				}
-
-			case *pm.ServerMessage_RevokeLuksDeviceKey:
-				if luksHandler, ok := handler.(LuksHandler); ok {
-					actionID := p.RevokeLuksDeviceKey.ActionId
-					// Run in goroutine: the handler calls GetLuksKey which sends
-					// a request on the stream and waits for a response. Processing
-					// that response requires this receive loop to keep running.
-					go func() {
-						success, errMsg := luksHandler.OnRevokeLuksDeviceKey(ctx, actionID)
-						if err := c.SendRevokeLuksDeviceKeyResult(ctx, actionID, success, errMsg); err != nil {
-							c.logger.Warn("failed to send LUKS revocation result", "action_id", actionID, "error", err)
-						}
-					}()
-				}
+			if err := c.dispatchServerMessage(ctx, result.msg, handler); err != nil {
+				return err
 			}
 		}
 	}
+}
+
+// dispatchServerMessage routes a single ServerMessage to the appropriate
+// handler method. Extracted from Run for testability — call sites that
+// need a fake stream or hand-built messages can drive this directly.
+// Returns a non-nil error only for fatal stream errors that should tear
+// down the connection; per-message handler failures (LUKS, terminal,
+// etc.) are wrapped before returning so callers see what failed.
+func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessage, handler StreamHandler) error {
+	switch p := msg.Payload.(type) {
+	case *pm.ServerMessage_Welcome:
+		if err := handler.OnWelcome(ctx, p.Welcome); err != nil {
+			return fmt.Errorf("handle welcome: %w", err)
+		}
+
+	case *pm.ServerMessage_Action:
+		var actionResult *pm.ActionResult
+		var err error
+
+		// Check if handler supports streaming
+		if streamingHandler, ok := handler.(StreamingHandler); ok {
+			// Create a callback that sends output chunks
+			sendChunk := func(chunk *pm.OutputChunk) error {
+				return c.SendOutputChunk(ctx, chunk)
+			}
+			actionResult, err = streamingHandler.OnActionWithStreaming(ctx, p.Action.Action, sendChunk)
+		} else {
+			actionResult, err = handler.OnAction(ctx, p.Action.Action)
+		}
+
+		if err != nil {
+			return fmt.Errorf("handle action: %w", err)
+		}
+		if actionResult != nil {
+			if err := c.SendActionResult(ctx, actionResult); err != nil {
+				return fmt.Errorf("send action result: %w", err)
+			}
+		}
+
+	case *pm.ServerMessage_Query:
+		queryResult, err := handler.OnQuery(ctx, p.Query)
+		if err != nil {
+			return fmt.Errorf("handle query: %w", err)
+		}
+		if queryResult != nil {
+			if err := c.SendQueryResult(ctx, queryResult); err != nil {
+				return fmt.Errorf("send query result: %w", err)
+			}
+		}
+
+	case *pm.ServerMessage_Error:
+		if err := handler.OnError(ctx, p.Error); err != nil {
+			return fmt.Errorf("handle error: %w", err)
+		}
+
+	case *pm.ServerMessage_GetLuksKey, *pm.ServerMessage_StoreLuksKey:
+		// LUKS request-response: deliver to pending request by message ID.
+		c.deliverPending(msg)
+
+	case *pm.ServerMessage_RequestInventory:
+		if invHandler, ok := handler.(InventoryHandler); ok {
+			go func() {
+				if inv := invHandler.CollectInventory(ctx); inv != nil {
+					if err := c.SendInventory(ctx, inv); err != nil {
+						c.logger.Warn("failed to send inventory", "error", err)
+					}
+				}
+			}()
+		}
+
+	case *pm.ServerMessage_LogQuery:
+		if lqHandler, ok := handler.(LogQueryHandler); ok {
+			result, err := lqHandler.OnLogQuery(ctx, p.LogQuery)
+			if err != nil {
+				return fmt.Errorf("handle log query: %w", err)
+			}
+			if result != nil {
+				if err := c.SendLogQueryResult(ctx, result); err != nil {
+					return fmt.Errorf("send log query result: %w", err)
+				}
+			}
+		}
+
+	case *pm.ServerMessage_RevokeLuksDeviceKey:
+		if luksHandler, ok := handler.(LuksHandler); ok {
+			actionID := p.RevokeLuksDeviceKey.ActionId
+			// Run in goroutine: the handler calls GetLuksKey which sends
+			// a request on the stream and waits for a response. Processing
+			// that response requires this receive loop to keep running.
+			go func() {
+				success, errMsg := luksHandler.OnRevokeLuksDeviceKey(ctx, actionID)
+				if err := c.SendRevokeLuksDeviceKeyResult(ctx, actionID, success, errMsg); err != nil {
+					c.logger.Warn("failed to send LUKS revocation result", "action_id", actionID, "error", err)
+				}
+			}()
+		}
+
+	case *pm.ServerMessage_TerminalStart:
+		if termHandler, ok := handler.(TerminalHandler); ok {
+			if err := termHandler.OnTerminalStart(ctx, p.TerminalStart); err != nil {
+				return fmt.Errorf("handle terminal start: %w", err)
+			}
+		} else {
+			c.logger.Debug("dropping TerminalStart: handler does not implement TerminalHandler",
+				"session_id", p.TerminalStart.SessionId)
+		}
+
+	case *pm.ServerMessage_TerminalInput:
+		if termHandler, ok := handler.(TerminalHandler); ok {
+			if err := termHandler.OnTerminalInput(ctx, p.TerminalInput); err != nil {
+				return fmt.Errorf("handle terminal input: %w", err)
+			}
+		}
+
+	case *pm.ServerMessage_TerminalResize:
+		if termHandler, ok := handler.(TerminalHandler); ok {
+			if err := termHandler.OnTerminalResize(ctx, p.TerminalResize); err != nil {
+				return fmt.Errorf("handle terminal resize: %w", err)
+			}
+		}
+
+	case *pm.ServerMessage_TerminalStop:
+		if termHandler, ok := handler.(TerminalHandler); ok {
+			if err := termHandler.OnTerminalStop(ctx, p.TerminalStop); err != nil {
+				return fmt.Errorf("handle terminal stop: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 // NewULID generates a new ULID string.

--- a/go/client.go
+++ b/go/client.go
@@ -923,6 +923,16 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 				return fmt.Errorf("handle terminal stop: %w", err)
 			}
 		}
+
+	default:
+		// Forward-compat: a newer server may add a ServerMessage
+		// payload variant that this SDK build does not yet recognise.
+		// Logging at debug keeps this observable without spamming
+		// production logs, and we deliberately do NOT return an error
+		// — that would tear down the agent connection on every
+		// unknown frame, which is much worse than silently dropping it.
+		c.logger.Debug("dropping unknown ServerMessage payload",
+			"message_id", msg.Id, "type", fmt.Sprintf("%T", msg.Payload))
 	}
 	return nil
 }

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -74,123 +75,175 @@ func newTestClient() *Client {
 	return NewClient("http://localhost:0")
 }
 
-func TestDispatch_TerminalStart_RoutesToHandler(t *testing.T) {
-	c := newTestClient()
-	h := &fakeTerminalHandler{}
-	msg := &pm.ServerMessage{
-		Id: NewULID(),
-		Payload: &pm.ServerMessage_TerminalStart{
+// makeTerminalMsg builds a ServerMessage carrying one of the four
+// Terminal* payload variants. Used by both routing and error tests.
+func makeTerminalMsg(name string) *pm.ServerMessage {
+	msg := &pm.ServerMessage{Id: NewULID()}
+	switch name {
+	case "TerminalStart":
+		msg.Payload = &pm.ServerMessage_TerminalStart{
 			TerminalStart: &pm.TerminalStart{
 				SessionId: "01ABCDEF",
 				TtyUser:   "pm-tty-test",
 				Cols:      80,
 				Rows:      24,
 			},
-		},
-	}
-	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
-		t.Fatalf("dispatch: %v", err)
-	}
-	if len(h.startCalls) != 1 {
-		t.Fatalf("OnTerminalStart calls = %d, want 1", len(h.startCalls))
-	}
-	if h.startCalls[0].SessionId != "01ABCDEF" {
-		t.Errorf("session_id = %q, want 01ABCDEF", h.startCalls[0].SessionId)
-	}
-	if h.startCalls[0].TtyUser != "pm-tty-test" {
-		t.Errorf("tty_user = %q, want pm-tty-test", h.startCalls[0].TtyUser)
-	}
-}
-
-func TestDispatch_TerminalInput_RoutesToHandler(t *testing.T) {
-	c := newTestClient()
-	h := &fakeTerminalHandler{}
-	msg := &pm.ServerMessage{
-		Id: NewULID(),
-		Payload: &pm.ServerMessage_TerminalInput{
+		}
+	case "TerminalInput":
+		msg.Payload = &pm.ServerMessage_TerminalInput{
 			TerminalInput: &pm.TerminalInput{
 				SessionId: "01ABCDEF",
 				Data:      []byte("ls -la\n"),
 			},
-		},
-	}
-	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
-		t.Fatalf("dispatch: %v", err)
-	}
-	if len(h.inputCalls) != 1 {
-		t.Fatalf("OnTerminalInput calls = %d, want 1", len(h.inputCalls))
-	}
-	if string(h.inputCalls[0].Data) != "ls -la\n" {
-		t.Errorf("data = %q, want %q", h.inputCalls[0].Data, "ls -la\n")
-	}
-}
-
-func TestDispatch_TerminalResize_RoutesToHandler(t *testing.T) {
-	c := newTestClient()
-	h := &fakeTerminalHandler{}
-	msg := &pm.ServerMessage{
-		Id: NewULID(),
-		Payload: &pm.ServerMessage_TerminalResize{
+		}
+	case "TerminalResize":
+		msg.Payload = &pm.ServerMessage_TerminalResize{
 			TerminalResize: &pm.TerminalResize{
 				SessionId: "01ABCDEF",
 				Cols:      120,
 				Rows:      40,
 			},
-		},
-	}
-	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
-		t.Fatalf("dispatch: %v", err)
-	}
-	if len(h.resizeCalls) != 1 {
-		t.Fatalf("OnTerminalResize calls = %d, want 1", len(h.resizeCalls))
-	}
-	if h.resizeCalls[0].Cols != 120 || h.resizeCalls[0].Rows != 40 {
-		t.Errorf("size = %dx%d, want 120x40", h.resizeCalls[0].Cols, h.resizeCalls[0].Rows)
-	}
-}
-
-func TestDispatch_TerminalStop_RoutesToHandler(t *testing.T) {
-	c := newTestClient()
-	h := &fakeTerminalHandler{}
-	msg := &pm.ServerMessage{
-		Id: NewULID(),
-		Payload: &pm.ServerMessage_TerminalStop{
+		}
+	case "TerminalStop":
+		msg.Payload = &pm.ServerMessage_TerminalStop{
 			TerminalStop: &pm.TerminalStop{
 				SessionId: "01ABCDEF",
 				Reason:    "admin terminate",
 			},
+		}
+	}
+	return msg
+}
+
+// TestDispatch_Terminal_Routing is the table-driven covering test for
+// the four Terminal* dispatch cases. Each row picks a payload, dispatches
+// it through dispatchServerMessage, then runs case-specific assertions
+// against the fake handler's recorded calls. Keeps the per-case error
+// messages identical to the previous one-test-per-case shape so test
+// failures stay readable.
+func TestDispatch_Terminal_Routing(t *testing.T) {
+	cases := []struct {
+		name   string
+		assert func(t *testing.T, h *fakeTerminalHandler)
+	}{
+		{
+			name: "TerminalStart",
+			assert: func(t *testing.T, h *fakeTerminalHandler) {
+				t.Helper()
+				if len(h.startCalls) != 1 {
+					t.Fatalf("OnTerminalStart calls = %d, want 1", len(h.startCalls))
+				}
+				if h.startCalls[0].SessionId != "01ABCDEF" {
+					t.Errorf("session_id = %q, want 01ABCDEF", h.startCalls[0].SessionId)
+				}
+				if h.startCalls[0].TtyUser != "pm-tty-test" {
+					t.Errorf("tty_user = %q, want pm-tty-test", h.startCalls[0].TtyUser)
+				}
+			},
+		},
+		{
+			name: "TerminalInput",
+			assert: func(t *testing.T, h *fakeTerminalHandler) {
+				t.Helper()
+				if len(h.inputCalls) != 1 {
+					t.Fatalf("OnTerminalInput calls = %d, want 1", len(h.inputCalls))
+				}
+				if string(h.inputCalls[0].Data) != "ls -la\n" {
+					t.Errorf("data = %q, want %q", h.inputCalls[0].Data, "ls -la\n")
+				}
+			},
+		},
+		{
+			name: "TerminalResize",
+			assert: func(t *testing.T, h *fakeTerminalHandler) {
+				t.Helper()
+				if len(h.resizeCalls) != 1 {
+					t.Fatalf("OnTerminalResize calls = %d, want 1", len(h.resizeCalls))
+				}
+				if h.resizeCalls[0].Cols != 120 || h.resizeCalls[0].Rows != 40 {
+					t.Errorf("size = %dx%d, want 120x40", h.resizeCalls[0].Cols, h.resizeCalls[0].Rows)
+				}
+			},
+		},
+		{
+			name: "TerminalStop",
+			assert: func(t *testing.T, h *fakeTerminalHandler) {
+				t.Helper()
+				if len(h.stopCalls) != 1 {
+					t.Fatalf("OnTerminalStop calls = %d, want 1", len(h.stopCalls))
+				}
+				if h.stopCalls[0].Reason != "admin terminate" {
+					t.Errorf("reason = %q, want admin terminate", h.stopCalls[0].Reason)
+				}
+			},
 		},
 	}
-	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
-		t.Fatalf("dispatch: %v", err)
-	}
-	if len(h.stopCalls) != 1 {
-		t.Fatalf("OnTerminalStop calls = %d, want 1", len(h.stopCalls))
-	}
-	if h.stopCalls[0].Reason != "admin terminate" {
-		t.Errorf("reason = %q, want admin terminate", h.stopCalls[0].Reason)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient()
+			h := &fakeTerminalHandler{}
+			if err := c.dispatchServerMessage(context.Background(), makeTerminalMsg(tc.name), h); err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			tc.assert(t, h)
+		})
 	}
 }
 
 // Handler errors must propagate from dispatchServerMessage so the
-// stream can be torn down. The error message must mention the message
-// kind so operators can spot the failing path in logs.
-func TestDispatch_TerminalStart_HandlerErrorPropagates(t *testing.T) {
-	c := newTestClient()
-	want := errors.New("pty alloc denied")
-	h := &fakeTerminalHandler{startErr: want}
-	msg := &pm.ServerMessage{
-		Id: NewULID(),
-		Payload: &pm.ServerMessage_TerminalStart{
-			TerminalStart: &pm.TerminalStart{SessionId: "01ABCDEF", TtyUser: "pm-tty-x"},
+// stream can be torn down. The wrapper text must mention the message
+// kind so operators can spot the failing path in logs — without that,
+// every terminal failure looks identical in the error tail.
+//
+// Asserted for all four Terminal* methods so the wrapper contract is
+// enforced uniformly, not just for Start.
+func TestDispatch_Terminal_HandlerErrorPropagates(t *testing.T) {
+	cases := []struct {
+		name    string
+		setErr  func(h *fakeTerminalHandler, want error)
+		wantSub string // substring expected in err.Error()
+	}{
+		{
+			name:    "TerminalStart",
+			setErr:  func(h *fakeTerminalHandler, want error) { h.startErr = want },
+			wantSub: "handle terminal start",
+		},
+		{
+			name:    "TerminalInput",
+			setErr:  func(h *fakeTerminalHandler, want error) { h.inputErr = want },
+			wantSub: "handle terminal input",
+		},
+		{
+			name:    "TerminalResize",
+			setErr:  func(h *fakeTerminalHandler, want error) { h.resizeErr = want },
+			wantSub: "handle terminal resize",
+		},
+		{
+			name:    "TerminalStop",
+			setErr:  func(h *fakeTerminalHandler, want error) { h.stopErr = want },
+			wantSub: "handle terminal stop",
 		},
 	}
-	err := c.dispatchServerMessage(context.Background(), msg, h)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, want) {
-		t.Errorf("expected errors.Is(err, want) = true, got err = %v", err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient()
+			want := errors.New("handler refused")
+			h := &fakeTerminalHandler{}
+			tc.setErr(h, want)
+
+			err := c.dispatchServerMessage(context.Background(), makeTerminalMsg(tc.name), h)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, want) {
+				t.Errorf("expected errors.Is(err, want) = true, got err = %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err.Error() = %q, want substring %q", err.Error(), tc.wantSub)
+			}
+		})
 	}
 }
 

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -215,6 +215,28 @@ func TestDispatch_Terminal_NoHandler_DropsSilently(t *testing.T) {
 	}
 }
 
+// An unknown / unrecognized ServerMessage payload (e.g. a future
+// variant from a newer server build) must NOT tear down the
+// connection. Returning an error from dispatchServerMessage causes
+// Run to terminate the stream, which is the wrong behaviour for an
+// unknown frame — silently drop it instead.
+//
+// We synthesize "unknown" by passing a ServerMessage with a nil
+// payload, which the type switch hits as the default case.
+func TestDispatch_UnknownPayload_DropsSilently(t *testing.T) {
+	c := newTestClient()
+	h := &fakeTerminalHandler{}
+
+	msg := &pm.ServerMessage{Id: NewULID()}
+	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+		t.Errorf("dispatch unknown payload: unexpected error: %v", err)
+	}
+	// And no handler method should have been touched.
+	if len(h.startCalls)+len(h.inputCalls)+len(h.resizeCalls)+len(h.stopCalls) != 0 {
+		t.Errorf("unknown payload should not invoke any handler method")
+	}
+}
+
 // TerminalHandler is a strict superset of StreamHandler — verify the
 // interface assertion at compile time so a future change that breaks
 // it shows up at build time, not at runtime.

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -1,0 +1,222 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// fakeTerminalHandler is a minimal StreamHandler+TerminalHandler that
+// records every call so dispatch tests can assert against it.
+type fakeTerminalHandler struct {
+	startCalls  []*pm.TerminalStart
+	inputCalls  []*pm.TerminalInput
+	resizeCalls []*pm.TerminalResize
+	stopCalls   []*pm.TerminalStop
+
+	// Per-method error overrides for failure-path tests.
+	startErr  error
+	inputErr  error
+	resizeErr error
+	stopErr   error
+}
+
+// StreamHandler bits — we don't care about them in dispatch tests, so
+// they're stubs that record nothing and return nil.
+func (h *fakeTerminalHandler) OnWelcome(ctx context.Context, w *pm.Welcome) error {
+	return nil
+}
+func (h *fakeTerminalHandler) OnAction(ctx context.Context, a *pm.Action) (*pm.ActionResult, error) {
+	return nil, nil
+}
+func (h *fakeTerminalHandler) OnQuery(ctx context.Context, q *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (h *fakeTerminalHandler) OnError(ctx context.Context, e *pm.Error) error { return nil }
+
+func (h *fakeTerminalHandler) OnTerminalStart(ctx context.Context, req *pm.TerminalStart) error {
+	h.startCalls = append(h.startCalls, req)
+	return h.startErr
+}
+func (h *fakeTerminalHandler) OnTerminalInput(ctx context.Context, req *pm.TerminalInput) error {
+	h.inputCalls = append(h.inputCalls, req)
+	return h.inputErr
+}
+func (h *fakeTerminalHandler) OnTerminalResize(ctx context.Context, req *pm.TerminalResize) error {
+	h.resizeCalls = append(h.resizeCalls, req)
+	return h.resizeErr
+}
+func (h *fakeTerminalHandler) OnTerminalStop(ctx context.Context, req *pm.TerminalStop) error {
+	h.stopCalls = append(h.stopCalls, req)
+	return h.stopErr
+}
+
+// fakeBareHandler implements StreamHandler but NOT TerminalHandler.
+// Used to verify that dispatching a Terminal* message at a handler
+// without terminal support is silently dropped (no error).
+type fakeBareHandler struct{}
+
+func (fakeBareHandler) OnWelcome(ctx context.Context, w *pm.Welcome) error { return nil }
+func (fakeBareHandler) OnAction(ctx context.Context, a *pm.Action) (*pm.ActionResult, error) {
+	return nil, nil
+}
+func (fakeBareHandler) OnQuery(ctx context.Context, q *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (fakeBareHandler) OnError(ctx context.Context, e *pm.Error) error { return nil }
+
+// newTestClient builds a Client that can run dispatchServerMessage but
+// is not actually connected to any server. The dispatch tests never
+// touch the underlying stream, so the missing transport is fine.
+func newTestClient() *Client {
+	return NewClient("http://localhost:0")
+}
+
+func TestDispatch_TerminalStart_RoutesToHandler(t *testing.T) {
+	c := newTestClient()
+	h := &fakeTerminalHandler{}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_TerminalStart{
+			TerminalStart: &pm.TerminalStart{
+				SessionId: "01ABCDEF",
+				TtyUser:   "pm-tty-test",
+				Cols:      80,
+				Rows:      24,
+			},
+		},
+	}
+	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.startCalls) != 1 {
+		t.Fatalf("OnTerminalStart calls = %d, want 1", len(h.startCalls))
+	}
+	if h.startCalls[0].SessionId != "01ABCDEF" {
+		t.Errorf("session_id = %q, want 01ABCDEF", h.startCalls[0].SessionId)
+	}
+	if h.startCalls[0].TtyUser != "pm-tty-test" {
+		t.Errorf("tty_user = %q, want pm-tty-test", h.startCalls[0].TtyUser)
+	}
+}
+
+func TestDispatch_TerminalInput_RoutesToHandler(t *testing.T) {
+	c := newTestClient()
+	h := &fakeTerminalHandler{}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_TerminalInput{
+			TerminalInput: &pm.TerminalInput{
+				SessionId: "01ABCDEF",
+				Data:      []byte("ls -la\n"),
+			},
+		},
+	}
+	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.inputCalls) != 1 {
+		t.Fatalf("OnTerminalInput calls = %d, want 1", len(h.inputCalls))
+	}
+	if string(h.inputCalls[0].Data) != "ls -la\n" {
+		t.Errorf("data = %q, want %q", h.inputCalls[0].Data, "ls -la\n")
+	}
+}
+
+func TestDispatch_TerminalResize_RoutesToHandler(t *testing.T) {
+	c := newTestClient()
+	h := &fakeTerminalHandler{}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_TerminalResize{
+			TerminalResize: &pm.TerminalResize{
+				SessionId: "01ABCDEF",
+				Cols:      120,
+				Rows:      40,
+			},
+		},
+	}
+	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.resizeCalls) != 1 {
+		t.Fatalf("OnTerminalResize calls = %d, want 1", len(h.resizeCalls))
+	}
+	if h.resizeCalls[0].Cols != 120 || h.resizeCalls[0].Rows != 40 {
+		t.Errorf("size = %dx%d, want 120x40", h.resizeCalls[0].Cols, h.resizeCalls[0].Rows)
+	}
+}
+
+func TestDispatch_TerminalStop_RoutesToHandler(t *testing.T) {
+	c := newTestClient()
+	h := &fakeTerminalHandler{}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_TerminalStop{
+			TerminalStop: &pm.TerminalStop{
+				SessionId: "01ABCDEF",
+				Reason:    "admin terminate",
+			},
+		},
+	}
+	if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(h.stopCalls) != 1 {
+		t.Fatalf("OnTerminalStop calls = %d, want 1", len(h.stopCalls))
+	}
+	if h.stopCalls[0].Reason != "admin terminate" {
+		t.Errorf("reason = %q, want admin terminate", h.stopCalls[0].Reason)
+	}
+}
+
+// Handler errors must propagate from dispatchServerMessage so the
+// stream can be torn down. The error message must mention the message
+// kind so operators can spot the failing path in logs.
+func TestDispatch_TerminalStart_HandlerErrorPropagates(t *testing.T) {
+	c := newTestClient()
+	want := errors.New("pty alloc denied")
+	h := &fakeTerminalHandler{startErr: want}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_TerminalStart{
+			TerminalStart: &pm.TerminalStart{SessionId: "01ABCDEF", TtyUser: "pm-tty-x"},
+		},
+	}
+	err := c.dispatchServerMessage(context.Background(), msg, h)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("expected errors.Is(err, want) = true, got err = %v", err)
+	}
+}
+
+// A handler that does NOT implement TerminalHandler must silently
+// drop terminal messages — no error, no panic. Critical for the
+// transition window where the proto has shipped but agents haven't
+// implemented terminal support yet.
+func TestDispatch_Terminal_NoHandler_DropsSilently(t *testing.T) {
+	c := newTestClient()
+	bare := fakeBareHandler{}
+
+	cases := []*pm.ServerMessage{
+		{Id: NewULID(), Payload: &pm.ServerMessage_TerminalStart{TerminalStart: &pm.TerminalStart{SessionId: "01"}}},
+		{Id: NewULID(), Payload: &pm.ServerMessage_TerminalInput{TerminalInput: &pm.TerminalInput{SessionId: "01"}}},
+		{Id: NewULID(), Payload: &pm.ServerMessage_TerminalResize{TerminalResize: &pm.TerminalResize{SessionId: "01"}}},
+		{Id: NewULID(), Payload: &pm.ServerMessage_TerminalStop{TerminalStop: &pm.TerminalStop{SessionId: "01"}}},
+	}
+	for _, msg := range cases {
+		if err := c.dispatchServerMessage(context.Background(), msg, bare); err != nil {
+			t.Errorf("dispatch %T: unexpected error: %v", msg.Payload, err)
+		}
+	}
+}
+
+// TerminalHandler is a strict superset of StreamHandler — verify the
+// interface assertion at compile time so a future change that breaks
+// it shows up at build time, not at runtime.
+var _ TerminalHandler = (*fakeTerminalHandler)(nil)
+var _ StreamHandler = fakeBareHandler{}


### PR DESCRIPTION
## Summary

Wires the four server-initiated terminal session control messages into the SDK Client's stream dispatch loop, plus the two outbound counterparts. This is the SDK glue between the merged proto contract (manchtools/power-manage-sdk#25) and the upcoming agent terminal handler (step 3 of manchtools/power-manage-sdk#16). Without it, the agent has no way to receive \`TerminalStart\` from the gateway or send \`TerminalOutput\` back.

## What's in this PR

### New \`TerminalHandler\` interface

Optional extension on \`StreamHandler\`, in the same shape as the existing \`StreamingHandler\`/\`LuksHandler\`/\`LogQueryHandler\`/\`InventoryHandler\` extensions:

\`\`\`go
type TerminalHandler interface {
    StreamHandler
    OnTerminalStart(ctx context.Context, req *pm.TerminalStart) error
    OnTerminalInput(ctx context.Context, req *pm.TerminalInput) error
    OnTerminalResize(ctx context.Context, req *pm.TerminalResize) error
    OnTerminalStop(ctx context.Context, req *pm.TerminalStop) error
}
\`\`\`

Documented contract: methods MUST return promptly (they run on the single-threaded receive loop), nil error means accepted, terminal-level failures surface via \`SendTerminalStateChange\` with \`STATE_ERROR\`, non-nil error is fatal and tears down the stream.

### New \`Send*\` helpers

\`\`\`go
func (c *Client) SendTerminalOutput(ctx context.Context, out *pm.TerminalOutput) error
func (c *Client) SendTerminalStateChange(ctx context.Context, change *pm.TerminalStateChange) error
\`\`\`

Identical pattern to \`SendInventory\`, \`SendLogQueryResult\`, etc.

### Dispatch wiring

Four new \`ServerMessage\` cases. \`Input\`/\`Resize\`/\`Stop\` silently drop when the handler does not implement \`TerminalHandler\` (otherwise we'd flood logs with every keystroke during the transition window). \`Start\` logs once at debug level with the session_id so operators can see when an agent receives a session request it cannot handle.

### Refactor: extract \`dispatchServerMessage\`

Pulled the receive-loop switch into a private \`(*Client).dispatchServerMessage(ctx, msg, handler) error\` method so the dispatch logic is unit-testable without standing up a fake bidi Connect server. The pre-existing 8 cases are preserved **verbatim** — only change is the \`deliverPending\` call now uses the function-arg \`msg\` instead of the closed-over \`result.msg\`. The \`Run\` loop becomes a thin wrapper that delegates to the new method.

This is a focused refactor that gives us a real test seam for all 12 cases (8 existing + 4 new) without invasive changes elsewhere.

### Tests (new \`client_test.go\`)

- 4 routing tests asserting each Terminal* message reaches the matching handler method with the right payload.
- 1 error-propagation test using \`errors.Is\` to verify handler errors bubble out of \`dispatchServerMessage\` so the stream can tear down.
- 1 silent-drop test asserting that all 4 Terminal* variants are no-ops on a handler that does not implement \`TerminalHandler\`.
- 2 compile-time interface assertions on the test fakes so future contract changes fail at build time.

All race-clean.

## Out of scope

- Agent \`TerminalHandler\` implementation (shell activation via \`usermod\`, internal session registry with the per-device limit and idle timeout, wiring to \`terminal.Start\`) — coordinated follow-up PR in the agent repo.
- Gateway WebSocket bridge — step 4 of the issue.
- Control \`StartTerminal\`/\`StopTerminal\` real implementation — step 5 of the issue.

## Test plan

- [x] \`go build ./...\` (sdk, agent, server)
- [x] \`go vet ./...\` (sdk, agent, server)
- [x] \`go test ./go/ -count=1 -race\` — 6 new dispatch tests pass
- [x] \`go test ./... -count=1 -race\` (full sdk suite) — all green
- [x] Refactor preserves pre-existing dispatch behavior verbatim (only \`result.msg\` → \`msg\` parameter rename in the LUKS branch)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-sdk#25 — proto contract this PR builds on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal support with lifecycle events: start, input, resize, and stop
  * Client can send terminal output and terminal state-change messages

* **Improvements**
  * Message dispatching now routes terminal events to capable handlers and drops unknown payloads without failing the connection
  * Unsupported terminal starts are debug-logged and non-terminal events are ignored silently

* **Tests**
  * Added tests for terminal routing, handler error propagation, and unknown-payload handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->