### PR TITLE
feat: return *exec.Result from sysuser write operations

### DIFF
--- a/go/sys/user/user.go
+++ b/go/sys/user/user.go
@@ -111,40 +111,39 @@ func IsValidName(username string) bool {
 
 // Create creates a new user account with the given options.
 // Extra args are passed before the username (e.g., "-m", "-s", "/bin/bash").
-func Create(ctx context.Context, username string, args ...string) error {
+// Returns the command result (stdout/stderr/exit code) so callers can
+// surface useradd's stderr — important context like "user 'foo' already
+// exists" lives there. The Result is non-nil on most failure paths too.
+func Create(ctx context.Context, username string, args ...string) (*exec.Result, error) {
 	fullArgs := append(args, username)
-	_, err := exec.Sudo(ctx, "useradd", fullArgs...)
-	return err
+	return exec.Sudo(ctx, "useradd", fullArgs...)
 }
 
 // Modify modifies an existing user account.
 // Extra args are passed before the username (e.g., "-s", "/bin/zsh").
-func Modify(ctx context.Context, username string, args ...string) error {
+// Returns the command result so callers can surface usermod's stderr.
+func Modify(ctx context.Context, username string, args ...string) (*exec.Result, error) {
 	fullArgs := append(args, username)
-	_, err := exec.Sudo(ctx, "usermod", fullArgs...)
-	return err
+	return exec.Sudo(ctx, "usermod", fullArgs...)
 }
 
 // Delete removes a user account. If removeHome is true, also removes the home directory.
-func Delete(ctx context.Context, username string, removeHome bool) error {
+// Returns the command result so callers can surface userdel's stderr.
+func Delete(ctx context.Context, username string, removeHome bool) (*exec.Result, error) {
 	if removeHome {
-		_, err := exec.Sudo(ctx, "userdel", "-r", username)
-		return err
+		return exec.Sudo(ctx, "userdel", "-r", username)
 	}
-	_, err := exec.Sudo(ctx, "userdel", username)
-	return err
+	return exec.Sudo(ctx, "userdel", username)
 }
 
 // Lock locks a user account (usermod -L).
-func Lock(ctx context.Context, username string) error {
-	_, err := exec.Sudo(ctx, "usermod", "-L", username)
-	return err
+func Lock(ctx context.Context, username string) (*exec.Result, error) {
+	return exec.Sudo(ctx, "usermod", "-L", username)
 }
 
 // Unlock unlocks a user account (usermod -U).
-func Unlock(ctx context.Context, username string) error {
-	_, err := exec.Sudo(ctx, "usermod", "-U", username)
-	return err
+func Unlock(ctx context.Context, username string) (*exec.Result, error) {
+	return exec.Sudo(ctx, "usermod", "-U", username)
 }
 
 // =============================================================================
@@ -189,15 +188,13 @@ func SupplementaryGroups(username string) ([]string, error) {
 // =============================================================================
 
 // SetPassword sets a user's password using chpasswd.
-func SetPassword(ctx context.Context, username, password string) error {
-	_, err := exec.SudoWithStdin(ctx, strings.NewReader(fmt.Sprintf("%s:%s", username, password)), "chpasswd")
-	return err
+func SetPassword(ctx context.Context, username, password string) (*exec.Result, error) {
+	return exec.SudoWithStdin(ctx, strings.NewReader(fmt.Sprintf("%s:%s", username, password)), "chpasswd")
 }
 
 // ExpirePassword forces a user to change their password on next login.
-func ExpirePassword(ctx context.Context, username string) error {
-	_, err := exec.Sudo(ctx, "chage", "-d", "0", username)
-	return err
+func ExpirePassword(ctx context.Context, username string) (*exec.Result, error) {
+	return exec.Sudo(ctx, "chage", "-d", "0", username)
 }
 
 // =============================================================================
@@ -205,11 +202,11 @@ func ExpirePassword(ctx context.Context, username string) error {
 // =============================================================================
 
 // ChownRecursive changes ownership of a path and all its contents.
-func ChownRecursive(ctx context.Context, path, owner, group string) error {
+// Returns nil result with nil error when owner+group are both empty (no-op).
+func ChownRecursive(ctx context.Context, path, owner, group string) (*exec.Result, error) {
 	ownership := fs.Ownership(owner, group)
 	if ownership == "" {
-		return nil
+		return nil, nil
 	}
-	_, err := exec.Sudo(ctx, "chown", "-R", ownership, path)
-	return err
+	return exec.Sudo(ctx, "chown", "-R", ownership, path)
 }

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -383,6 +383,16 @@ func TestChownRecursive(t *testing.T) {
 	if group != name {
 		t.Errorf("expected group %q, got %q", name, group)
 	}
+
+	// No-op path: empty owner and group should return (nil, nil) so
+	// callers can distinguish skipped from succeeded.
+	res, err := user.ChownRecursive(ctx, dir, "", "")
+	if err != nil {
+		t.Fatalf("ChownRecursive no-op returned error: %v", err)
+	}
+	if res != nil {
+		t.Errorf("expected nil *exec.Result on no-op, got %+v", res)
+	}
 }
 
 func TestIsValidName(t *testing.T) {

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -36,9 +36,16 @@ func TestCreate(t *testing.T) {
 	name := testUsername("cr")
 	defer cleanupUser(t, name)
 
-	_, err := user.Create(ctx, name, "-m", "-s", "/bin/bash")
+	result, err := user.Create(ctx, name, "-m", "-s", "/bin/bash")
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
+	}
+	// Verify the *exec.Result contract on the success path.
+	if result == nil {
+		t.Fatal("expected non-nil *exec.Result on success")
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("expected exit code 0 on success, got %d", result.ExitCode)
 	}
 
 	if !user.Exists(name) {
@@ -184,9 +191,21 @@ func TestDeleteWithHome(t *testing.T) {
 
 func TestDeleteNonexistent(t *testing.T) {
 	ctx := context.Background()
-	_, err := user.Delete(ctx, "pm-nonexistent-user-12345", false)
+	result, err := user.Delete(ctx, "pm-nonexistent-user-12345", false)
 	if err == nil {
 		t.Fatal("expected error deleting non-existent user")
+	}
+	// The whole point of returning *exec.Result is that callers can
+	// surface the underlying tool's stderr. Verify the contract holds
+	// on a deterministic failure path.
+	if result == nil {
+		t.Fatal("expected non-nil *exec.Result on failure")
+	}
+	if result.ExitCode == 0 {
+		t.Errorf("expected non-zero exit code on failure, got %d", result.ExitCode)
+	}
+	if result.Stderr == "" {
+		t.Errorf("expected stderr to be populated on failure, got empty (exit=%d)", result.ExitCode)
 	}
 }
 

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -26,7 +26,7 @@ func cleanupUser(t *testing.T, username string) {
 func createTestUser(t *testing.T, username string) {
 	t.Helper()
 	ctx := context.Background()
-	if err := user.Create(ctx, username, "-m", "-s", "/bin/bash"); err != nil {
+	if _, err := user.Create(ctx, username, "-m", "-s", "/bin/bash"); err != nil {
 		t.Fatalf("failed to create test user %s: %v", username, err)
 	}
 }
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 	name := testUsername("cr")
 	defer cleanupUser(t, name)
 
-	err := user.Create(ctx, name, "-m", "-s", "/bin/bash")
+	_, err := user.Create(ctx, name, "-m", "-s", "/bin/bash")
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestCreateSystemUser(t *testing.T) {
 	name := testUsername("sys")
 	defer cleanupUser(t, name)
 
-	err := user.Create(ctx, name, "--system", "--no-create-home", "-s", "/usr/sbin/nologin")
+	_, err := user.Create(ctx, name, "--system", "--no-create-home", "-s", "/usr/sbin/nologin")
 	if err != nil {
 		t.Fatalf("Create system user failed: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestGet(t *testing.T) {
 	name := testUsername("gt")
 	defer cleanupUser(t, name)
 
-	if err := user.Create(ctx, name, "-m", "-s", "/bin/bash", "-c", "Test User"); err != nil {
+	if _, err := user.Create(ctx, name, "-m", "-s", "/bin/bash", "-c", "Test User"); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestModify(t *testing.T) {
 
 	createTestUser(t, name)
 
-	err := user.Modify(ctx, name, "-s", "/bin/sh")
+	_, err := user.Modify(ctx, name, "-s", "/bin/sh")
 	if err != nil {
 		t.Fatalf("Modify failed: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestDelete(t *testing.T) {
 
 	createTestUser(t, name)
 
-	err := user.Delete(ctx, name, false)
+	_, err := user.Delete(ctx, name, false)
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestDeleteWithHome(t *testing.T) {
 	}
 	homeDir := info.HomeDir
 
-	err = user.Delete(ctx, name, true)
+	_, err = user.Delete(ctx, name, true)
 	if err != nil {
 		t.Fatalf("Delete with home failed: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestDeleteWithHome(t *testing.T) {
 
 func TestDeleteNonexistent(t *testing.T) {
 	ctx := context.Background()
-	err := user.Delete(ctx, "pm-nonexistent-user-12345", false)
+	_, err := user.Delete(ctx, "pm-nonexistent-user-12345", false)
 	if err == nil {
 		t.Fatal("expected error deleting non-existent user")
 	}
@@ -198,12 +198,12 @@ func TestLockUnlock(t *testing.T) {
 	createTestUser(t, name)
 
 	// Set a password first so lock is meaningful
-	if err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
+	if _, err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
 		t.Fatalf("SetPassword failed: %v", err)
 	}
 
 	// Lock
-	if err := user.Lock(ctx, name); err != nil {
+	if _, err := user.Lock(ctx, name); err != nil {
 		t.Fatalf("Lock failed: %v", err)
 	}
 	info, err := user.Get(name)
@@ -215,7 +215,7 @@ func TestLockUnlock(t *testing.T) {
 	}
 
 	// Unlock
-	if err := user.Unlock(ctx, name); err != nil {
+	if _, err := user.Unlock(ctx, name); err != nil {
 		t.Fatalf("Unlock failed: %v", err)
 	}
 	info, err = user.Get(name)
@@ -234,7 +234,7 @@ func TestSetPassword(t *testing.T) {
 
 	createTestUser(t, name)
 
-	err := user.SetPassword(ctx, name, "TestPass123!")
+	_, err := user.SetPassword(ctx, name, "TestPass123!")
 	if err != nil {
 		t.Fatalf("SetPassword failed: %v", err)
 	}
@@ -255,11 +255,11 @@ func TestExpirePassword(t *testing.T) {
 	defer cleanupUser(t, name)
 
 	createTestUser(t, name)
-	if err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
+	if _, err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
 		t.Fatalf("SetPassword failed: %v", err)
 	}
 
-	err := user.ExpirePassword(ctx, name)
+	_, err := user.ExpirePassword(ctx, name)
 	if err != nil {
 		t.Fatalf("ExpirePassword failed: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestChownRecursive(t *testing.T) {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
-	if err := user.ChownRecursive(ctx, dir, name, name); err != nil {
+	if _, err := user.ChownRecursive(ctx, dir, name, name); err != nil {
 		t.Fatalf("ChownRecursive failed: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Change \`sysuser.{Create,Modify,Delete,Lock,Unlock,SetPassword,ExpirePassword,ChownRecursive}\` to return \`(*exec.Result, error)\` instead of just \`error\`.

## Motivation

The previous signatures discarded the command result, which meant callers couldn't surface useradd/usermod/userdel/chpasswd **stderr** in their own error reports. Important context like \`useradd: user 'alice' already exists\` was lost — admins viewing failed user-management actions in the server UI saw only \"exit code 9\" instead of the actual reason.

The agent's \`createUser\` / \`updateUser\` / \`removeUser\` executors were still calling \`runSudoCmd(\"useradd\", ...)\` directly precisely so they could capture stderr. With this change they can use the SDK functions.

## Breaking change

Direct callers (only the agent at present) need a one-line update:
\`\`\`go
err := sysuser.Create(ctx, name, args...)        // before
_, err := sysuser.Create(ctx, name, args...)     // after, if no stderr needed
result, err := sysuser.Create(ctx, name, args...) // after, with stderr access
\`\`\`

\`ChownRecursive\` returns \`(nil, nil)\` on the no-op path (empty owner+group) so callers can distinguish skipped from succeeded.

## Test plan
- [x] go vet ./... clean
- [x] go test ./go/sys/user/ passes (unit)
- [x] go vet -tags integration ./go/sys/user/ clean (integration test build)
- [x] Agent + handler updated to match new signatures (separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * User-management operations now return command execution results alongside error values, exposing execution status and outputs; recursive ownership change returns nil result for explicit no-op cases.

* **Tests**
  * Integration tests updated to handle new return values and assert execution result details (exit codes and stderr) on success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->