### PR TITLE
refactor: remove proto skip_verify field + WithInsecureSkipVerify option

### DIFF
--- a/gen/go/pm/v1/device_auth.pb.go
+++ b/gen/go/pm/v1/device_auth.pb.go
@@ -26,8 +26,7 @@ type EnrollRequest struct {
 	// @gotags: validate:"required,url"
 	ServerUrl string `protobuf:"bytes,1,opt,name=server_url,json=serverUrl,proto3" json:"server_url,omitempty" validate:"required,url"` // Control server URL
 	// @gotags: validate:"required"
-	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required"`                              // Registration token from web UI
-	SkipVerify    bool   `protobuf:"varint,3,opt,name=skip_verify,json=skipVerify,proto3" json:"skip_verify,omitempty"` // Skip TLS verification (development only)
+	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required"` // Registration token from web UI
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -74,13 +73,6 @@ func (x *EnrollRequest) GetToken() string {
 		return x.Token
 	}
 	return ""
-}
-
-func (x *EnrollRequest) GetSkipVerify() bool {
-	if x != nil {
-		return x.SkipVerify
-	}
-	return false
 }
 
 type EnrollResponse struct {
@@ -235,13 +227,11 @@ var File_pm_v1_device_auth_proto protoreflect.FileDescriptor
 
 const file_pm_v1_device_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x17pm/v1/device_auth.proto\x12\x05pm.v1\"e\n" +
+	"\x17pm/v1/device_auth.proto\x12\x05pm.v1\"W\n" +
 	"\rEnrollRequest\x12\x1d\n" +
 	"\n" +
 	"server_url\x18\x01 \x01(\tR\tserverUrl\x12\x14\n" +
-	"\x05token\x18\x02 \x01(\tR\x05token\x12\x1f\n" +
-	"\vskip_verify\x18\x03 \x01(\bR\n" +
-	"skipVerify\"]\n" +
+	"\x05token\x18\x02 \x01(\tR\x05tokenJ\x04\b\x03\x10\x04R\vskip_verify\"]\n" +
 	"\x0eEnrollResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x1b\n" +
 	"\tdevice_id\x18\x02 \x01(\tR\bdeviceId\x12\x14\n" +

--- a/gen/ts/pm/v1/device_auth_pb.ts
+++ b/gen/ts/pm/v1/device_auth_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file pm/v1/device_auth.proto.
  */
 export const file_pm_v1_device_auth: GenFile = /*@__PURE__*/
-  fileDesc("ChdwbS92MS9kZXZpY2VfYXV0aC5wcm90bxIFcG0udjEiRwoNRW5yb2xsUmVxdWVzdBISCgpzZXJ2ZXJfdXJsGAEgASgJEg0KBXRva2VuGAIgASgJEhMKC3NraXBfdmVyaWZ5GAMgASgIIkMKDkVucm9sbFJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgSEQoJZGV2aWNlX2lkGAIgASgJEg0KBWVycm9yGAMgASgJIhwKGkdldEVucm9sbG1lbnRTdGF0dXNSZXF1ZXN0IkIKG0dldEVucm9sbG1lbnRTdGF0dXNSZXNwb25zZRIQCghlbnJvbGxlZBgBIAEoCBIRCglkZXZpY2VfaWQYAiABKAkyqAEKEURldmljZUF1dGhTZXJ2aWNlEjUKBkVucm9sbBIULnBtLnYxLkVucm9sbFJlcXVlc3QaFS5wbS52MS5FbnJvbGxSZXNwb25zZRJcChNHZXRFbnJvbGxtZW50U3RhdHVzEiEucG0udjEuR2V0RW5yb2xsbWVudFN0YXR1c1JlcXVlc3QaIi5wbS52MS5HZXRFbnJvbGxtZW50U3RhdHVzUmVzcG9uc2VCOlo4Z2l0aHViLmNvbS9tYW5jaHRvb2xzL3Bvd2VyLW1hbmFnZS9zZGsvZ2VuL2dvL3BtL3YxO3BtdjFiBnByb3RvMw");
+  fileDesc("ChdwbS92MS9kZXZpY2VfYXV0aC5wcm90bxIFcG0udjEiRQoNRW5yb2xsUmVxdWVzdBISCgpzZXJ2ZXJfdXJsGAEgASgJEg0KBXRva2VuGAIgASgJSgQIAxAEUgtza2lwX3ZlcmlmeSJDCg5FbnJvbGxSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEhEKCWRldmljZV9pZBgCIAEoCRINCgVlcnJvchgDIAEoCSIcChpHZXRFbnJvbGxtZW50U3RhdHVzUmVxdWVzdCJCChtHZXRFbnJvbGxtZW50U3RhdHVzUmVzcG9uc2USEAoIZW5yb2xsZWQYASABKAgSEQoJZGV2aWNlX2lkGAIgASgJMqgBChFEZXZpY2VBdXRoU2VydmljZRI1CgZFbnJvbGwSFC5wbS52MS5FbnJvbGxSZXF1ZXN0GhUucG0udjEuRW5yb2xsUmVzcG9uc2USXAoTR2V0RW5yb2xsbWVudFN0YXR1cxIhLnBtLnYxLkdldEVucm9sbG1lbnRTdGF0dXNSZXF1ZXN0GiIucG0udjEuR2V0RW5yb2xsbWVudFN0YXR1c1Jlc3BvbnNlQjpaOGdpdGh1Yi5jb20vbWFuY2h0b29scy9wb3dlci1tYW5hZ2Uvc2RrL2dlbi9nby9wbS92MTtwbXYxYgZwcm90bzM");
 
 /**
  * @generated from message pm.v1.EnrollRequest
@@ -33,13 +33,6 @@ export type EnrollRequest = Message<"pm.v1.EnrollRequest"> & {
    * @generated from field: string token = 2;
    */
   token: string;
-
-  /**
-   * Skip TLS verification (development only)
-   *
-   * @generated from field: bool skip_verify = 3;
-   */
-  skipVerify: boolean;
 };
 
 /**

--- a/go/client.go
+++ b/go/client.go
@@ -218,16 +218,6 @@ func WithMTLSFromPEMAndSystemRoots(certPEM, keyPEM, caPEM []byte) (ClientOption,
 	}}, nil
 }
 
-// WithInsecureSkipVerify disables TLS certificate verification.
-// WARNING: Only use this for development/testing!
-func WithInsecureSkipVerify() ClientOption {
-	return &funcOption{func(c *Client, httpClient **http.Client) {
-		*httpClient = newHTTPClientWithTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-	}}
-}
-
 // newHTTPClientWithTLS creates an HTTP client with HTTP/2 support enabled.
 // A bare http.Transport with a custom TLSClientConfig disables Go's automatic
 // HTTP/2 negotiation, so we explicitly configure it via http2.ConfigureTransport.

--- a/proto/pm/v1/device_auth.proto
+++ b/proto/pm/v1/device_auth.proto
@@ -30,7 +30,8 @@ message EnrollRequest {
   string server_url = 1;   // Control server URL
   // @gotags: validate:"required"
   string token = 2;        // Registration token from web UI
-  bool skip_verify = 3;    // Skip TLS verification (development only)
+  reserved 3;              // was bool skip_verify; removed in 2026.05 (TLS bypass is not supported)
+  reserved "skip_verify";
 }
 
 message EnrollResponse {


### PR DESCRIPTION
## Summary

Two paths previously allowed bypassing TLS certificate verification in agent-facing flows. Both are removed together so the SDK has no remaining \"disable TLS\" surface.

- **\`EnrollRequest.skip_verify\` proto field** — development-only escape hatch for agents to skip certificate validation during enrollment. Agent PR #61 stopped exposing it on the CLI and started rejecting requests that set it, so the only remaining wire usage was defensive code for a setting we never want anyone to set. Removed via \`reserved 3; reserved \"skip_verify\";\` so the field number can't be reused.
- **\`sdk.WithInsecureSkipVerify()\`** — constructed a \`*tls.Config{InsecureSkipVerify: true}\` *without* setting \`MinVersion\`, so a caller using it also got a silent downgrade to TLS 1.0 acceptance. Both bypasses go in one PR.

Callers who genuinely need a custom TLS config can still use \`WithTLSConfig(*tls.Config)\` with their own \`MinVersion\`.

## Test plan

- [x] \`go build ./...\` clean across SDK + server (workspace).
- [x] \`go test ./...\` clean in SDK.
- [x] sdk \`make generate\` clean (proto reserved-field marker present in generated Go).
- [x] No remaining \`SkipVerify\` references in SDK source (grep clean ex generated dirs).

## Coordination

Agent PR follows after this lands — it drops the now-dead \`SkipVerify\` rejection check in \`internal/deviceauth/enroll.go\` and bumps the SDK pin in \`go.mod\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the ability to skip TLS certificate verification in client connections and device enrollment. Applications relying on this insecure option must transition to standard TLS certificate verification through alternative configuration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->