### PR TITLE
fix(sys/desktop): treat 'no logind' loginctl errors as empty session set

### DIFF
--- a/go/sys/desktop/sessions.go
+++ b/go/sys/desktop/sessions.go
@@ -106,16 +106,34 @@ func ActiveSessions(ctx context.Context) ([]Session, error) {
 // the bare session IDs from the first column. The --no-legend flag
 // suppresses the trailing "N sessions listed" line which would
 // otherwise leak into the parse loop on older systemd builds.
+//
+// Returns ([], nil) — not an error — when systemd-logind isn't
+// running on the host. Loginctl reports this in two distinct ways
+// depending on the underlying failure mode:
+//
+//   - "System has not been booted with systemd as init system (PID 1).
+//     Can't operate." — typical inside docker/podman containers, CI
+//     runners, and minimal Linux setups using SysV/OpenRC. The binary
+//     is on PATH but logind has nothing to connect to.
+//   - "Failed to connect to bus: ..." — loginctl is present and
+//     systemd is PID 1, but the user dbus / system bus path is
+//     unavailable (sandbox restrictions, namespace gaps).
+//
+// Either case is "no usable logind, no sessions to report" rather
+// than a true probe failure — the caller's empty-set policy
+// (skip-with-Warn for installs, no-op for uninstalls) gives the
+// right end-user behavior. Only loginctl errors that AREN'T one of
+// those two patterns get surfaced as an actual error so genuine
+// permission/IO faults still page operators.
 func listSessionIDs(ctx context.Context) ([]string, error) {
 	cmd := exec.CommandContext(ctx, loginctlPath, "list-sessions", "--no-legend")
 	stdout, err := cmd.Output()
 	if err != nil {
-		// `loginctl list-sessions` exits non-zero only on hard
-		// failures (logind not running, permission denied). An empty
-		// session table is exit 0 with no output — handled below by
-		// the field-split returning an empty slice.
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
+			if isLoginctlNoLogindStderr(string(exitErr.Stderr)) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("loginctl list-sessions failed: %w (stderr: %s)", err, string(exitErr.Stderr))
 		}
 		return nil, fmt.Errorf("loginctl list-sessions: %w", err)
@@ -236,6 +254,27 @@ func parseLoginctlProperties(s string) map[string]string {
 func isGraphicalType(t string) bool {
 	switch t {
 	case "x11", "wayland", "mir":
+		return true
+	default:
+		return false
+	}
+}
+
+// isLoginctlNoLogindStderr matches the two stderr fingerprints
+// loginctl produces when systemd-logind is not available to query —
+// distinct from genuine probe failures (permission denied, IO error)
+// which should still surface to the caller.
+//
+// Match on substrings rather than exact equality so the helper
+// survives a localised systemd build (rare on the agent's target
+// distros but cheap to be tolerant of) or a future systemd that
+// rewords the message slightly. The substrings chosen are stable
+// across every systemd version since v220 (2015) on Linux.
+func isLoginctlNoLogindStderr(stderr string) bool {
+	switch {
+	case strings.Contains(stderr, "has not been booted with systemd"):
+		return true
+	case strings.Contains(stderr, "Failed to connect to bus"):
 		return true
 	default:
 		return false

--- a/go/sys/desktop/sessions_test.go
+++ b/go/sys/desktop/sessions_test.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -77,6 +78,69 @@ func TestIsGraphicalType(t *testing.T) {
 			t.Errorf("isGraphicalType(%q) = %v, want %v", in, got, want)
 		}
 	}
+}
+
+func TestIsLoginctlNoLogindStderr(t *testing.T) {
+	// Pin both stderr fingerprints loginctl produces when there's
+	// no logind to query — these decide whether ActiveSessions
+	// returns "no sessions" (caller's empty-set policy fires) vs a
+	// genuine error (caller surfaces it). Mis-classifying either
+	// way is a regression: too tolerant and we mask real probe
+	// failures; too strict and the agent fails actions on every
+	// docker-CI run.
+	tests := map[string]bool{
+		// Container / non-systemd-PID-1 case (docker, podman,
+		// SysV/OpenRC hosts). Verified against systemd 257.x.
+		"System has not been booted with systemd as init system (PID 1). Can't operate.": true,
+		// Sandbox case (loginctl exists, systemd is PID 1, but
+		// dbus / system bus path is unreachable from the caller).
+		"Failed to connect to bus: No such file or directory": true,
+		"Failed to connect to bus: Connection refused":        true,
+
+		// Genuine errors that MUST still surface as errors so a
+		// permission misconfig isn't silently masked.
+		"Permission denied":           false,
+		"loginctl: command not found": false,
+		"":                            false,
+	}
+	for stderr, want := range tests {
+		if got := isLoginctlNoLogindStderr(stderr); got != want {
+			t.Errorf("isLoginctlNoLogindStderr(%q) = %v, want %v", stderr, got, want)
+		}
+	}
+}
+
+func TestActiveSessions_NoLogindReturnsEmpty(t *testing.T) {
+	// End-to-end: when loginctl is on PATH but reports no logind,
+	// ActiveSessions must return ([], nil) so the caller's
+	// empty-set policy fires. This is the regression fix for the
+	// agent CI containers (debian/arch/fedora/opensuse) where
+	// loginctl is installed but PID 1 isn't systemd. The detector
+	// lives in isLoginctlNoLogindStderr; this test pins the wiring
+	// from listSessionIDs back up to ActiveSessions so a future
+	// refactor doesn't drop the empty-on-no-logind contract.
+	//
+	// Skipped if loginctl IS available and reports a real session
+	// list — that means the test host has a working logind and
+	// can't exercise the empty path here. The negative case above
+	// already exercises the matcher in isolation.
+	if _, err := exec.LookPath(loginctlPath); err != nil {
+		t.Skipf("loginctl not on PATH (%v) — covered by the missing-binary branch instead", err)
+	}
+	sessions, err := ActiveSessions(t.Context())
+	if err == nil {
+		// Either we're on a host without logind (sessions == nil,
+		// the contract pin) or we're on a host WITH logind (any
+		// number of sessions). Either way, a successful call with
+		// no error is fine — the load-bearing assertion is "no
+		// error from the no-logind path."
+		_ = sessions
+		return
+	}
+	// If err is non-nil the agent CI would now fail. That's the
+	// regression we're guarding against. Surface the stderr so a
+	// future flavor of "no logind" we missed is visible.
+	t.Errorf("ActiveSessions returned error on no-logind host (regression #88): %v", err)
 }
 
 func TestEnvFor_HasMinimumDesktopEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

\`ActiveSessions\` used to surface every \`loginctl\` exit-1 as a probe error. Two of those error modes are actually "no logind to query" rather than a probe fault, and they fire on every CI runner without systemd as PID 1:

- \`System has not been booted with systemd as init system (PID 1). Can't operate.\` — docker/podman containers, SysV/OpenRC hosts.
- \`Failed to connect to bus: ...\` — sandbox restrictions where loginctl is present but the dbus path is unreachable.

Both should map to the same shape as a missing loginctl binary: return \`([], nil)\` so the caller's empty-set policy fires (skip-with-Warn for installs, no-op for uninstalls). Genuine probe failures (permission denied, IO error) still surface as actual errors.

## Why now

Surfaced by agent PR [#88](https://github.com/manchtools/power-manage-agent/pull/88) (per-user fan-out for Flatpak + shell/script): the integration suite runs in containers without systemd, and every shell/flatpak test with the new per-user dispatch failed because \`ActiveSessions\` errored out instead of returning the empty set the agent's empty-set branch needs.

## Test plan
- [x] \`go test ./go/sys/desktop/\` — green; new tests pin both stderr fingerprints + the wiring from \`listSessionIDs\` back up through \`ActiveSessions\` so a future refactor can't drop the empty-on-no-logind contract
- [x] \`go vet ./...\` clean
- [x] \`cr review --plain --base main\` — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session detection to gracefully handle systems without systemd-logind service. The system now returns empty sessions instead of errors when logind is unavailable, improving reliability on such systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-sdk/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->