### PR TITLE
fix(validate): ToSnakeCase handles acronyms (#140)

### DIFF
--- a/go/validate/validate.go
+++ b/go/validate/validate.go
@@ -87,14 +87,44 @@ func FormatFieldError(e validator.FieldError) string {
 }
 
 // ToSnakeCase converts a PascalCase or camelCase string to snake_case.
+// Handles acronyms correctly: `UserID` → `user_id`, `HTTPStatusCode` →
+// `http_status_code`. The previous shape walked uppercase letters one
+// at a time, producing `user_i_d` / `h_t_t_p_status_code` — neither
+// of those matches any Go-stdlib convention and the result leaks into
+// validation error messages users see (#140).
+//
+// Rule: insert `_` before an uppercase letter at position i > 0 when
+// either of the following transitions holds:
+//  1. previous char is lowercase  → leaving a word, entering an acronym
+//     or a new word: `userID` → `user_ID`, `myValue` → `my_Value`
+//  2. previous char is uppercase AND next char is lowercase
+//     → end of acronym, start of a new
+//     word: `HTTPStatus` → `HTTP_Status`, `userID` keeps `ID` together
+//     because `D` has no lowercase next.
+//
+// Both rules then lowercase the uppercase letter. Digits + non-ASCII
+// runes pass through unchanged (they don't trigger transitions).
 func ToSnakeCase(s string) string {
+	runes := []rune(s)
 	var result strings.Builder
-	for i, r := range s {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteByte('_')
+	result.Grow(len(s) + 4) // small headroom for inserted underscores
+	for i, r := range runes {
+		isUpper := r >= 'A' && r <= 'Z'
+		if i > 0 && isUpper {
+			prev := runes[i-1]
+			prevLower := prev >= 'a' && prev <= 'z'
+			nextLower := false
+			if i+1 < len(runes) {
+				next := runes[i+1]
+				nextLower = next >= 'a' && next <= 'z'
+			}
+			prevUpper := prev >= 'A' && prev <= 'Z'
+			if prevLower || (prevUpper && nextLower) {
+				result.WriteByte('_')
+			}
 		}
-		if r >= 'A' && r <= 'Z' {
-			result.WriteRune(r + 32) // Convert to lowercase
+		if isUpper {
+			result.WriteRune(r + 32) // ASCII-shift to lowercase
 		} else {
 			result.WriteRune(r)
 		}

--- a/go/validate/validate_test.go
+++ b/go/validate/validate_test.go
@@ -79,14 +79,23 @@ func TestStruct_EmptyULID(t *testing.T) {
 }
 
 func TestToSnakeCase(t *testing.T) {
+	// Acronym handling pinned by manchtools/power-manage-server#140 —
+	// the previous shape split contiguous uppercase letters one at a
+	// time (`ServerURL` → `server_u_r_l`), which leaked nonsense into
+	// operator-facing validation error messages. New rule: `_` is
+	// inserted before an uppercase letter only at word boundaries
+	// (lowercase→upper or end-of-acronym), so acronyms ride together.
 	tests := []struct {
 		input string
 		want  string
 	}{
-		{"ServerURL", "server_u_r_l"},
+		{"ServerURL", "server_url"},
 		{"Name", "name"},
 		{"FirstName", "first_name"},
-		{"ID", "i_d"},
+		{"ID", "id"},
+		{"UserID", "user_id"},
+		{"HTTPStatusCode", "http_status_code"},
+		{"IDOnly", "id_only"},
 		{"", ""},
 		{"lowercase", "lowercase"},
 	}

--- a/ts/errors.ts
+++ b/ts/errors.ts
@@ -27,6 +27,7 @@ export const ErrIdentityLinkNotFound = 'identity_link_not_found';
 export const ErrTokenNotFound = 'token_not_found';
 export const ErrExecutionNotFound = 'execution_not_found';
 export const ErrAssignmentNotFound = 'assignment_not_found';
+export const ErrLuksKeyNotFound = 'luks_key_not_found';
 export const ErrEmailAlreadyExists = 'email_already_exists';
 export const ErrUserGroupNameExists = 'user_group_name_exists';
 export const ErrDeviceGroupNameExists = 'device_group_name_exists';


### PR DESCRIPTION
## Summary
Surfaced by CodeRabbit during Bundle A review. The previous shape walked uppercase letters one at a time:

| Input | Old | New |
|---|---|---|
| \`UserID\` | \`user_i_d\` | **\`user_id\`** |
| \`ServerURL\` | \`server_u_r_l\` | **\`server_url\`** |
| \`HTTPStatusCode\` | \`h_t_t_p_status_code\` | **\`http_status_code\`** |
| \`ID\` | \`i_d\` | **\`id\`** |

The old result leaks into operator-facing validation error messages and matches no Go-stdlib convention.

## Rule
Insert \`_\` before an uppercase letter at position i > 0 only at word boundaries:
1. previous char is lowercase → leaving a word, entering an acronym/new word
2. previous is upper AND next is lower → end of acronym, start of new word

Both rules then lowercase the uppercase letter. Acronyms ride together.

## Companion
Server-side test update + SDK pin bump will land in a follow-up server PR (part of the v2026.06 polish batch — server #140 + #143 + #139 + #138 + #137 + #79 + #78 bundled).

## Test plan
- [x] \`go test ./go/validate/\` passes (covers acronym + edge cases)
- [x] \`go vet\` + gofmt clean
- [ ] CI gate

Closes manchtools/power-manage-server#140 (SDK side).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snake_case conversion to correctly handle acronyms and compound words so identifiers convert as expected (e.g., UserID → user_id, HTTPStatusCode → http_status_code).

* **New Features**
  * Added a new exported error code: luks_key_not_found.

* **Tests**
  * Updated and expanded tests to cover acronym-boundary and compound-word scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->