### PR TITLE
feat: honor server-supplied heartbeat interval on every Welcome

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -24,6 +24,16 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 )
 
+// Heartbeat interval bounds. The SDK clamps server-supplied values from
+// Welcome.heartbeat_interval into this range before applying them, so a
+// misconfigured or malicious server can never push the cadence outside
+// what's safe for both sides (too fast = stream spam, too slow = agent
+// looks dead to the gateway's liveness tracking).
+const (
+	MinHeartbeatInterval = 5 * time.Second
+	MaxHeartbeatInterval = 5 * time.Minute
+)
+
 // Client provides methods to communicate with the power-manage server.
 type Client struct {
 	client    pmv1connect.AgentServiceClient
@@ -41,6 +51,11 @@ type Client struct {
 	// pendingMu protects pendingRequests for LUKS request-response correlation.
 	pendingMu       sync.Mutex
 	pendingRequests map[string]chan *pm.ServerMessage
+
+	// heartbeatUpdate is the channel Run's heartbeat goroutine reads
+	// to reset its ticker when Welcome arrives with a new interval.
+	// Non-nil only while Run() is active; guarded by mu.
+	heartbeatUpdate chan time.Duration
 }
 
 // NewClient creates a new SDK client.
@@ -700,6 +715,14 @@ func (c *Client) StartReceiver(ctx context.Context) context.CancelFunc {
 }
 
 // Run connects to the server and processes messages using the provided handler.
+//
+// heartbeatInterval is the initial cadence used until the server's
+// Welcome message arrives. If Welcome.heartbeat_interval is set and
+// falls within [MinHeartbeatInterval, MaxHeartbeatInterval], the SDK
+// resets the heartbeat ticker to that value — both on the initial
+// connect and on every subsequent reconnect (each reconnect is a fresh
+// Run() call that receives a fresh Welcome). Out-of-range values are
+// clamped; zero / unset keeps the caller-supplied interval.
 func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbeatInterval time.Duration, handler StreamHandler) error {
 	if err := c.Connect(ctx); err != nil {
 		return err
@@ -714,6 +737,20 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
 	defer cancelHeartbeat()
 
+	// Buffered channel (capacity 1, latest-wins) lets dispatchServerMessage
+	// push a new interval without blocking. Published on Client so the
+	// Welcome handler can find it; cleared on Run exit so a reconnect's
+	// next Run() call starts from scratch.
+	hbUpdate := make(chan time.Duration, 1)
+	c.mu.Lock()
+	c.heartbeatUpdate = hbUpdate
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.heartbeatUpdate = nil
+		c.mu.Unlock()
+	}()
+
 	go func() {
 		ticker := time.NewTicker(heartbeatInterval)
 		defer ticker.Stop()
@@ -722,6 +759,8 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 			select {
 			case <-heartbeatCtx.Done():
 				return
+			case d := <-hbUpdate:
+				ticker.Reset(d)
 			case <-ticker.C:
 				hb := &pm.Heartbeat{}
 				// Handler can populate heartbeat data if needed
@@ -798,6 +837,46 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 	}
 }
 
+// applyWelcomeHeartbeat extracts the server-requested heartbeat
+// interval from a Welcome message, clamps it to [MinHeartbeatInterval,
+// MaxHeartbeatInterval], and pushes it to the running heartbeat
+// goroutine. No-op when Welcome.heartbeat_interval is zero/unset or
+// when no Run() is currently active. The update channel has capacity
+// 1 and latest-wins semantics — a stale pending update is dropped so
+// the goroutine always picks up the most recent value the server sent.
+func (c *Client) applyWelcomeHeartbeat(w *pm.Welcome) {
+	if w == nil || w.HeartbeatInterval == nil {
+		return
+	}
+	d := w.HeartbeatInterval.AsDuration()
+	if d <= 0 {
+		return
+	}
+	if d < MinHeartbeatInterval {
+		d = MinHeartbeatInterval
+	}
+	if d > MaxHeartbeatInterval {
+		d = MaxHeartbeatInterval
+	}
+	c.mu.RLock()
+	ch := c.heartbeatUpdate
+	c.mu.RUnlock()
+	if ch == nil {
+		return
+	}
+	// Drain any stale pending value, then push the fresh one. Both
+	// sends are non-blocking so a hung / exited heartbeat goroutine
+	// can't wedge the dispatcher.
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- d:
+	default:
+	}
+}
+
 // dispatchServerMessage routes a single ServerMessage to the appropriate
 // handler method. Extracted from Run for testability — call sites that
 // need a fake stream or hand-built messages can drive this directly.
