### PR TITLE
chore: remove coderabbit linked_repositories

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,9 +25,3 @@ reviews:
 knowledge_base:
   learnings:
     scope: auto
-  linked_repositories:
-    - repository: manchtools/power-manage-server
-      instructions: >
-        Primary downstream consumer of SDK proto and client changes. Use this
-        repository to validate wire compatibility, enum semantics, and API
-        contract expectations for shared definitions.


### PR DESCRIPTION
CodeRabbit's current plan tier allows 0 linked repositories. The configured cross-repo reference to `power-manage-server` was being silently dropped on every review with a warning. Removing the block to stop the noise.

Same change going out on `power-manage-server` and `power-manage-agent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings related to code review and knowledge management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->