### PR TITLE
refactor: SDK audit-followup bundle (verify doc, TS transport cache, ErrorDetail bounds)

### DIFF
--- a/gen/go/pm/v1/common.pb.go
+++ b/gen/go/pm/v1/common.pb.go
@@ -346,9 +346,17 @@ func (x *DeviceId) GetValue() string {
 type ErrorDetail struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Machine-readable error code (e.g., "user_not_found", "email_already_exists").
-	Code string `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	// Capped at 128 chars — every existing code uses snake_case names well
+	// under that, and the bound prevents a misbehaving caller (or a future
+	// codepath that constructs the detail from user-supplied input) from
+	// pushing arbitrarily long payloads into client-side error toasts.
+	// @gotags: validate:"max=128"
+	Code string `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty" validate:"max=128"`
 	// Server-generated request ID for correlating errors with server logs.
-	RequestId     string `protobuf:"bytes,2,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	// ULIDs are 26 chars; bound at 64 to leave headroom for prefixes
+	// without inviting unbounded growth.
+	// @gotags: validate:"max=64"
+	RequestId     string `protobuf:"bytes,2,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty" validate:"max=64"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/ts/pm/v1/common_pb.ts
+++ b/gen/ts/pm/v1/common_pb.ts
@@ -62,6 +62,11 @@ export const DeviceIdSchema: GenMessage<DeviceId> = /*@__PURE__*/
 export type ErrorDetail = Message<"pm.v1.ErrorDetail"> & {
   /**
    * Machine-readable error code (e.g., "user_not_found", "email_already_exists").
+   * Capped at 128 chars — every existing code uses snake_case names well
+   * under that, and the bound prevents a misbehaving caller (or a future
+   * codepath that constructs the detail from user-supplied input) from
+   * pushing arbitrarily long payloads into client-side error toasts.
+   * @gotags: validate:"max=128"
    *
    * @generated from field: string code = 1;
    */
@@ -69,6 +74,9 @@ export type ErrorDetail = Message<"pm.v1.ErrorDetail"> & {
 
   /**
    * Server-generated request ID for correlating errors with server logs.
+   * ULIDs are 26 chars; bound at 64 to leave headroom for prefixes
+   * without inviting unbounded growth.
+   * @gotags: validate:"max=64"
    *
    * @generated from field: string request_id = 2;
    */

--- a/go/verify/verify.go
+++ b/go/verify/verify.go
@@ -1,11 +1,25 @@
 // Package verify provides action signature verification and signing.
 //
-// Actions are signed by the control server and verified by agents using the
-// CA certificate's public key. The canonical payload format is:
+// The control server signs actions with its CA private key
+// (ActionSigner). Agents verify those signatures against the
+// matching CA certificate's public key (ActionVerifier). The two
+// sides exchange the signature over an SHA-256 hash of the
+// canonical payload:
 //
-//	"actionID:actionType:base64(paramsJSON)"
+//	canonical = sprintf("%s:%d:%s", actionID, actionType,
+//	                    base64.StdEncoding.EncodeToString(paramsJSON))
 //
-// Both ECDSA and RSA keys are supported.
+// `actionType` is the protobuf enum's integer value (rendered with
+// %d), so signing and verifying must agree on the enum encoding —
+// renaming an enum entry in the proto without coordinating server
+// and agent rollouts will not break verification, but renumbering
+// it will.
+//
+// Supported key algorithms: ECDSA (verified via ecdsa.VerifyASN1,
+// signed via ecdsa.SignASN1) and RSA (PKCS#1 v1.5 with SHA-256).
+// Other key types — including Ed25519 — are explicitly rejected so
+// a key-type drift between server and agent surfaces as a clear
+// error instead of a silent signature mismatch.
 package verify
 
 import (

--- a/proto/pm/v1/common.proto
+++ b/proto/pm/v1/common.proto
@@ -54,8 +54,16 @@ enum AssignmentMode {
 // Structured error detail attached to Connect-RPC errors.
 message ErrorDetail {
   // Machine-readable error code (e.g., "user_not_found", "email_already_exists").
+  // Capped at 128 chars — every existing code uses snake_case names well
+  // under that, and the bound prevents a misbehaving caller (or a future
+  // codepath that constructs the detail from user-supplied input) from
+  // pushing arbitrarily long payloads into client-side error toasts.
+  // @gotags: validate:"max=128"
   string code = 1;
   // Server-generated request ID for correlating errors with server logs.
+  // ULIDs are 26 chars; bound at 64 to leave headroom for prefixes
+  // without inviting unbounded growth.
+  // @gotags: validate:"max=64"
   string request_id = 2;
 }
 

--- a/ts/client.ts
+++ b/ts/client.ts
@@ -251,6 +251,16 @@ export interface ClientOptions {
 export class ApiClient {
 	private opts: ClientOptions;
 
+	// Cached transport. createConnectTransport allocates a fetch
+	// wrapper + interceptor chain on every call; before this cache,
+	// every RPC built one from scratch even though the
+	// authentication interceptor closes over `this.opts` and never
+	// changes shape. Keyed by the resolved baseUrl so a runtime
+	// server-URL switch (multi-tenant, environment swap) rebuilds
+	// transparently.
+	private cachedTransport: ReturnType<typeof createConnectTransport> | null = null;
+	private cachedTransportUrl: string | null = null;
+
 	constructor(opts: ClientOptions) {
 		this.opts = opts;
 	}
@@ -260,8 +270,11 @@ export class ApiClient {
 		if (!serverUrl) {
 			throw new Error('Server URL not configured');
 		}
+		if (this.cachedTransport && this.cachedTransportUrl === serverUrl) {
+			return this.cachedTransport;
+		}
 
-		return createConnectTransport({
+		const transport = createConnectTransport({
 			baseUrl: serverUrl,
 			interceptors: [
 				(next) => async (req) => {
@@ -291,21 +304,33 @@ export class ApiClient {
 				}
 			]
 		});
+		this.cachedTransport = transport;
+		this.cachedTransportUrl = serverUrl;
+		return transport;
 	}
 
 	private getClient() {
 		return createClient(ControlService, this.getTransport());
 	}
 
+	// Auth-only transport (no token interceptor — login itself
+	// produces the token). Cached on the same key as the primary
+	// transport since the URL is the only meaningful input.
+	private cachedAuthTransport: ReturnType<typeof createConnectTransport> | null = null;
+	private cachedAuthTransportUrl: string | null = null;
+
 	private getAuthTransport() {
 		const serverUrl = this.opts.getServerUrl();
 		if (!serverUrl) {
 			throw new Error('Server URL not configured');
 		}
-
-		return createConnectTransport({
-			baseUrl: serverUrl
-		});
+		if (this.cachedAuthTransport && this.cachedAuthTransportUrl === serverUrl) {
+			return this.cachedAuthTransport;
+		}
+		const transport = createConnectTransport({ baseUrl: serverUrl });
+		this.cachedAuthTransport = transport;
+		this.cachedAuthTransportUrl = serverUrl;
+		return transport;
 	}
 
 	private getAuthClient() {

--- a/ts/client.ts
+++ b/ts/client.ts
@@ -1833,7 +1833,7 @@ export class ApiClient {
 export function getErrorCode(error: unknown): string | undefined {
 	if (error instanceof ConnectError) {
 		const details = error.findDetails(ErrorDetailSchema);
-		if (details.length > 0) {
+		if (details.length > 0 && details[0].code) {
 			return details[0].code;
 		}
 	}


### PR DESCRIPTION
## Summary

Three small, isolated cleanups bundled into one review:

- **\`go/verify/verify.go\`** package doc was vague about the asymmetry between sign and verify (signer takes a private key, verifier uses the CA cert) and silent about which key algorithms are supported in practice. Spell out the \`actionType\` encoding (protobuf enum integer rendered with \`%d\`), enumerate the supported key types (ECDSA + RSA-PKCS#1v15), and call out that other types — including Ed25519 — are explicitly rejected.
- **\`ts/client.ts\`** was building a fresh Connect transport on every RPC. \`createConnectTransport\` allocates a fetch wrapper + interceptor chain, but the interceptor closes over \`this.opts\` and never changes shape. Cache both the primary transport and the auth-only variant, keyed by resolved baseUrl so a runtime server-URL switch still rebuilds.
- **\`proto/pm/v1/common.proto\`** \`ErrorDetail\` was unbounded. Add \`@gotags\` validate length bounds (code: 128, request_id: 64) so a misbehaving caller — or a future codepath that constructs the detail from user input — cannot push arbitrarily long payloads into client-side error toasts.

Regenerated Go + TS bindings via \`make generate\`.

## Test plan

- [x] \`go build ./...\` clean.
- [x] sdk \`make generate\` clean.
- [x] Generated Go struct carries \`validate:\"max=128\"\` on Code, \`validate:\"max=64\"\` on RequestId.
- [x] Generated TS file carries the new doc comments on ErrorDetail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API transport now caches connections and transparently refreshes tokens on auth failures
  * Added helpers to extract error codes and request IDs from error responses

* **Documentation**
  * Expanded documentation for signing and verification architecture, including roles and supported algorithms
  * Clarified error detail documentation with improved field constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->