### PR TITLE
feat: strict WithMTLSFromPEM + package-name validator (audit pass)

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -146,17 +146,61 @@ func WithTLSConfig(tlsConfig *tls.Config) ClientOption {
 }
 
 // WithMTLSFromPEM configures mTLS using PEM-encoded certificate data.
-// This is useful when certificates are stored in memory (e.g., from registration response).
+//
+// Trust is strict: the returned TLS config verifies the server ONLY
+// against caPEM. This is the correct setup for talking to the
+// internal-CA-signed gateway over mTLS — system roots are NOT
+// consulted, so a cert signed by any public CA cannot impersonate
+// the gateway even if its SNI matches.
+//
+// For reaching servers whose public-facing HTTPS cert is signed by
+// a public CA (typically a Traefik reverse proxy with Let's Encrypt
+// in front of the control server), pair the client certificate with
+// system roots via WithMTLSFromPEMAndSystemRoots instead.
 func WithMTLSFromPEM(certPEM, keyPEM, caPEM []byte) (ClientOption, error) {
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
 		return nil, fmt.Errorf("parse client certificate: %w", err)
 	}
 
-	// Start from system roots so we also trust publicly-issued certificates
-	// (e.g. Let's Encrypt on a reverse proxy), then add the internal CA.
-	caPool, err := x509.SystemCertPool()
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("failed to parse CA certificate")
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	return &funcOption{func(c *Client, httpClient **http.Client) {
+		*httpClient = newHTTPClientWithTLS(tlsConfig)
+	}}, nil
+}
+
+// WithMTLSFromPEMAndSystemRoots is like WithMTLSFromPEM but the
+// server-verification root pool contains caPEM PLUS the host's
+// system roots. Use this when the server sits behind a public CA
+// (e.g. a Traefik reverse proxy terminating TLS with Let's Encrypt)
+// and the client cert must still authenticate the agent's identity
+// at the application layer — for example the
+// ControlService.RenewCertificate RPC, which can travel over a
+// public-LE-fronted HTTPS endpoint and also passes the current
+// certificate in the request body.
+//
+// Do NOT use this for the agent-to-gateway mTLS connection: the
+// gateway is internal-CA only, and broadening its trust to system
+// roots lets any publicly-trusted cert with a matching SNI
+// impersonate the gateway.
+func WithMTLSFromPEMAndSystemRoots(certPEM, keyPEM, caPEM []byte) (ClientOption, error) {
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
+		return nil, fmt.Errorf("parse client certificate: %w", err)
+	}
+
+	caPool, err := x509.SystemCertPool()
+	if err != nil || caPool == nil {
 		caPool = x509.NewCertPool()
 	}
 	if !caPool.AppendCertsFromPEM(caPEM) {

--- a/go/pkg/builder.go
+++ b/go/pkg/builder.go
@@ -45,10 +45,17 @@ func (b *RemoveBuilder) Purge() *RemoveBuilder {
 }
 
 // Run executes the remove operation.
+//
+// Type-asserts the Manager against the Purger interface rather than
+// the concrete *Apt type so validation-wrapped managers (from
+// WithValidation / Detect) continue to dispatch to the purge path.
+// A previous `b.manager.(*Apt)` shape silently degraded to Remove
+// when the manager was wrapped, leaving apt package configs on
+// disk under /etc/* despite the caller's Purge() request.
 func (b *RemoveBuilder) Run() (*CommandResult, error) {
 	if b.purge {
-		if apt, ok := b.manager.(*Apt); ok {
-			return apt.Purge(b.packages...)
+		if p, ok := b.manager.(Purger); ok {
+			return p.Purge(b.packages...)
 		}
 	}
 	return b.manager.Remove(b.packages...)

--- a/go/pkg/detect.go
+++ b/go/pkg/detect.go
@@ -9,31 +9,38 @@ import (
 // ErrNoPackageManager is returned when no supported package manager is found.
 var ErrNoPackageManager = errors.New("no supported package manager found")
 
-// Detect returns the appropriate package manager for the current system.
+// Detect returns the appropriate package manager for the current
+// system. The returned Manager has package-name validation applied
+// via WithValidation — every public method that takes a package
+// name refuses inputs that fail ValidatePackageName. Callers that
+// want the raw underlying Manager (e.g. for tests that deliberately
+// exercise invalid names) can instantiate NewApt / NewDnf /
+// NewPacman / NewZypper directly.
 func Detect() (Manager, error) {
 	return DetectWithContext(context.Background())
 }
 
-// DetectWithContext returns the appropriate package manager with context.
+// DetectWithContext returns the appropriate package manager with
+// context. See Detect for the validation-wrapping contract.
 func DetectWithContext(ctx context.Context) (Manager, error) {
 	// Check for apt (Debian/Ubuntu)
 	if _, err := os.Stat("/usr/bin/apt-get"); err == nil {
-		return NewAptWithContext(ctx), nil
+		return WithValidation(NewAptWithContext(ctx)), nil
 	}
 
 	// Check for dnf (Fedora/RHEL 8+)
 	if _, err := os.Stat("/usr/bin/dnf"); err == nil {
-		return NewDnfWithContext(ctx), nil
+		return WithValidation(NewDnfWithContext(ctx)), nil
 	}
 
 	// Check for pacman (Arch Linux)
 	if _, err := os.Stat("/usr/bin/pacman"); err == nil {
-		return NewPacmanWithContext(ctx), nil
+		return WithValidation(NewPacmanWithContext(ctx)), nil
 	}
 
 	// Check for zypper (openSUSE/SLES)
 	if _, err := os.Stat("/usr/bin/zypper"); err == nil {
-		return NewZypperWithContext(ctx), nil
+		return WithValidation(NewZypperWithContext(ctx)), nil
 	}
 
 	return nil, ErrNoPackageManager

--- a/go/pkg/pkg_test.go
+++ b/go/pkg/pkg_test.go
@@ -368,8 +368,17 @@ func TestRemoveBuilder_Multiple(t *testing.T) {
 	}
 }
 
-func TestRemoveBuilder_PurgeWithNonApt(t *testing.T) {
-	// Purge with non-Apt manager should fall back to Remove
+func TestRemoveBuilder_PurgeUsesPurgerInterface(t *testing.T) {
+	// The builder now dispatches `.Purge()` via the Purger
+	// interface, not a concrete `*Apt` type assertion. MockManager
+	// implements Purger (has a Purge method), so its Purge hook
+	// must be the one that fires.
+	//
+	// This replaces the old TestRemoveBuilder_PurgeWithNonApt
+	// which asserted the *Apt type assertion would fail and the
+	// builder would fall back to Remove. That shape used to hide
+	// the SDK audit regression where a validation-wrapped manager
+	// silently lost its purge semantics.
 	mock := NewMockManager()
 	pm := NewPackageManager(mock)
 
@@ -378,9 +387,11 @@ func TestRemoveBuilder_PurgeWithNonApt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Should call Remove since mock is not *Apt
-	if len(mock.RemoveCalls) != 1 {
-		t.Fatalf("expected 1 Remove call for non-Apt purge, got %d", len(mock.RemoveCalls))
+	if len(mock.PurgeCalls) != 1 {
+		t.Fatalf("expected 1 Purge call via Purger interface, got %d", len(mock.PurgeCalls))
+	}
+	if len(mock.RemoveCalls) != 0 {
+		t.Errorf("Remove should NOT fire when the manager implements Purger; got %d calls", len(mock.RemoveCalls))
 	}
 }
 

--- a/go/pkg/validate.go
+++ b/go/pkg/validate.go
@@ -1,0 +1,61 @@
+package pkg
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// validPackageName is the allowlist every package-name argument must
+// match before it reaches apt / dnf / pacman / zypper / flatpak.
+//
+// The first character MUST be alphanumeric. That single rule kills
+// the entire class of "option injection" attacks where a caller
+// smuggles a flag past the verb by naming a package `--force` or
+// `-y=evil` — every package manager would have treated those as
+// additional options rather than a package name. The subsequent
+// character set covers the grammars every manager we support
+// actually uses:
+//
+//   - apt / dpkg: alphanum + `._-` plus multiarch `:arch` suffix.
+//   - dnf / zypper: alphanum + `._-`, occasionally `+` (libstdc++).
+//   - pacman: alphanum + `._-+@`.
+//   - flatpak refs: reverse-DNS app IDs with `.`, plus optional
+//     `/arch/branch` suffix, e.g. `org.videolan.VLC/x86_64/stable`.
+//
+// Characters we intentionally forbid: whitespace, NUL, shell
+// metacharacters (`|&;<>`, backticks, `$`, `\`), quote chars, `=`
+// (apt's name=version separator — version must come through the
+// dedicated InstallOptions.Version field, not the name), `*`, `?`
+// and other glob characters.
+//
+// Length is capped at 256 to bound pathological inputs before they
+// reach argv.
+var validPackageName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+:/@~-]{0,255}$`)
+
+// ValidatePackageName returns a non-nil error when name would be
+// unsafe to pass as a positional argument to any of the supported
+// package managers. Callers MUST invoke this (or
+// ValidatePackageNames) at the top of every public method that
+// accepts a package name, before any exec.CommandContext call.
+func ValidatePackageName(name string) error {
+	if name == "" {
+		return fmt.Errorf("package name is empty")
+	}
+	if !validPackageName.MatchString(name) {
+		return fmt.Errorf("invalid package name %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._+:/@~-]", name)
+	}
+	return nil
+}
+
+// ValidatePackageNames runs ValidatePackageName against every entry.
+// Returns the first rejection; does not try to be exhaustive —
+// actions are signed and a rejection here is a caller bug, not an
+// adversarial probe to enumerate.
+func ValidatePackageNames(names []string) error {
+	for _, n := range names {
+		if err := ValidatePackageName(n); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/pkg/validate_test.go
+++ b/go/pkg/validate_test.go
@@ -1,0 +1,95 @@
+package pkg
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidatePackageName_Accepts pins the set of shapes we know
+// real-world package managers use. Regressions that reject any of
+// these break legitimate actions.
+func TestValidatePackageName_Accepts(t *testing.T) {
+	cases := []string{
+		"nginx",
+		"curl",
+		"gcc-12",
+		"libasound2t64",
+		"libstdc++6",
+		"firefox-esr",
+		"linux-image-amd64",
+		"libc6:i386",          // apt multiarch
+		"libc6:amd64",         // apt multiarch
+		"python3.11",          // dnf
+		"base-devel",          // pacman
+		"org.videolan.VLC",    // flatpak reverse-DNS
+		"org.videolan.VLC/x86_64/stable",
+		"runtime/org.freedesktop.Platform/x86_64/23.08",
+		"foo-1.2.3",
+		"_notquite",           // starts alphanum... actually "_" is not alphanum. Skip.
+	}
+	for _, name := range cases {
+		if name == "_notquite" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			if err := ValidatePackageName(name); err != nil {
+				t.Errorf("legitimate name rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePackageName_RejectsOptionInjection is the core of the
+// fix: every leading-dash / leading-equals input is a potential
+// option-injection attack on the underlying package manager, and
+// must be refused at the SDK boundary.
+func TestValidatePackageName_RejectsOptionInjection(t *testing.T) {
+	cases := []string{
+		"",
+		"-y",
+		"--force",
+		"=evil",
+		" nginx",              // leading whitespace
+		"nginx ",              // trailing whitespace — we refuse via character class
+		"foo bar",             // embedded space — argv confusion
+		"pkg;rm -rf /",        // shell metachar
+		"pkg|cat",
+		"pkg&whoami",
+		"`reboot`",
+		"$(reboot)",
+		"pkg\nmalicious",
+		"pkg\x00",
+		"pkg=1.2.3",           // apt name=version goes via InstallOptions.Version
+		"pkg*",                // glob
+		"pkg?",
+		"pkg>out",
+		"pkg<in",
+		"pkg'quote",
+		"pkg\"quote",
+		"pkg\\back",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidatePackageName(name)
+			if err == nil {
+				t.Errorf("expected rejection of %q", name)
+				return
+			}
+			if !strings.Contains(err.Error(), "package name") {
+				t.Errorf("error should name the field; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePackageName_LengthCap asserts the 256-character cap.
+func TestValidatePackageName_LengthCap(t *testing.T) {
+	ok := "a" + strings.Repeat("b", 255)
+	if err := ValidatePackageName(ok); err != nil {
+		t.Errorf("256-char name rejected: %v", err)
+	}
+	tooLong := "a" + strings.Repeat("b", 256)
+	if err := ValidatePackageName(tooLong); err == nil {
+		t.Errorf("257-char name accepted; expected rejection")
+	}
+}

--- a/go/pkg/validating_manager.go
+++ b/go/pkg/validating_manager.go
@@ -1,0 +1,105 @@
+package pkg
+
+// validatingManager wraps any Manager and runs ValidatePackageName /
+// ValidatePackageNames against every public entry point that takes a
+// package-name argument. Callers that obtain their Manager via the
+// package-level New() / Detect() helpers (which is the common path,
+// including the agent's internal/executor) get this protection for
+// free. Users who instantiate NewApt / NewDnf / NewPacman / NewZypper
+// / NewFlatpak directly can opt in explicitly via WithValidation.
+//
+// Methods whose argument is unavoidably free-form (Search queries,
+// list operations) are passed through unchanged.
+type validatingManager struct {
+	Manager
+}
+
+// WithValidation returns m wrapped so that every package-name input
+// is checked by ValidatePackageName before it reaches the concrete
+// package manager. Nil m returns nil.
+func WithValidation(m Manager) Manager {
+	if m == nil {
+		return nil
+	}
+	if _, already := m.(*validatingManager); already {
+		return m
+	}
+	return &validatingManager{Manager: m}
+}
+
+func (v *validatingManager) Install(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	return v.Manager.Install(packages...)
+}
+
+func (v *validatingManager) InstallVersion(name string, opts InstallOptions) (*CommandResult, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return nil, err
+	}
+	return v.Manager.InstallVersion(name, opts)
+}
+
+func (v *validatingManager) Remove(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	return v.Manager.Remove(packages...)
+}
+
+func (v *validatingManager) Upgrade(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	return v.Manager.Upgrade(packages...)
+}
+
+func (v *validatingManager) Show(name string) (*Package, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return nil, err
+	}
+	return v.Manager.Show(name)
+}
+
+func (v *validatingManager) ListVersions(name string) (*VersionInfo, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return nil, err
+	}
+	return v.Manager.ListVersions(name)
+}
+
+func (v *validatingManager) IsInstalled(name string) (bool, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return false, err
+	}
+	return v.Manager.IsInstalled(name)
+}
+
+func (v *validatingManager) GetInstalledVersion(name string) (string, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return "", err
+	}
+	return v.Manager.GetInstalledVersion(name)
+}
+
+func (v *validatingManager) Pin(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	return v.Manager.Pin(packages...)
+}
+
+func (v *validatingManager) Unpin(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	return v.Manager.Unpin(packages...)
+}
+
+func (v *validatingManager) IsPinned(name string) (bool, error) {
+	if err := ValidatePackageName(name); err != nil {
+		return false, err
+	}
+	return v.Manager.IsPinned(name)
+}

--- a/go/pkg/validating_manager.go
+++ b/go/pkg/validating_manager.go
@@ -27,6 +27,37 @@ func WithValidation(m Manager) Manager {
 	return &validatingManager{Manager: m}
 }
 
+// Purger is the opt-in interface package managers implement to signal
+// they support `apt purge`-style removal (delete packages AND
+// configuration files). Currently only apt honours this semantically;
+// dnf/pacman/zypper have no equivalent and the RemoveBuilder falls
+// back to plain Remove().
+//
+// validatingManager implements Purger when the wrapped Manager does,
+// so `RemoveBuilder.Run()` continues to reach the underlying purge
+// path through the validation wrapper. Without this interface, the
+// builder's old `b.manager.(*Apt)` type assertion would fail against
+// *validatingManager and silently degrade `.Purge()` to `.Remove()`,
+// leaving /etc/* config files on disk on `apt` deployments.
+type Purger interface {
+	Purge(packages ...string) (*CommandResult, error)
+}
+
+// Purge forwards to the wrapped Manager if it implements Purger.
+// Callers typically reach this via RemoveBuilder.Run(); direct
+// invocation is valid too. Validation runs before dispatch; if the
+// wrapped Manager does not implement Purger, fall back to Remove()
+// so the caller never gets a silent no-op.
+func (v *validatingManager) Purge(packages ...string) (*CommandResult, error) {
+	if err := ValidatePackageNames(packages); err != nil {
+		return nil, err
+	}
+	if p, ok := v.Manager.(Purger); ok {
+		return p.Purge(packages...)
+	}
+	return v.Manager.Remove(packages...)
+}
+
 func (v *validatingManager) Install(packages ...string) (*CommandResult, error) {
 	if err := ValidatePackageNames(packages); err != nil {
 		return nil, err

--- a/go/pkg/validating_manager_test.go
+++ b/go/pkg/validating_manager_test.go
@@ -1,0 +1,109 @@
+package pkg
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeManager is a minimal Manager stub that records whether its
+// entry points were reached, so the tests can assert that
+// validatingManager short-circuits on invalid names.
+type fakeManager struct {
+	Manager
+	installCalled bool
+	removeCalled  bool
+	pinCalled     bool
+}
+
+func (f *fakeManager) Install(names ...string) (*CommandResult, error) {
+	f.installCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) Remove(names ...string) (*CommandResult, error) {
+	f.removeCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) InstallVersion(name string, _ InstallOptions) (*CommandResult, error) {
+	f.installCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) Upgrade(names ...string) (*CommandResult, error) {
+	f.installCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) Pin(names ...string) (*CommandResult, error) {
+	f.pinCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) Unpin(names ...string) (*CommandResult, error) {
+	f.pinCalled = true
+	return &CommandResult{Success: true}, nil
+}
+func (f *fakeManager) Show(string) (*Package, error)                   { return nil, errors.New("x") }
+func (f *fakeManager) ListVersions(string) (*VersionInfo, error)       { return nil, errors.New("x") }
+func (f *fakeManager) IsInstalled(string) (bool, error)                { return true, nil }
+func (f *fakeManager) GetInstalledVersion(string) (string, error)      { return "1.0", nil }
+func (f *fakeManager) IsPinned(string) (bool, error)                   { return false, nil }
+
+// TestValidatingManager_BlocksInjection asserts that every entry
+// point that accepts a package name refuses option-injection shapes
+// BEFORE dispatching to the underlying Manager. Reaching the fake
+// means the wrapper failed closed.
+func TestValidatingManager_BlocksInjection(t *testing.T) {
+	inner := &fakeManager{}
+	v := WithValidation(inner)
+
+	if _, err := v.Install("-y"); err == nil {
+		t.Error("Install('-y'): expected rejection")
+	}
+	if inner.installCalled {
+		t.Error("Install reached underlying manager despite bad name")
+	}
+
+	if _, err := v.Remove("--force"); err == nil {
+		t.Error("Remove('--force'): expected rejection")
+	}
+	if inner.removeCalled {
+		t.Error("Remove reached underlying manager despite bad name")
+	}
+
+	if _, err := v.Pin("pkg;rm -rf /"); err == nil {
+		t.Error("Pin(shell injection): expected rejection")
+	}
+	if inner.pinCalled {
+		t.Error("Pin reached underlying manager despite bad name")
+	}
+}
+
+// TestValidatingManager_ForwardsValid asserts the happy path: a
+// legitimate package name flows through to the underlying manager.
+func TestValidatingManager_ForwardsValid(t *testing.T) {
+	inner := &fakeManager{}
+	v := WithValidation(inner)
+
+	if _, err := v.Install("nginx"); err != nil {
+		t.Errorf("Install('nginx'): unexpected error: %v", err)
+	}
+	if !inner.installCalled {
+		t.Error("Install did not reach underlying manager")
+	}
+}
+
+// TestWithValidation_IsIdempotent asserts double-wrapping is a
+// no-op — New()/Detect() returning an already-wrapped Manager
+// should not re-wrap on every call through a caller's defensive
+// WithValidation.
+func TestWithValidation_IsIdempotent(t *testing.T) {
+	inner := &fakeManager{}
+	once := WithValidation(inner)
+	twice := WithValidation(once)
+	if once != twice {
+		t.Errorf("WithValidation(WithValidation(m)) should be same instance")
+	}
+}
+
+func TestWithValidation_NilPassthrough(t *testing.T) {
+	if got := WithValidation(nil); got != nil {
+		t.Errorf("WithValidation(nil) = %v, want nil", got)
+	}
+}

--- a/go/pkg/validating_manager_test.go
+++ b/go/pkg/validating_manager_test.go
@@ -107,3 +107,66 @@ func TestWithValidation_NilPassthrough(t *testing.T) {
 		t.Errorf("WithValidation(nil) = %v, want nil", got)
 	}
 }
+
+// fakePurger wraps fakeManager and implements the Purger interface
+// so validatingManager's Purge forwarding can be exercised.
+type fakePurger struct {
+	fakeManager
+	purgeCalled bool
+}
+
+func (f *fakePurger) Purge(packages ...string) (*CommandResult, error) {
+	f.purgeCalled = true
+	return &CommandResult{Success: true}, nil
+}
+
+// TestValidatingManager_ForwardsPurge is the regression guard for
+// the SDK audit finding that `RemoveBuilder.Run().Purge()` silently
+// degraded to Remove() when the underlying Manager was wrapped in
+// validatingManager — the builder used to type-assert against the
+// concrete *Apt rather than the Purger interface. Once Detect()
+// returns a wrapped Manager, that assertion fails and Purge is
+// lost. This test pins the new shape: validatingManager implements
+// Purger and forwards with validation intact.
+func TestValidatingManager_ForwardsPurge(t *testing.T) {
+	inner := &fakePurger{}
+	v := WithValidation(inner)
+
+	p, ok := v.(Purger)
+	if !ok {
+		t.Fatal("validatingManager should satisfy the Purger interface when wrapped Manager does")
+	}
+	if _, err := p.Purge("nginx"); err != nil {
+		t.Errorf("Purge('nginx'): unexpected error: %v", err)
+	}
+	if !inner.purgeCalled {
+		t.Error("Purge did not reach the underlying manager via the Purger interface")
+	}
+
+	// Validation still runs in front of purge — injection-shaped
+	// names must be refused before the underlying Purge is reached.
+	inner.purgeCalled = false
+	if _, err := p.Purge("-y"); err == nil {
+		t.Error("Purge('-y'): expected validation rejection")
+	}
+	if inner.purgeCalled {
+		t.Error("Purge reached underlying manager despite option-injection name")
+	}
+}
+
+// TestValidatingManager_PurgeFallsBackToRemove asserts that when the
+// wrapped Manager does NOT implement Purger (dnf/pacman/zypper), the
+// wrapper falls back to Remove rather than failing silently or
+// panicking on a failed type assertion.
+func TestValidatingManager_PurgeFallsBackToRemove(t *testing.T) {
+	inner := &fakeManager{} // no Purge method
+	v := WithValidation(inner)
+
+	p := v.(Purger) // validatingManager itself implements Purger
+	if _, err := p.Purge("nginx"); err != nil {
+		t.Errorf("Purge fallback: unexpected error: %v", err)
+	}
+	if !inner.removeCalled {
+		t.Error("Purge should fall back to Remove when wrapped manager does not implement Purger")
+	}
+}


### PR DESCRIPTION
## Summary

Two findings from the agent security audit that belong at the SDK boundary.

### 1. `WithMTLSFromPEM` is now strict (trust-broadening fix)

Previously the function merged `caPEM` into `x509.SystemCertPool()`, so a client using it to connect to the gateway trusted every public CA *in addition* to the intended internal CA — a cert signed by any public CA with a matching SNI could impersonate the gateway.

- `WithMTLSFromPEM(cert, key, caPEM)` now trusts **only** `caPEM`. This is the correct setup for the agent-to-gateway mTLS path (internal-CA only).
- New `WithMTLSFromPEMAndSystemRoots(cert, key, caPEM)` keeps the old "caPEM ∪ system roots" behaviour, for the one legitimate use case: calling `ControlService.RenewCertificate` at the control server's public URL (Traefik + Let's Encrypt in the reference deployment). Application-layer identity is already proven by the `currentCertificate` field on the request.

**BREAKING CHANGE** — callers who relied on the old permissive behaviour must switch to `WithMTLSFromPEMAndSystemRoots`.

### 2. Package-name validator at the SDK boundary

Every public method on `pkg.Manager` that accepts a package name now runs `ValidatePackageName` before dispatching to the concrete manager (apt / dnf / pacman / zypper / flatpak).

- Refuses the entire class of option-injection shapes — leading \`-\` or \`=\`, whitespace, shell metacharacters, glob / redirect / quote / NUL, embedded newlines.
- Allowlist supports realistic names across all five managers, including apt multiarch (\`libc6:i386\`) and flatpak refs (\`org.videolan.VLC/x86_64/stable\`).
- Wired in at \`Detect()\` / \`DetectWithContext()\` so \`pkg.New()\` — the common entry point — is protected by default. \`WithValidation(m)\` is exported for users who call \`NewApt\` / \`NewDnf\` / etc. directly and want the same guarantees.

## Test plan

- [x] \`go test ./...\` — full SDK sweep passes
- New: \`TestValidatePackageName_Accepts\` pins realistic shapes across all managers
- New: \`TestValidatePackageName_RejectsOptionInjection\` pins the refused shapes
- New: \`TestValidatingManager_BlocksInjection\` asserts fail-closed before dispatch
- New: \`TestWithValidation_IsIdempotent\` / \`TestWithValidation_NilPassthrough\`