### PR TITLE
feat(sys/desktop): user-scoped action plumbing

### DIFF
--- a/go/sys/desktop/runas.go
+++ b/go/sys/desktop/runas.go
@@ -1,0 +1,68 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// runuserPath pins the absolute path to runuser. Like loginctlPath,
+// pinning sidesteps PATH-injection concerns when the agent runs as
+// root and matches what every supported distro ships.
+const runuserPath = "/usr/sbin/runuser"
+
+// EnvFor builds the minimum environment a user-scoped command needs
+// to behave like it was launched from inside that user's desktop
+// session: HOME, USER, LOGNAME, XDG_RUNTIME_DIR, plus DBUS_SESSION_BUS_ADDRESS
+// (so commands that talk to the user's session bus — Flatpak's
+// notification path, GNOME settings, etc. — find it without falling
+// back to a fresh autolaunched bus).
+//
+// PATH is not added here — callers append it themselves so they can
+// pick a curated value rather than inherit the agent's PATH (which
+// may include /usr/local/sbin and other privileged dirs the user
+// shouldn't reach via subshell expansion).
+func EnvFor(s Session) []string {
+	return []string{
+		"HOME=" + s.Home,
+		"USER=" + s.Username,
+		"LOGNAME=" + s.Username,
+		"XDG_RUNTIME_DIR=" + s.RuntimeDir,
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + s.RuntimeDir + "/bus",
+	}
+}
+
+// RunAsCommand returns an *exec.Cmd that runs `name args...` as the
+// user owning the given session, with the per-user environment from
+// EnvFor plus the caller-supplied extraEnv merged on top.
+//
+// The wrapper is `runuser -u <name> -- <name> <args...>`. We use
+// runuser rather than `sudo -u` because runuser doesn't go through
+// sudoers (no policy to misconfigure, no audit-noise from auth
+// failures) and has been part of util-linux on every supported
+// distro since well before the lowest target.
+//
+// extraEnv may include PATH or anything action-specific; entries win
+// over the per-user defaults if both set the same key (Go's exec
+// honors the last occurrence).
+//
+// Returns an error if name is empty (programming bug) — runuser's
+// own error in that case is a confusing "exec: required") so
+// short-circuit with something meaningful.
+func RunAsCommand(ctx context.Context, s Session, extraEnv []string, name string, args ...string) (*exec.Cmd, error) {
+	if name == "" {
+		return nil, fmt.Errorf("desktop.RunAsCommand: name is required")
+	}
+	if s.Username == "" {
+		return nil, fmt.Errorf("desktop.RunAsCommand: session has empty Username")
+	}
+	full := append([]string{"-u", s.Username, "--", name}, args...)
+	cmd := exec.CommandContext(ctx, runuserPath, full...)
+	// Replace inherited env wholesale — agent's env (LD_PRELOAD,
+	// LD_LIBRARY_PATH, etc.) must not leak into a user-scoped
+	// command. Caller's extraEnv is appended last so it wins on
+	// duplicate keys.
+	cmd.Env = append(EnvFor(s), extraEnv...)
+	cmd.Dir = s.Home
+	return cmd, nil
+}

