### PR TITLE
fix(pkg): strip os.Environ() from runPM env builders

### DIFF
--- a/go/pkg/apt.go
+++ b/go/pkg/apt.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -486,7 +485,13 @@ func (a *Apt) run(ctx context.Context, cmd string, args ...string) (*CommandResu
 
 	// Prevent debconf from trying interactive frontends when there is no terminal.
 	// Force English locale for reliable output parsing.
-	env := append(os.Environ(), "DEBIAN_FRONTEND=noninteractive", "LANG=C", "LC_ALL=C")
+	//
+	// Do NOT seed with os.Environ() — F-31 hardening in sys/exec.RunStreaming
+	// refuses caller-supplied PATH/LD_PRELOAD/BASH_ENV etc., which os.Environ()
+	// always carries. RunStreaming auto-injects its own sanitized PATH when
+	// envVars is non-empty, so the only entries the package backend has to
+	// ship are the locale + noninteractive bits.
+	env := []string{"DEBIAN_FRONTEND=noninteractive", "LANG=C", "LC_ALL=C"}
 
 	return runPM(ctx, a.useSudo, cmd, args, env)
 }

--- a/go/pkg/dnf.go
+++ b/go/pkg/dnf.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -474,7 +473,12 @@ func (d *Dnf) getPinnedSet() (map[string]bool, error) {
 
 func (d *Dnf) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	// Force English locale for reliable output parsing.
-	env := append(os.Environ(), "LANG=C", "LC_ALL=C")
+	//
+	// Do NOT seed with os.Environ() — F-31 hardening in sys/exec.RunStreaming
+	// refuses caller-supplied PATH/LD_PRELOAD/BASH_ENV etc., which os.Environ()
+	// always carries. RunStreaming auto-injects its own sanitized PATH when
+	// envVars is non-empty.
+	env := []string{"LANG=C", "LC_ALL=C"}
 	return runPM(ctx, d.useSudo, "dnf", args, env)
 }
 

--- a/go/pkg/flatpak.go
+++ b/go/pkg/flatpak.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -614,7 +613,12 @@ func (f *Flatpak) ListRemotes() ([]string, error) {
 
 func (f *Flatpak) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	// Force English locale for reliable output parsing.
-	env := append(os.Environ(), "LANG=C", "LC_ALL=C")
+	//
+	// Do NOT seed with os.Environ() — F-31 hardening in sys/exec.RunStreaming
+	// refuses caller-supplied PATH/LD_PRELOAD/BASH_ENV etc., which os.Environ()
+	// always carries. RunStreaming auto-injects its own sanitized PATH when
+	// envVars is non-empty.
+	env := []string{"LANG=C", "LC_ALL=C"}
 	return runPM(ctx, f.useSudo, "flatpak", args, env)
 }
 

--- a/go/pkg/pacman.go
+++ b/go/pkg/pacman.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -552,7 +551,12 @@ func (p *Pacman) updateIgnorePkg(confContent string, ignoredPkgs []string) (*Com
 
 func (p *Pacman) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	// Force English locale for reliable output parsing.
-	env := append(os.Environ(), "LANG=C", "LC_ALL=C")
+	//
+	// Do NOT seed with os.Environ() — F-31 hardening in sys/exec.RunStreaming
+	// refuses caller-supplied PATH/LD_PRELOAD/BASH_ENV etc., which os.Environ()
+	// always carries. RunStreaming auto-injects its own sanitized PATH when
+	// envVars is non-empty.
+	env := []string{"LANG=C", "LC_ALL=C"}
 	return runPM(ctx, p.useSudo, "pacman", args, env)
 }
 

--- a/go/pkg/zypper.go
+++ b/go/pkg/zypper.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -501,7 +500,12 @@ func (z *Zypper) getPinnedSet() (map[string]bool, error) {
 
 func (z *Zypper) run(ctx context.Context, args ...string) (*CommandResult, error) {
 	// Force English locale for reliable output parsing.
-	env := append(os.Environ(), "LANG=C", "LC_ALL=C")
+	//
+	// Do NOT seed with os.Environ() — F-31 hardening in sys/exec.RunStreaming
+	// refuses caller-supplied PATH/LD_PRELOAD/BASH_ENV etc., which os.Environ()
+	// always carries. RunStreaming auto-injects its own sanitized PATH when
+	// envVars is non-empty.
+	env := []string{"LANG=C", "LC_ALL=C"}
 	return runPM(ctx, z.useSudo, "zypper", args, env)
 }
 


### PR DESCRIPTION
## Summary

Five package backends — \`apt\`, \`dnf\`, \`pacman\`, \`zypper\`, \`flatpak\` — built their \`runPM\` env via \`append(os.Environ(), LANG=C, …)\`. \`os.Environ()\` always carries PATH (and LD_PRELOAD, BASH_ENV, etc. when set on the host), which \`sys/exec.RunStreaming\` F-31 hardening (#75) refuses with \`ErrBlockedEnvVar\`. End-to-end effect: every privileged write path through any package backend errored at the SDK boundary, breaking the agent's integration suite as soon as a downstream bumped past sdk \`15d123e\`.

Fix is one-line per backend: build the env from scratch with the locale / noninteractive entries the package manager actually needs. \`RunStreaming\` auto-injects its own sanitized PATH when \`envVars\` is non-empty, so callers don't have to ship one.

## Why this fix here

Surfaced by manchtools/power-manage-server#327 — bumping the agent's SDK pin past the F-31 hardening exposed the regression. The agent PR (manchtools/power-manage-agent#94) needs this fix landed before its integration suite can go green.

## Test plan

- [x] \`go build ./go/...\`
- [x] \`go test ./go/pkg/... -count=1\` — green locally (the existing unit tests exercise \`runPM\` on every backend; a blocked env name would have failed them all)
- [x] \`gofmt -l\` clean on all 5 files
- [x] Local \`cr review\` — no findings
- [ ] CI green
- [ ] CR clean

The agent integration suite (debian/fedora/opensuse/archlinux) on PR #94 will verify the end-to-end fix once the SDK pin re-bumps to this commit.

## Affected files

- \`go/pkg/apt.go\` — also drops \`DEBIAN_FRONTEND=noninteractive\` retention (kept, not regressed)
- \`go/pkg/dnf.go\`
- \`go/pkg/pacman.go\`
- \`go/pkg/zypper.go\`
- \`go/pkg/flatpak.go\`

Each also drops the now-unused \`"os"\` import.

Refs manchtools/power-manage-server#327, blocks manchtools/power-manage-agent#94.