### PR TITLE
build: gofmt -w gen/go after protoc to keep gen files clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate generate-go generate-ts clean install-tools
+.PHONY: generate generate-go generate-ts gofmt-gen clean install-tools
 
 # Proto source directory
 PROTO_DIR := proto
@@ -10,7 +10,15 @@ install-tools:
 	go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
 	go install github.com/favadi/protoc-go-inject-tag@latest
 
-generate: generate-go inject-tags generate-ts
+generate: generate-go inject-tags gofmt-gen generate-ts
+
+# protoc-go-inject-tag rewrites struct tags but does NOT re-run gofmt
+# afterwards, so its output can leave the generated .pb.go files with
+# multi-field struct alignment that gofmt -l flags. Run gofmt -w over
+# the gen directory once at the end of the Go pipeline to keep the
+# committed gen files clean against `gofmt -l ./...`.
+gofmt-gen:
+	gofmt -w $(GEN_DIR)/go
 
 generate-go:
 	@mkdir -p $(GEN_DIR)/go/pm/v1

--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -4114,8 +4114,8 @@ type CreateTokenRequest struct {
 	Name    string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty" validate:"required,min=1,max=128"`
 	OneTime bool   `protobuf:"varint,2,opt,name=one_time,json=oneTime,proto3" json:"one_time,omitempty"`
 	// @gotags: validate:"omitempty,min=0"
-	MaxUses   int32                  `protobuf:"varint,3,opt,name=max_uses,json=maxUses,proto3" json:"max_uses,omitempty" validate:"omitempty,min=0"`      // 0 = unlimited (for reusable tokens)
-	ExpiresAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"` // optional
+	MaxUses   int32                  `protobuf:"varint,3,opt,name=max_uses,json=maxUses,proto3" json:"max_uses,omitempty" validate:"omitempty,min=0"` // 0 = unlimited (for reusable tokens)
+	ExpiresAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`                       // optional
 	// Optional. When set to a user ID, devices enrolled through this
 	// token are auto-assigned to that user. When empty, the token is
 	// ownerless — no auto-assignment happens, suitable for bulk/imaging


### PR DESCRIPTION
## Summary
\`protoc-go-inject-tag\` rewrites struct tags but doesn't re-run gofmt afterwards, so its output can leave struct fields with the kind of multi-field tag alignment that \`gofmt -l ./...\` flags. The committed \`control.pb.go\` drifted on the \`CreateTokenRequest\` struct (\`MaxUses\` / \`ExpiresAt\` comment alignment) — pre-existing, but visible after the v2026.06 rollback ran the regen pipeline.

## Change
- New Make target \`gofmt-gen\` runs \`gofmt -w gen/go\` between \`inject-tags\` and \`generate-ts\`.
- Updates the committed \`gen/go/pm/v1/control.pb.go\` to the gofmt-aligned form.

Future regenerations stay deterministically clean against \`gofmt -l ./...\`.

No semantic change — only whitespace inside struct-tag comments.

## Test plan
- [x] \`make generate\` produces no diff from the committed file.
- [x] \`gofmt -l .\` returns nothing across the whole repo.
- [ ] CI gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to automatically ensure consistent code formatting in generated artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/65)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->