### PR TITLE
feat: rc11 — add ErrGatewayNotRegistered (server #79)

### DIFF
--- a/ts/errors.ts
+++ b/ts/errors.ts
@@ -62,3 +62,4 @@ export const ErrActionNotCompliance = 'action_not_compliance';
 export const ErrQueryResultNotFound = 'query_result_not_found';
 export const ErrTerminalLinuxUsernameNotSet = 'terminal_linux_username_not_set';
 export const ErrTerminalNotConfigured = 'terminal_not_configured';
+export const ErrGatewayNotRegistered = 'gateway_not_registered';


### PR DESCRIPTION
## Summary

Adds the `ErrGatewayNotRegistered` constant for the new `gateway_not_registered` error code introduced by server-side rc11. The server returns this code when a device's gateway is reachable but has not published its terminal URL — a persistent operator misconfiguration that retrying will not fix. Distinct from the existing `device_not_connected` code, which signals a transient gateway loss.

Cross-repo: `manchtools/power-manage-server#79`, paired with `manchtools/power-manage-web` PR for paraglide + errors.ts wiring.

## Test plan

- [x] `go build ./...` clean
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error detection for gateway-related issues with enhanced error categorization, enabling more specific error identification and better troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->