--- a/go/sys/desktop/runas_test.go
+++ b/go/sys/desktop/runas_test.go
@@ -1,0 +1,129 @@
+package desktop
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunAsCommand_RequiresName(t *testing.T) {
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice"}
+	if _, err := RunAsCommand(context.Background(), s, nil, ""); err == nil {
+		t.Fatal("expected error for empty name — caller bug, runuser would fail with a confusing message")
+	}
+}
+
+func TestRunAsCommand_RequiresUsername(t *testing.T) {
+	s := Session{UID: 1000, Home: "/home/alice"}
+	if _, err := RunAsCommand(context.Background(), s, nil, "/bin/true"); err == nil {
+		t.Fatal("expected error for session with empty Username — would silently run as the agent's own UID")
+	}
+}
+
+func TestRunAsCommand_BuildsRunuserInvocation(t *testing.T) {
+	s := Session{
+		Username:   "alice",
+		UID:        1000,
+		Home:       "/home/alice",
+		RuntimeDir: "/run/user/1000",
+	}
+	cmd, err := RunAsCommand(context.Background(), s, nil, "/usr/bin/flatpak", "--user", "info", "org.example.App")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The wrapper must always go through runuser, never sudo. Pin
+	// the binary path so a refactor toward sudo (which involves
+	// sudoers policy and audit-log noise) is caught here.
+	if cmd.Path != runuserPath {
+		t.Errorf("Path: got %q, want %q (runuser is the only acceptable wrapper)", cmd.Path, runuserPath)
+	}
+
+	wantArgs := []string{runuserPath, "-u", "alice", "--", "/usr/bin/flatpak", "--user", "info", "org.example.App"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("Args length: got %d, want %d (got=%v)", len(cmd.Args), len(wantArgs), cmd.Args)
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Errorf("Args[%d]: got %q, want %q", i, cmd.Args[i], want)
+		}
+	}
+
+	// Working dir must be the user's home so relative-path
+	// commands (e.g. `flatpak --user install some-bundle.flatpak`
+	// when bundle is in $HOME) resolve consistently across users.
+	if cmd.Dir != "/home/alice" {
+		t.Errorf("Dir: got %q, want %q", cmd.Dir, "/home/alice")
+	}
+}
+
+func TestRunAsCommand_EnvIsolatesAgentEnvironment(t *testing.T) {
+	s := Session{
+		Username:   "alice",
+		UID:        1000,
+		Home:       "/home/alice",
+		RuntimeDir: "/run/user/1000",
+	}
+	cmd, err := RunAsCommand(context.Background(), s, []string{"PATH=/usr/bin:/bin", "FLATPAK_USER_DIR=/foo"}, "/bin/true")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Critical: cmd.Env REPLACES the inherited env wholesale —
+	// LD_PRELOAD, LD_LIBRARY_PATH, GOROOT, etc. from the agent
+	// process must NOT leak into the user-scoped command.
+	envSet := make(map[string]string, len(cmd.Env))
+	for _, e := range cmd.Env {
+		eq := strings.IndexByte(e, '=')
+		if eq <= 0 {
+			continue
+		}
+		envSet[e[:eq]] = e[eq+1:]
+	}
+
+	must := map[string]string{
+		"HOME":                     "/home/alice",
+		"USER":                     "alice",
+		"LOGNAME":                  "alice",
+		"XDG_RUNTIME_DIR":          "/run/user/1000",
+		"DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+		"PATH":                     "/usr/bin:/bin",
+		"FLATPAK_USER_DIR":         "/foo",
+	}
+	for k, want := range must {
+		if got := envSet[k]; got != want {
+			t.Errorf("env[%q]: got %q, want %q\nfull env: %v", k, got, want, cmd.Env)
+		}
+	}
+
+	// Negative coverage: any one of these would indicate the
+	// inherit-then-override pattern crept back in. Pinned because
+	// LD_* leaking into a user-scoped command opens an obvious
+	// privilege-escalation gap.
+	for _, leaked := range []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "GOROOT", "GOPATH"} {
+		if _, present := envSet[leaked]; present {
+			t.Errorf("agent env %q must not leak into user-scoped command (env=%v)", leaked, cmd.Env)
+		}
+	}
+}
+
+func TestRunAsCommand_ExtraEnvWinsOnDuplicateKey(t *testing.T) {
+	// Pin Go's exec.Cmd contract: when cmd.Env contains duplicate
+	// keys, the *last* occurrence wins. Our wrapper appends extraEnv
+	// after EnvFor, so an extraEnv override (e.g. a custom HOME for
+	// a specific action) reliably beats the desktop default.
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+	cmd, err := RunAsCommand(context.Background(), s, []string{"HOME=/var/empty"}, "/bin/true")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var lastHome string
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "HOME=") {
+			lastHome = e
+		}
+	}
+	if lastHome != "HOME=/var/empty" {
+		t.Errorf("last HOME entry: got %q, want %q (extraEnv must win on duplicate keys)", lastHome, "HOME=/var/empty")
+	}
+}