@@ -807,6 +886,7 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessage, handler StreamHandler) error {
 	switch p := msg.Payload.(type) {
 	case *pm.ServerMessage_Welcome:
+		c.applyWelcomeHeartbeat(p.Welcome)
 		if err := handler.OnWelcome(ctx, p.Welcome); err != nil {
 			return fmt.Errorf("handle welcome: %w", err)
 		}

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
@@ -295,3 +298,165 @@ func TestDispatch_UnknownPayload_DropsSilently(t *testing.T) {
 // it shows up at build time, not at runtime.
 var _ TerminalHandler = (*fakeTerminalHandler)(nil)
 var _ StreamHandler = fakeBareHandler{}
+
+// applyWelcomeHeartbeat is the contract the server relies on: any
+// Welcome with a non-zero heartbeat_interval replaces the running
+// cadence, clamped to [Min, Max]. These tests lock that in so a
+// future change to the clamp or the dispatch path can't silently
+// regress the reconnect-reconfig flow.
+func TestApplyWelcomeHeartbeat_ClampsAndPushes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input time.Duration
+		want  time.Duration
+	}{
+		{"within range", 45 * time.Second, 45 * time.Second},
+		{"min edge", MinHeartbeatInterval, MinHeartbeatInterval},
+		{"max edge", MaxHeartbeatInterval, MaxHeartbeatInterval},
+		{"below min clamps up", 1 * time.Second, MinHeartbeatInterval},
+		{"above max clamps down", 10 * time.Minute, MaxHeartbeatInterval},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient()
+			// Simulate an active Run: install the update channel.
+			hb := make(chan time.Duration, 1)
+			c.mu.Lock()
+			c.heartbeatUpdate = hb
+			c.mu.Unlock()
+
+			c.applyWelcomeHeartbeat(&pm.Welcome{
+				HeartbeatInterval: durationpb.New(tc.input),
+			})
+
+			select {
+			case got := <-hb:
+				if got != tc.want {
+					t.Errorf("interval = %v, want %v", got, tc.want)
+				}
+			default:
+				t.Fatal("no interval pushed to heartbeat channel")
+			}
+		})
+	}
+}
+
+// A Welcome without heartbeat_interval (field unset) must not push
+// anything — the caller-supplied initial cadence stays in effect.
+// Same for zero / negative durations, which are nonsensical and
+// should be ignored rather than silently clamped.
+func TestApplyWelcomeHeartbeat_NoOpCases(t *testing.T) {
+	cases := []struct {
+		name string
+		w    *pm.Welcome
+	}{
+		{"nil welcome", nil},
+		{"unset field", &pm.Welcome{}},
+		{"zero duration", &pm.Welcome{HeartbeatInterval: durationpb.New(0)}},
+		{"negative duration", &pm.Welcome{HeartbeatInterval: durationpb.New(-5 * time.Second)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient()
+			hb := make(chan time.Duration, 1)
+			c.mu.Lock()
+			c.heartbeatUpdate = hb
+			c.mu.Unlock()
+
+			c.applyWelcomeHeartbeat(tc.w)
+
+			select {
+			case got := <-hb:
+				t.Errorf("expected no push, got %v", got)
+			default:
+			}
+		})
+	}
+}
+
+// When Run() isn't active the update channel is nil; applying a
+// Welcome heartbeat must be a safe no-op rather than panicking on a
+// nil-channel send.
+func TestApplyWelcomeHeartbeat_NoRunActive(t *testing.T) {
+	c := newTestClient()
+	// heartbeatUpdate is nil by default.
+	c.applyWelcomeHeartbeat(&pm.Welcome{
+		HeartbeatInterval: durationpb.New(42 * time.Second),
+	})
+	// Assertion is the absence of a panic.
+}
+
+// Second Welcome overwrites a stale pending update rather than
+// queuing — latest-wins is what the heartbeat goroutine expects,
+// otherwise an old value could be picked up after the server
+// already changed its mind.
+func TestApplyWelcomeHeartbeat_LatestWins(t *testing.T) {
+	c := newTestClient()
+	hb := make(chan time.Duration, 1)
+	c.mu.Lock()
+	c.heartbeatUpdate = hb
+	c.mu.Unlock()
+
+	c.applyWelcomeHeartbeat(&pm.Welcome{HeartbeatInterval: durationpb.New(10 * time.Second)})
+	c.applyWelcomeHeartbeat(&pm.Welcome{HeartbeatInterval: durationpb.New(45 * time.Second)})
+
+	got := <-hb
+	if got != 45*time.Second {
+		t.Errorf("interval = %v, want 45s", got)
+	}
+	select {
+	case extra := <-hb:
+		t.Errorf("channel should be drained, got extra %v", extra)
+	default:
+	}
+}
+
+// Dispatching a Welcome through dispatchServerMessage must apply the
+// heartbeat interval AND still call handler.OnWelcome — the two
+// behaviours are independent and both must fire.
+func TestDispatch_Welcome_AppliesHeartbeatAndHandler(t *testing.T) {
+	c := newTestClient()
+	hb := make(chan time.Duration, 1)
+	c.mu.Lock()
+	c.heartbeatUpdate = hb
+	c.mu.Unlock()
+
+	rec := &recordingWelcomeHandler{}
+	msg := &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_Welcome{Welcome: &pm.Welcome{
+			ServerVersion:     "test",
+			HeartbeatInterval: durationpb.New(60 * time.Second),
+		}},
+	}
+	if err := c.dispatchServerMessage(context.Background(), msg, rec); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if !rec.called {
+		t.Error("OnWelcome was not called")
+	}
+	select {
+	case got := <-hb:
+		if got != 60*time.Second {
+			t.Errorf("interval = %v, want 60s", got)
+		}
+	default:
+		t.Fatal("heartbeat update not pushed")
+	}
+}
+
+type recordingWelcomeHandler struct {
+	called bool
+}
+
+func (h *recordingWelcomeHandler) OnWelcome(ctx context.Context, w *pm.Welcome) error {
+	h.called = true
+	return nil
+}
+func (h *recordingWelcomeHandler) OnAction(ctx context.Context, a *pm.Action) (*pm.ActionResult, error) {
+	return nil, nil
+}
+func (h *recordingWelcomeHandler) OnQuery(ctx context.Context, q *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (h *recordingWelcomeHandler) OnError(ctx context.Context, e *pm.Error) error { return nil }

--- a/ts/action-types.ts
+++ b/ts/action-types.ts
@@ -16,8 +16,8 @@ export function getActionTypeEnum(type: string): ActionType {
 			return ActionType.UPDATE;
 		case 'SHELL':
 			return ActionType.SHELL;
-		case 'SYSTEMD':
-			return ActionType.SYSTEMD;
+		case 'SERVICE':
+			return ActionType.SERVICE;
 		case 'FILE':
 			return ActionType.FILE;
 		case 'APP_IMAGE':
@@ -36,14 +36,14 @@ export function getActionTypeEnum(type: string): ActionType {
 			return ActionType.SSH;
 		case 'SSHD':
 			return ActionType.SSHD;
-		case 'SUDO':
-			return ActionType.SUDO;
+		case 'ADMIN_POLICY':
+			return ActionType.ADMIN_POLICY;
 		case 'LPS':
 			return ActionType.LPS;
 		case 'GROUP':
 			return ActionType.GROUP;
-		case 'LUKS':
-			return ActionType.LUKS;
+		case 'ENCRYPTION':
+			return ActionType.ENCRYPTION;
 		case 'SCRIPT_RUN':
 			return ActionType.SCRIPT_RUN;
 		case 'WIFI':
@@ -70,8 +70,8 @@ export function actionTypeToString(type: ActionType): string {
 			return 'UPDATE';
 		case ActionType.SHELL:
 			return 'SHELL';
-		case ActionType.SYSTEMD:
-			return 'SYSTEMD';
+		case ActionType.SERVICE:
+			return 'SERVICE';
 		case ActionType.FILE:
 			return 'FILE';
 		case ActionType.APP_IMAGE:
@@ -90,14 +90,14 @@ export function actionTypeToString(type: ActionType): string {
 			return 'SSH';
 		case ActionType.SSHD:
 			return 'SSHD';
-		case ActionType.SUDO:
-			return 'SUDO';
+		case ActionType.ADMIN_POLICY:
+			return 'ADMIN_POLICY';
 		case ActionType.LPS:
 			return 'LPS';
 		case ActionType.GROUP:
 			return 'GROUP';
-		case ActionType.LUKS:
-			return 'LUKS';
+		case ActionType.ENCRYPTION:
+			return 'ENCRYPTION';
 		case ActionType.SCRIPT_RUN:
 			return 'SCRIPT_RUN';
 		case ActionType.WIFI:
@@ -117,7 +117,7 @@ export const ACTION_TYPE_OPTIONS = [
 	{ value: 'REPOSITORY', type: ActionType.REPOSITORY },
 	{ value: 'UPDATE', type: ActionType.UPDATE },
 	{ value: 'SHELL', type: ActionType.SHELL },
-	{ value: 'SYSTEMD', type: ActionType.SYSTEMD },
+	{ value: 'SERVICE', type: ActionType.SERVICE },
 	{ value: 'FILE', type: ActionType.FILE },
 	{ value: 'DIRECTORY', type: ActionType.DIRECTORY },
 	{ value: 'APP_IMAGE', type: ActionType.APP_IMAGE },
@@ -127,9 +127,9 @@ export const ACTION_TYPE_OPTIONS = [
 	{ value: 'USER', type: ActionType.USER },
 	{ value: 'SSH', type: ActionType.SSH },
 	{ value: 'SSHD', type: ActionType.SSHD },
-	{ value: 'SUDO', type: ActionType.SUDO },
+	{ value: 'ADMIN_POLICY', type: ActionType.ADMIN_POLICY },
 	{ value: 'LPS', type: ActionType.LPS },
-	{ value: 'LUKS', type: ActionType.LUKS },
+	{ value: 'ENCRYPTION', type: ActionType.ENCRYPTION },
 	{ value: 'GROUP', type: ActionType.GROUP },
 	{ value: 'AGENT_UPDATE', type: ActionType.AGENT_UPDATE }
 ] as const;


### PR DESCRIPTION
## Summary

- SDK client reads `Welcome.heartbeat_interval` on every connect/reconnect and resets the heartbeat ticker to that cadence, clamped to `[5s, 5min]`.
- Zero / unset field keeps the caller-supplied initial interval — older servers that don't populate it keep working unchanged.
- Exposes `MinHeartbeatInterval` / `MaxHeartbeatInterval` constants so server-side clamps can stay in sync.
- Also updates hand-written `ts/action-types.ts` to the v0.2.0 enum names (`SERVICE` / `ADMIN_POLICY` / `ENCRYPTION`) that the regenerated TS already uses.

Unblocks `manchtools/power-manage-server#27` and `manchtools/power-manage-agent#27`.

## Test plan

- [x] `go test ./go/...` — new tests for clamp, no-op cases, latest-wins, no-Run-active, dispatcher integration
- [x] `go build ./...`