### PR TITLE
docs: fix misleading SCHEDULED/CANCELLED proto comments (no Schedule/Cancel-OneShotDispatch RPCs exist)

### DIFF
--- a/gen/go/pm/v1/common.pb.go
+++ b/gen/go/pm/v1/common.pb.go
@@ -32,14 +32,15 @@ const (
 	ExecutionStatus_EXECUTION_STATUS_FAILED      ExecutionStatus = 4
 	ExecutionStatus_EXECUTION_STATUS_SKIPPED     ExecutionStatus = 5
 	ExecutionStatus_EXECUTION_STATUS_TIMEOUT     ExecutionStatus = 6
-	// Queued for delayed dispatch via ControlService.ScheduleOneShotDispatch.
-	// Transitions to PENDING / RUNNING when the deferred Asynq task fires
-	// at run_at, then onward to a terminal status the same way as any
-	// other execution.
+	// Queued for delayed dispatch — the Dispatch* request carried a
+	// run_at timestamp, so the server enqueued the Asynq task at that
+	// future time. Transitions to PENDING / RUNNING when the deferred
+	// task fires, then onward to a terminal status the same way as
+	// any other execution.
 	ExecutionStatus_EXECUTION_STATUS_SCHEDULED ExecutionStatus = 7
 	// Operator cancelled the scheduled dispatch via
-	// ControlService.CancelOneShotDispatch before it fired. Cancellation
-	// is a no-op past the moment of dispatch — once status leaves
+	// ControlService.CancelExecution before it fired. Cancellation is
+	// a no-op past the moment of dispatch — once status leaves
 	// SCHEDULED, the execution runs to completion as normal.
 	ExecutionStatus_EXECUTION_STATUS_CANCELLED ExecutionStatus = 8
 )

