### PR TITLE
chore: add ErrCannotRemoveLastAdmin error const

### DIFF
--- a/ts/errors.ts
+++ b/ts/errors.ts
@@ -41,6 +41,7 @@ export const ErrGroupNotDynamic = 'group_not_dynamic';
 export const ErrDynamicGroupManualModify = 'dynamic_group_manual_modify';
 export const ErrCannotDeleteSystemRole = 'cannot_delete_system_role';
 export const ErrCannotRenameSystemRole = 'cannot_rename_system_role';
+export const ErrCannotRemoveLastAdmin = 'cannot_remove_last_admin';
 export const ErrRoleInUse = 'role_in_use';
 export const ErrScimAlreadyEnabled = 'scim_already_enabled';
 export const ErrScimNotEnabled = 'scim_not_enabled';


### PR DESCRIPTION
Trivial 1-line addition. Forthcoming server PR introduces \`ErrCannotRemoveLastAdmin\` to fix \`role_handler.go:359\` which was misusing \`ErrCannotRenameSystemRole\` ("System roles cannot be modified") for the "cannot remove last user from Admin role" precondition.

The server's \`TestErrorCodeParityWithTSSDK\` test enforces a 1:1 mapping between Go-side error codes and TS SDK exports, so the const must land in the SDK first. Web i18n keys (\`error_cannot_remove_last_admin\`) already pushed to web/main (\`dc84f65\`).

## Test plan

- [x] No tests needed; pure const addition mirrored from server-side proposal.

After merge, the server PR can run with parity checks passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for admin role management to prevent invalid state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->