### PR TITLE
feat: InternalService.ProxyValidateTerminalToken RPC

### DIFF
--- a/gen/go/pm/v1/internal.pb.go
+++ b/gen/go/pm/v1/internal.pb.go
@@ -486,12 +486,21 @@ func (x *InternalValidateTerminalTokenRequest) GetToken() string {
 // session_id for ownership decisions because it has no access to the
 // JWT.
 type InternalValidateTerminalTokenResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
-	DeviceId      string                 `protobuf:"bytes,2,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
-	TtyUser       string                 `protobuf:"bytes,3,opt,name=tty_user,json=ttyUser,proto3" json:"tty_user,omitempty"`
-	Cols          uint32                 `protobuf:"varint,4,opt,name=cols,proto3" json:"cols,omitempty"`
-	Rows          uint32                 `protobuf:"varint,5,opt,name=rows,proto3" json:"rows,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// @gotags: validate:"required,ulid"
+	UserId string `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" validate:"required,ulid"`
+	// @gotags: validate:"required,ulid"
+	DeviceId string `protobuf:"bytes,2,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
+	// Matches the agent-side username constraint and the public
+	// TerminalStart bounds.
+	// @gotags: validate:"required,min=1,max=64"
+	TtyUser string `protobuf:"bytes,3,opt,name=tty_user,json=ttyUser,proto3" json:"tty_user,omitempty" validate:"required,min=1,max=64"`
+	// Same window-size bounds as the public TerminalStart message
+	// (proto3 has no uint16; cap at 65535).
+	// @gotags: validate:"required,gt=0,lte=65535"
+	Cols uint32 `protobuf:"varint,4,opt,name=cols,proto3" json:"cols,omitempty" validate:"required,gt=0,lte=65535"`
+	// @gotags: validate:"required,gt=0,lte=65535"
+	Rows          uint32 `protobuf:"varint,5,opt,name=rows,proto3" json:"rows,omitempty" validate:"required,gt=0,lte=65535"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/pm/v1/internal.pb.go
+++ b/gen/go/pm/v1/internal.pb.go
@@ -418,6 +418,149 @@ func (*InternalStoreLpsPasswordsResponse) Descriptor() ([]byte, []int) {
 	return file_pm_v1_internal_proto_rawDescGZIP(), []int{6}
 }
 
+// InternalValidateTerminalTokenRequest is sent by the gateway when a
+// web client opens the WebSocket terminal endpoint with a session_id
+// and bearer token. The control server looks the session up in the
+// Valkey-backed token store, compares the SHA-256 of the supplied
+// token against the stored hash, and returns the session metadata.
+type InternalValidateTerminalTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// @gotags: validate:"required,ulid"
+	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty" validate:"required,ulid"`
+	// The plaintext bearer token the web client received from
+	// ControlService.StartTerminal.
+	// @gotags: validate:"required,min=1"
+	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required,min=1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InternalValidateTerminalTokenRequest) Reset() {
+	*x = InternalValidateTerminalTokenRequest{}
+	mi := &file_pm_v1_internal_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InternalValidateTerminalTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InternalValidateTerminalTokenRequest) ProtoMessage() {}
+
+func (x *InternalValidateTerminalTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pm_v1_internal_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InternalValidateTerminalTokenRequest.ProtoReflect.Descriptor instead.
+func (*InternalValidateTerminalTokenRequest) Descriptor() ([]byte, []int) {
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *InternalValidateTerminalTokenRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *InternalValidateTerminalTokenRequest) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+// InternalValidateTerminalTokenResponse carries the session metadata
+// the gateway needs to bridge the WebSocket connection to the matching
+// agent. The user_id is included so the gateway can record it on the
+// active session for the admin List path; the gateway never trusts the
+// session_id for ownership decisions because it has no access to the
+// JWT.
+type InternalValidateTerminalTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	DeviceId      string                 `protobuf:"bytes,2,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	TtyUser       string                 `protobuf:"bytes,3,opt,name=tty_user,json=ttyUser,proto3" json:"tty_user,omitempty"`
+	Cols          uint32                 `protobuf:"varint,4,opt,name=cols,proto3" json:"cols,omitempty"`
+	Rows          uint32                 `protobuf:"varint,5,opt,name=rows,proto3" json:"rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InternalValidateTerminalTokenResponse) Reset() {
+	*x = InternalValidateTerminalTokenResponse{}
+	mi := &file_pm_v1_internal_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InternalValidateTerminalTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InternalValidateTerminalTokenResponse) ProtoMessage() {}
+
+func (x *InternalValidateTerminalTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pm_v1_internal_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InternalValidateTerminalTokenResponse.ProtoReflect.Descriptor instead.
+func (*InternalValidateTerminalTokenResponse) Descriptor() ([]byte, []int) {
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *InternalValidateTerminalTokenResponse) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *InternalValidateTerminalTokenResponse) GetDeviceId() string {
+	if x != nil {
+		return x.DeviceId
+	}
+	return ""
+}
+
+func (x *InternalValidateTerminalTokenResponse) GetTtyUser() string {
+	if x != nil {
+		return x.TtyUser
+	}
+	return ""
+}
+
+func (x *InternalValidateTerminalTokenResponse) GetCols() uint32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+func (x *InternalValidateTerminalTokenResponse) GetRows() uint32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
 // VerifyDeviceRequest is sent by the gateway to verify a device before
 // allowing it to connect. Contains the device_id from the mTLS certificate.
 type VerifyDeviceRequest struct {
@@ -429,7 +572,7 @@ type VerifyDeviceRequest struct {
 
 func (x *VerifyDeviceRequest) Reset() {
 	*x = VerifyDeviceRequest{}
-	mi := &file_pm_v1_internal_proto_msgTypes[7]
+	mi := &file_pm_v1_internal_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +584,7 @@ func (x *VerifyDeviceRequest) String() string {
 func (*VerifyDeviceRequest) ProtoMessage() {}
 
 func (x *VerifyDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[7]
+	mi := &file_pm_v1_internal_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +597,7 @@ func (x *VerifyDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyDeviceRequest.ProtoReflect.Descriptor instead.
 func (*VerifyDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{7}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *VerifyDeviceRequest) GetDeviceId() string {
@@ -473,7 +616,7 @@ type VerifyDeviceResponse struct {
 
 func (x *VerifyDeviceResponse) Reset() {
 	*x = VerifyDeviceResponse{}
-	mi := &file_pm_v1_internal_proto_msgTypes[8]
+	mi := &file_pm_v1_internal_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -485,7 +628,7 @@ func (x *VerifyDeviceResponse) String() string {
 func (*VerifyDeviceResponse) ProtoMessage() {}
 
 func (x *VerifyDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[8]
+	mi := &file_pm_v1_internal_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -498,7 +641,7 @@ func (x *VerifyDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyDeviceResponse.ProtoReflect.Descriptor instead.
 func (*VerifyDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{8}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{10}
 }
 
 // GatewayTerminalSessionInfo is a single entry in a gateway's session
@@ -524,7 +667,7 @@ type GatewayTerminalSessionInfo struct {
 
 func (x *GatewayTerminalSessionInfo) Reset() {
 	*x = GatewayTerminalSessionInfo{}
-	mi := &file_pm_v1_internal_proto_msgTypes[9]
+	mi := &file_pm_v1_internal_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -536,7 +679,7 @@ func (x *GatewayTerminalSessionInfo) String() string {
 func (*GatewayTerminalSessionInfo) ProtoMessage() {}
 
 func (x *GatewayTerminalSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[9]
+	mi := &file_pm_v1_internal_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -549,7 +692,7 @@ func (x *GatewayTerminalSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GatewayTerminalSessionInfo.ProtoReflect.Descriptor instead.
 func (*GatewayTerminalSessionInfo) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{9}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GatewayTerminalSessionInfo) GetSessionId() string {
@@ -602,7 +745,7 @@ type ListGatewayTerminalSessionsRequest struct {
 
 func (x *ListGatewayTerminalSessionsRequest) Reset() {
 	*x = ListGatewayTerminalSessionsRequest{}
-	mi := &file_pm_v1_internal_proto_msgTypes[10]
+	mi := &file_pm_v1_internal_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +757,7 @@ func (x *ListGatewayTerminalSessionsRequest) String() string {
 func (*ListGatewayTerminalSessionsRequest) ProtoMessage() {}
 
 func (x *ListGatewayTerminalSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[10]
+	mi := &file_pm_v1_internal_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +770,7 @@ func (x *ListGatewayTerminalSessionsRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use ListGatewayTerminalSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListGatewayTerminalSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{10}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{12}
 }
 
 type ListGatewayTerminalSessionsResponse struct {
@@ -639,7 +782,7 @@ type ListGatewayTerminalSessionsResponse struct {
 
 func (x *ListGatewayTerminalSessionsResponse) Reset() {
 	*x = ListGatewayTerminalSessionsResponse{}
-	mi := &file_pm_v1_internal_proto_msgTypes[11]
+	mi := &file_pm_v1_internal_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -651,7 +794,7 @@ func (x *ListGatewayTerminalSessionsResponse) String() string {
 func (*ListGatewayTerminalSessionsResponse) ProtoMessage() {}
 
 func (x *ListGatewayTerminalSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[11]
+	mi := &file_pm_v1_internal_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -664,7 +807,7 @@ func (x *ListGatewayTerminalSessionsResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ListGatewayTerminalSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListGatewayTerminalSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{11}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListGatewayTerminalSessionsResponse) GetSessions() []*GatewayTerminalSessionInfo {
@@ -689,7 +832,7 @@ type TerminateGatewayTerminalSessionRequest struct {
 
 func (x *TerminateGatewayTerminalSessionRequest) Reset() {
 	*x = TerminateGatewayTerminalSessionRequest{}
-	mi := &file_pm_v1_internal_proto_msgTypes[12]
+	mi := &file_pm_v1_internal_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -701,7 +844,7 @@ func (x *TerminateGatewayTerminalSessionRequest) String() string {
 func (*TerminateGatewayTerminalSessionRequest) ProtoMessage() {}
 
 func (x *TerminateGatewayTerminalSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[12]
+	mi := &file_pm_v1_internal_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -714,7 +857,7 @@ func (x *TerminateGatewayTerminalSessionRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use TerminateGatewayTerminalSessionRequest.ProtoReflect.Descriptor instead.
 func (*TerminateGatewayTerminalSessionRequest) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{12}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TerminateGatewayTerminalSessionRequest) GetSessionId() string {
@@ -743,7 +886,7 @@ type TerminateGatewayTerminalSessionResponse struct {
 
 func (x *TerminateGatewayTerminalSessionResponse) Reset() {
 	*x = TerminateGatewayTerminalSessionResponse{}
-	mi := &file_pm_v1_internal_proto_msgTypes[13]
+	mi := &file_pm_v1_internal_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -755,7 +898,7 @@ func (x *TerminateGatewayTerminalSessionResponse) String() string {
 func (*TerminateGatewayTerminalSessionResponse) ProtoMessage() {}
 
 func (x *TerminateGatewayTerminalSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pm_v1_internal_proto_msgTypes[13]
+	mi := &file_pm_v1_internal_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -768,7 +911,7 @@ func (x *TerminateGatewayTerminalSessionResponse) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use TerminateGatewayTerminalSessionResponse.ProtoReflect.Descriptor instead.
 func (*TerminateGatewayTerminalSessionResponse) Descriptor() ([]byte, []int) {
-	return file_pm_v1_internal_proto_rawDescGZIP(), []int{13}
+	return file_pm_v1_internal_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TerminateGatewayTerminalSessionResponse) GetFound() bool {
@@ -810,7 +953,17 @@ const file_pm_v1_internal_proto_rawDesc = "" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1b\n" +
 	"\taction_id\x18\x02 \x01(\tR\bactionId\x128\n" +
 	"\trotations\x18\x03 \x03(\v2\x1a.pm.v1.LpsPasswordRotationR\trotations\"#\n" +
-	"!InternalStoreLpsPasswordsResponse\"2\n" +
+	"!InternalStoreLpsPasswordsResponse\"[\n" +
+	"$InternalValidateTerminalTokenRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\"\xa0\x01\n" +
+	"%InternalValidateTerminalTokenResponse\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n" +
+	"\tdevice_id\x18\x02 \x01(\tR\bdeviceId\x12\x19\n" +
+	"\btty_user\x18\x03 \x01(\tR\attyUser\x12\x12\n" +
+	"\x04cols\x18\x04 \x01(\rR\x04cols\x12\x12\n" +
+	"\x04rows\x18\x05 \x01(\rR\x04rows\"2\n" +
 	"\x13VerifyDeviceRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"\x16\n" +
 	"\x14VerifyDeviceResponse\"\x8d\x02\n" +
@@ -831,14 +984,15 @@ const file_pm_v1_internal_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\"?\n" +
 	"'TerminateGatewayTerminalSessionResponse\x12\x14\n" +
-	"\x05found\x18\x01 \x01(\bR\x05found2\xa5\x04\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found2\x9e\x05\n" +
 	"\x0fInternalService\x12G\n" +
 	"\fVerifyDevice\x12\x1a.pm.v1.VerifyDeviceRequest\x1a\x1b.pm.v1.VerifyDeviceResponse\x12Q\n" +
 	"\x10ProxySyncActions\x12!.pm.v1.InternalSyncActionsRequest\x1a\x1a.pm.v1.SyncActionsResponse\x12c\n" +
 	"\x16ProxyValidateLuksToken\x12'.pm.v1.InternalValidateLuksTokenRequest\x1a .pm.v1.ValidateLuksTokenResponse\x12N\n" +
 	"\x0fProxyGetLuksKey\x12 .pm.v1.InternalGetLuksKeyRequest\x1a\x19.pm.v1.GetLuksKeyResponse\x12T\n" +
 	"\x11ProxyStoreLuksKey\x12\".pm.v1.InternalStoreLuksKeyRequest\x1a\x1b.pm.v1.StoreLuksKeyResponse\x12k\n" +
-	"\x16ProxyStoreLpsPasswords\x12'.pm.v1.InternalStoreLpsPasswordsRequest\x1a(.pm.v1.InternalStoreLpsPasswordsResponse2\x89\x02\n" +
+	"\x16ProxyStoreLpsPasswords\x12'.pm.v1.InternalStoreLpsPasswordsRequest\x1a(.pm.v1.InternalStoreLpsPasswordsResponse\x12w\n" +
+	"\x1aProxyValidateTerminalToken\x12+.pm.v1.InternalValidateTerminalTokenRequest\x1a,.pm.v1.InternalValidateTerminalTokenResponse2\x89\x02\n" +
 	"\x0eGatewayService\x12t\n" +
 	"\x1bListGatewayTerminalSessions\x12).pm.v1.ListGatewayTerminalSessionsRequest\x1a*.pm.v1.ListGatewayTerminalSessionsResponse\x12\x80\x01\n" +
 	"\x1fTerminateGatewayTerminalSession\x12-.pm.v1.TerminateGatewayTerminalSessionRequest\x1a..pm.v1.TerminateGatewayTerminalSessionResponseB:Z8github.com/manchtools/power-manage/sdk/gen/go/pm/v1;pmv1b\x06proto3"
@@ -855,7 +1009,7 @@ func file_pm_v1_internal_proto_rawDescGZIP() []byte {
 	return file_pm_v1_internal_proto_rawDescData
 }
 
-var file_pm_v1_internal_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_pm_v1_internal_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_pm_v1_internal_proto_goTypes = []any{
 	(*InternalSyncActionsRequest)(nil),              // 0: pm.v1.InternalSyncActionsRequest
 	(*InternalValidateLuksTokenRequest)(nil),        // 1: pm.v1.InternalValidateLuksTokenRequest
@@ -864,42 +1018,46 @@ var file_pm_v1_internal_proto_goTypes = []any{
 	(*LpsPasswordRotation)(nil),                     // 4: pm.v1.LpsPasswordRotation
 	(*InternalStoreLpsPasswordsRequest)(nil),        // 5: pm.v1.InternalStoreLpsPasswordsRequest
 	(*InternalStoreLpsPasswordsResponse)(nil),       // 6: pm.v1.InternalStoreLpsPasswordsResponse
-	(*VerifyDeviceRequest)(nil),                     // 7: pm.v1.VerifyDeviceRequest
-	(*VerifyDeviceResponse)(nil),                    // 8: pm.v1.VerifyDeviceResponse
-	(*GatewayTerminalSessionInfo)(nil),              // 9: pm.v1.GatewayTerminalSessionInfo
-	(*ListGatewayTerminalSessionsRequest)(nil),      // 10: pm.v1.ListGatewayTerminalSessionsRequest
-	(*ListGatewayTerminalSessionsResponse)(nil),     // 11: pm.v1.ListGatewayTerminalSessionsResponse
-	(*TerminateGatewayTerminalSessionRequest)(nil),  // 12: pm.v1.TerminateGatewayTerminalSessionRequest
-	(*TerminateGatewayTerminalSessionResponse)(nil), // 13: pm.v1.TerminateGatewayTerminalSessionResponse
-	(*timestamppb.Timestamp)(nil),                   // 14: google.protobuf.Timestamp
-	(*SyncActionsResponse)(nil),                     // 15: pm.v1.SyncActionsResponse
-	(*ValidateLuksTokenResponse)(nil),               // 16: pm.v1.ValidateLuksTokenResponse
-	(*GetLuksKeyResponse)(nil),                      // 17: pm.v1.GetLuksKeyResponse
-	(*StoreLuksKeyResponse)(nil),                    // 18: pm.v1.StoreLuksKeyResponse
+	(*InternalValidateTerminalTokenRequest)(nil),    // 7: pm.v1.InternalValidateTerminalTokenRequest
+	(*InternalValidateTerminalTokenResponse)(nil),   // 8: pm.v1.InternalValidateTerminalTokenResponse
+	(*VerifyDeviceRequest)(nil),                     // 9: pm.v1.VerifyDeviceRequest
+	(*VerifyDeviceResponse)(nil),                    // 10: pm.v1.VerifyDeviceResponse
+	(*GatewayTerminalSessionInfo)(nil),              // 11: pm.v1.GatewayTerminalSessionInfo
+	(*ListGatewayTerminalSessionsRequest)(nil),      // 12: pm.v1.ListGatewayTerminalSessionsRequest
+	(*ListGatewayTerminalSessionsResponse)(nil),     // 13: pm.v1.ListGatewayTerminalSessionsResponse
+	(*TerminateGatewayTerminalSessionRequest)(nil),  // 14: pm.v1.TerminateGatewayTerminalSessionRequest
+	(*TerminateGatewayTerminalSessionResponse)(nil), // 15: pm.v1.TerminateGatewayTerminalSessionResponse
+	(*timestamppb.Timestamp)(nil),                   // 16: google.protobuf.Timestamp
+	(*SyncActionsResponse)(nil),                     // 17: pm.v1.SyncActionsResponse
+	(*ValidateLuksTokenResponse)(nil),               // 18: pm.v1.ValidateLuksTokenResponse
+	(*GetLuksKeyResponse)(nil),                      // 19: pm.v1.GetLuksKeyResponse
+	(*StoreLuksKeyResponse)(nil),                    // 20: pm.v1.StoreLuksKeyResponse
 }
 var file_pm_v1_internal_proto_depIdxs = []int32{
 	4,  // 0: pm.v1.InternalStoreLpsPasswordsRequest.rotations:type_name -> pm.v1.LpsPasswordRotation
-	14, // 1: pm.v1.GatewayTerminalSessionInfo.started_at:type_name -> google.protobuf.Timestamp
-	14, // 2: pm.v1.GatewayTerminalSessionInfo.last_activity_at:type_name -> google.protobuf.Timestamp
-	9,  // 3: pm.v1.ListGatewayTerminalSessionsResponse.sessions:type_name -> pm.v1.GatewayTerminalSessionInfo
-	7,  // 4: pm.v1.InternalService.VerifyDevice:input_type -> pm.v1.VerifyDeviceRequest
+	16, // 1: pm.v1.GatewayTerminalSessionInfo.started_at:type_name -> google.protobuf.Timestamp
+	16, // 2: pm.v1.GatewayTerminalSessionInfo.last_activity_at:type_name -> google.protobuf.Timestamp
+	11, // 3: pm.v1.ListGatewayTerminalSessionsResponse.sessions:type_name -> pm.v1.GatewayTerminalSessionInfo
+	9,  // 4: pm.v1.InternalService.VerifyDevice:input_type -> pm.v1.VerifyDeviceRequest
 	0,  // 5: pm.v1.InternalService.ProxySyncActions:input_type -> pm.v1.InternalSyncActionsRequest
 	1,  // 6: pm.v1.InternalService.ProxyValidateLuksToken:input_type -> pm.v1.InternalValidateLuksTokenRequest
 	2,  // 7: pm.v1.InternalService.ProxyGetLuksKey:input_type -> pm.v1.InternalGetLuksKeyRequest
 	3,  // 8: pm.v1.InternalService.ProxyStoreLuksKey:input_type -> pm.v1.InternalStoreLuksKeyRequest
 	5,  // 9: pm.v1.InternalService.ProxyStoreLpsPasswords:input_type -> pm.v1.InternalStoreLpsPasswordsRequest
-	10, // 10: pm.v1.GatewayService.ListGatewayTerminalSessions:input_type -> pm.v1.ListGatewayTerminalSessionsRequest
-	12, // 11: pm.v1.GatewayService.TerminateGatewayTerminalSession:input_type -> pm.v1.TerminateGatewayTerminalSessionRequest
-	8,  // 12: pm.v1.InternalService.VerifyDevice:output_type -> pm.v1.VerifyDeviceResponse
-	15, // 13: pm.v1.InternalService.ProxySyncActions:output_type -> pm.v1.SyncActionsResponse
-	16, // 14: pm.v1.InternalService.ProxyValidateLuksToken:output_type -> pm.v1.ValidateLuksTokenResponse
-	17, // 15: pm.v1.InternalService.ProxyGetLuksKey:output_type -> pm.v1.GetLuksKeyResponse
-	18, // 16: pm.v1.InternalService.ProxyStoreLuksKey:output_type -> pm.v1.StoreLuksKeyResponse
-	6,  // 17: pm.v1.InternalService.ProxyStoreLpsPasswords:output_type -> pm.v1.InternalStoreLpsPasswordsResponse
-	11, // 18: pm.v1.GatewayService.ListGatewayTerminalSessions:output_type -> pm.v1.ListGatewayTerminalSessionsResponse
-	13, // 19: pm.v1.GatewayService.TerminateGatewayTerminalSession:output_type -> pm.v1.TerminateGatewayTerminalSessionResponse
-	12, // [12:20] is the sub-list for method output_type
-	4,  // [4:12] is the sub-list for method input_type
+	7,  // 10: pm.v1.InternalService.ProxyValidateTerminalToken:input_type -> pm.v1.InternalValidateTerminalTokenRequest
+	12, // 11: pm.v1.GatewayService.ListGatewayTerminalSessions:input_type -> pm.v1.ListGatewayTerminalSessionsRequest
+	14, // 12: pm.v1.GatewayService.TerminateGatewayTerminalSession:input_type -> pm.v1.TerminateGatewayTerminalSessionRequest
+	10, // 13: pm.v1.InternalService.VerifyDevice:output_type -> pm.v1.VerifyDeviceResponse
+	17, // 14: pm.v1.InternalService.ProxySyncActions:output_type -> pm.v1.SyncActionsResponse
+	18, // 15: pm.v1.InternalService.ProxyValidateLuksToken:output_type -> pm.v1.ValidateLuksTokenResponse
+	19, // 16: pm.v1.InternalService.ProxyGetLuksKey:output_type -> pm.v1.GetLuksKeyResponse
+	20, // 17: pm.v1.InternalService.ProxyStoreLuksKey:output_type -> pm.v1.StoreLuksKeyResponse
+	6,  // 18: pm.v1.InternalService.ProxyStoreLpsPasswords:output_type -> pm.v1.InternalStoreLpsPasswordsResponse
+	8,  // 19: pm.v1.InternalService.ProxyValidateTerminalToken:output_type -> pm.v1.InternalValidateTerminalTokenResponse
+	13, // 20: pm.v1.GatewayService.ListGatewayTerminalSessions:output_type -> pm.v1.ListGatewayTerminalSessionsResponse
+	15, // 21: pm.v1.GatewayService.TerminateGatewayTerminalSession:output_type -> pm.v1.TerminateGatewayTerminalSessionResponse
+	13, // [13:22] is the sub-list for method output_type
+	4,  // [4:13] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name
@@ -917,7 +1075,7 @@ func file_pm_v1_internal_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pm_v1_internal_proto_rawDesc), len(file_pm_v1_internal_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/gen/go/pm/v1/pmv1connect/internal.connect.go
+++ b/gen/go/pm/v1/pmv1connect/internal.connect.go
@@ -53,6 +53,9 @@ const (
 	// InternalServiceProxyStoreLpsPasswordsProcedure is the fully-qualified name of the
 	// InternalService's ProxyStoreLpsPasswords RPC.
 	InternalServiceProxyStoreLpsPasswordsProcedure = "/pm.v1.InternalService/ProxyStoreLpsPasswords"
+	// InternalServiceProxyValidateTerminalTokenProcedure is the fully-qualified name of the
+	// InternalService's ProxyValidateTerminalToken RPC.
+	InternalServiceProxyValidateTerminalTokenProcedure = "/pm.v1.InternalService/ProxyValidateTerminalToken"
 	// GatewayServiceListGatewayTerminalSessionsProcedure is the fully-qualified name of the
 	// GatewayService's ListGatewayTerminalSessions RPC.
 	GatewayServiceListGatewayTerminalSessionsProcedure = "/pm.v1.GatewayService/ListGatewayTerminalSessions"
@@ -76,6 +79,16 @@ type InternalServiceClient interface {
 	ProxyStoreLuksKey(context.Context, *connect.Request[v1.InternalStoreLuksKeyRequest]) (*connect.Response[v1.StoreLuksKeyResponse], error)
 	// Proxy StoreLpsPasswords: encrypts and stores LPS password rotation entries.
 	ProxyStoreLpsPasswords(context.Context, *connect.Request[v1.InternalStoreLpsPasswordsRequest]) (*connect.Response[v1.InternalStoreLpsPasswordsResponse], error)
+	// ProxyValidateTerminalToken validates a session token presented by a
+	// web client opening the gateway's WebSocket terminal endpoint, and
+	// returns the session metadata the gateway needs to bridge the
+	// connection (target device, TTY user, initial cols/rows). The token
+	// is single-use: a successful validation MUST NOT consume the entry,
+	// because the same gateway uses the metadata across the lifetime of
+	// the session. Revocation happens explicitly via
+	// ControlService.StopTerminal or the admin TerminateTerminalSession
+	// path.
+	ProxyValidateTerminalToken(context.Context, *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error)
 }
 
 // NewInternalServiceClient constructs a client for the pm.v1.InternalService service. By default,
@@ -125,17 +138,24 @@ func NewInternalServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(internalServiceMethods.ByName("ProxyStoreLpsPasswords")),
 			connect.WithClientOptions(opts...),
 		),
+		proxyValidateTerminalToken: connect.NewClient[v1.InternalValidateTerminalTokenRequest, v1.InternalValidateTerminalTokenResponse](
+			httpClient,
+			baseURL+InternalServiceProxyValidateTerminalTokenProcedure,
+			connect.WithSchema(internalServiceMethods.ByName("ProxyValidateTerminalToken")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // internalServiceClient implements InternalServiceClient.
 type internalServiceClient struct {
-	verifyDevice           *connect.Client[v1.VerifyDeviceRequest, v1.VerifyDeviceResponse]
-	proxySyncActions       *connect.Client[v1.InternalSyncActionsRequest, v1.SyncActionsResponse]
-	proxyValidateLuksToken *connect.Client[v1.InternalValidateLuksTokenRequest, v1.ValidateLuksTokenResponse]
-	proxyGetLuksKey        *connect.Client[v1.InternalGetLuksKeyRequest, v1.GetLuksKeyResponse]
-	proxyStoreLuksKey      *connect.Client[v1.InternalStoreLuksKeyRequest, v1.StoreLuksKeyResponse]
-	proxyStoreLpsPasswords *connect.Client[v1.InternalStoreLpsPasswordsRequest, v1.InternalStoreLpsPasswordsResponse]
+	verifyDevice               *connect.Client[v1.VerifyDeviceRequest, v1.VerifyDeviceResponse]
+	proxySyncActions           *connect.Client[v1.InternalSyncActionsRequest, v1.SyncActionsResponse]
+	proxyValidateLuksToken     *connect.Client[v1.InternalValidateLuksTokenRequest, v1.ValidateLuksTokenResponse]
+	proxyGetLuksKey            *connect.Client[v1.InternalGetLuksKeyRequest, v1.GetLuksKeyResponse]
+	proxyStoreLuksKey          *connect.Client[v1.InternalStoreLuksKeyRequest, v1.StoreLuksKeyResponse]
+	proxyStoreLpsPasswords     *connect.Client[v1.InternalStoreLpsPasswordsRequest, v1.InternalStoreLpsPasswordsResponse]
+	proxyValidateTerminalToken *connect.Client[v1.InternalValidateTerminalTokenRequest, v1.InternalValidateTerminalTokenResponse]
 }
 
 // VerifyDevice calls pm.v1.InternalService.VerifyDevice.
@@ -168,6 +188,11 @@ func (c *internalServiceClient) ProxyStoreLpsPasswords(ctx context.Context, req 
 	return c.proxyStoreLpsPasswords.CallUnary(ctx, req)
 }
 
+// ProxyValidateTerminalToken calls pm.v1.InternalService.ProxyValidateTerminalToken.
+func (c *internalServiceClient) ProxyValidateTerminalToken(ctx context.Context, req *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error) {
+	return c.proxyValidateTerminalToken.CallUnary(ctx, req)
+}
+
 // InternalServiceHandler is an implementation of the pm.v1.InternalService service.
 type InternalServiceHandler interface {
 	// VerifyDevice checks that a device exists and is not deleted.
@@ -183,6 +208,16 @@ type InternalServiceHandler interface {
 	ProxyStoreLuksKey(context.Context, *connect.Request[v1.InternalStoreLuksKeyRequest]) (*connect.Response[v1.StoreLuksKeyResponse], error)
 	// Proxy StoreLpsPasswords: encrypts and stores LPS password rotation entries.
 	ProxyStoreLpsPasswords(context.Context, *connect.Request[v1.InternalStoreLpsPasswordsRequest]) (*connect.Response[v1.InternalStoreLpsPasswordsResponse], error)
+	// ProxyValidateTerminalToken validates a session token presented by a
+	// web client opening the gateway's WebSocket terminal endpoint, and
+	// returns the session metadata the gateway needs to bridge the
+	// connection (target device, TTY user, initial cols/rows). The token
+	// is single-use: a successful validation MUST NOT consume the entry,
+	// because the same gateway uses the metadata across the lifetime of
+	// the session. Revocation happens explicitly via
+	// ControlService.StopTerminal or the admin TerminateTerminalSession
+	// path.
+	ProxyValidateTerminalToken(context.Context, *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error)
 }
 
 // NewInternalServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -228,6 +263,12 @@ func NewInternalServiceHandler(svc InternalServiceHandler, opts ...connect.Handl
 		connect.WithSchema(internalServiceMethods.ByName("ProxyStoreLpsPasswords")),
 		connect.WithHandlerOptions(opts...),
 	)
+	internalServiceProxyValidateTerminalTokenHandler := connect.NewUnaryHandler(
+		InternalServiceProxyValidateTerminalTokenProcedure,
+		svc.ProxyValidateTerminalToken,
+		connect.WithSchema(internalServiceMethods.ByName("ProxyValidateTerminalToken")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/pm.v1.InternalService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case InternalServiceVerifyDeviceProcedure:
@@ -242,6 +283,8 @@ func NewInternalServiceHandler(svc InternalServiceHandler, opts ...connect.Handl
 			internalServiceProxyStoreLuksKeyHandler.ServeHTTP(w, r)
 		case InternalServiceProxyStoreLpsPasswordsProcedure:
 			internalServiceProxyStoreLpsPasswordsHandler.ServeHTTP(w, r)
+		case InternalServiceProxyValidateTerminalTokenProcedure:
+			internalServiceProxyValidateTerminalTokenHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -273,6 +316,10 @@ func (UnimplementedInternalServiceHandler) ProxyStoreLuksKey(context.Context, *c
 
 func (UnimplementedInternalServiceHandler) ProxyStoreLpsPasswords(context.Context, *connect.Request[v1.InternalStoreLpsPasswordsRequest]) (*connect.Response[v1.InternalStoreLpsPasswordsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pm.v1.InternalService.ProxyStoreLpsPasswords is not implemented"))
+}
+
+func (UnimplementedInternalServiceHandler) ProxyValidateTerminalToken(context.Context, *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pm.v1.InternalService.ProxyValidateTerminalToken is not implemented"))
 }
 
 // GatewayServiceClient is a client for the pm.v1.GatewayService service.

--- a/gen/go/pm/v1/pmv1connect/internal.connect.go
+++ b/gen/go/pm/v1/pmv1connect/internal.connect.go
@@ -82,12 +82,14 @@ type InternalServiceClient interface {
 	// ProxyValidateTerminalToken validates a session token presented by a
 	// web client opening the gateway's WebSocket terminal endpoint, and
 	// returns the session metadata the gateway needs to bridge the
-	// connection (target device, TTY user, initial cols/rows). The token
-	// is single-use: a successful validation MUST NOT consume the entry,
-	// because the same gateway uses the metadata across the lifetime of
-	// the session. Revocation happens explicitly via
+	// connection (target device, TTY user, initial cols/rows).
+	//
+	// The token entry is reusable for the lifetime of the gateway
+	// session: a successful validation MUST NOT consume the entry,
+	// because the same gateway needs the metadata for the duration of
+	// the WebSocket connection. Revocation happens explicitly via
 	// ControlService.StopTerminal or the admin TerminateTerminalSession
-	// path.
+	// path — never as a side effect of validation.
 	ProxyValidateTerminalToken(context.Context, *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error)
 }
 
@@ -211,12 +213,14 @@ type InternalServiceHandler interface {
 	// ProxyValidateTerminalToken validates a session token presented by a
 	// web client opening the gateway's WebSocket terminal endpoint, and
 	// returns the session metadata the gateway needs to bridge the
-	// connection (target device, TTY user, initial cols/rows). The token
-	// is single-use: a successful validation MUST NOT consume the entry,
-	// because the same gateway uses the metadata across the lifetime of
-	// the session. Revocation happens explicitly via
+	// connection (target device, TTY user, initial cols/rows).
+	//
+	// The token entry is reusable for the lifetime of the gateway
+	// session: a successful validation MUST NOT consume the entry,
+	// because the same gateway needs the metadata for the duration of
+	// the WebSocket connection. Revocation happens explicitly via
 	// ControlService.StopTerminal or the admin TerminateTerminalSession
-	// path.
+	// path — never as a side effect of validation.
 	ProxyValidateTerminalToken(context.Context, *connect.Request[v1.InternalValidateTerminalTokenRequest]) (*connect.Response[v1.InternalValidateTerminalTokenResponse], error)
 }
 

--- a/gen/ts/pm/v1/internal_pb.ts
+++ b/gen/ts/pm/v1/internal_pb.ts
@@ -246,26 +246,40 @@ export const InternalValidateTerminalTokenRequestSchema: GenMessage<InternalVali
  */
 export type InternalValidateTerminalTokenResponse = Message<"pm.v1.InternalValidateTerminalTokenResponse"> & {
   /**
+   * @gotags: validate:"required,ulid"
+   *
    * @generated from field: string user_id = 1;
    */
   userId: string;
 
   /**
+   * @gotags: validate:"required,ulid"
+   *
    * @generated from field: string device_id = 2;
    */
   deviceId: string;
 
   /**
+   * Matches the agent-side username constraint and the public
+   * TerminalStart bounds.
+   * @gotags: validate:"required,min=1,max=64"
+   *
    * @generated from field: string tty_user = 3;
    */
   ttyUser: string;
 
   /**
+   * Same window-size bounds as the public TerminalStart message
+   * (proto3 has no uint16; cap at 65535).
+   * @gotags: validate:"required,gt=0,lte=65535"
+   *
    * @generated from field: uint32 cols = 4;
    */
   cols: number;
 
   /**
+   * @gotags: validate:"required,gt=0,lte=65535"
+   *
    * @generated from field: uint32 rows = 5;
    */
   rows: number;
@@ -518,12 +532,14 @@ export const InternalService: GenService<{
    * ProxyValidateTerminalToken validates a session token presented by a
    * web client opening the gateway's WebSocket terminal endpoint, and
    * returns the session metadata the gateway needs to bridge the
-   * connection (target device, TTY user, initial cols/rows). The token
-   * is single-use: a successful validation MUST NOT consume the entry,
-   * because the same gateway uses the metadata across the lifetime of
-   * the session. Revocation happens explicitly via
+   * connection (target device, TTY user, initial cols/rows).
+   *
+   * The token entry is reusable for the lifetime of the gateway
+   * session: a successful validation MUST NOT consume the entry,
+   * because the same gateway needs the metadata for the duration of
+   * the WebSocket connection. Revocation happens explicitly via
    * ControlService.StopTerminal or the admin TerminateTerminalSession
-   * path.
+   * path — never as a side effect of validation.
    *
    * @generated from rpc pm.v1.InternalService.ProxyValidateTerminalToken
    */

--- a/gen/ts/pm/v1/internal_pb.ts
+++ b/gen/ts/pm/v1/internal_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file pm/v1/internal.proto.
  */
 export const file_pm_v1_internal: GenFile = /*@__PURE__*/
-  fileDesc("ChRwbS92MS9pbnRlcm5hbC5wcm90bxIFcG0udjEiLwoaSW50ZXJuYWxTeW5jQWN0aW9uc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJIkQKIEludGVybmFsVmFsaWRhdGVMdWtzVG9rZW5SZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRINCgV0b2tlbhgCIAEoCSJBChlJbnRlcm5hbEdldEx1a3NLZXlSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRIRCglhY3Rpb25faWQYAiABKAkihQEKG0ludGVybmFsU3RvcmVMdWtzS2V5UmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkSEQoJYWN0aW9uX2lkGAIgASgJEhMKC2RldmljZV9wYXRoGAMgASgJEhIKCnBhc3NwaHJhc2UYBCABKAkSFwoPcm90YXRpb25fcmVhc29uGAUgASgJIl0KE0xwc1Bhc3N3b3JkUm90YXRpb24SEAoIdXNlcm5hbWUYASABKAkSEAoIcGFzc3dvcmQYAiABKAkSEgoKcm90YXRlZF9hdBgDIAEoCRIOCgZyZWFzb24YBCABKAkidwogSW50ZXJuYWxTdG9yZUxwc1Bhc3N3b3Jkc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJEhEKCWFjdGlvbl9pZBgCIAEoCRItCglyb3RhdGlvbnMYAyADKAsyGi5wbS52MS5McHNQYXNzd29yZFJvdGF0aW9uIiMKIUludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXNwb25zZSIoChNWZXJpZnlEZXZpY2VSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCSIWChRWZXJpZnlEZXZpY2VSZXNwb25zZSLMAQoaR2F0ZXdheVRlcm1pbmFsU2Vzc2lvbkluZm8SEgoKc2Vzc2lvbl9pZBgBIAEoCRIPCgd1c2VyX2lkGAIgASgJEhEKCWRldmljZV9pZBgDIAEoCRIQCgh0dHlfdXNlchgEIAEoCRIuCgpzdGFydGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBI0ChBsYXN0X2FjdGl2aXR5X2F0GAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCIkCiJMaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXF1ZXN0IloKI0xpc3RHYXRld2F5VGVybWluYWxTZXNzaW9uc1Jlc3BvbnNlEjMKCHNlc3Npb25zGAEgAygLMiEucG0udjEuR2F0ZXdheVRlcm1pbmFsU2Vzc2lvbkluZm8iTAomVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRIOCgZyZWFzb24YAiABKAkiOAonVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlc3BvbnNlEg0KBWZvdW5kGAEgASgIMqUECg9JbnRlcm5hbFNlcnZpY2USRwoMVmVyaWZ5RGV2aWNlEhoucG0udjEuVmVyaWZ5RGV2aWNlUmVxdWVzdBobLnBtLnYxLlZlcmlmeURldmljZVJlc3BvbnNlElEKEFByb3h5U3luY0FjdGlvbnMSIS5wbS52MS5JbnRlcm5hbFN5bmNBY3Rpb25zUmVxdWVzdBoaLnBtLnYxLlN5bmNBY3Rpb25zUmVzcG9uc2USYwoWUHJveHlWYWxpZGF0ZUx1a3NUb2tlbhInLnBtLnYxLkludGVybmFsVmFsaWRhdGVMdWtzVG9rZW5SZXF1ZXN0GiAucG0udjEuVmFsaWRhdGVMdWtzVG9rZW5SZXNwb25zZRJOCg9Qcm94eUdldEx1a3NLZXkSIC5wbS52MS5JbnRlcm5hbEdldEx1a3NLZXlSZXF1ZXN0GhkucG0udjEuR2V0THVrc0tleVJlc3BvbnNlElQKEVByb3h5U3RvcmVMdWtzS2V5EiIucG0udjEuSW50ZXJuYWxTdG9yZUx1a3NLZXlSZXF1ZXN0GhsucG0udjEuU3RvcmVMdWtzS2V5UmVzcG9uc2USawoWUHJveHlTdG9yZUxwc1Bhc3N3b3JkcxInLnBtLnYxLkludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXF1ZXN0GigucG0udjEuSW50ZXJuYWxTdG9yZUxwc1Bhc3N3b3Jkc1Jlc3BvbnNlMokCCg5HYXRld2F5U2VydmljZRJ0ChtMaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnMSKS5wbS52MS5MaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXF1ZXN0GioucG0udjEuTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zUmVzcG9uc2USgAEKH1Rlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb24SLS5wbS52MS5UZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uUmVxdWVzdBouLnBtLnYxLlRlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb25SZXNwb25zZUI6WjhnaXRodWIuY29tL21hbmNodG9vbHMvcG93ZXItbWFuYWdlL3Nkay9nZW4vZ28vcG0vdjE7cG12MWIGcHJvdG8z", [file_google_protobuf_timestamp, file_pm_v1_agent]);
+  fileDesc("ChRwbS92MS9pbnRlcm5hbC5wcm90bxIFcG0udjEiLwoaSW50ZXJuYWxTeW5jQWN0aW9uc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJIkQKIEludGVybmFsVmFsaWRhdGVMdWtzVG9rZW5SZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRINCgV0b2tlbhgCIAEoCSJBChlJbnRlcm5hbEdldEx1a3NLZXlSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRIRCglhY3Rpb25faWQYAiABKAkihQEKG0ludGVybmFsU3RvcmVMdWtzS2V5UmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkSEQoJYWN0aW9uX2lkGAIgASgJEhMKC2RldmljZV9wYXRoGAMgASgJEhIKCnBhc3NwaHJhc2UYBCABKAkSFwoPcm90YXRpb25fcmVhc29uGAUgASgJIl0KE0xwc1Bhc3N3b3JkUm90YXRpb24SEAoIdXNlcm5hbWUYASABKAkSEAoIcGFzc3dvcmQYAiABKAkSEgoKcm90YXRlZF9hdBgDIAEoCRIOCgZyZWFzb24YBCABKAkidwogSW50ZXJuYWxTdG9yZUxwc1Bhc3N3b3Jkc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJEhEKCWFjdGlvbl9pZBgCIAEoCRItCglyb3RhdGlvbnMYAyADKAsyGi5wbS52MS5McHNQYXNzd29yZFJvdGF0aW9uIiMKIUludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXNwb25zZSJJCiRJbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRINCgV0b2tlbhgCIAEoCSJ5CiVJbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlc3BvbnNlEg8KB3VzZXJfaWQYASABKAkSEQoJZGV2aWNlX2lkGAIgASgJEhAKCHR0eV91c2VyGAMgASgJEgwKBGNvbHMYBCABKA0SDAoEcm93cxgFIAEoDSIoChNWZXJpZnlEZXZpY2VSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCSIWChRWZXJpZnlEZXZpY2VSZXNwb25zZSLMAQoaR2F0ZXdheVRlcm1pbmFsU2Vzc2lvbkluZm8SEgoKc2Vzc2lvbl9pZBgBIAEoCRIPCgd1c2VyX2lkGAIgASgJEhEKCWRldmljZV9pZBgDIAEoCRIQCgh0dHlfdXNlchgEIAEoCRIuCgpzdGFydGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBI0ChBsYXN0X2FjdGl2aXR5X2F0GAYgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCIkCiJMaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXF1ZXN0IloKI0xpc3RHYXRld2F5VGVybWluYWxTZXNzaW9uc1Jlc3BvbnNlEjMKCHNlc3Npb25zGAEgAygLMiEucG0udjEuR2F0ZXdheVRlcm1pbmFsU2Vzc2lvbkluZm8iTAomVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRIOCgZyZWFzb24YAiABKAkiOAonVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlc3BvbnNlEg0KBWZvdW5kGAEgASgIMp4FCg9JbnRlcm5hbFNlcnZpY2USRwoMVmVyaWZ5RGV2aWNlEhoucG0udjEuVmVyaWZ5RGV2aWNlUmVxdWVzdBobLnBtLnYxLlZlcmlmeURldmljZVJlc3BvbnNlElEKEFByb3h5U3luY0FjdGlvbnMSIS5wbS52MS5JbnRlcm5hbFN5bmNBY3Rpb25zUmVxdWVzdBoaLnBtLnYxLlN5bmNBY3Rpb25zUmVzcG9uc2USYwoWUHJveHlWYWxpZGF0ZUx1a3NUb2tlbhInLnBtLnYxLkludGVybmFsVmFsaWRhdGVMdWtzVG9rZW5SZXF1ZXN0GiAucG0udjEuVmFsaWRhdGVMdWtzVG9rZW5SZXNwb25zZRJOCg9Qcm94eUdldEx1a3NLZXkSIC5wbS52MS5JbnRlcm5hbEdldEx1a3NLZXlSZXF1ZXN0GhkucG0udjEuR2V0THVrc0tleVJlc3BvbnNlElQKEVByb3h5U3RvcmVMdWtzS2V5EiIucG0udjEuSW50ZXJuYWxTdG9yZUx1a3NLZXlSZXF1ZXN0GhsucG0udjEuU3RvcmVMdWtzS2V5UmVzcG9uc2USawoWUHJveHlTdG9yZUxwc1Bhc3N3b3JkcxInLnBtLnYxLkludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXF1ZXN0GigucG0udjEuSW50ZXJuYWxTdG9yZUxwc1Bhc3N3b3Jkc1Jlc3BvbnNlEncKGlByb3h5VmFsaWRhdGVUZXJtaW5hbFRva2VuEisucG0udjEuSW50ZXJuYWxWYWxpZGF0ZVRlcm1pbmFsVG9rZW5SZXF1ZXN0GiwucG0udjEuSW50ZXJuYWxWYWxpZGF0ZVRlcm1pbmFsVG9rZW5SZXNwb25zZTKJAgoOR2F0ZXdheVNlcnZpY2USdAobTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zEikucG0udjEuTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zUmVxdWVzdBoqLnBtLnYxLkxpc3RHYXRld2F5VGVybWluYWxTZXNzaW9uc1Jlc3BvbnNlEoABCh9UZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uEi0ucG0udjEuVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlcXVlc3QaLi5wbS52MS5UZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uUmVzcG9uc2VCOlo4Z2l0aHViLmNvbS9tYW5jaHRvb2xzL3Bvd2VyLW1hbmFnZS9zZGsvZ2VuL2dvL3BtL3YxO3BtdjFiBnByb3RvMw", [file_google_protobuf_timestamp, file_pm_v1_agent]);
 
 /**
  * InternalSyncActionsRequest wraps SyncActionsRequest with the device_id
@@ -201,6 +201,84 @@ export const InternalStoreLpsPasswordsResponseSchema: GenMessage<InternalStoreLp
   messageDesc(file_pm_v1_internal, 6);
 
 /**
+ * InternalValidateTerminalTokenRequest is sent by the gateway when a
+ * web client opens the WebSocket terminal endpoint with a session_id
+ * and bearer token. The control server looks the session up in the
+ * Valkey-backed token store, compares the SHA-256 of the supplied
+ * token against the stored hash, and returns the session metadata.
+ *
+ * @generated from message pm.v1.InternalValidateTerminalTokenRequest
+ */
+export type InternalValidateTerminalTokenRequest = Message<"pm.v1.InternalValidateTerminalTokenRequest"> & {
+  /**
+   * @gotags: validate:"required,ulid"
+   *
+   * @generated from field: string session_id = 1;
+   */
+  sessionId: string;
+
+  /**
+   * The plaintext bearer token the web client received from
+   * ControlService.StartTerminal.
+   * @gotags: validate:"required,min=1"
+   *
+   * @generated from field: string token = 2;
+   */
+  token: string;
+};
+
+/**
+ * Describes the message pm.v1.InternalValidateTerminalTokenRequest.
+ * Use `create(InternalValidateTerminalTokenRequestSchema)` to create a new message.
+ */
+export const InternalValidateTerminalTokenRequestSchema: GenMessage<InternalValidateTerminalTokenRequest> = /*@__PURE__*/
+  messageDesc(file_pm_v1_internal, 7);
+
+/**
+ * InternalValidateTerminalTokenResponse carries the session metadata
+ * the gateway needs to bridge the WebSocket connection to the matching
+ * agent. The user_id is included so the gateway can record it on the
+ * active session for the admin List path; the gateway never trusts the
+ * session_id for ownership decisions because it has no access to the
+ * JWT.
+ *
+ * @generated from message pm.v1.InternalValidateTerminalTokenResponse
+ */
+export type InternalValidateTerminalTokenResponse = Message<"pm.v1.InternalValidateTerminalTokenResponse"> & {
+  /**
+   * @generated from field: string user_id = 1;
+   */
+  userId: string;
+
+  /**
+   * @generated from field: string device_id = 2;
+   */
+  deviceId: string;
+
+  /**
+   * @generated from field: string tty_user = 3;
+   */
+  ttyUser: string;
+
+  /**
+   * @generated from field: uint32 cols = 4;
+   */
+  cols: number;
+
+  /**
+   * @generated from field: uint32 rows = 5;
+   */
+  rows: number;
+};
+
+/**
+ * Describes the message pm.v1.InternalValidateTerminalTokenResponse.
+ * Use `create(InternalValidateTerminalTokenResponseSchema)` to create a new message.
+ */
+export const InternalValidateTerminalTokenResponseSchema: GenMessage<InternalValidateTerminalTokenResponse> = /*@__PURE__*/
+  messageDesc(file_pm_v1_internal, 8);
+
+/**
  * VerifyDeviceRequest is sent by the gateway to verify a device before
  * allowing it to connect. Contains the device_id from the mTLS certificate.
  *
@@ -218,7 +296,7 @@ export type VerifyDeviceRequest = Message<"pm.v1.VerifyDeviceRequest"> & {
  * Use `create(VerifyDeviceRequestSchema)` to create a new message.
  */
 export const VerifyDeviceRequestSchema: GenMessage<VerifyDeviceRequest> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 7);
+  messageDesc(file_pm_v1_internal, 9);
 
 /**
  * VerifyDeviceResponse indicates whether the device is valid for connection.
@@ -233,7 +311,7 @@ export type VerifyDeviceResponse = Message<"pm.v1.VerifyDeviceResponse"> & {
  * Use `create(VerifyDeviceResponseSchema)` to create a new message.
  */
 export const VerifyDeviceResponseSchema: GenMessage<VerifyDeviceResponse> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 8);
+  messageDesc(file_pm_v1_internal, 10);
 
 /**
  * GatewayTerminalSessionInfo is a single entry in a gateway's session
@@ -289,7 +367,7 @@ export type GatewayTerminalSessionInfo = Message<"pm.v1.GatewayTerminalSessionIn
  * Use `create(GatewayTerminalSessionInfoSchema)` to create a new message.
  */
 export const GatewayTerminalSessionInfoSchema: GenMessage<GatewayTerminalSessionInfo> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 9);
+  messageDesc(file_pm_v1_internal, 11);
 
 /**
  * @generated from message pm.v1.ListGatewayTerminalSessionsRequest
@@ -302,7 +380,7 @@ export type ListGatewayTerminalSessionsRequest = Message<"pm.v1.ListGatewayTermi
  * Use `create(ListGatewayTerminalSessionsRequestSchema)` to create a new message.
  */
 export const ListGatewayTerminalSessionsRequestSchema: GenMessage<ListGatewayTerminalSessionsRequest> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 10);
+  messageDesc(file_pm_v1_internal, 12);
 
 /**
  * @generated from message pm.v1.ListGatewayTerminalSessionsResponse
@@ -319,7 +397,7 @@ export type ListGatewayTerminalSessionsResponse = Message<"pm.v1.ListGatewayTerm
  * Use `create(ListGatewayTerminalSessionsResponseSchema)` to create a new message.
  */
 export const ListGatewayTerminalSessionsResponseSchema: GenMessage<ListGatewayTerminalSessionsResponse> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 11);
+  messageDesc(file_pm_v1_internal, 13);
 
 /**
  * @generated from message pm.v1.TerminateGatewayTerminalSessionRequest
@@ -348,7 +426,7 @@ export type TerminateGatewayTerminalSessionRequest = Message<"pm.v1.TerminateGat
  * Use `create(TerminateGatewayTerminalSessionRequestSchema)` to create a new message.
  */
 export const TerminateGatewayTerminalSessionRequestSchema: GenMessage<TerminateGatewayTerminalSessionRequest> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 12);
+  messageDesc(file_pm_v1_internal, 14);
 
 /**
  * @generated from message pm.v1.TerminateGatewayTerminalSessionResponse
@@ -369,7 +447,7 @@ export type TerminateGatewayTerminalSessionResponse = Message<"pm.v1.TerminateGa
  * Use `create(TerminateGatewayTerminalSessionResponseSchema)` to create a new message.
  */
 export const TerminateGatewayTerminalSessionResponseSchema: GenMessage<TerminateGatewayTerminalSessionResponse> = /*@__PURE__*/
-  messageDesc(file_pm_v1_internal, 13);
+  messageDesc(file_pm_v1_internal, 15);
 
 /**
  * @generated from service pm.v1.InternalService
@@ -435,6 +513,24 @@ export const InternalService: GenService<{
     methodKind: "unary";
     input: typeof InternalStoreLpsPasswordsRequestSchema;
     output: typeof InternalStoreLpsPasswordsResponseSchema;
+  },
+  /**
+   * ProxyValidateTerminalToken validates a session token presented by a
+   * web client opening the gateway's WebSocket terminal endpoint, and
+   * returns the session metadata the gateway needs to bridge the
+   * connection (target device, TTY user, initial cols/rows). The token
+   * is single-use: a successful validation MUST NOT consume the entry,
+   * because the same gateway uses the metadata across the lifetime of
+   * the session. Revocation happens explicitly via
+   * ControlService.StopTerminal or the admin TerminateTerminalSession
+   * path.
+   *
+   * @generated from rpc pm.v1.InternalService.ProxyValidateTerminalToken
+   */
+  proxyValidateTerminalToken: {
+    methodKind: "unary";
+    input: typeof InternalValidateTerminalTokenRequestSchema;
+    output: typeof InternalValidateTerminalTokenResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_pm_v1_internal, 0);

--- a/proto/pm/v1/internal.proto
+++ b/proto/pm/v1/internal.proto
@@ -38,12 +38,14 @@ service InternalService {
   // ProxyValidateTerminalToken validates a session token presented by a
   // web client opening the gateway's WebSocket terminal endpoint, and
   // returns the session metadata the gateway needs to bridge the
-  // connection (target device, TTY user, initial cols/rows). The token
-  // is single-use: a successful validation MUST NOT consume the entry,
-  // because the same gateway uses the metadata across the lifetime of
-  // the session. Revocation happens explicitly via
+  // connection (target device, TTY user, initial cols/rows).
+  //
+  // The token entry is reusable for the lifetime of the gateway
+  // session: a successful validation MUST NOT consume the entry,
+  // because the same gateway needs the metadata for the duration of
+  // the WebSocket connection. Revocation happens explicitly via
   // ControlService.StopTerminal or the admin TerminateTerminalSession
-  // path.
+  // path — never as a side effect of validation.
   rpc ProxyValidateTerminalToken(InternalValidateTerminalTokenRequest) returns (InternalValidateTerminalTokenResponse);
 }
 
@@ -117,10 +119,19 @@ message InternalValidateTerminalTokenRequest {
 // session_id for ownership decisions because it has no access to the
 // JWT.
 message InternalValidateTerminalTokenResponse {
+  // @gotags: validate:"required,ulid"
   string user_id = 1;
+  // @gotags: validate:"required,ulid"
   string device_id = 2;
+  // Matches the agent-side username constraint and the public
+  // TerminalStart bounds.
+  // @gotags: validate:"required,min=1,max=64"
   string tty_user = 3;
+  // Same window-size bounds as the public TerminalStart message
+  // (proto3 has no uint16; cap at 65535).
+  // @gotags: validate:"required,gt=0,lte=65535"
   uint32 cols = 4;
+  // @gotags: validate:"required,gt=0,lte=65535"
   uint32 rows = 5;
 }
 

--- a/proto/pm/v1/internal.proto
+++ b/proto/pm/v1/internal.proto
@@ -34,6 +34,17 @@ service InternalService {
 
   // Proxy StoreLpsPasswords: encrypts and stores LPS password rotation entries.
   rpc ProxyStoreLpsPasswords(InternalStoreLpsPasswordsRequest) returns (InternalStoreLpsPasswordsResponse);
+
+  // ProxyValidateTerminalToken validates a session token presented by a
+  // web client opening the gateway's WebSocket terminal endpoint, and
+  // returns the session metadata the gateway needs to bridge the
+  // connection (target device, TTY user, initial cols/rows). The token
+  // is single-use: a successful validation MUST NOT consume the entry,
+  // because the same gateway uses the metadata across the lifetime of
+  // the session. Revocation happens explicitly via
+  // ControlService.StopTerminal or the admin TerminateTerminalSession
+  // path.
+  rpc ProxyValidateTerminalToken(InternalValidateTerminalTokenRequest) returns (InternalValidateTerminalTokenResponse);
 }
 
 // ============================================================================
@@ -84,6 +95,34 @@ message InternalStoreLpsPasswordsRequest {
 }
 
 message InternalStoreLpsPasswordsResponse {}
+
+// InternalValidateTerminalTokenRequest is sent by the gateway when a
+// web client opens the WebSocket terminal endpoint with a session_id
+// and bearer token. The control server looks the session up in the
+// Valkey-backed token store, compares the SHA-256 of the supplied
+// token against the stored hash, and returns the session metadata.
+message InternalValidateTerminalTokenRequest {
+  // @gotags: validate:"required,ulid"
+  string session_id = 1;
+  // The plaintext bearer token the web client received from
+  // ControlService.StartTerminal.
+  // @gotags: validate:"required,min=1"
+  string token = 2;
+}
+
+// InternalValidateTerminalTokenResponse carries the session metadata
+// the gateway needs to bridge the WebSocket connection to the matching
+// agent. The user_id is included so the gateway can record it on the
+// active session for the admin List path; the gateway never trusts the
+// session_id for ownership decisions because it has no access to the
+// JWT.
+message InternalValidateTerminalTokenResponse {
+  string user_id = 1;
+  string device_id = 2;
+  string tty_user = 3;
+  uint32 cols = 4;
+  uint32 rows = 5;
+}
 
 // VerifyDeviceRequest is sent by the gateway to verify a device before
 // allowing it to connect. Contains the device_id from the mTLS certificate.


### PR DESCRIPTION
## Summary

Adds the gateway → control RPC the WebSocket terminal endpoint needs to validate session tokens. This is the **last SDK proto change required for the remote terminal feature** (manchtools/power-manage-sdk#16).

The gateway has no database access by design, so it must call into control over the existing internal mTLS channel to validate session tokens against the Valkey-backed store maintained by manchtools/power-manage-server#35.

## What's in this PR

### \`internal.proto\`

- New \`InternalService.ProxyValidateTerminalToken\` RPC.
- New \`InternalValidateTerminalTokenRequest\` carrying:
  - \`session_id\` (\`required,ulid\`)
  - \`token\` (\`required,min=1\`) — plaintext bearer the web client received from \`ControlService.StartTerminal\`
- New \`InternalValidateTerminalTokenResponse\` carrying:
  - \`user_id\` — recorded on the gateway's active session for the future admin \`List\` path
  - \`device_id\`, \`tty_user\`, \`cols\`, \`rows\` — what the gateway needs to bridge the WebSocket to the matching agent

### Behaviour notes (documented inline)

- **Validation is NOT consume-on-success.** The same gateway uses the metadata across the lifetime of the session, and revocation happens explicitly via \`ControlService.StopTerminal\` or \`TerminateTerminalSession\`. Single-use validation would force the gateway to cache the response anyway, gaining nothing.
- **The gateway never makes ownership decisions** — it has no JWT access. \`user_id\` is returned for diagnostics + admin listing only; ownership checks live in \`ControlService.StopTerminal\`.

### Generated code

\`make generate\` was run. Go and TypeScript bindings are regenerated and committed:
- \`gen/go/pm/v1/internal.pb.go\`
- \`gen/go/pm/v1/pmv1connect/internal.connect.go\`
- \`gen/ts/pm/v1/internal_pb.ts\`

## SDK debt after this PR

**Zero, as best I can see.** Walking through every component:

| Component | SDK gap? |
|---|---|
| Agent terminal handler | none (uses existing types from #25/#26) |
| Control \`StartTerminal\`/\`StopTerminal\` | none (uses existing \`StartTerminalRequest\`/\`StopTerminalRequest\`) |
| Gateway WebSocket bridge | **closed by this PR** |
| Web xterm.js | none (TS bindings auto-generate) |
| Admin \`List\`/\`Terminate\` fan-out | none (uses existing \`GatewayService\` from #25) |
| TTY user auto-provisioning | none (uses existing \`User\` action type) |

If something surfaces during the gateway implementation, I'll flag it then rather than pretend it can't happen — but I've now done the walk three times and this is the only gap.

## Test plan

- [x] \`go build ./...\` (sdk, agent, server)
- [x] \`go vet ./...\` (sdk, agent, server)
- [x] \`go test ./... -count=1\` (sdk full suite, all green)
- [x] Generated symbols verified in Go (32 + 21 references) and TypeScript (16 references)
- [x] Server's existing \`UnimplementedInternalServiceHandler\` embed covers the new method, so no coordinated server PR is needed for compile parity

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue
- manchtools/power-manage-server#35 — control real implementation that mints these tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal terminal token validation proxy to verify session tokens and return authenticated user/device identifiers plus terminal session metadata (TTY user and initial cols/rows).
* **Infrastructure**
  * Improved internal API for secure terminal session validation and initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->