### PR TITLE
fix(pkg): runPM must surface non-zero exit codes as errors

### DIFF
--- a/go/pkg/exec.go
+++ b/go/pkg/exec.go
@@ -17,6 +17,7 @@ package pkg
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -49,6 +50,16 @@ func readCmd(ctx context.Context, name string, args ...string) *exec.Cmd {
 // backend (sudo or doas, see exec.SetPrivilegeBackend). Both paths share
 // the same env / output capture / exit code recording so callers see a
 // uniform CommandResult regardless of escalation.
+//
+// Non-zero exit codes are surfaced as errors (and CommandResult.Success
+// is false) even when the underlying go-cmd library reports a clean
+// status. The pre-runPM shape used os/exec.Cmd.Run, which returned an
+// *exec.ExitError on non-zero exit; the go-cmd library does not, so
+// without this synthesised error the agent would treat
+// `apt install <nonexistent-package>` (exits 100) as a successful
+// install. PR #57 of the cleanup release shipped that regression;
+// callers (Apt.Install / Dnf.Install / etc.) check err and Success to
+// decide between EXECUTION_STATUS_SUCCESS and EXECUTION_STATUS_FAILED.
 func runPM(ctx context.Context, useSudo bool, name string, args []string, envVars []string) (*CommandResult, error) {
 	start := time.Now()
 
@@ -68,13 +79,17 @@ func runPM(ctx context.Context, useSudo bool, name string, args []string, envVar
 		result.Stderr = res.Stderr
 		result.ExitCode = res.ExitCode
 	}
+	if err == nil && result.ExitCode != 0 {
+		err = fmt.Errorf("%s exited with status %d", name, result.ExitCode)
+	}
 	result.Success = err == nil
 	return result, err
 }
 
 // runPMWithStdin is the stdin-bearing companion of runPM. It dispatches
 // through PrivilegedWithStdin / RunWithStdin instead of the streaming
-// variants (which do not accept stdin).
+// variants (which do not accept stdin). Non-zero exit codes are
+// surfaced as errors for the same reason as runPM.
 func runPMWithStdin(ctx context.Context, useSudo bool, stdin string, name string, args ...string) (*CommandResult, error) {
 	start := time.Now()
 	var reader io.Reader
@@ -97,6 +112,9 @@ func runPMWithStdin(ctx context.Context, useSudo bool, stdin string, name string
 		result.Stdout = res.Stdout
 		result.Stderr = res.Stderr
 		result.ExitCode = res.ExitCode
+	}
+	if err == nil && result.ExitCode != 0 {
+		err = fmt.Errorf("%s exited with status %d", name, result.ExitCode)
 	}
 	result.Success = err == nil
 	return result, err


### PR DESCRIPTION
## Summary

PR #57's pkg/* refactor (3dc3090) routed every backend's `run()` through `runPM`, which delegates to `sys/exec.PrivilegedStreaming` / `sys/exec.RunStreaming` (go-cmd library). The old shape used `os/exec.Cmd.Run`, which returns `*exec.ExitError` on non-zero exit codes — the go-cmd library does NOT.

So `runPM` was returning `err=nil` + `Success=true` even when the underlying command exited with a failure code.

Concrete repro: `apt install <nonexistent-package>` exits 100 with "Unable to locate package", but `runPM` returned `Success=true` and the agent reported `EXECUTION_STATUS_SUCCESS` for the install action.

`TestIntegration_Package*/InstallNonExistent` (apt + dnf + pacman + zypper, all 4 distros) on the agent's PR G CI run caught this.

## Fix

Synthesise a non-nil error in `runPM` / `runPMWithStdin` when the underlying call returned cleanly but `ExitCode != 0`:

```go
if err == nil && result.ExitCode != 0 {
    err = fmt.Errorf("%s exited with status %d", name, result.ExitCode)
}
result.Success = err == nil
```

`CommandResult.Success` falls out of `err == nil`, so the existing success-or-failure check at every Apt/Dnf/Pacman/Zypper/Flatpak callsite keeps working without further changes.

## Test plan

- [ ] `go build ./...` — clean locally
- [ ] `go vet ./...` — clean locally
- [ ] `go test -short ./...` — clean locally
- [ ] CI green
- [ ] Agent PR G's `TestIntegration_Package*/InstallNonExistent` should pass after agent re-pins to the merged SHA from this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error handling for package manager commands to properly treat non-zero exit codes as failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->