--- a/go/sys/desktop/sessions.go
+++ b/go/sys/desktop/sessions.go
@@ -1,0 +1,243 @@
+// Package desktop discovers active graphical desktop sessions on the
+// host so user-scoped actions (Flatpak --user installs, shell scripts
+// that need a real $HOME and DBus session bus, etc.) can fan out to
+// every currently-signed-in user instead of running under the agent's
+// own root context.
+//
+// The discovery contract is intentionally narrow: only sessions that
+//   - are local (Remote=no)
+//   - are graphical (Type ∈ {x11, wayland, mir})
+//   - are active (Active=yes)
+//
+// count. SSH sessions, getty TTYs, headless sessions, and inactive
+// graphical sessions are filtered out — they don't have a usable
+// XDG_RUNTIME_DIR / DBus session bus that user-scoped commands need.
+//
+// All discovery goes through systemd-logind (`loginctl`). Hosts
+// without systemd return an empty list with no error so callers can
+// uniformly treat "no signed-in users" as a no-op.
+package desktop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+// Session is a single active graphical desktop session.
+//
+// All fields are populated from systemd-logind (loginctl) plus a
+// passwd lookup for Home / GID. Callers should treat the struct as
+// immutable — the SDK constructs it once per ActiveSessions call.
+type Session struct {
+	// ID is the systemd-logind session ID (e.g. "c1", "2"). Stable for
+	// the lifetime of the session; not stable across logout/login.
+	ID string
+	// Username is the Linux account name (`loginctl show-session ... -p Name`).
+	Username string
+	// UID is the numeric user ID. Used to derive XDG_RUNTIME_DIR.
+	UID int
+	// GID is the user's primary group ID, looked up via os/user.
+	GID int
+	// Home is the user's home directory, looked up via os/user. Required
+	// for Flatpak --user installs (which resolve everything against
+	// $HOME) and for shell scripts that expect a sane working directory.
+	Home string
+	// RuntimeDir is /run/user/<UID>. Populated unconditionally — the
+	// caller decides whether to verify it exists before invoking a
+	// command that needs it (e.g. anything touching DBus).
+	RuntimeDir string
+	// Type is the session type (`x11`, `wayland`, `mir`). Always one of
+	// the graphical types because non-graphical sessions are filtered
+	// out before construction.
+	Type string
+}
+
+// loginctlPath is the absolute path to the loginctl binary. Pinned to
+// /usr/bin/loginctl because that's where systemd installs it on every
+// supported distro and absolute paths sidestep PATH-injection
+// concerns when the agent runs as root.
+const loginctlPath = "/usr/bin/loginctl"
+
+// ActiveSessions returns every active local graphical session on the
+// host, ready for fanning a user-scoped command out to each.
+//
+// Returns an empty slice (not an error) when:
+//   - loginctl is missing (host without systemd-logind)
+//   - no graphical sessions are active (machine is at login screen,
+//     headless server, etc.)
+//
+// Returns an error only when loginctl is present but its output is
+// malformed or the per-session detail probe fails for a reason other
+// than the session disappearing mid-call.
+func ActiveSessions(ctx context.Context) ([]Session, error) {
+	if _, err := exec.LookPath(loginctlPath); err != nil {
+		// Host doesn't ship systemd-logind. Treat as "no sessions" so
+		// the caller's empty-set policy (skip-with-warn vs fail) drives
+		// the user-facing behavior consistently regardless of the
+		// underlying init system.
+		return nil, nil
+	}
+
+	ids, err := listSessionIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Session, 0, len(ids))
+	for _, id := range ids {
+		s, ok, err := loadSession(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("loginctl show-session %q: %w", id, err)
+		}
+		if !ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// listSessionIDs runs `loginctl list-sessions --no-legend` and returns
+// the bare session IDs from the first column. The --no-legend flag
+// suppresses the trailing "N sessions listed" line which would
+// otherwise leak into the parse loop on older systemd builds.
+func listSessionIDs(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, loginctlPath, "list-sessions", "--no-legend")
+	stdout, err := cmd.Output()
+	if err != nil {
+		// `loginctl list-sessions` exits non-zero only on hard
+		// failures (logind not running, permission denied). An empty
+		// session table is exit 0 with no output — handled below by
+		// the field-split returning an empty slice.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("loginctl list-sessions failed: %w (stderr: %s)", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("loginctl list-sessions: %w", err)
+	}
+	var ids []string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		ids = append(ids, fields[0])
+	}
+	return ids, nil
+}
+
+// loadSession runs `loginctl show-session <id> -p ...` and returns a
+// fully-populated Session if the session passes the active+local+
+// graphical filter, or (zero, false, nil) if it should be skipped.
+//
+// Returns an error only on truly-broken probes: a missing session
+// (race with logout) is treated as "skip" rather than failing the
+// whole ActiveSessions call.
+func loadSession(ctx context.Context, id string) (Session, bool, error) {
+	cmd := exec.CommandContext(ctx, loginctlPath, "show-session", id,
+		"--property=Name",
+		"--property=User",
+		"--property=Type",
+		"--property=Active",
+		"--property=Remote",
+	)
+	stdout, err := cmd.Output()
+	if err != nil {
+		// Session disappeared between list-sessions and show-session
+		// — common when a user logs out concurrently with our probe.
+		// loginctl exits 1 with "Failed to get session: No session
+		// 'X'." on stderr in that case. Skip rather than fail.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if strings.Contains(string(exitErr.Stderr), "No session") {
+				return Session{}, false, nil
+			}
+			return Session{}, false, fmt.Errorf("%w (stderr: %s)", err, string(exitErr.Stderr))
+		}
+		return Session{}, false, err
+	}
+
+	props := parseLoginctlProperties(string(stdout))
+	if props["Remote"] != "no" {
+		return Session{}, false, nil
+	}
+	if props["Active"] != "yes" {
+		return Session{}, false, nil
+	}
+	if !isGraphicalType(props["Type"]) {
+		return Session{}, false, nil
+	}
+
+	uidStr := props["User"]
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return Session{}, false, fmt.Errorf("loginctl returned non-numeric User=%q for session %q", uidStr, id)
+	}
+
+	// passwd lookup for Home + GID. Username from logind is
+	// authoritative for "who's signed in," but we still need the
+	// passwd entry for $HOME — logind's session metadata doesn't
+	// carry it.
+	u, err := user.LookupId(uidStr)
+	if err != nil {
+		// Account exists in logind but not in passwd — extremely
+		// unusual (would mean the user was deleted while logged in).
+		// Skip rather than synthesize a fake $HOME.
+		return Session{}, false, nil
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return Session{}, false, fmt.Errorf("non-numeric GID %q for user %q", u.Gid, u.Username)
+	}
+
+	return Session{
+		ID:         id,
+		Username:   props["Name"],
+		UID:        uid,
+		GID:        gid,
+		Home:       u.HomeDir,
+		RuntimeDir: "/run/user/" + uidStr,
+		Type:       props["Type"],
+	}, true, nil
+}
+
+// parseLoginctlProperties parses the `Key=Value` lines that
+// `loginctl show-session ... -p Key` emits. One key per line,
+// no quoting (loginctl already strips it for the property form).
+func parseLoginctlProperties(s string) map[string]string {
+	out := make(map[string]string, 8)
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+		out[line[:eq]] = line[eq+1:]
+	}
+	return out
+}
+
+// isGraphicalType reports whether the loginctl "Type" property names
+// a session that owns a desktop ($DISPLAY / Wayland socket). Pinned
+// here rather than inlined so future session types (e.g. a hypothetical
+// "wayland-headless") can be added in one place.
+func isGraphicalType(t string) bool {
+	switch t {
+	case "x11", "wayland", "mir":
+		return true
+	default:
+		return false
+	}
+}

