### PR TITLE
feat(ts/client): wrappers for group-scoped variable RPCs

### DIFF
--- a/ts/client.ts
+++ b/ts/client.ts
@@ -87,6 +87,14 @@ import {
 	SetDeviceGroupSyncIntervalRequestSchema,
 	SetDeviceGroupMaintenanceWindowRequestSchema,
 	SetUserGroupMaintenanceWindowRequestSchema,
+	// Group-scoped variables (manchtools/power-manage-server#59)
+	SetDeviceGroupVariableRequestSchema,
+	DeleteDeviceGroupVariableRequestSchema,
+	GetDeviceGroupVariablesRequestSchema,
+	SetUserGroupVariableRequestSchema,
+	DeleteUserGroupVariableRequestSchema,
+	GetUserGroupVariablesRequestSchema,
+	ListAvailableVariablesRequestSchema,
 	// Assignments
 	CreateAssignmentRequestSchema,
 	DeleteAssignmentRequestSchema,
@@ -238,6 +246,7 @@ import {
 	type ExecutionStatus,
 	ErrorDetailSchema,
 	type MaintenanceWindow,
+	type Variable,
 	AssignmentSourceType,
 	AssignmentTargetType,
 	DeviceStatus,
@@ -1617,6 +1626,70 @@ export class ApiClient {
 			create(SetUserGroupMaintenanceWindowRequestSchema, { id, maintenanceWindow })
 		);
 		return response.group;
+	}
+
+	// ============================================================================
+	// Group-scoped Variables (manchtools/power-manage-server#59)
+	// ============================================================================
+	//
+	// Variables are an array attached to a device-group / user-group
+	// projection row; full-replace by name on Set, idempotent on
+	// Delete. Secret variables flow through the same Variable shape
+	// but the value comes back as `***REDACTED***` from Get; the
+	// renderer materialises plaintext server-side at action dispatch.
+
+	async setDeviceGroupVariable(deviceGroupId: string, variable: Variable) {
+		const client = this.getClient();
+		const response = await client.setDeviceGroupVariable(
+			create(SetDeviceGroupVariableRequestSchema, { deviceGroupId, variable })
+		);
+		return response.variable;
+	}
+
+	async deleteDeviceGroupVariable(deviceGroupId: string, name: string) {
+		const client = this.getClient();
+		await client.deleteDeviceGroupVariable(
+			create(DeleteDeviceGroupVariableRequestSchema, { deviceGroupId, name })
+		);
+	}
+
+	async getDeviceGroupVariables(deviceGroupId: string) {
+		const client = this.getClient();
+		const response = await client.getDeviceGroupVariables(
+			create(GetDeviceGroupVariablesRequestSchema, { deviceGroupId })
+		);
+		return response.variables;
+	}
+
+	async setUserGroupVariable(userGroupId: string, variable: Variable) {
+		const client = this.getClient();
+		const response = await client.setUserGroupVariable(
+			create(SetUserGroupVariableRequestSchema, { userGroupId, variable })
+		);
+		return response.variable;
+	}
+
+	async deleteUserGroupVariable(userGroupId: string, name: string) {
+		const client = this.getClient();
+		await client.deleteUserGroupVariable(
+			create(DeleteUserGroupVariableRequestSchema, { userGroupId, name })
+		);
+	}
+
+	async getUserGroupVariables(userGroupId: string) {
+		const client = this.getClient();
+		const response = await client.getUserGroupVariables(
+			create(GetUserGroupVariablesRequestSchema, { userGroupId })
+		);
+		return response.variables;
+	}
+
+	async listAvailableVariables(deviceId: string) {
+		const client = this.getClient();
+		const response = await client.listAvailableVariables(
+			create(ListAvailableVariablesRequestSchema, { deviceId })
+		);
+		return response.variables;
 	}
 
 	// ============================================================================


### PR DESCRIPTION
## Summary

Adds the seven TS client wrappers consumed by web ticket D
(manchtools/power-manage-server#59) for group-based variables:

- setDeviceGroupVariable / deleteDeviceGroupVariable / getDeviceGroupVariables
- setUserGroupVariable / deleteUserGroupVariable / getUserGroupVariables
- listAvailableVariables (for action-form autocomplete)

Mirrors the existing wrapper shape (Schema-typed request via
\`@bufbuild/protobuf\`'s \`create()\`, return the typed response
field, throw on RPC error). No other surface affected.

## Test plan

- [x] \`npm run check\` clean in web (which type-checks against this client.ts via the workspace alias)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group-scoped variables now supported for both device groups and user groups.
  * Manage device group variables with set, delete, and retrieve operations.
  * Manage user group variables with set, delete, and retrieve operations.
  * View variables available to individual devices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->