### PR TITLE
feat: AtomicWriteFile in sys/fs for in-process atomic writes

### DIFF
--- a/go/sys/fs/atomic_write.go
+++ b/go/sys/fs/atomic_write.go
@@ -1,0 +1,77 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to path via a same-directory temp file
+// followed by chmod + fsync + rename + directory fsync. Use it for
+// any file where a half-written state would corrupt downstream
+// readers (credentials, secrets, durable state files, etc.).
+//
+// Behaviour notes:
+//   - The temp file is created in the SAME directory as path so the
+//     final os.Rename is a same-filesystem operation (atomic on
+//     POSIX). Cross-filesystem renames degrade to copy+delete and
+//     defeat the purpose.
+//   - perm is applied to the temp file BEFORE the rename so the
+//     final inode carries the intended mode from the first moment
+//     it is reachable by name. Callers passing 0600 for secret
+//     files therefore never observe a wider mode mid-write.
+//   - The directory is fsync'd after the rename so a crash before
+//     the next sync still recovers the new inode by name. The
+//     directory-sync error is intentionally ignored — exotic
+//     filesystems return ENOSYS for directory fsync, but the
+//     rename itself has already completed.
+//   - On any failure path the temp file is removed so callers do
+//     not accumulate `.tmp-*` clutter in the data directory.
+//
+// Unlike the privileged operations elsewhere in this package, this
+// function does NOT shell out to sudo — the caller's process must
+// already have write permission on path's directory. That makes it
+// suitable for agent-local data dirs and CLI-installed config
+// files but not for system paths owned by root. For atomic writes
+// to root-owned paths, use WriteFileAtomic in this package — it
+// shells out to sudo tee + chmod + mv and accepts owner/group.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/go/sys/fs/atomic_write.go
+++ b/go/sys/fs/atomic_write.go
@@ -1,3 +1,12 @@
+//go:build unix
+
+// Atomicity here depends on POSIX rename(2) (same-filesystem rename
+// is atomic) and on the ability to fsync a directory file
+// descriptor. Neither holds on Windows, where this function would
+// still execute but lose the contract callers depend on. Restrict
+// it to Unix targets so misuse fails at build time rather than
+// silently producing non-atomic writes.
+
 package fs
 
 import (

--- a/go/sys/fs/atomic_write_test.go
+++ b/go/sys/fs/atomic_write_test.go
@@ -1,0 +1,84 @@
+package fs
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAtomicWriteFile_WritesAndReplaces covers the success paths: first
+// write creates the file; a subsequent write replaces it
+// atomically without leaving behind the temp file.
+func TestAtomicWriteFile_WritesAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "creds.enc")
+
+	if err := AtomicWriteFile(target, []byte("v1"), 0600); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("got %q, want %q", got, "v1")
+	}
+
+	if err := AtomicWriteFile(target, []byte("v2"), 0600); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Fatalf("got %q, want %q", got, "v2")
+	}
+
+	// No leftover temp files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "creds.enc" {
+			t.Errorf("unexpected leftover: %q", e.Name())
+		}
+	}
+}
+
+// TestAtomicWriteFile_AppliesMode asserts the final file carries the
+// requested permissions — secret-bearing files must be 0600 the
+// moment they become visible under the target name, not briefly
+// world-readable.
+func TestAtomicWriteFile_AppliesMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "salt")
+
+	if err := AtomicWriteFile(target, []byte("secret"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+// TestAtomicWriteFile_WriteFailsNoLeftover is the reliability guarantee:
+// a failed write into a nonexistent directory must NOT leave a
+// temp file somewhere for a future operator to stumble over.
+func TestAtomicWriteFile_WriteFailsNoLeftover(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist", "creds.enc")
+	if err := AtomicWriteFile(missing, []byte("x"), 0600); err == nil {
+		t.Fatal("expected error writing into nonexistent directory")
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		t.Errorf("unexpected artifact in %s: %s", dir, e.Name())
+	}
+}

--- a/go/sys/fs/atomic_write_test.go
+++ b/go/sys/fs/atomic_write_test.go
@@ -1,3 +1,9 @@
+//go:build unix
+
+// Mirrors the build tag on atomic_write.go — the test references
+// AtomicWriteFile directly, so it would fail to compile on
+// non-Unix targets.
+
 package fs
 
 import (
@@ -77,7 +83,10 @@ func TestAtomicWriteFile_WriteFailsNoLeftover(t *testing.T) {
 	if err := AtomicWriteFile(missing, []byte("x"), 0600); err == nil {
 		t.Fatal("expected error writing into nonexistent directory")
 	}
-	entries, _ := os.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
 	for _, e := range entries {
 		t.Errorf("unexpected artifact in %s: %s", dir, e.Name())
 	}


### PR DESCRIPTION
## Summary

Lifts the agent's internal \`atomicWriteFile\` (currently in \`internal/credentials/credentials.go\`) into the SDK so callers that need a single-process atomic write (credentials, secrets, durable state) don't have to re-implement the create-temp + chmod + fsync + rename + dir-fsync dance.

Distinct from this package's existing \`WriteFileAtomic\`, which shells out to sudo tee + chmod + mv for system paths owned by root. Naming is called out in the doc so callers pick the right one:

- \`AtomicWriteFile(path, data, perm)\` — in-process, no sudo, for paths the calling process can already write to.
- \`WriteFileAtomic(ctx, path, content, mode, owner, group)\` — sudo-based, for system paths.

Tests cover the three guarantees the agent's existing test file exercised:
1. Basic write + replace
2. Mode application (final inode visible at requested perm)
3. No leftover \`.tmp-*\` artifact when the underlying open fails

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./go/sys/fs/...\` clean.

## Coordination

Coordinated agent change (replace the local \`atomicWriteFile\` with \`fs.AtomicWriteFile\`, drop the local impl + tests, bump SDK pin) follows in a separate PR after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic file-write support (Unix): writes via a same-directory temporary file, applies requested permissions, atomically replaces the target, ensures cleanup of temp artifacts, and performs final directory synchronization.

* **Tests**
  * Added tests covering successful write-and-replace, permission preservation, and error behavior when the target directory is missing (verifying no leftover temporary files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->