--- a/go/sys/desktop/sessions_test.go
+++ b/go/sys/desktop/sessions_test.go
@@ -1,0 +1,121 @@
+package desktop
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLoginctlProperties(t *testing.T) {
+	in := strings.Join([]string{
+		"Name=alice",
+		"User=1000",
+		"Type=wayland",
+		"Active=yes",
+		"Remote=no",
+		"",
+	}, "\n")
+
+	got := parseLoginctlProperties(in)
+	want := map[string]string{
+		"Name":   "alice",
+		"User":   "1000",
+		"Type":   "wayland",
+		"Active": "yes",
+		"Remote": "no",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseLoginctlProperties: got %d keys, want %d (got=%v)", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestParseLoginctlProperties_IgnoresMalformed(t *testing.T) {
+	in := strings.Join([]string{
+		"Name=alice",
+		"no_equals_here",
+		"=empty_key",
+		"Active=yes",
+	}, "\n")
+	got := parseLoginctlProperties(in)
+	if got["Name"] != "alice" || got["Active"] != "yes" {
+		t.Errorf("legitimate keys lost when parsing malformed lines: %v", got)
+	}
+	if _, ok := got["no_equals_here"]; ok {
+		t.Errorf("malformed line treated as a key: %v", got)
+	}
+	if _, ok := got[""]; ok {
+		t.Errorf("empty-key line silently kept: %v", got)
+	}
+}
+
+func TestIsGraphicalType(t *testing.T) {
+	tests := map[string]bool{
+		// Anything that owns a display surface counts. Pinning the
+		// allow-list rather than excluding from a blocklist keeps a
+		// future systemd session-type addition (say, "wayland-headless")
+		// from accidentally enabling user-scoped fan-out into a
+		// session that has no usable DBus / XDG runtime dir.
+		"x11":     true,
+		"wayland": true,
+		"mir":     true,
+		// Common non-graphical types we explicitly do NOT fan out to
+		// — these have no $DISPLAY / Wayland socket / session bus,
+		// so a Flatpak --user install would land in the right $HOME
+		// but a script that needs the desktop bus would silently
+		// degrade to autolaunching a fresh session bus.
+		"tty":         false,
+		"unspecified": false,
+		"":            false,
+		"WAYLAND":     false, // case-sensitive — loginctl always emits lowercase
+	}
+	for in, want := range tests {
+		if got := isGraphicalType(in); got != want {
+			t.Errorf("isGraphicalType(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestEnvFor_HasMinimumDesktopEnv(t *testing.T) {
+	s := Session{
+		Username:   "alice",
+		UID:        1000,
+		Home:       "/home/alice",
+		RuntimeDir: "/run/user/1000",
+	}
+	env := EnvFor(s)
+
+	mustContain := []string{
+		"HOME=/home/alice",
+		"USER=alice",
+		"LOGNAME=alice",
+		"XDG_RUNTIME_DIR=/run/user/1000",
+		// DBus session bus is critical for any user-scoped command
+		// that touches notifications or GNOME settings — pin its
+		// presence so a future refactor doesn't drop it back to
+		// the autolaunched-fresh-bus default.
+		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+	}
+	envSet := make(map[string]struct{}, len(env))
+	for _, e := range env {
+		envSet[e] = struct{}{}
+	}
+	for _, e := range mustContain {
+		if _, ok := envSet[e]; !ok {
+			t.Errorf("EnvFor missing %q\nfull env: %v", e, env)
+		}
+	}
+
+	// Negative: PATH must NOT be set here. Callers add their own
+	// curated PATH so the user can't reach /usr/local/sbin via
+	// subshell expansion. Pin the absence so a well-meaning future
+	// "just add PATH" PR has to update this test deliberately.
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			t.Errorf("EnvFor must not set PATH (caller picks one); got %q", e)
+		}
+	}
+}

--- a/go/sys/desktop/users.go
+++ b/go/sys/desktop/users.go
@@ -1,0 +1,146 @@
+package desktop
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+// homeRoot is the root directory enumerated by HomeUsers. Pinned as a
+// var so tests can swap it for a fixture; production code never
+// reassigns it.
+var homeRoot = "/home"
+
+// HomeUsers enumerates every Linux account on the host whose home
+// directory lives directly under /home/<name>. For each /home/<name>
+// subdir we call os/user.Lookup to confirm a real account exists
+// (catches stale `userdel`-without-`-r` directories) and to recover
+// the canonical UID/GID/Home from passwd or NSS.
+//
+// This is the primitive for "do something for every offline user" —
+// the install / online path uses ActiveSessions, the uninstall /
+// passive path (and similar "clean up every user's home" sweeps)
+// uses HomeUsers.
+//
+// Returns an empty slice — not an error — when /home is missing or
+// empty. Returns an error only when /home exists but cannot be read
+// (permission denied, IO error). Per-user lookup failures are
+// silently skipped: a non-resolving home dir means a stale entry,
+// not a fault we want to surface.
+//
+// Limitations (intentional, documented for callers picking the
+// right helper):
+//   - Custom $HOME paths outside /home/ (LDAP /home/<domain>/<user>,
+//     /auto.home/<user>, etc.) are missed. Those layouts are
+//     uncommon on managed Linux endpoints; passwd-iterating
+//     wouldn't catch them either if the home dir is auto-mounted
+//     on first access.
+//   - Encrypted homes (ecryptfs) appear as a single /home/<name>
+//     dir but the contents are unreadable without the user's
+//     session. Per-user state inside the encrypted volume is
+//     invisible to a sweep that runs while the user is offline.
+func HomeUsers() ([]Session, error) {
+	entries, err := os.ReadDir(homeRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", homeRoot, err)
+	}
+
+	out := make([]Session, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Skip dot-prefixed directories (.ecryptfs, .pwd.lock, etc.)
+		// and the conventional /home/lost+found left by fsck.
+		name := e.Name()
+		if name == "" || name[0] == '.' || name == "lost+found" {
+			continue
+		}
+		s, ok := homeUserFor(name)
+		if !ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// homeUserFor builds a Session for the given /home/<name> subdir if
+// it resolves to a real account. Returns (zero, false) on any lookup
+// failure — callers treat that as "not a real user, skip silently."
+func homeUserFor(name string) (Session, bool) {
+	u, err := user.Lookup(name)
+	if err != nil {
+		return Session{}, false
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return Session{}, false
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return Session{}, false
+	}
+	// Trust the canonical home from the lookup over the directory
+	// name — a system with /etc/skel symlinks or unusual NSS modules
+	// can have /home/<name> exist while the canonical home is
+	// elsewhere; using the lookup result keeps us aligned with what
+	// runuser will see.
+	return Session{
+		Username:   u.Username,
+		UID:        uid,
+		GID:        gid,
+		Home:       u.HomeDir,
+		RuntimeDir: "/run/user/" + u.Uid,
+	}, true
+}
+
+// UsersWithFlatpakInstall returns the subset of HomeUsers whose
+// per-user Flatpak repository contains the named app. This is the
+// authoritative answer to "which offline users need this app
+// uninstalled from their per-user install" — covers users who
+// installed at a previous management cycle and aren't currently
+// signed in.
+//
+// Errors:
+//   - returns an error if appID is empty (caller bug — would otherwise
+//     glob "every per-user flatpak install on the box")
+//   - propagates the error from HomeUsers when /home itself is
+//     unreadable (permission denied, IO error). The caller treats
+//     that as fail-the-whole-uninstall, since we can't say the action
+//     converged when we can't even enumerate the candidate set.
+//
+// Per-user os.Stat failures inside the loop (e.g. an unreadable
+// $HOME for one specific account) are silently skipped — they
+// represent "we can't see whether this user has it installed," and
+// the next reconciliation tick re-checks once the access issue
+// resolves. The caller still logs per-user uninstall errors from the
+// returned set itself.
+func UsersWithFlatpakInstall(appID string) ([]Session, error) {
+	if appID == "" {
+		return nil, fmt.Errorf("UsersWithFlatpakInstall: appID required")
+	}
+	users, err := HomeUsers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Session, 0, len(users))
+	for _, u := range users {
+		// Per-user installs land under
+		// $HOME/.local/share/flatpak/app/<appID>/. Existence of the
+		// directory is the cheapest possible "is it installed" check
+		// — a full `flatpak --user info` invocation per user would
+		// be 10-100× slower on a box with many accounts.
+		appDir := filepath.Join(u.Home, ".local", "share", "flatpak", "app", appID)
+		if _, err := os.Stat(appDir); err != nil {
+			continue
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}

--- a/go/sys/desktop/users_test.go
+++ b/go/sys/desktop/users_test.go
@@ -1,0 +1,175 @@
+package desktop
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// withHomeRoot swaps the package-level homeRoot for the duration of t.
+// Restores on cleanup so tests can run in any order.
+func withHomeRoot(t *testing.T, dir string) {
+	t.Helper()
+	prev := homeRoot
+	homeRoot = dir
+	t.Cleanup(func() { homeRoot = prev })
+}
+
+// currentUserSession builds a Session pointing at the running test
+// user's home, used as the fixture identity. Skips when the test
+// user can't be looked up (CI sandboxes without nsswitch/passwd).
+func currentUserSession(t *testing.T) (user.User, int, int) {
+	t.Helper()
+	u, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot resolve current user: %v", err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		t.Skipf("non-numeric UID for current user: %v", err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		t.Skipf("non-numeric GID for current user: %v", err)
+	}
+	return *u, uid, gid
+}
+
+func TestHomeUsers_EmptyHomeRoot(t *testing.T) {
+	withHomeRoot(t, t.TempDir())
+	got, err := HomeUsers()
+	if err != nil {
+		t.Fatalf("unexpected error on empty /home: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty /home should return zero users, got %d: %v", len(got), got)
+	}
+}
+
+func TestHomeUsers_MissingHomeRoot(t *testing.T) {
+	// Pin the contract: a non-existent /home is "no users", not an
+	// error. Containers and minimal systems sometimes lack /home
+	// entirely; the agent still needs to make a uninstall-loop
+	// decision without exiting the action with a hard error.
+	withHomeRoot(t, filepath.Join(t.TempDir(), "does-not-exist"))
+	got, err := HomeUsers()
+	if err != nil {
+		t.Fatalf("missing /home should not error, got: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected zero users for missing /home, got %d", len(got))
+	}
+}
+
+func TestHomeUsers_SkipsNonDirectoryAndDotPrefixed(t *testing.T) {
+	root := t.TempDir()
+	withHomeRoot(t, root)
+
+	// Files, dot-prefixed dirs, and lost+found must all be skipped
+	// before we even try to resolve a username — otherwise a stray
+	// `.ecryptfs` ghost dir or fsck's `lost+found` would trigger a
+	// noisy os/user.Lookup failure log on every run.
+	if err := os.WriteFile(filepath.Join(root, "shared.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{".ecryptfs", ".pwd.lock", "lost+found"} {
+		if err := os.Mkdir(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Bait: a dir whose name resolves to no real user. Should be
+	// silently skipped (no failure surfaced to the caller).
+	if err := os.Mkdir(filepath.Join(root, "_definitely_not_a_real_user_name_pmtest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := HomeUsers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("non-real entries should produce zero users, got %d: %v", len(got), got)
+	}
+}
+
+func TestHomeUsers_ResolvesRealAccount(t *testing.T) {
+	u, uid, gid := currentUserSession(t)
+
+	root := t.TempDir()
+	withHomeRoot(t, root)
+	if err := os.Mkdir(filepath.Join(root, u.Username), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := HomeUsers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 user, got %d: %v", len(got), got)
+	}
+	s := got[0]
+	if s.Username != u.Username {
+		t.Errorf("Username: got %q, want %q", s.Username, u.Username)
+	}
+	if s.UID != uid {
+		t.Errorf("UID: got %d, want %d", s.UID, uid)
+	}
+	if s.GID != gid {
+		t.Errorf("GID: got %d, want %d", s.GID, gid)
+	}
+	// HomeDir comes from the os/user lookup, not the synthetic
+	// /home/<name> path under the test root — pin that the lookup
+	// wins so a future refactor doesn't accidentally start trusting
+	// the directory layout over passwd.
+	if s.Home != u.HomeDir {
+		t.Errorf("Home: got %q, want %q (the os/user lookup is authoritative, not the directory layout)",
+			s.Home, u.HomeDir)
+	}
+	if s.RuntimeDir != "/run/user/"+u.Uid {
+		t.Errorf("RuntimeDir: got %q, want %q", s.RuntimeDir, "/run/user/"+u.Uid)
+	}
+}
+
+func TestUsersWithFlatpakInstall_RequiresAppID(t *testing.T) {
+	if _, err := UsersWithFlatpakInstall(""); err == nil {
+		t.Fatal("expected error for empty appID — guards against silently uninstalling for everyone")
+	}
+}
+
+func TestUsersWithFlatpakInstall_FiltersByInstallDir(t *testing.T) {
+	u, _, _ := currentUserSession(t)
+
+	root := t.TempDir()
+	withHomeRoot(t, root)
+	if err := os.Mkdir(filepath.Join(root, u.Username), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const appID = "com.example.PmTest"
+
+	// First pass: nobody has the app installed in the synthetic
+	// home root — should be empty.
+	got, err := UsersWithFlatpakInstall(appID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range got {
+		if s.Username == u.Username && s.Home == filepath.Join(root, u.Username) {
+			// Only fail if the lookup-derived home actually points
+			// into our test root (production runs have a real
+			// HomeDir from passwd, which we should exclude here).
+			t.Errorf("did not expect current user pre-install: %v", s)
+		}
+	}
+
+	// We can't fabricate the install dir under the real $HOME from
+	// inside a unit test (would clobber the dev's actual home), so
+	// the positive direction is exercised by inspecting the filter
+	// path in users.go and trusting the negative case above. The
+	// rotation tests cover the loop behavior end-to-end via the
+	// agent's executor tests.
+}


### PR DESCRIPTION
## Summary

Adds the SDK helpers the agent needs to fan user-scoped actions (Flatpak \`--user\` installs, \`RunAsRoot=false\` shell scripts, future file-action drops into a user's home) out to the right Linux accounts instead of running everything as root with \`HOME=/root\` — the bug profile that surfaced as agent #79.

### Three primitives, one per failure mode

| Helper | When to use |
|---|---|
| \`ActiveSessions(ctx)\` | PRESENT path — install for whoever's currently signed in. Filtered to local graphical (\`x11\`/\`wayland\`/\`mir\`) \`Active=yes\` sessions via \`loginctl\`. |
| \`HomeUsers()\` | ABSENT/passive path — act on every real account on the box, signed in or not. Walks \`/home/*\` + \`os/user.Lookup\`. |
| \`UsersWithFlatpakInstall(appID)\` | Flatpak-specific filter on top of \`HomeUsers\` — uninstall path checks for \`~/.local/share/flatpak/app/<appID>/\`. |

Plus the runuser wrapper:

- \`RunAsCommand(ctx, session, extraEnv, name, args...)\` — builds \`runuser -u <user> -- <name> <args...>\` with \`cmd.Env\` *replacing* the inherited env wholesale (no \`LD_PRELOAD\` / \`LD_LIBRARY_PATH\` leak), \`HOME\`/\`USER\`/\`LOGNAME\`/\`XDG_RUNTIME_DIR\`/\`DBUS_SESSION_BUS_ADDRESS\` pre-populated, and \`cmd.Dir = \$HOME\`.
- \`EnvFor(session)\` — exposed separately for callers that build their own \`*exec.Cmd\` (the agent's streaming \`runShellScript\` path).

### Documented limits

- Custom \`\$HOME\` paths outside \`/home/\` (LDAP, autofs) and ecryptfs-encrypted dormant homes are missed by \`HomeUsers\` — passwd-iterating wouldn't reach them either, so no functionality is lost.
- Per-user \`os.Stat\` failures inside \`UsersWithFlatpakInstall\` (e.g. unreadable home) are silently skipped; the next reconciliation tick re-checks once the access issue resolves.

## Why it lives in the SDK

Three components will need this (agent flatpak action, agent shell action, future agent file action) — putting it in the SDK from day one matches the project's SDK-first rule and avoids a copy-paste round through the agent first.

## Test plan
- [x] \`go test ./go/sys/desktop/\` — unit tests cover loginctl property parsing, graphical-type filter, env isolation (negative coverage on \`LD_*\`), extraEnv-wins-on-duplicate, \`HomeUsers\` stale-dir filtering, missing \`/home\`, empty-appID guard
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` clean
- [x] \`cr review --plain --base main\` — 1 finding (doc-vs-behavior on \`UsersWithFlatpakInstall\` error semantics) addressed in this commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering active graphical desktop user sessions on the system.
  * Added ability to run commands within a specific user's desktop environment with appropriate session variables.
  * Added user enumeration to identify local users and detect those with specific applications installed.

* **Tests**
  * Comprehensive test coverage added for desktop session discovery, command execution, and user detection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/67)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->