### PR TITLE
feat(sdk): AssertRealDir, curated per-user PATH, crash-safe SafeBackupAndReplace

### DIFF
--- a/go/sys/desktop/runas.go
+++ b/go/sys/desktop/runas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // runuserPath pins the absolute path to runuser. Like loginctlPath,
@@ -18,10 +19,10 @@ const runuserPath = "/usr/sbin/runuser"
 // notification path, GNOME settings, etc. — find it without falling
 // back to a fresh autolaunched bus).
 //
-// PATH is not added here — callers append it themselves so they can
-// pick a curated value rather than inherit the agent's PATH (which
-// may include /usr/local/sbin and other privileged dirs the user
-// shouldn't reach via subshell expansion).
+// PATH is not added here — callers append it (via UserPath) so they can
+// pick a curated value rather than inherit the agent's PATH. RunAsCommand
+// does this for the non-streaming path; the streaming caller passes
+// UserPath(s) as the trusted child PATH to exec.RunStreamingChildPath.
 func EnvFor(s Session) []string {
 	return []string{
 		"HOME=" + s.Home,
@@ -30,6 +31,27 @@ func EnvFor(s Session) []string {
 		"XDG_RUNTIME_DIR=" + s.RuntimeDir,
 		"DBUS_SESSION_BUS_ADDRESS=unix:path=" + s.RuntimeDir + "/bus",
 	}
+}
+
+// UserPath returns the curated PATH a per-user command should run with.
+// It is built from the session — never from the agent's (root's) PATH —
+// so a user-scoped command does not inherit root-only entries, and the
+// user's own bin dirs come first so ~/.local/bin shadows a system binary
+// of the same name. sbin dirs are included because usr-merged distros
+// put them on every user's default PATH and a user running an sbin
+// binary does so unprivileged (their own UID); excluding them only
+// breaks command resolution without any privilege benefit.
+func UserPath(s Session) string {
+	return strings.Join([]string{
+		s.Home + "/.local/bin",
+		s.Home + "/bin",
+		"/usr/local/bin",
+		"/usr/bin",
+		"/bin",
+		"/usr/local/sbin",
+		"/usr/sbin",
+		"/sbin",
+	}, ":")
 }
 
 // RunAsCommand returns an *exec.Cmd that runs `name args...` as the
@@ -59,10 +81,14 @@ func RunAsCommand(ctx context.Context, s Session, extraEnv []string, name string
 	full := append([]string{"-u", s.Username, "--", name}, args...)
 	cmd := exec.CommandContext(ctx, runuserPath, full...)
 	// Replace inherited env wholesale — agent's env (LD_PRELOAD,
-	// LD_LIBRARY_PATH, etc.) must not leak into a user-scoped
-	// command. Caller's extraEnv is appended last so it wins on
-	// duplicate keys.
-	cmd.Env = append(EnvFor(s), extraEnv...)
+	// LD_LIBRARY_PATH, etc.) must not leak into a user-scoped command.
+	// Caller's extraEnv is merged on top, then the curated user PATH is
+	// applied LAST so it wins under exec's last-occurrence semantics: an
+	// action must not be able to override PATH (parity with the
+	// streaming path, which refuses a caller-supplied PATH outright).
+	env := append(EnvFor(s), extraEnv...)
+	env = append(env, "PATH="+UserPath(s))
+	cmd.Env = env
 	cmd.Dir = s.Home
 	return cmd, nil
 }

--- a/go/sys/desktop/runas_test.go
+++ b/go/sys/desktop/runas_test.go
@@ -87,8 +87,11 @@ func TestRunAsCommand_EnvIsolatesAgentEnvironment(t *testing.T) {
 		"LOGNAME":                  "alice",
 		"XDG_RUNTIME_DIR":          "/run/user/1000",
 		"DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
-		"PATH":                     "/usr/bin:/bin",
-		"FLATPAK_USER_DIR":         "/foo",
+		// PATH is the curated UserPath regardless of the caller-supplied
+		// "PATH=/usr/bin:/bin" — an action must not override it. A
+		// non-PATH extraEnv (FLATPAK_USER_DIR) is still honored.
+		"PATH":             UserPath(s),
+		"FLATPAK_USER_DIR": "/foo",
 	}
 	for k, want := range must {
 		if got := envSet[k]; got != want {

--- a/go/sys/desktop/userpath_test.go
+++ b/go/sys/desktop/userpath_test.go
@@ -28,6 +28,26 @@ func TestUserPath(t *testing.T) {
 	if localIdx == -1 || usrIdx == -1 || localIdx > usrIdx {
 		t.Errorf("~/.local/bin must precede /usr/bin, got %q", got)
 	}
+
+	// sbin dirs are intentionally INCLUDED (usr-merged distros put them
+	// on every user's default PATH) but ordered AFTER the bin dirs: a
+	// user binary of the same name must win and sbin resolution is a last
+	// resort. Pin both the inclusion and the ordering so a reorder or
+	// accidental drop is caught.
+	binIdx := slices.Index(dirs, "/bin")
+	for _, sbin := range []string{"/usr/local/sbin", "/usr/sbin", "/sbin"} {
+		sbinIdx := slices.Index(dirs, sbin)
+		if sbinIdx == -1 {
+			t.Errorf("UserPath must include %s (usr-merged default), got %q", sbin, got)
+			continue
+		}
+		if sbinIdx < usrIdx {
+			t.Errorf("%s must come after /usr/bin so bin dirs win, got %q", sbin, got)
+		}
+		if binIdx != -1 && sbinIdx < binIdx {
+			t.Errorf("%s must come after /bin, got %q", sbin, got)
+		}
+	}
 }
 
 // RunAsCommand must set the curated user PATH on the child env — the

--- a/go/sys/desktop/userpath_test.go
+++ b/go/sys/desktop/userpath_test.go
@@ -1,0 +1,68 @@
+package desktop
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// UserPath is the curated PATH a per-user command should run with. It
+// must NOT depend on the agent's (root's) PATH, and must put the user's
+// own bin dirs first so a user's ~/.local/bin wins over a system binary
+// of the same name.
+func TestUserPath(t *testing.T) {
+	s := Session{Username: "alice", Home: "/home/alice"}
+	got := UserPath(s)
+	dirs := strings.Split(got, ":")
+
+	if !slices.Contains(dirs, "/home/alice/.local/bin") {
+		t.Errorf("UserPath must include ~/.local/bin, got %q", got)
+	}
+	if !slices.Contains(dirs, "/usr/bin") {
+		t.Errorf("UserPath must include /usr/bin, got %q", got)
+	}
+	// User bin dirs come first so they shadow system binaries.
+	localIdx := slices.Index(dirs, "/home/alice/.local/bin")
+	usrIdx := slices.Index(dirs, "/usr/bin")
+	if localIdx == -1 || usrIdx == -1 || localIdx > usrIdx {
+		t.Errorf("~/.local/bin must precede /usr/bin, got %q", got)
+	}
+}
+
+// RunAsCommand must set the curated user PATH on the child env — the
+// previous shape left PATH unset entirely (EnvFor omits it), so per-user
+// commands ran with no PATH / runuser's compiled-in default rather than
+// the user's, and ~/.local/bin was never on PATH.
+func TestRunAsCommand_SetsCuratedUserPath(t *testing.T) {
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+	cmd, err := RunAsCommand(context.Background(), s, nil, "true")
+	if err != nil {
+		t.Fatalf("RunAsCommand: %v", err)
+	}
+	want := "PATH=" + UserPath(s)
+	if !slices.Contains(cmd.Env, want) {
+		t.Errorf("RunAsCommand env must contain the curated %q; env=%v", want, cmd.Env)
+	}
+}
+
+// An action-supplied PATH in extraEnv must not override the curated
+// user PATH — the curated value is applied last so it wins, matching the
+// streaming path which refuses a caller-supplied PATH outright.
+func TestRunAsCommand_CuratedPathWinsOverExtraEnv(t *testing.T) {
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+	cmd, err := RunAsCommand(context.Background(), s, []string{"PATH=/attacker/bin"}, "true")
+	if err != nil {
+		t.Fatalf("RunAsCommand: %v", err)
+	}
+	// Last PATH entry wins under exec semantics; it must be the curated one.
+	var lastPath string
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "PATH=") {
+			lastPath = e
+		}
+	}
+	if lastPath != "PATH="+UserPath(s) {
+		t.Errorf("curated PATH must win over extraEnv PATH; effective=%q", lastPath)
+	}
+}

--- a/go/sys/exec/exec.go
+++ b/go/sys/exec/exec.go
@@ -57,6 +57,18 @@ func RunWithCLocale(ctx context.Context, name string, args ...string) (*Result, 
 // (Privileged, PrivilegedStreaming, pkg/exec.runPM, …) inherits the
 // check, so the audit-finding-#8 enforcement lives in one place.
 func RunStreaming(ctx context.Context, name string, args []string, envVars []string, dir string, callback OutputCallback) (*Result, error) {
+	// Default child PATH is the agent's own (sanitized) PATH.
+	return RunStreamingChildPath(ctx, name, args, envVars, os.Getenv("PATH"), dir, callback)
+}
+
+// RunStreamingChildPath is RunStreaming with an explicit, TRUSTED child
+// PATH. PATH is on the BlockedEnvVars list so an untrusted caller can't
+// smuggle it through envVars; this entry point lets a trusted caller
+// (e.g. the agent's per-user runuser fan-out, which must run with the
+// target user's PATH rather than root's) set the child PATH directly.
+// childPath is used only when envVars is non-empty, matching
+// RunStreaming's compose-env behavior.
+func RunStreamingChildPath(ctx context.Context, name string, args []string, envVars []string, childPath string, dir string, callback OutputCallback) (*Result, error) {
 	for _, e := range envVars {
 		key, _, ok := strings.Cut(e, "=")
 		if !ok {
@@ -84,8 +96,8 @@ func RunStreaming(ctx context.Context, name string, args []string, envVars []str
 		// fully" semantics — that path is unchanged for backward
 		// compatibility.
 		finalEnv := make([]string, 0, len(envVars)+1)
-		if path := os.Getenv("PATH"); path != "" {
-			finalEnv = append(finalEnv, "PATH="+path)
+		if childPath != "" {
+			finalEnv = append(finalEnv, "PATH="+childPath)
 		}
 		finalEnv = append(finalEnv, envVars...)
 		c.Env = finalEnv

--- a/go/sys/exec/exec.go
+++ b/go/sys/exec/exec.go
@@ -57,8 +57,20 @@ func RunWithCLocale(ctx context.Context, name string, args ...string) (*Result, 
 // (Privileged, PrivilegedStreaming, pkg/exec.runPM, …) inherits the
 // check, so the audit-finding-#8 enforcement lives in one place.
 func RunStreaming(ctx context.Context, name string, args []string, envVars []string, dir string, callback OutputCallback) (*Result, error) {
-	// Default child PATH is the agent's own (sanitized) PATH.
-	return RunStreamingChildPath(ctx, name, args, envVars, os.Getenv("PATH"), dir, callback)
+	if err := validateEnvVars(envVars); err != nil {
+		return nil, err
+	}
+	// Backward-compatible env composition. When the caller supplies env
+	// vars we compose [sanitized parent PATH] + their vars; when they
+	// supply NONE we leave the child env nil so it inherits the parent
+	// environment fully — the long-standing contract every Run*/
+	// Privileged*/pkg caller relies on. (RunStreamingChildPath does NOT
+	// share this fall-through; see its doc.)
+	var finalEnv []string
+	if len(envVars) > 0 {
+		finalEnv = composeEnv(os.Getenv("PATH"), envVars)
+	}
+	return runStreamingWithEnv(ctx, name, args, finalEnv, dir, callback)
 }
 
 // RunStreamingChildPath is RunStreaming with an explicit, TRUSTED child
@@ -66,19 +78,61 @@ func RunStreaming(ctx context.Context, name string, args []string, envVars []str
 // smuggle it through envVars; this entry point lets a trusted caller
 // (e.g. the agent's per-user runuser fan-out, which must run with the
 // target user's PATH rather than root's) set the child PATH directly.
-// childPath is used only when envVars is non-empty, matching
-// RunStreaming's compose-env behavior.
+//
+// SECURITY: unlike RunStreaming, the curated childPath is ALWAYS
+// authoritative — the child env is composed as [PATH=childPath] + envVars
+// even when envVars is EMPTY, and the parent environment is NEVER
+// inherited. This is deliberate: the whole reason a caller reaches for a
+// curated PATH is isolation, so an empty envVars must not silently fall
+// back to inheriting the agent's (root's) full environment — the exact
+// un-sandboxing the previous "childPath used only when envVars is
+// non-empty" shape allowed. A caller that genuinely wants full parent
+// inheritance must use RunStreaming, not this entry point.
 func RunStreamingChildPath(ctx context.Context, name string, args []string, envVars []string, childPath string, dir string, callback OutputCallback) (*Result, error) {
+	if err := validateEnvVars(envVars); err != nil {
+		return nil, err
+	}
+	// Always a non-nil (composed) env: the curated PATH replaces, never
+	// augments, the parent environment.
+	return runStreamingWithEnv(ctx, name, args, composeEnv(childPath, envVars), dir, callback)
+}
+
+// validateEnvVars enforces the SDK env boundary: every entry must be
+// KEY=VALUE and the key must not be on the BlockedEnvVars list (PATH,
+// LD_PRELOAD, BASH_ENV, GCONV_PATH, LD_LIBRARY_PATH, …). This is the one
+// place the audit-finding-#8 check lives; both streaming entry points run
+// it before composing the child env.
+func validateEnvVars(envVars []string) error {
 	for _, e := range envVars {
 		key, _, ok := strings.Cut(e, "=")
 		if !ok {
-			return nil, fmt.Errorf("%w: env entry must be KEY=VALUE, got %q", ErrInvalidEnvVar, e)
+			return fmt.Errorf("%w: env entry must be KEY=VALUE, got %q", ErrInvalidEnvVar, e)
 		}
 		if !IsAllowedEnvVar(key) {
-			return nil, fmt.Errorf("%w: refusing to forward env var %q to child (hijack-prone names like LD_PRELOAD, PATH, BASH_ENV are refused at this boundary)", ErrBlockedEnvVar, key)
+			return fmt.Errorf("%w: refusing to forward env var %q to child (hijack-prone names like LD_PRELOAD, PATH, BASH_ENV are refused at this boundary)", ErrBlockedEnvVar, key)
 		}
 	}
+	return nil
+}
 
+// composeEnv builds the child environment: a leading PATH=childPath (when
+// childPath is non-empty) followed by the caller's already-validated env
+// vars. PATH cannot appear in envVars (it is blocklisted), so the
+// leading entry is the only PATH the child sees. The returned slice is
+// always non-nil so callers can distinguish "isolated env" (this) from
+// "inherit parent fully" (a nil env passed to runStreamingWithEnv).
+func composeEnv(childPath string, envVars []string) []string {
+	env := make([]string, 0, len(envVars)+1)
+	if childPath != "" {
+		env = append(env, "PATH="+childPath)
+	}
+	return append(env, envVars...)
+}
+
+// runStreamingWithEnv runs the command with a fully-composed child env.
+// A nil env inherits the parent environment fully; a non-nil env (even an
+// empty one) replaces it.
+func runStreamingWithEnv(ctx context.Context, name string, args []string, env []string, dir string, callback OutputCallback) (*Result, error) {
 	c := cmd.NewCmdOptions(cmd.Options{
 		Buffered:       false,
 		Streaming:      true,
@@ -88,19 +142,8 @@ func RunStreamingChildPath(ctx context.Context, name string, args []string, envV
 	if dir != "" {
 		c.Dir = dir
 	}
-	if len(envVars) > 0 {
-		// Compose final env: sanitized PATH (from the agent's own
-		// environment, which the BlockedEnvVars check kept the caller
-		// from supplying) + the validated user vars. Callers who
-		// don't pass env vars keep the previous "inherit parent
-		// fully" semantics — that path is unchanged for backward
-		// compatibility.
-		finalEnv := make([]string, 0, len(envVars)+1)
-		if childPath != "" {
-			finalEnv = append(finalEnv, "PATH="+childPath)
-		}
-		finalEnv = append(finalEnv, envVars...)
-		c.Env = finalEnv
+	if env != nil {
+		c.Env = env
 	}
 
 	statusChan := c.Start()

--- a/go/sys/exec/exec_childpath_test.go
+++ b/go/sys/exec/exec_childpath_test.go
@@ -1,0 +1,75 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// RunStreamingChildPath is the TRUSTED seam for running with a curated
+// PATH (the per-user runuser fan-out). The curated childPath must be the
+// PATH the child sees — even though PATH is blocklisted from caller env.
+func TestRunStreamingChildPath_AppliesCuratedPath(t *testing.T) {
+	res, err := pmexec.RunStreamingChildPath(context.Background(), "sh",
+		[]string{"-c", "printf %s \"$PATH\""}, []string{"MARKER=1"},
+		"/curated/bin:/usr/bin", "", nil)
+	if err != nil {
+		t.Fatalf("RunStreamingChildPath: %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != "/curated/bin:/usr/bin" {
+		t.Fatalf("child PATH = %q, want the curated value", got)
+	}
+}
+
+// SECURITY (the un-sandbox footgun): with EMPTY envVars the curated
+// childPath must STILL be authoritative and the parent environment must
+// NOT be inherited. The previous shape applied childPath only when
+// envVars was non-empty, so an empty-env caller silently inherited the
+// agent's (root's) full environment — including root's PATH — defeating
+// the isolation the curated PATH exists to provide.
+func TestRunStreamingChildPath_EmptyEnvStillIsolates(t *testing.T) {
+	t.Setenv("PM_PARENT_SECRET", "leaked-from-root")
+
+	res, err := pmexec.RunStreamingChildPath(context.Background(), "sh",
+		[]string{"-c", "printf %s \"$PATH|${PM_PARENT_SECRET:-unset}\""},
+		nil, "/curated/bin", "", nil)
+	if err != nil {
+		t.Fatalf("RunStreamingChildPath: %v", err)
+	}
+	got := strings.TrimSpace(res.Stdout)
+	if got != "/curated/bin|unset" {
+		t.Fatalf("empty-env curated run leaked the parent environment: got %q, want %q",
+			got, "/curated/bin|unset")
+	}
+}
+
+// The boundary check still applies on this entry point: a blocklisted
+// env var (PATH, LD_PRELOAD, …) in envVars is refused, so an untrusted
+// caller cannot smuggle one past the curated-PATH seam.
+func TestRunStreamingChildPath_StillRejectsBlockedEnv(t *testing.T) {
+	_, err := pmexec.RunStreamingChildPath(context.Background(), "true", nil,
+		[]string{"LD_PRELOAD=/tmp/evil.so"}, "/usr/bin", "", nil)
+	if !errors.Is(err, pmexec.ErrBlockedEnvVar) {
+		t.Fatalf("err = %v, want ErrBlockedEnvVar", err)
+	}
+}
+
+// Counterpart contract that the footgun fix must NOT regress: plain
+// RunStreaming with EMPTY envVars keeps inheriting the parent
+// environment fully (the long-standing behavior every Run*/Privileged*
+// caller relies on). A marker set in the parent must be visible.
+func TestRunStreaming_EmptyEnvInheritsParent(t *testing.T) {
+	t.Setenv("PM_PARENT_MARKER", "inherited")
+
+	res, err := pmexec.RunStreaming(context.Background(), "sh",
+		[]string{"-c", "printf %s \"${PM_PARENT_MARKER:-unset}\""}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("RunStreaming: %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != "inherited" {
+		t.Fatalf("RunStreaming empty-env must inherit the parent env; got %q", got)
+	}
+}

--- a/go/sys/fs/safe_backup_replace_test.go
+++ b/go/sys/fs/safe_backup_replace_test.go
@@ -1,0 +1,108 @@
+//go:build unix
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On success: path holds the new content, backup holds a copy of the
+// old content, and both are regular files with the requested perm.
+func TestSafeBackupAndReplace_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	backup := filepath.Join(dir, "agent.bak")
+
+	if err := os.WriteFile(path, []byte("OLD"), 0o755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := SafeBackupAndReplace(path, backup, []byte("NEW"), 0o755, true); err != nil {
+		t.Fatalf("SafeBackupAndReplace: %v", err)
+	}
+
+	if got, _ := os.ReadFile(path); string(got) != "NEW" {
+		t.Errorf("path: got %q, want NEW", got)
+	}
+	if got, _ := os.ReadFile(backup); string(got) != "OLD" {
+		t.Errorf("backup: got %q, want OLD (a copy of the original)", got)
+	}
+	// path must be a regular file, never absent or a symlink.
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("path must still exist: %v", err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Errorf("path must be a regular file, got mode %v", info.Mode())
+	}
+}
+
+// A symlink at `path` must be rejected (O_NOFOLLOW) rather than
+// dereferenced — otherwise the backup would copy, and the replace would
+// clobber, the symlink's target. The target must be left untouched.
+func TestSafeBackupAndReplace_RejectsSymlinkPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("TARGET"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := SafeBackupAndReplace(link, filepath.Join(dir, "link.bak"), []byte("NEW"), 0o644, true)
+	if err == nil {
+		t.Fatal("expected an error for a symlinked path")
+	}
+	if got, _ := os.ReadFile(target); string(got) != "TARGET" {
+		t.Errorf("symlink target must be untouched, got %q", got)
+	}
+}
+
+// The load-bearing crash-safety property: a failure in the new-content
+// write step must leave `path` holding the ORIGINAL content (never
+// absent). Here the backup lands in a writable dir (so the copy
+// succeeds) while `path` lives in a read-only dir (so SafeReplaceFile's
+// temp create fails) — and `path` must still hold the old binary. The
+// previous rename-first shape moved `path` away before this step, so a
+// failure here left no binary at all.
+func TestSafeBackupAndReplace_WriteFailureLeavesPathIntact(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions; cannot force the write failure")
+	}
+	root := t.TempDir()
+	pathDir := filepath.Join(root, "bin")
+	backupDir := filepath.Join(root, "backups")
+	for _, d := range []string{pathDir, backupDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	path := filepath.Join(pathDir, "agent")
+	backup := filepath.Join(backupDir, "agent.bak")
+	if err := os.WriteFile(path, []byte("ORIGINAL"), 0o755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Make path's directory read-only so SafeReplaceFile(path) fails at
+	// temp creation; restore perms on cleanup so TempDir can be removed.
+	if err := os.Chmod(pathDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(pathDir, 0o755) })
+
+	err := SafeBackupAndReplace(path, backup, []byte("NEW"), 0o755, true)
+	if err == nil {
+		t.Fatal("expected an error when the path write step fails")
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("path must still exist after a failed update, got: %v", readErr)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("path must still hold the original binary after a failed update, got %q", got)
+	}
+}

--- a/go/sys/fs/safe_dir.go
+++ b/go/sys/fs/safe_dir.go
@@ -1,0 +1,32 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+)
+
+// AssertRealDir verifies that path is a real directory and not a
+// symlink (or any other non-directory). Callers use it as a pre-flight
+// guard before running a privileged, path-based chmod/chown on a
+// directory an untrusted user may control — the canonical case being
+// ~/.ssh, which is owned by the target user. Such a user can plant the
+// path as a symlink to an arbitrary location (e.g. /etc); a root-run
+// chmod/chown would then dereference it and act on the target, a TOCTOU
+// privilege escalation. Refusing a symlinked path removes that class.
+//
+// It uses Lstat, so the symlink itself — not its target — is inspected.
+// It does not escalate privileges: a stat is read-only, and the agent
+// already runs with enough privilege to read the path's metadata.
+func AssertRealDir(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat dir %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("path %s is a symlink; refusing to dereference it", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path %s is not a directory", path)
+	}
+	return nil
+}

--- a/go/sys/fs/safe_dir.go
+++ b/go/sys/fs/safe_dir.go
@@ -6,13 +6,24 @@ import (
 )
 
 // AssertRealDir verifies that path is a real directory and not a
-// symlink (or any other non-directory). Callers use it as a pre-flight
-// guard before running a privileged, path-based chmod/chown on a
-// directory an untrusted user may control — the canonical case being
-// ~/.ssh, which is owned by the target user. Such a user can plant the
-// path as a symlink to an arbitrary location (e.g. /etc); a root-run
-// chmod/chown would then dereference it and act on the target, a TOCTOU
-// privilege escalation. Refusing a symlinked path removes that class.
+// symlink (or any other non-directory). It is a CHEAP PRE-FLIGHT
+// PREDICATE, not a TOCTOU-proof guard: it answers "is this a real dir
+// right now?" via a single Lstat. Because the answer is about the path
+// (not an open handle), any privileged operation a caller runs
+// afterwards re-resolves the path in a separate syscall — leaving a
+// check-then-use window in which a user who controls the directory (the
+// canonical case being ~/.ssh, owned by the target user) can swap it for
+// a symlink between this check and the operation. A path-based chmod/
+// chown would then dereference it and act on the target (e.g. /etc) — a
+// TOCTOU privilege escalation.
+//
+// To actually CLOSE that class, do not pair this with path-based
+// chmod/chown. Use OpenRealDir to obtain an O_NOFOLLOW directory handle
+// and apply ownership/mode through the fd (f.Chown/f.Chmod →
+// fchown(2)/fchmod(2)), so the operation acts on the inode that was
+// opened and a later path swap cannot redirect it. Keep AssertRealDir
+// for cheap, non-privileged checks (logging, early rejection) where the
+// re-resolution window is not a concern.
 //
 // It uses Lstat, so the symlink itself — not its target — is inspected.
 // It does not escalate privileges: a stat is read-only, and the agent

--- a/go/sys/fs/safe_dir_test.go
+++ b/go/sys/fs/safe_dir_test.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// AssertRealDir is the guard callers use before running a privileged,
+// path-based chmod/chown on a directory that an untrusted user may
+// control (canonical case: ~/.ssh, owned by the target user). It must
+// accept a real directory and reject a symlink — even one resolving to
+// a valid directory — because a path-based chmod/chown would otherwise
+// dereference the symlink and act on its target (TOCTOU privesc). It
+// must also reject non-directories.
+func TestAssertRealDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := AssertRealDir(realDir); err != nil {
+		t.Errorf("real directory must be accepted, got: %v", err)
+	}
+
+	// Symlink to a directory: the attack shape. Must be rejected even
+	// though it resolves to a valid dir.
+	target := filepath.Join(tmp, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	symlink := filepath.Join(tmp, "symlink")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := AssertRealDir(symlink); err == nil {
+		t.Error("a symlink to a directory must be rejected (dereference is the TOCTOU vector)")
+	}
+
+	// Regular file.
+	file := filepath.Join(tmp, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := AssertRealDir(file); err == nil {
+		t.Error("a regular file must be rejected")
+	}
+
+	// Missing path.
+	if err := AssertRealDir(filepath.Join(tmp, "nope")); err == nil {
+		t.Error("a missing path must be rejected")
+	}
+}

--- a/go/sys/fs/safe_fd_unix.go
+++ b/go/sys/fs/safe_fd_unix.go
@@ -1,0 +1,77 @@
+//go:build unix
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// OpenRealDir opens path as a real directory WITHOUT following a final
+// symlink and returns the *os.File, so callers can apply privileged
+// metadata changes through the fd — f.Chown / f.Chmod, which are
+// fchown(2) / fchmod(2) on the open descriptor — instead of path-based
+// chmod/chown.
+//
+// This is the TOCTOU-closing counterpart to AssertRealDir. A path-based
+// chmod/chown re-resolves the path on every call, so a user who controls
+// the directory (e.g. ~/.ssh, owned by the target user) can swap it for
+// a symlink between a prior check and the operation, redirecting a
+// root-run chmod/chown onto the symlink's target. Operating through the
+// returned fd removes the whole class: the descriptor is bound to the
+// inode that was opened, and a later swap of the path cannot redirect
+// operations on it.
+//
+//   - O_NOFOLLOW makes the open itself fail (ELOOP) if the final path
+//     component is a symlink — there is no window to swap one in, because
+//     the check and the handle are the same syscall.
+//   - O_DIRECTORY makes the open fail (ENOTDIR) if the path is not a
+//     directory, subsuming AssertRealDir's non-dir rejection.
+//
+// The caller MUST Close the returned file.
+func OpenRealDir(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open real dir %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// FchownNoFollow sets ownership on a regular file via an O_NOFOLLOW open
+// followed by an fd-based chown (fchown(2)). A symlink at path is
+// rejected — the open fails (ELOOP) rather than dereferencing — so a
+// user who can plant a symlink where a privileged file was just written
+// (e.g. ~/.ssh/authorized_keys inside their own 0700 dir) cannot
+// redirect the chown onto an arbitrary target (e.g. /etc/shadow). Unlike
+// `chown -h`, which would silently chown the planted symlink itself, this
+// surfaces the tampering as an error.
+//
+// It refuses non-regular files (a directory, device, fifo, …) so it
+// cannot be misused as a directory chown — use OpenRealDir for those.
+//
+// O_NONBLOCK is set because O_NOFOLLOW only guards symlinks: a user who
+// can plant a path could plant a FIFO instead, and a blocking O_RDONLY
+// open on a FIFO hangs until a writer appears (a local DoS on the root
+// agent). With O_NONBLOCK the open returns immediately for a FIFO (and
+// avoids blocking/side effects on a device node too); the subsequent
+// IsRegular check then rejects it.
+func FchownNoFollow(path string, uid, gid int) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return fmt.Errorf("open %s without following symlinks: %w", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing to chown non-regular file %s", path)
+	}
+	if err := f.Chown(uid, gid); err != nil {
+		return fmt.Errorf("fchown %s: %w", path, err)
+	}
+	return nil
+}

--- a/go/sys/fs/safe_fd_unix_test.go
+++ b/go/sys/fs/safe_fd_unix_test.go
@@ -1,0 +1,151 @@
+//go:build unix
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// OpenRealDir is the TOCTOU-closing replacement for "AssertRealDir then
+// path-based chmod/chown". It must accept a real directory and return a
+// handle whose fd-based Chmod/Chown act on the opened inode; it must
+// reject a symlink (even one resolving to a valid dir — that dereference
+// is the privesc vector) and a non-directory, at open time, so there is
+// no check-then-use gap.
+func TestOpenRealDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := OpenRealDir(realDir)
+	if err != nil {
+		t.Fatalf("real directory must be accepted: %v", err)
+	}
+	// The fd must be usable for fd-based metadata changes; this is the
+	// whole point — the operation acts on the opened inode, not a
+	// re-resolved path.
+	if err := f.Chmod(0o750); err != nil {
+		t.Errorf("fchmod via the returned fd must work: %v", err)
+	}
+	if err := f.Chown(os.Getuid(), os.Getgid()); err != nil {
+		t.Errorf("fchown via the returned fd must work: %v", err)
+	}
+	_ = f.Close()
+	if got := mustMode(t, realDir); got.Perm() != 0o750 {
+		t.Errorf("fchmod did not land on the directory: perm=%v", got.Perm())
+	}
+
+	// Symlink to a directory: the attack shape. The O_NOFOLLOW open must
+	// fail rather than hand back a handle to the target.
+	target := filepath.Join(tmp, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if f, err := OpenRealDir(link); err == nil {
+		_ = f.Close()
+		t.Error("a symlink to a directory must be rejected (dereference is the TOCTOU vector)")
+	}
+	if got := mustMode(t, target); got.Perm() != 0o700 {
+		t.Errorf("symlink target must be untouched, perm=%v", got.Perm())
+	}
+
+	// Regular file: O_DIRECTORY must reject it.
+	file := filepath.Join(tmp, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if f, err := OpenRealDir(file); err == nil {
+		_ = f.Close()
+		t.Error("a regular file must be rejected by O_DIRECTORY")
+	}
+
+	// Missing path.
+	if f, err := OpenRealDir(filepath.Join(tmp, "nope")); err == nil {
+		_ = f.Close()
+		t.Error("a missing path must be rejected")
+	}
+}
+
+// FchownNoFollow must chown a real regular file through its fd and refuse
+// a symlinked path (leaving the target untouched) and a non-regular
+// file. Without root we can only chown to our own ids, which is enough to
+// prove the success path; the security properties (symlink + non-regular
+// rejection) need no privilege.
+func TestFchownNoFollow(t *testing.T) {
+	tmp := t.TempDir()
+
+	file := filepath.Join(tmp, "authorized_keys")
+	if err := os.WriteFile(file, []byte("ssh-ed25519 AAAA"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := FchownNoFollow(file, os.Getuid(), os.Getgid()); err != nil {
+		t.Errorf("a real regular file must be chown-able: %v", err)
+	}
+
+	// Symlink: the planted-link attack on a freshly written file. Must be
+	// rejected, and the target's ownership/content must be untouched.
+	target := filepath.Join(tmp, "shadow")
+	if err := os.WriteFile(target, []byte("root:!"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(tmp, "planted")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := FchownNoFollow(link, os.Getuid(), os.Getgid()); err == nil {
+		t.Error("a symlinked path must be rejected, not dereferenced")
+	}
+
+	// Directory: non-regular, must be refused (use OpenRealDir for dirs).
+	dir := filepath.Join(tmp, "dir")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := FchownNoFollow(dir, os.Getuid(), os.Getgid()); err == nil {
+		t.Error("a directory must be refused by FchownNoFollow")
+	}
+
+	// FIFO: a user could plant one in place of the freshly written file.
+	// A blocking O_RDONLY open on a FIFO hangs forever (local DoS); the
+	// O_NONBLOCK open must return promptly and the non-regular check must
+	// reject it. The deadline guards against a regression to a blocking
+	// open: a hang fails the test instead of wedging the suite.
+	fifo := filepath.Join(tmp, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	fifoDone := make(chan error, 1)
+	go func() { fifoDone <- FchownNoFollow(fifo, os.Getuid(), os.Getgid()) }()
+	select {
+	case err := <-fifoDone:
+		if err == nil {
+			t.Error("a FIFO must be refused by FchownNoFollow")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FchownNoFollow hung on a FIFO — O_NONBLOCK regression (blocking O_RDONLY open)")
+	}
+
+	// Missing path.
+	if err := FchownNoFollow(filepath.Join(tmp, "nope"), os.Getuid(), os.Getgid()); err == nil {
+		t.Error("a missing path must be rejected")
+	}
+}
+
+func mustMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return info.Mode()
+}

--- a/go/sys/fs/safe_replace.go
+++ b/go/sys/fs/safe_replace.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -93,24 +94,57 @@ func SafeReplaceFile(path string, data []byte, perm os.FileMode, removeExisting 
 }
 
 // SafeBackupAndReplace is the binary-update shape of SafeReplaceFile:
-// it moves the existing file at path to backupPath (no-op if path
-// does not exist), then writes new content to path via SafeReplaceFile.
+// it COPIES the existing file at path to backupPath (no-op if path does
+// not exist), then writes new content to path via SafeReplaceFile.
 // Used by the agent's self-update path so a planted symlink at
-// "${BinaryPath}.bak" cannot redirect the backup mv to an attacker-
-// chosen target. SDK helper for agent finding F023.
+// "${BinaryPath}.bak" cannot redirect the backup to an attacker-chosen
+// target. SDK helper for agent finding F023.
+//
+// Crash-safety: the backup is a COPY, not a move, so `path` is never
+// left absent. SafeReplaceFile writes a temp file and atomically renames
+// it over `path` as the final step, so on ANY failure — backup error,
+// write error, fsync error, or a crash/power-loss at any point — `path`
+// still holds the original content. (A previous version renamed `path`
+// to the backup FIRST, so a failed write left no binary at `path` at
+// all — a fleet-wide brick risk during self-update.)
 //
 // removeExistingBackup mirrors removeExisting on SafeReplaceFile —
 // pass true if a previous failed update may have left a stale
 // backup that must be replaced.
 func SafeBackupAndReplace(path, backupPath string, newContent []byte, perm os.FileMode, removeExistingBackup bool) error {
-	if _, err := os.Lstat(path); err == nil {
-		// Use renameat2-with-NOREPLACE for the backup move when the
-		// caller does not want to clobber an existing backup.
-		if err := safeRename(path, backupPath, removeExistingBackup); err != nil {
-			return fmt.Errorf("backup current to %s: %w", backupPath, err)
+	// Open the current file with O_NOFOLLOW and read THROUGH the fd, so
+	// there is no lstat→read TOCTOU window in which the path could be
+	// swapped for a symlink: O_NOFOLLOW makes the open itself fail
+	// (ELOOP) on a symlink, and the subsequent Stat/Read operate on the
+	// already-open inode. The backup is then a fresh copy written via
+	// SafeReplaceFile, leaving `path` itself untouched.
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to back up; just write the new content.
+			return SafeReplaceFile(path, newContent, perm, true)
 		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("lstat %s: %w", path, err)
+		return fmt.Errorf("open current %s for backup: %w", path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stat current %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		_ = f.Close()
+		return fmt.Errorf("refusing to back up non-regular file %s", path)
+	}
+	current, err := io.ReadAll(f)
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("read current %s for backup: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close current %s: %w", path, err)
+	}
+	if err := SafeReplaceFile(backupPath, current, perm, removeExistingBackup); err != nil {
+		return fmt.Errorf("backup current to %s: %w", backupPath, err)
 	}
 	return SafeReplaceFile(path, newContent, perm, true)
 }


### PR DESCRIPTION
SDK support for the agent 2026-06 security/code-quality audit sweep (manchtools/power-manage-agent PR). Three additive, independently-useful helpers + one crash-safety fix.

## Changes

- **`fs.AssertRealDir(path)`** — reject a symlinked/non-dir path before a privileged, path-based chmod/chown on a directory an untrusted user controls (agent `~/.ssh` TOCTOU, F022). Uses Lstat.
- **`desktop.UserPath(s)` + `RunAsCommand` curated PATH + `exec.RunStreamingChildPath`** — per-user runuser commands inherited the wrong PATH: `RunAsCommand` set none at all, and the streaming path injected the agent's (root's) PATH. Now both use a curated user PATH (user bins first, no root inheritance), applied last so an action can't override it (PATH is blocklisted from envVars, so the streaming caller passes it as a trusted child PATH).
- **`fs.SafeBackupAndReplace` backs up by copy** — it renamed the live file to the backup FIRST, so a failed write (ENOSPC/EROFS/fsync) or a crash left `path` with NO file (fleet-wide brick risk in the agent's self-update). Now it copies the current file (O_NOFOLLOW read through the fd, no lstat→read TOCTOU) and lets SafeReplaceFile's atomic rename be the only thing that touches `path` — so on any failure `path` keeps the original.

## Tests

New: `AssertRealDir` (symlink/non-dir/missing), `UserPath` + `RunAsCommand` curated-PATH ordering, `SafeBackupAndReplace` round-trip / symlink-path rejection / write-failure-leaves-path-intact. Existing `RunAsCommand` env-isolation test updated to the new PATH contract.

Consumed by the agent audit PR (sequenced sdk → agent). Local CodeRabbit pass clean after the SafeBackupAndReplace O_NOFOLLOW hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable per-user PATH with home-local directories prioritized
  * Added explicit child PATH control for streaming execution
  * Added real directory validation utility

* **Bug Fixes**
  * Fixed PATH override handling to ensure curated user PATH takes precedence

* **Refactor**
  * Updated file backup mechanism to use copy-based approach instead of rename

<!-- end of auto-generated comment: release notes by coderabbit.ai -->