--- a/gen/go/pm/v1/common.pb.go
+++ b/gen/go/pm/v1/common.pb.go
@@ -33,10 +33,10 @@ const (
 	ExecutionStatus_EXECUTION_STATUS_SKIPPED     ExecutionStatus = 5
 	ExecutionStatus_EXECUTION_STATUS_TIMEOUT     ExecutionStatus = 6
 	// Queued for delayed dispatch — the Dispatch* request carried a
-	// run_at timestamp, so the server enqueued the Asynq task at that
-	// future time. Transitions to PENDING / RUNNING when the deferred
-	// task fires, then onward to a terminal status the same way as
-	// any other execution.
+	// run_at timestamp, so the server deferred the dispatch until
+	// that future time. Transitions to PENDING / RUNNING when the
+	// deferred task fires, then onward to a terminal status the same
+	// way as any other execution.
 	ExecutionStatus_EXECUTION_STATUS_SCHEDULED ExecutionStatus = 7
 	// Operator cancelled the dispatch via
 	// ControlService.CancelExecution. CancelExecution acts only

--- a/gen/go/pm/v1/common.pb.go
+++ b/gen/go/pm/v1/common.pb.go
@@ -38,10 +38,12 @@ const (
 	// task fires, then onward to a terminal status the same way as
 	// any other execution.
 	ExecutionStatus_EXECUTION_STATUS_SCHEDULED ExecutionStatus = 7
-	// Operator cancelled the scheduled dispatch via
-	// ControlService.CancelExecution before it fired. Cancellation is
-	// a no-op past the moment of dispatch — once status leaves
-	// SCHEDULED, the execution runs to completion as normal.
+	// Operator cancelled the dispatch via
+	// ControlService.CancelExecution. CancelExecution acts only
+	// while the execution is still in SCHEDULED or PENDING — once
+	// the agent has picked it up (RUNNING) or it has reached a
+	// terminal status, the cancel is a no-op and the row keeps its
+	// observed outcome.
 	ExecutionStatus_EXECUTION_STATUS_CANCELLED ExecutionStatus = 8
 )
 

--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -11163,7 +11163,7 @@ type ActionExecution struct {
 	// UTC timestamp at which the deferred dispatch is configured to
 	// fire. Populated when a Dispatch* request supplies the run_at
 	// field — DispatchActionRequest, DispatchInstantActionRequest,
-	// and friends — so the server can defer the Asynq task until the
+	// and friends — so the server can defer the dispatch until the
 	// operator-chosen time.
 	ScheduledFor  *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=scheduled_for,json=scheduledFor,proto3" json:"scheduled_for,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -11348,11 +11348,10 @@ type DispatchActionRequest struct {
 	// running it immediately. The execution record is created up front
 	// with status SCHEDULED so the operator can see the pending dispatch
 	// in the execution-history UI before it fires; on run_at the
-	// deferred Asynq task hits the standard dispatch path and the
-	// execution transitions through PENDING / RUNNING / SUCCESS the
-	// same as any immediate dispatch. Cancelable via CancelExecution
-	// until the dispatch fires. Must be in the future at scheduling
-	// time. See manchtools/power-manage-server#57.
+	// deferred dispatch hits the standard path and the execution
+	// transitions through PENDING / RUNNING / SUCCESS the same as any
+	// immediate dispatch. Cancelable via CancelExecution until the
+	// dispatch fires. Must be in the future at scheduling time.
 	RunAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=run_at,json=runAt,proto3" json:"run_at,omitempty"`
 	// When true, the dispatched action still respects the device's
 	// maintenance window if the device has one configured. The default

--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -11161,9 +11161,10 @@ type ActionExecution struct {
 	ActionName      string                 `protobuf:"bytes,18,opt,name=action_name,json=actionName,proto3" json:"action_name,omitempty"`                                // Resolved from actions_projection (empty for inline actions)
 	// Set when status is SCHEDULED (or was, before dispatch fired). The
 	// UTC timestamp at which the deferred dispatch is configured to
-	// fire. Populated by ControlService.ScheduleOneShotDispatch / the
-	// deferred path of DispatchAction. See
-	// manchtools/power-manage-server#57.
+	// fire. Populated when a Dispatch* request supplies the run_at
+	// field — DispatchActionRequest, DispatchInstantActionRequest,
+	// and friends — so the server can defer the Asynq task until the
+	// operator-chosen time.
 	ScheduledFor  *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=scheduled_for,json=scheduledFor,proto3" json:"scheduled_for,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -11349,9 +11349,11 @@ type DispatchActionRequest struct {
 	// with status SCHEDULED so the operator can see the pending dispatch
 	// in the execution-history UI before it fires; on run_at the
 	// deferred dispatch hits the standard path and the execution
-	// transitions through PENDING / RUNNING / SUCCESS the same as any
-	// immediate dispatch. Cancelable via CancelExecution until the
-	// dispatch fires. Must be in the future at scheduling time.
+	// transitions through PENDING / RUNNING and then onward to a
+	// terminal status (SUCCESS, FAILED, TIMEOUT, SKIPPED, or
+	// CANCELLED) the same as any immediate dispatch. Cancelable via
+	// CancelExecution until the dispatch fires. Must be in the future
+	// at scheduling time.
 	RunAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=run_at,json=runAt,proto3" json:"run_at,omitempty"`
 	// When true, the dispatched action still respects the device's
 	// maintenance window if the device has one configured. The default

--- a/gen/ts/pm/v1/common_pb.ts
+++ b/gen/ts/pm/v1/common_pb.ts
@@ -229,10 +229,11 @@ export enum ExecutionStatus {
   TIMEOUT = 6,
 
   /**
-   * Queued for delayed dispatch via ControlService.ScheduleOneShotDispatch.
-   * Transitions to PENDING / RUNNING when the deferred Asynq task fires
-   * at run_at, then onward to a terminal status the same way as any
-   * other execution.
+   * Queued for delayed dispatch — the Dispatch* request carried a
+   * run_at timestamp, so the server enqueued the Asynq task at that
+   * future time. Transitions to PENDING / RUNNING when the deferred
+   * task fires, then onward to a terminal status the same way as
+   * any other execution.
    *
    * @generated from enum value: EXECUTION_STATUS_SCHEDULED = 7;
    */
@@ -240,8 +241,8 @@ export enum ExecutionStatus {
 
   /**
    * Operator cancelled the scheduled dispatch via
-   * ControlService.CancelOneShotDispatch before it fired. Cancellation
-   * is a no-op past the moment of dispatch — once status leaves
+   * ControlService.CancelExecution before it fired. Cancellation is
+   * a no-op past the moment of dispatch — once status leaves
    * SCHEDULED, the execution runs to completion as normal.
    *
    * @generated from enum value: EXECUTION_STATUS_CANCELLED = 8;

--- a/gen/ts/pm/v1/common_pb.ts
+++ b/gen/ts/pm/v1/common_pb.ts
@@ -230,10 +230,10 @@ export enum ExecutionStatus {
 
   /**
    * Queued for delayed dispatch — the Dispatch* request carried a
-   * run_at timestamp, so the server enqueued the Asynq task at that
-   * future time. Transitions to PENDING / RUNNING when the deferred
-   * task fires, then onward to a terminal status the same way as
-   * any other execution.
+   * run_at timestamp, so the server deferred the dispatch until
+   * that future time. Transitions to PENDING / RUNNING when the
+   * deferred task fires, then onward to a terminal status the same
+   * way as any other execution.
    *
    * @generated from enum value: EXECUTION_STATUS_SCHEDULED = 7;
    */

--- a/gen/ts/pm/v1/common_pb.ts
+++ b/gen/ts/pm/v1/common_pb.ts
@@ -240,10 +240,12 @@ export enum ExecutionStatus {
   SCHEDULED = 7,
 
   /**
-   * Operator cancelled the scheduled dispatch via
-   * ControlService.CancelExecution before it fired. Cancellation is
-   * a no-op past the moment of dispatch — once status leaves
-   * SCHEDULED, the execution runs to completion as normal.
+   * Operator cancelled the dispatch via
+   * ControlService.CancelExecution. CancelExecution acts only
+   * while the execution is still in SCHEDULED or PENDING — once
+   * the agent has picked it up (RUNNING) or it has reached a
+   * terminal status, the cancel is a no-op and the row keeps its
+   * observed outcome.
    *
    * @generated from enum value: EXECUTION_STATUS_CANCELLED = 8;
    */

--- a/gen/ts/pm/v1/control_pb.ts
+++ b/gen/ts/pm/v1/control_pb.ts
@@ -5443,7 +5443,7 @@ export type ActionExecution = Message<"pm.v1.ActionExecution"> & {
    * UTC timestamp at which the deferred dispatch is configured to
    * fire. Populated when a Dispatch* request supplies the run_at
    * field — DispatchActionRequest, DispatchInstantActionRequest,
-   * and friends — so the server can defer the Asynq task until the
+   * and friends — so the server can defer the dispatch until the
    * operator-chosen time.
    *
    * @generated from field: google.protobuf.Timestamp scheduled_for = 19;
@@ -5497,11 +5497,10 @@ export type DispatchActionRequest = Message<"pm.v1.DispatchActionRequest"> & {
    * running it immediately. The execution record is created up front
    * with status SCHEDULED so the operator can see the pending dispatch
    * in the execution-history UI before it fires; on run_at the
-   * deferred Asynq task hits the standard dispatch path and the
-   * execution transitions through PENDING / RUNNING / SUCCESS the
-   * same as any immediate dispatch. Cancelable via CancelExecution
-   * until the dispatch fires. Must be in the future at scheduling
-   * time. See manchtools/power-manage-server#57.
+   * deferred dispatch hits the standard path and the execution
+   * transitions through PENDING / RUNNING / SUCCESS the same as any
+   * immediate dispatch. Cancelable via CancelExecution until the
+   * dispatch fires. Must be in the future at scheduling time.
    *
    * @generated from field: google.protobuf.Timestamp run_at = 4;
    */

--- a/gen/ts/pm/v1/control_pb.ts
+++ b/gen/ts/pm/v1/control_pb.ts
@@ -5498,9 +5498,11 @@ export type DispatchActionRequest = Message<"pm.v1.DispatchActionRequest"> & {
    * with status SCHEDULED so the operator can see the pending dispatch
    * in the execution-history UI before it fires; on run_at the
    * deferred dispatch hits the standard path and the execution
-   * transitions through PENDING / RUNNING / SUCCESS the same as any
-   * immediate dispatch. Cancelable via CancelExecution until the
-   * dispatch fires. Must be in the future at scheduling time.
+   * transitions through PENDING / RUNNING and then onward to a
+   * terminal status (SUCCESS, FAILED, TIMEOUT, SKIPPED, or
+   * CANCELLED) the same as any immediate dispatch. Cancelable via
+   * CancelExecution until the dispatch fires. Must be in the future
+   * at scheduling time.
    *
    * @generated from field: google.protobuf.Timestamp run_at = 4;
    */

--- a/gen/ts/pm/v1/control_pb.ts
+++ b/gen/ts/pm/v1/control_pb.ts
@@ -5441,9 +5441,10 @@ export type ActionExecution = Message<"pm.v1.ActionExecution"> & {
   /**
    * Set when status is SCHEDULED (or was, before dispatch fired). The
    * UTC timestamp at which the deferred dispatch is configured to
-   * fire. Populated by ControlService.ScheduleOneShotDispatch / the
-   * deferred path of DispatchAction. See
-   * manchtools/power-manage-server#57.
+   * fire. Populated when a Dispatch* request supplies the run_at
+   * field — DispatchActionRequest, DispatchInstantActionRequest,
+   * and friends — so the server can defer the Asynq task until the
+   * operator-chosen time.
    *
    * @generated from field: google.protobuf.Timestamp scheduled_for = 19;
    */

--- a/proto/pm/v1/common.proto
+++ b/proto/pm/v1/common.proto
@@ -31,10 +31,12 @@ enum ExecutionStatus {
   // task fires, then onward to a terminal status the same way as
   // any other execution.
   EXECUTION_STATUS_SCHEDULED = 7;
-  // Operator cancelled the scheduled dispatch via
-  // ControlService.CancelExecution before it fired. Cancellation is
-  // a no-op past the moment of dispatch — once status leaves
-  // SCHEDULED, the execution runs to completion as normal.
+  // Operator cancelled the dispatch via
+  // ControlService.CancelExecution. CancelExecution acts only
+  // while the execution is still in SCHEDULED or PENDING — once
+  // the agent has picked it up (RUNNING) or it has reached a
+  // terminal status, the cancel is a no-op and the row keeps its
+  // observed outcome.
   EXECUTION_STATUS_CANCELLED = 8;
 }
 

--- a/proto/pm/v1/common.proto
+++ b/proto/pm/v1/common.proto
@@ -25,14 +25,15 @@ enum ExecutionStatus {
   EXECUTION_STATUS_FAILED = 4;
   EXECUTION_STATUS_SKIPPED = 5;
   EXECUTION_STATUS_TIMEOUT = 6;
-  // Queued for delayed dispatch via ControlService.ScheduleOneShotDispatch.
-  // Transitions to PENDING / RUNNING when the deferred Asynq task fires
-  // at run_at, then onward to a terminal status the same way as any
-  // other execution.
+  // Queued for delayed dispatch — the Dispatch* request carried a
+  // run_at timestamp, so the server enqueued the Asynq task at that
+  // future time. Transitions to PENDING / RUNNING when the deferred
+  // task fires, then onward to a terminal status the same way as
+  // any other execution.
   EXECUTION_STATUS_SCHEDULED = 7;
   // Operator cancelled the scheduled dispatch via
-  // ControlService.CancelOneShotDispatch before it fired. Cancellation
-  // is a no-op past the moment of dispatch — once status leaves
+  // ControlService.CancelExecution before it fired. Cancellation is
+  // a no-op past the moment of dispatch — once status leaves
   // SCHEDULED, the execution runs to completion as normal.
   EXECUTION_STATUS_CANCELLED = 8;
 }

--- a/proto/pm/v1/common.proto
+++ b/proto/pm/v1/common.proto
@@ -26,10 +26,10 @@ enum ExecutionStatus {
   EXECUTION_STATUS_SKIPPED = 5;
   EXECUTION_STATUS_TIMEOUT = 6;
   // Queued for delayed dispatch — the Dispatch* request carried a
-  // run_at timestamp, so the server enqueued the Asynq task at that
-  // future time. Transitions to PENDING / RUNNING when the deferred
-  // task fires, then onward to a terminal status the same way as
-  // any other execution.
+  // run_at timestamp, so the server deferred the dispatch until
+  // that future time. Transitions to PENDING / RUNNING when the
+  // deferred task fires, then onward to a terminal status the same
+  // way as any other execution.
   EXECUTION_STATUS_SCHEDULED = 7;
   // Operator cancelled the dispatch via
   // ControlService.CancelExecution. CancelExecution acts only

--- a/proto/pm/v1/control.proto
+++ b/proto/pm/v1/control.proto
@@ -1411,7 +1411,7 @@ message ActionExecution {
   // UTC timestamp at which the deferred dispatch is configured to
   // fire. Populated when a Dispatch* request supplies the run_at
   // field — DispatchActionRequest, DispatchInstantActionRequest,
-  // and friends — so the server can defer the Asynq task until the
+  // and friends — so the server can defer the dispatch until the
   // operator-chosen time.
   google.protobuf.Timestamp scheduled_for = 19;
 }
@@ -1429,11 +1429,10 @@ message DispatchActionRequest {
   // running it immediately. The execution record is created up front
   // with status SCHEDULED so the operator can see the pending dispatch
   // in the execution-history UI before it fires; on run_at the
-  // deferred Asynq task hits the standard dispatch path and the
-  // execution transitions through PENDING / RUNNING / SUCCESS the
-  // same as any immediate dispatch. Cancelable via CancelExecution
-  // until the dispatch fires. Must be in the future at scheduling
-  // time. See manchtools/power-manage-server#57.
+  // deferred dispatch hits the standard path and the execution
+  // transitions through PENDING / RUNNING / SUCCESS the same as any
+  // immediate dispatch. Cancelable via CancelExecution until the
+  // dispatch fires. Must be in the future at scheduling time.
   google.protobuf.Timestamp run_at = 4;
   // When true, the dispatched action still respects the device's
   // maintenance window if the device has one configured. The default

--- a/proto/pm/v1/control.proto
+++ b/proto/pm/v1/control.proto
@@ -1409,9 +1409,10 @@ message ActionExecution {
   string action_name = 18;  // Resolved from actions_projection (empty for inline actions)
   // Set when status is SCHEDULED (or was, before dispatch fired). The
   // UTC timestamp at which the deferred dispatch is configured to
-  // fire. Populated by ControlService.ScheduleOneShotDispatch / the
-  // deferred path of DispatchAction. See
-  // manchtools/power-manage-server#57.
+  // fire. Populated when a Dispatch* request supplies the run_at
+  // field — DispatchActionRequest, DispatchInstantActionRequest,
+  // and friends — so the server can defer the Asynq task until the
+  // operator-chosen time.
   google.protobuf.Timestamp scheduled_for = 19;
 }
 

--- a/proto/pm/v1/control.proto
+++ b/proto/pm/v1/control.proto
@@ -1430,9 +1430,11 @@ message DispatchActionRequest {
   // with status SCHEDULED so the operator can see the pending dispatch
   // in the execution-history UI before it fires; on run_at the
   // deferred dispatch hits the standard path and the execution
-  // transitions through PENDING / RUNNING / SUCCESS the same as any
-  // immediate dispatch. Cancelable via CancelExecution until the
-  // dispatch fires. Must be in the future at scheduling time.
+  // transitions through PENDING / RUNNING and then onward to a
+  // terminal status (SUCCESS, FAILED, TIMEOUT, SKIPPED, or
+  // CANCELLED) the same as any immediate dispatch. Cancelable via
+  // CancelExecution until the dispatch fires. Must be in the future
+  // at scheduling time.
   google.protobuf.Timestamp run_at = 4;
   // When true, the dispatched action still respects the device's
   // maintenance window if the device has one configured. The default


### PR DESCRIPTION
## Summary

External self-review pointed out that the proto comments for the \`SCHEDULED\` + \`CANCELLED\` execution-status enum values and for \`ActionExecution.scheduled_for\` reference RPCs that don't exist in \`ControlService\`:

- **\`ScheduleOneShotDispatch\`** — fictional. Deferred dispatch happens via the \`run_at\` field on the regular \`Dispatch*\` requests (\`DispatchActionRequest\`, \`DispatchInstantActionRequest\`, etc.). The server enqueues the Asynq task at the supplied timestamp.
- **\`CancelOneShotDispatch\`** — also fictional. The cancellation path is \`ControlService.CancelExecution\`.

Verified against the server's actual handlers:

- \`server/internal/api/action_handler.go:925\` (DispatchAction sets \`scheduled_for\` from \`req.Msg.RunAt\`)
- \`server/internal/api/action_handler.go:1431\` (DispatchInstantAction same)
- \`server/internal/api/action_handler.go:1812\` (response mapping)
- \`sdk/proto/pm/v1/control.proto\` rpc declarations (no Schedule/Cancel one-shot RPCs anywhere)

Doc-only fix to the three affected comment blocks. Generated Go + TS bindings re-emit the corrected comments.

## Test plan

- [x] \`make generate\` clean.
- [x] \`go build ./...\` clean.
- [x] No \`ScheduleOneShotDispatch\` or \`CancelOneShotDispatch\` strings remain in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that deferred dispatches are scheduled using a specified UTC timestamp (run_at) provided with dispatch requests.
  * Clarified how that timestamp is interpreted and enforced (must be in the future at scheduling time).
  * Clarified that deferred executions enter the standard lifecycle and state transitions once the dispatch fires.
  * Clarified cancellation behavior: cancels only take effect while an execution remains in pre-execution states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->