### PR TITLE
fix(sdk): harden native command-invocation surface (#88)

### DIFF
--- a/go/pkg/flatpak.go
+++ b/go/pkg/flatpak.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // Flatpak implements the Manager interface for Flatpak applications.
@@ -564,26 +566,57 @@ func (f *Flatpak) getPinnedSet() (map[string]bool, error) {
 	return pinned, nil
 }
 
-// AddRemote adds a Flatpak remote repository.
+// AddRemote adds a Flatpak remote repository. The name and URL are
+// validated (ValidateRemoteName / ValidateRemoteURL) and placed behind a
+// "--" so neither can be reinterpreted as a remote-add flag such as
+// --gpg-import or --no-gpg-verify.
 func (f *Flatpak) AddRemote(name, url string) (*CommandResult, error) {
-	args := []string{"remote-add", "--if-not-exists", name, url}
-	if f.useSudo {
-		args = append(args, "--system")
-	} else {
-		args = append(args, "--user")
+	args, err := flatpakRemoteAddArgs(name, url, f.useSudo)
+	if err != nil {
+		return nil, err
 	}
 	return f.run(f.ctx, args...)
 }
 
 // RemoveRemote removes a Flatpak remote repository.
 func (f *Flatpak) RemoveRemote(name string) (*CommandResult, error) {
-	args := []string{"remote-delete", "--force", name}
-	if f.useSudo {
-		args = append(args, "--system")
-	} else {
-		args = append(args, "--user")
+	args, err := flatpakRemoteDeleteArgs(name, f.useSudo)
+	if err != nil {
+		return nil, err
 	}
 	return f.run(f.ctx, args...)
+}
+
+// flatpakScopeFlag selects the install scope: --system under privilege,
+// --user otherwise.
+func flatpakScopeFlag(useSudo bool) string {
+	if useSudo {
+		return "--system"
+	}
+	return "--user"
+}
+
+// flatpakRemoteAddArgs validates the remote name + URL and builds the
+// `flatpak remote-add` argv with the positionals behind a "--".
+func flatpakRemoteAddArgs(name, url string, useSudo bool) ([]string, error) {
+	if err := ValidateRemoteName(name); err != nil {
+		return nil, err
+	}
+	if err := ValidateRemoteURL(url); err != nil {
+		return nil, err
+	}
+	flags := []string{"remote-add", "--if-not-exists", flatpakScopeFlag(useSudo)}
+	return pmexec.SeparatePositionals(flags, name, url), nil
+}
+
+// flatpakRemoteDeleteArgs validates the remote name and builds the
+// `flatpak remote-delete` argv with the name behind a "--".
+func flatpakRemoteDeleteArgs(name string, useSudo bool) ([]string, error) {
+	if err := ValidateRemoteName(name); err != nil {
+		return nil, err
+	}
+	flags := []string{"remote-delete", "--force", flatpakScopeFlag(useSudo)}
+	return pmexec.SeparatePositionals(flags, name), nil
 }
 
 // ListRemotes lists configured Flatpak remotes.

--- a/go/pkg/flatpak_remote_test.go
+++ b/go/pkg/flatpak_remote_test.go
@@ -1,0 +1,105 @@
+package pkg
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Threat model: AddRemote/RemoveRemote take an operator-supplied remote
+// name and URL that reach `flatpak remote-add/-delete` argv. flatpak
+// accepts behaviour-altering flags (--gpg-import=FILE, --no-gpg-verify,
+// --from), so a name or URL beginning with "-" (or a non-repo URL scheme)
+// must be refused, and the positionals must sit behind a "--".
+
+func TestValidateRemoteName(t *testing.T) {
+	for _, ok := range []string{"flathub", "gnome-nightly", "my.repo_1"} {
+		if err := ValidateRemoteName(ok); err != nil {
+			t.Errorf("ValidateRemoteName(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{
+		"",                      // empty
+		"-flathub",              // flag shape
+		"--no-gpg-verify",       // flag shape
+		"has space",             // whitespace
+		"name\ninjected",        // control char
+		"slash/name",            // path separator
+		strings.Repeat("a", 65), // over length cap
+	} {
+		if err := ValidateRemoteName(bad); err == nil {
+			t.Errorf("ValidateRemoteName(%q) = nil, want error", bad)
+		}
+	}
+}
+
+func TestValidateRemoteURL(t *testing.T) {
+	for _, ok := range []string{
+		"https://flathub.org/repo/flathub.flatpakrepo",
+		"oci+https://registry.example.com/repo",
+		"http://mirror.internal/repo",
+	} {
+		if err := ValidateRemoteURL(ok); err != nil {
+			t.Errorf("ValidateRemoteURL(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{
+		"",                   // empty
+		"--from",             // flag shape, no scheme
+		"-x",                 // flag shape
+		"file:///etc/passwd", // non-repo scheme
+		"ext::sh -c evil",    // transport injection shape
+		"https://h\nost/x",   // control char
+		"not-a-url",          // no scheme
+	} {
+		if err := ValidateRemoteURL(bad); err == nil {
+			t.Errorf("ValidateRemoteURL(%q) = nil, want error", bad)
+		}
+	}
+}
+
+func TestFlatpakRemoteAddArgs_ValidatesAndSeparates(t *testing.T) {
+	args, err := flatpakRemoteAddArgs("flathub", "https://flathub.org/repo/flathub.flatpakrepo", true)
+	if err != nil {
+		t.Fatalf("flatpakRemoteAddArgs = %v, want nil", err)
+	}
+	// remote-add and option flags precede "--"; name + url follow it.
+	i := slices.Index(args, "--")
+	if i < 0 {
+		t.Fatalf("no end-of-options marker in %v", args)
+	}
+	if args[0] != "remote-add" {
+		t.Errorf("argv[0] = %q, want remote-add", args[0])
+	}
+	if got := args[i+1:]; !slices.Equal(got, []string{"flathub", "https://flathub.org/repo/flathub.flatpakrepo"}) {
+		t.Errorf("positionals = %v, want [flathub <url>]", got)
+	}
+	if !slices.Contains(args, "--system") {
+		t.Errorf("useSudo=true must add --system: %v", args)
+	}
+
+	// Invalid input is rejected before any argv is built.
+	if _, err := flatpakRemoteAddArgs("-evil", "https://x/y", false); err == nil {
+		t.Error("flatpakRemoteAddArgs accepted flag-shaped name")
+	}
+	if _, err := flatpakRemoteAddArgs("ok", "file:///etc/passwd", false); err == nil {
+		t.Error("flatpakRemoteAddArgs accepted file:// url")
+	}
+}
+
+func TestFlatpakRemoteDeleteArgs_ValidatesAndSeparates(t *testing.T) {
+	args, err := flatpakRemoteDeleteArgs("flathub", false)
+	if err != nil {
+		t.Fatalf("flatpakRemoteDeleteArgs = %v, want nil", err)
+	}
+	i := slices.Index(args, "--")
+	if i < 0 || !slices.Equal(args[i+1:], []string{"flathub"}) {
+		t.Errorf("delete argv = %v, want name behind --", args)
+	}
+	if !slices.Contains(args, "--user") {
+		t.Errorf("useSudo=false must add --user: %v", args)
+	}
+	if _, err := flatpakRemoteDeleteArgs("--force", false); err == nil {
+		t.Error("flatpakRemoteDeleteArgs accepted flag-shaped name")
+	}
+}

--- a/go/pkg/pacman.go
+++ b/go/pkg/pacman.go
@@ -87,18 +87,22 @@ func (p *Pacman) InstallVersion(name string, opts InstallOptions) (*CommandResul
 	if opts.Version == "" {
 		return p.Install(name)
 	}
+	return p.run(p.ctx, pacmanInstallVersionArgs(name, opts.Version)...)
+}
 
-	// Try to install with version specification (name=version format)
-	// This works if the version is available in the repos
-	pkgSpec := fmt.Sprintf("%s=%s", name, opts.Version)
-
-	args := []string{"-S", "--noconfirm"}
-	if opts.AllowDowngrade {
-		args = append(args, "--overwrite", "*")
-	}
-	args = append(args, pkgSpec)
-
-	return p.run(p.ctx, args...)
+// pacmanInstallVersionArgs builds `pacman -S --noconfirm <name>=<version>`.
+//
+// AllowDowngrade is deliberately a no-op for pacman: installing an explicit
+// older version from a version spec needs no permit-downgrade flag (pacman
+// has none). The previous implementation injected `--overwrite "*"` here,
+// which force-overwrites ANY conflicting file on disk — including files
+// owned by OTHER packages — a far broader and more dangerous action than
+// the targeted `--allow-downgrades` (apt) / `--oldpackage` (zypper) the
+// sibling backends use. A genuine file conflict now fails loudly rather
+// than silently clobbering unrelated files. (name/version are validated by
+// the caller before reaching here.)
+func pacmanInstallVersionArgs(name, version string) []string {
+	return []string{"-S", "--noconfirm", fmt.Sprintf("%s=%s", name, version)}
 }
 
 // Remove removes packages.

--- a/go/pkg/pacman_downgrade_test.go
+++ b/go/pkg/pacman_downgrade_test.go
@@ -1,0 +1,31 @@
+package pkg
+
+import (
+	"slices"
+	"testing"
+)
+
+// pacman has no "permit downgrade" flag — `pacman -S pkg=<older>` installs
+// an explicit older version directly. The previous implementation injected
+// `--overwrite "*"` for AllowDowngrade, which force-clobbers ANY conflicting
+// file on disk, including files owned by OTHER packages. That blanket glob
+// must not appear: a real file conflict should fail loudly, not silently
+// overwrite unrelated files (the apt/zypper backends use the targeted
+// --allow-downgrades / --oldpackage, not a wildcard overwrite).
+func TestPacmanInstallVersionArgs_NoBlanketOverwrite(t *testing.T) {
+	args := pacmanInstallVersionArgs("vim", "8.0.1")
+
+	if slices.Contains(args, "--overwrite") {
+		t.Errorf("argv must not contain --overwrite (blanket clobber): %v", args)
+	}
+	if slices.Contains(args, "*") {
+		t.Errorf("argv must not contain the '*' overwrite glob: %v", args)
+	}
+	// It must still install the requested version spec non-interactively.
+	if !slices.Contains(args, "vim=8.0.1") {
+		t.Errorf("argv missing version spec vim=8.0.1: %v", args)
+	}
+	if !slices.Contains(args, "-S") || !slices.Contains(args, "--noconfirm") {
+		t.Errorf("argv missing -S/--noconfirm: %v", args)
+	}
+}

--- a/go/pkg/validate.go
+++ b/go/pkg/validate.go
@@ -2,7 +2,9 @@ package pkg
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 // validPackageName is the allowlist every package-name argument must
@@ -90,6 +92,60 @@ func ValidatePackageVersion(version string) error {
 	}
 	if !validPackageVersion.MatchString(version) {
 		return fmt.Errorf("invalid package version %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._+:~^-]", version)
+	}
+	return nil
+}
+
+// validRemoteName guards a Flatpak remote name. First char alphanumeric
+// (so a name can never be flag-shaped), then the reverse-DNS / id charset
+// flatpak accepts, capped at 64. Same option-injection rationale as
+// validPackageName.
+var validRemoteName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`)
+
+// remoteURLSchemes are the only schemes a Flatpak remote URL may carry.
+// flatpak remotes are served over https / oci (optionally plain http for
+// an internal mirror). Restricting the scheme refuses both transport
+// injection (ext::, file://) and flag-shaped values (which have no
+// scheme), so a URL can never be reinterpreted as a remote-add option
+// like --from or --gpg-import.
+var remoteURLSchemes = map[string]bool{
+	"https":     true,
+	"http":      true,
+	"oci+https": true,
+	"oci+http":  true,
+}
+
+// ValidateRemoteName returns a non-nil error when name is unsafe to pass
+// as a Flatpak remote name argument.
+func ValidateRemoteName(name string) error {
+	if name == "" {
+		return fmt.Errorf("remote name is empty")
+	}
+	if !validRemoteName.MatchString(name) {
+		return fmt.Errorf("invalid remote name %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-], max 64 chars", name)
+	}
+	return nil
+}
+
+// ValidateRemoteURL returns a non-nil error when rawURL is unsafe to pass
+// as a Flatpak remote URL. It must be a control-character-free absolute URL
+// whose scheme is one of remoteURLSchemes.
+func ValidateRemoteURL(rawURL string) error {
+	if rawURL == "" {
+		return fmt.Errorf("remote url is empty")
+	}
+	if strings.ContainsAny(rawURL, "\x00\n\r\t ") {
+		return fmt.Errorf("invalid remote url: contains whitespace or control characters")
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid remote url %q: %w", rawURL, err)
+	}
+	if !remoteURLSchemes[strings.ToLower(u.Scheme)] {
+		return fmt.Errorf("invalid remote url %q: scheme must be one of https, http, oci+https, oci+http", rawURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid remote url %q: missing host", rawURL)
 	}
 	return nil
 }

--- a/go/sys/encryption/devicepath_test.go
+++ b/go/sys/encryption/devicepath_test.go
@@ -1,0 +1,86 @@
+package encryption
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// Threat model: devicePath reaches cryptsetup / systemd-cryptenroll argv,
+// which run as ROOT. A flag-shaped value ("--header=...", "--key-file",
+// "--master-key-file") would be parsed by cryptsetup as an option,
+// redirecting the privileged operation; a path-escape ("/dev/../etc/x")
+// would point it elsewhere. validateDevicePath must require an absolute,
+// canonical path under /dev/, which makes both impossible (a "/dev/"-
+// prefixed value can't begin with '-', and a canonical path has no `..`).
+
+func TestValidateDevicePath_RejectsUnsafe(t *testing.T) {
+	// Wrong cases derived from the threat model, not from the validator.
+	bad := []string{
+		"",                   // empty
+		"--header=/tmp/evil", // flag injection
+		"-d",                 // flag injection
+		"/etc/passwd",        // outside /dev
+		"sda3",               // relative
+		"dev/sda3",           // relative
+		"/dev/../etc/shadow", // path escape
+		"/dev/./sda3",        // non-canonical
+		"/dev//sda3",         // non-canonical (redundant sep)
+		"/dev/",              // names the directory, no device
+		"/dev",               // the directory itself
+		"/dev/sda3\n",        // trailing newline (arg smuggling / log forging)
+		"/dev/sda3\x00extra", // NUL
+		"/dev/disk\rby-uuid", // CR
+	}
+	for _, d := range bad {
+		if err := validateDevicePath(d); err == nil {
+			t.Errorf("validateDevicePath(%q) = nil, want ErrInvalidDevicePath", d)
+		} else if !errors.Is(err, ErrInvalidDevicePath) {
+			t.Errorf("validateDevicePath(%q) error = %v, want ErrInvalidDevicePath", d, err)
+		}
+	}
+}
+
+func TestValidateDevicePath_AcceptsRealDevices(t *testing.T) {
+	// Must not over-reject the real shapes the agent passes: plain block
+	// devices, NVMe partitions, device-mapper names, and by-uuid / by-label
+	// symlink paths (all live under /dev/).
+	for _, d := range []string{
+		"/dev/sda3",
+		"/dev/nvme0n1p3",
+		"/dev/mapper/cryptroot",
+		"/dev/disk/by-uuid/4c1f-9a2b-deadbeef",
+		"/dev/null",
+	} {
+		if err := validateDevicePath(d); err != nil {
+			t.Errorf("validateDevicePath(%q) = %v, want nil", d, err)
+		}
+	}
+}
+
+// Each exported LUKS/TPM entry point must reject an unsafe device path
+// BEFORE shelling out. We drive a flag-shaped path through the real
+// functions and require ErrInvalidDevicePath — proving the guard runs at
+// the boundary, not just in the helper.
+func TestLUKSEntryPoints_RejectFlagShapedDevicePath(t *testing.T) {
+	SetBackend(BackendLUKS)
+	ctx := context.Background()
+	const evil = "--header=/tmp/evil"
+
+	checks := map[string]func() error{
+		"IsLuks":         func() error { _, err := IsLuks(ctx, evil); return err },
+		"AddKey":         func() error { return AddKey(ctx, evil, "old", "new") },
+		"AddKeyToSlot":   func() error { return AddKeyToSlot(ctx, evil, 0, "old", "new") },
+		"RemoveKey":      func() error { return RemoveKey(ctx, evil, "key") },
+		"KillSlot":       func() error { return KillSlot(ctx, evil, 0, "old") },
+		"TestPassphrase": func() error { _, err := TestPassphrase(ctx, evil, "pw"); return err },
+		"EnrollTPM":      func() error { return EnrollTPM(ctx, evil, "old") },
+		"WipeTPM":        func() error { return WipeTPM(ctx, evil, "old") },
+	}
+	for name, call := range checks {
+		err := call()
+		if !errors.Is(err, ErrInvalidDevicePath) {
+			t.Errorf("%s(%q) error = %v, want ErrInvalidDevicePath", name, evil, err)
+		}
+	}
+}

--- a/go/sys/encryption/luks.go
+++ b/go/sys/encryption/luks.go
@@ -44,6 +44,9 @@ func IsLuks(ctx context.Context, devicePath string) (bool, error) {
 	if err := requireBackend(BackendLUKS, "IsLuks"); err != nil {
 		return false, err
 	}
+	if err := validateDevicePath(devicePath); err != nil {
+		return false, err
+	}
 	result, err := exec.Privileged(ctx, "cryptsetup", "isLuks", devicePath)
 	if err != nil {
 		if result != nil && result.ExitCode == 1 {
@@ -57,6 +60,9 @@ func IsLuks(ctx context.Context, devicePath string) (bool, error) {
 // AddKey adds a new passphrase to a LUKS volume using an existing key for authentication.
 func AddKey(ctx context.Context, devicePath, existingKey, newKey string) error {
 	if err := requireBackend(BackendLUKS, "AddKey"); err != nil {
+		return err
+	}
+	if err := validateDevicePath(devicePath); err != nil {
 		return err
 	}
 	existingFile, err := writeKeyFile(existingKey)
@@ -81,6 +87,9 @@ func AddKey(ctx context.Context, devicePath, existingKey, newKey string) error {
 // AddKeyToSlot adds a new passphrase to a specific LUKS slot.
 func AddKeyToSlot(ctx context.Context, devicePath string, slot int, existingKey, newKey string) error {
 	if err := requireBackend(BackendLUKS, "AddKeyToSlot"); err != nil {
+		return err
+	}
+	if err := validateDevicePath(devicePath); err != nil {
 		return err
 	}
 	if err := validateKeySlot(slot); err != nil {
@@ -111,6 +120,9 @@ func RemoveKey(ctx context.Context, devicePath, key string) error {
 	if err := requireBackend(BackendLUKS, "RemoveKey"); err != nil {
 		return err
 	}
+	if err := validateDevicePath(devicePath); err != nil {
+		return err
+	}
 	keyFile, err := writeKeyFile(key)
 	if err != nil {
 		return err
@@ -127,6 +139,9 @@ func RemoveKey(ctx context.Context, devicePath, key string) error {
 // KillSlot removes a specific LUKS slot using an existing key for authentication.
 func KillSlot(ctx context.Context, devicePath string, slot int, existingKey string) error {
 	if err := requireBackend(BackendLUKS, "KillSlot"); err != nil {
+		return err
+	}
+	if err := validateDevicePath(devicePath); err != nil {
 		return err
 	}
 	if err := validateKeySlot(slot); err != nil {
@@ -206,6 +221,9 @@ const keyFileDir = "/dev/shm/pm-luks"
 // Returns true if the passphrase is accepted, false if rejected.
 func TestPassphrase(ctx context.Context, devicePath, passphrase string) (bool, error) {
 	if err := requireBackend(BackendLUKS, "TestPassphrase"); err != nil {
+		return false, err
+	}
+	if err := validateDevicePath(devicePath); err != nil {
 		return false, err
 	}
 	keyFile, err := writeKeyFile(passphrase)

--- a/go/sys/encryption/tpm.go
+++ b/go/sys/encryption/tpm.go
@@ -28,6 +28,9 @@ func EnrollTPM(ctx context.Context, devicePath, existingKey string) error {
 	if err := requireBackend(BackendLUKS, "EnrollTPM"); err != nil {
 		return err
 	}
+	if err := validateDevicePath(devicePath); err != nil {
+		return err
+	}
 	stdin := strings.NewReader(existingKey)
 	_, err := exec.PrivilegedWithStdin(ctx, stdin, "systemd-cryptenroll",
 		"--tpm2-device=auto", "--tpm2-pcrs=7+14", devicePath)
@@ -41,6 +44,9 @@ func EnrollTPM(ctx context.Context, devicePath, existingKey string) error {
 // passphrase for authentication.
 func WipeTPM(ctx context.Context, devicePath, existingKey string) error {
 	if err := requireBackend(BackendLUKS, "WipeTPM"); err != nil {
+		return err
+	}
+	if err := validateDevicePath(devicePath); err != nil {
 		return err
 	}
 	stdin := strings.NewReader(existingKey)

--- a/go/sys/encryption/validate.go
+++ b/go/sys/encryption/validate.go
@@ -3,9 +3,42 @@ package encryption
 import (
 	"crypto/sha512"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"unicode"
 )
+
+// ErrInvalidDevicePath is returned when a device path passed to a LUKS /
+// TPM operation is not an absolute, canonical path under /dev/.
+var ErrInvalidDevicePath = errors.New("invalid device path")
+
+// validateDevicePath guards the devicePath argument before it reaches
+// cryptsetup / systemd-cryptenroll argv. Those run as root, so a
+// flag-shaped value (e.g. "--header=/tmp/evil", "--master-key-file") would
+// be parsed as an option and redirect the privileged operation, and a
+// path-escape ("/dev/../etc/x") would point it elsewhere. Requiring an
+// absolute, canonical path under /dev/ closes both: a "/dev/"-prefixed
+// value can never begin with '-', and a canonical path has no `.`/`..`
+// segments. The check is lexical only — symlink resolution (e.g. of
+// /dev/disk/by-uuid/...) is left to cryptsetup, which the operation needs
+// anyway.
+func validateDevicePath(devicePath string) error {
+	if devicePath == "" {
+		return fmt.Errorf("%w: device path is empty", ErrInvalidDevicePath)
+	}
+	if strings.ContainsAny(devicePath, "\x00\n\r") {
+		return fmt.Errorf("%w: device path contains control characters", ErrInvalidDevicePath)
+	}
+	if filepath.Clean(devicePath) != devicePath {
+		return fmt.Errorf("%w: device path %q is not canonical", ErrInvalidDevicePath, devicePath)
+	}
+	if !strings.HasPrefix(devicePath, "/dev/") || devicePath == "/dev/" {
+		return fmt.Errorf("%w: device path %q must name a device under /dev/", ErrInvalidDevicePath, devicePath)
+	}
+	return nil
+}
 
 // Complexity represents password complexity requirements.
 type Complexity int

--- a/go/sys/exec/argv.go
+++ b/go/sys/exec/argv.go
@@ -1,0 +1,23 @@
+package exec
+
+// EndOfOptions is the conventional getopt/popt "--" token that tells a CLI
+// to stop parsing options: every argument after it is an operand, even one
+// that begins with "-". Place it immediately before positional arguments
+// whose values aren't fixed literals (a username, device path, package
+// name, notification title, …) so a value shaped like a flag can never be
+// reinterpreted as one.
+const EndOfOptions = "--"
+
+// SeparatePositionals returns flags, then a single EndOfOptions marker,
+// then the positionals — the fail-safe argv shape for any tool that
+// honours "--" (useradd, usermod, groupadd, userdel, mount, shutdown,
+// notify-send, …). It guarantees a flag-shaped positional is treated as an
+// operand without relying on each caller's input validation. The result is
+// a freshly allocated slice; the caller's flags slice is never mutated.
+func SeparatePositionals(flags []string, positionals ...string) []string {
+	out := make([]string, 0, len(flags)+1+len(positionals))
+	out = append(out, flags...)
+	out = append(out, EndOfOptions)
+	out = append(out, positionals...)
+	return out
+}

--- a/go/sys/exec/argv_test.go
+++ b/go/sys/exec/argv_test.go
@@ -1,0 +1,56 @@
+package exec
+
+import (
+	"slices"
+	"testing"
+)
+
+// SeparatePositionals exists so a value that happens to begin with "-"
+// (a username, device path, notification title, …) is always parsed by
+// the target CLI as an operand, never as a flag. The contract: the "--"
+// end-of-options marker is inserted exactly once, immediately after the
+// flags and before every positional.
+
+func TestSeparatePositionals_InsertsMarkerBeforePositionals(t *testing.T) {
+	got := SeparatePositionals([]string{"-r", "-m"}, "alice")
+	want := []string{"-r", "-m", "--", "alice"}
+	if !slices.Equal(got, want) {
+		t.Errorf("SeparatePositionals = %v, want %v", got, want)
+	}
+}
+
+func TestSeparatePositionals_NoFlags(t *testing.T) {
+	got := SeparatePositionals(nil, "/dev/sda3")
+	want := []string{"--", "/dev/sda3"}
+	if !slices.Equal(got, want) {
+		t.Errorf("SeparatePositionals = %v, want %v", got, want)
+	}
+}
+
+func TestSeparatePositionals_MultiplePositionals(t *testing.T) {
+	got := SeparatePositionals([]string{"-u", "critical"}, "title", "body")
+	want := []string{"-u", "critical", "--", "title", "body"}
+	if !slices.Equal(got, want) {
+		t.Errorf("SeparatePositionals = %v, want %v", got, want)
+	}
+}
+
+// A flag-shaped positional must end up AFTER the marker so it can't be
+// read as an option — this is the whole point.
+func TestSeparatePositionals_FlagShapedPositionalIsAfterMarker(t *testing.T) {
+	got := SeparatePositionals([]string{"-L"}, "-evil")
+	want := []string{"-L", "--", "-evil"}
+	if !slices.Equal(got, want) {
+		t.Errorf("SeparatePositionals = %v, want %v", got, want)
+	}
+}
+
+// The helper must not write into the caller's flags backing array.
+func TestSeparatePositionals_DoesNotAliasCallerSlice(t *testing.T) {
+	flags := make([]string, 1, 8) // spare capacity → naive append would alias
+	flags[0] = "-r"
+	_ = SeparatePositionals(flags, "alice")
+	if len(flags) != 1 || flags[0] != "-r" {
+		t.Errorf("caller flags mutated: %v", flags)
+	}
+}

--- a/go/sys/fs/mount.go
+++ b/go/sys/fs/mount.go
@@ -34,7 +34,9 @@ func IsReadOnly(path string) (bool, error) {
 // RemountRW attempts to remount the filesystem at path as read-write
 // via the configured privilege backend: mount -o remount,rw.
 func RemountRW(ctx context.Context, path string) error {
-	_, err := exec.Privileged(ctx, "mount", "-o", "remount,rw", path)
+	// "--" before the path so a path that begins with "-" is read as the
+	// mount target, never as a mount option.
+	_, err := exec.Privileged(ctx, "mount", exec.SeparatePositionals([]string{"-o", "remount,rw"}, path)...)
 	if err != nil {
 		return fmt.Errorf("remount %s read-write: %w", path, err)
 	}

--- a/go/sys/keyfile/keyfile.go
+++ b/go/sys/keyfile/keyfile.go
@@ -1,0 +1,166 @@
+// Package keyfile builds glib-style INI / keyfile content — the format
+// used by NetworkManager system-connections, systemd units, and
+// freedesktop .desktop entries — with fail-closed validation of every
+// section name, key, and value.
+//
+// Why this exists: the format is line-oriented. A value is everything
+// after `key=` up to the newline, and a `[name]` on its own line opens a
+// section. A value (or key, or section name) that contains a newline,
+// carriage return, or NUL can therefore inject additional keys or whole
+// sections into a file that a privileged daemon later parses as root —
+// exactly the class of bug where a wifi SSID or PSK carrying
+// "\n[connection]\npermissions=user:root:" reshapes a profile the
+// operator never authored.
+//
+// Builder refuses such input rather than silently stripping it, so a
+// malformed field surfaces as an error at the boundary instead of a
+// structurally-corrupted file on disk. Callers that interpolate external
+// input into a keyfile should build it through Builder (or at minimum run
+// each value through ValidateValue) rather than hand-rolling fmt.Fprintf.
+package keyfile
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUnsafeValue is returned when a section name, key, or value contains a
+// character that would break the line-oriented keyfile grammar.
+var ErrUnsafeValue = errors.New("unsafe keyfile content")
+
+// lineBreakingBytes are the bytes that let a single field break out of its
+// `key=value` line: newline and carriage return open a new line (and thus
+// a new key or `[section]`), and NUL truncates the field in glib's C-string
+// parser. This is the same set sys/remote uses to guard URLs.
+const lineBreakingBytes = "\n\r\x00"
+
+// ValidateValue returns ErrUnsafeValue when v cannot appear as a scalar
+// keyfile value without altering the file's structure. It is the
+// fail-closed boundary every caller interpolating external input into a
+// keyfile value must pass through. Ordinary content — spaces, `=`, `#`,
+// `;`, brackets, unicode — is accepted, because none of those break a
+// value line (they matter only in the key/section position or for
+// list-typed keys), and rejecting them would refuse legitimate WPA
+// passphrases and SSIDs.
+func ValidateValue(v string) error {
+	if i := strings.IndexAny(v, lineBreakingBytes); i >= 0 {
+		return fmt.Errorf("%w: value contains %q at offset %d", ErrUnsafeValue, v[i], i)
+	}
+	return nil
+}
+
+// ValidateKey applies the value ban plus the key-specific ones: a key must
+// be non-empty, must not contain `=` (which would split it into a
+// different key/value), and must not begin with `[` (which would read as a
+// section header).
+func ValidateKey(k string) error {
+	if k == "" {
+		return fmt.Errorf("%w: empty key", ErrUnsafeValue)
+	}
+	if err := ValidateValue(k); err != nil {
+		return err
+	}
+	if strings.ContainsRune(k, '=') {
+		return fmt.Errorf("%w: key %q contains '='", ErrUnsafeValue, k)
+	}
+	if strings.HasPrefix(k, "[") {
+		return fmt.Errorf("%w: key %q begins with '['", ErrUnsafeValue, k)
+	}
+	return nil
+}
+
+// ValidateSection applies the value ban plus a bracket ban: a section name
+// must be non-empty and must not contain `[` or `]`, either of which would
+// reshape the `[name]` header line.
+func ValidateSection(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: empty section name", ErrUnsafeValue)
+	}
+	if err := ValidateValue(name); err != nil {
+		return err
+	}
+	if strings.ContainsAny(name, "[]") {
+		return fmt.Errorf("%w: section name %q contains '[' or ']'", ErrUnsafeValue, name)
+	}
+	return nil
+}
+
+// Builder accumulates sections and key/value pairs and renders a keyfile
+// body, validating every section, key, and value as it is added. The
+// zero value is ready to use.
+//
+// Errors are sticky: the first failed Comment/Section/Set records the
+// error and every later add is a no-op, so a caller can append fluently
+// and check exactly once via Bytes. This guarantees Bytes never returns a
+// partially-rendered file that contains an injected line.
+type Builder struct {
+	b            strings.Builder
+	err          error
+	sectionCount int
+}
+
+// Comment writes a `# text` comment line. The comment text is validated
+// like a value (no line-breaking bytes) so it cannot itself inject keys.
+func (k *Builder) Comment(text string) *Builder {
+	if k.err != nil {
+		return k
+	}
+	if err := ValidateValue(text); err != nil {
+		k.err = err
+		return k
+	}
+	fmt.Fprintf(&k.b, "# %s\n", text)
+	return k
+}
+
+// Section opens a new `[name]` section. A blank line is emitted before
+// every section after the first so a value can never visually run into the
+// following header.
+func (k *Builder) Section(name string) *Builder {
+	if k.err != nil {
+		return k
+	}
+	if err := ValidateSection(name); err != nil {
+		k.err = err
+		return k
+	}
+	if k.sectionCount > 0 {
+		k.b.WriteByte('\n')
+	}
+	fmt.Fprintf(&k.b, "[%s]\n", name)
+	k.sectionCount++
+	return k
+}
+
+// Set writes a `key=value` line, validating both halves.
+func (k *Builder) Set(key, value string) *Builder {
+	if k.err != nil {
+		return k
+	}
+	if err := ValidateKey(key); err != nil {
+		k.err = err
+		return k
+	}
+	if err := ValidateValue(value); err != nil {
+		k.err = err
+		return k
+	}
+	fmt.Fprintf(&k.b, "%s=%s\n", key, value)
+	return k
+}
+
+// Bytes returns the rendered keyfile body, or the first validation error
+// encountered. On error it returns a nil body so a caller can never write
+// a partially-rendered (and possibly injected) file.
+func (k *Builder) Bytes() ([]byte, error) {
+	if k.err != nil {
+		return nil, k.err
+	}
+	return []byte(k.b.String()), nil
+}
+
+// Err returns the first validation error recorded so far, or nil.
+func (k *Builder) Err() error {
+	return k.err
+}

--- a/go/sys/keyfile/keyfile_test.go
+++ b/go/sys/keyfile/keyfile_test.go
@@ -1,0 +1,159 @@
+package keyfile
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The contract under test: a glib-style keyfile is line-oriented. A value
+// is everything after `key=` up to the newline; `[name]` on its own line
+// opens a section. So a newline, carriage return, or NUL in any section
+// name, key, or value lets a single field inject additional keys or whole
+// sections into a file a privileged daemon (NetworkManager, systemd) later
+// parses as root. The builder must REFUSE such input (fail closed), never
+// silently strip it.
+
+func TestValidateValue_RejectsLineBreakingBytes(t *testing.T) {
+	// Derived from the format's grammar, not from the implementation:
+	// these are exactly the bytes that terminate or restructure a
+	// `key=value` line. Each must be rejected wherever it appears in the
+	// value (start, middle, end) so a check can't pass by only guarding
+	// one position.
+	for _, bad := range []string{
+		"\n",
+		"\r",
+		"\x00",
+		"value\ninjected=1",
+		"value\r\n[evil]",
+		"trailing\n",
+		"\nleading",
+		"mid\x00dle",
+	} {
+		if err := ValidateValue(bad); err == nil {
+			t.Errorf("ValidateValue(%q) = nil, want ErrUnsafeValue", bad)
+		} else if !errors.Is(err, ErrUnsafeValue) {
+			t.Errorf("ValidateValue(%q) error = %v, want ErrUnsafeValue", bad, err)
+		}
+	}
+}
+
+func TestValidateValue_AcceptsOrdinaryValues(t *testing.T) {
+	// A scalar value legitimately carries spaces, `=`, `#`, `;`, `[`, `]`,
+	// and unicode — none of those break a keyfile line (they are only
+	// meaningful in the key/section position, or as list separators for
+	// list-typed keys). Rejecting them would break real WPA passphrases
+	// and SSIDs, so the validator must accept them.
+	for _, ok := range []string{
+		"hunter2",
+		"Corp Net 5GHz",
+		"p@ss=w0rd#1;2[3]",
+		"日本語ネット",
+		"",
+	} {
+		if err := ValidateValue(ok); err != nil {
+			t.Errorf("ValidateValue(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
+func TestValidateKey_RejectsSeparatorAndHeader(t *testing.T) {
+	// A key carries the same line-break ban as a value, PLUS it must not
+	// contain `=` (that would split into a different key/value) and must
+	// not begin with `[` (that would read as a section header). An empty
+	// key is meaningless and rejected.
+	for _, bad := range []string{"", "a=b", "[section", "k\ney", "k\x00"} {
+		if err := ValidateKey(bad); err == nil {
+			t.Errorf("ValidateKey(%q) = nil, want error", bad)
+		} else if !errors.Is(err, ErrUnsafeValue) {
+			t.Errorf("ValidateKey(%q) error = %v, want ErrUnsafeValue", bad, err)
+		}
+	}
+	for _, ok := range []string{"id", "autoconnect-priority", "key-mgmt"} {
+		if err := ValidateKey(ok); err != nil {
+			t.Errorf("ValidateKey(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
+func TestValidateSection_RejectsBrackets(t *testing.T) {
+	for _, bad := range []string{"", "a]b", "a[b", "sec\ntion", "sec\x00"} {
+		if err := ValidateSection(bad); err == nil {
+			t.Errorf("ValidateSection(%q) = nil, want error", bad)
+		} else if !errors.Is(err, ErrUnsafeValue) {
+			t.Errorf("ValidateSection(%q) error = %v, want ErrUnsafeValue", bad, err)
+		}
+	}
+	for _, ok := range []string{"connection", "wifi-security", "802-1x"} {
+		if err := ValidateSection(ok); err != nil {
+			t.Errorf("ValidateSection(%q) = %v, want nil", ok, err)
+		}
+	}
+}
+
+func TestBuilder_RendersValidKeyfile(t *testing.T) {
+	b := &Builder{}
+	b.Comment("Managed — do not edit")
+	b.Section("connection")
+	b.Set("id", "pm-wifi-1")
+	b.Set("type", "wifi")
+	b.Section("wifi")
+	b.Set("ssid", "Corp Net")
+
+	out, err := b.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes() error = %v, want nil", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"# Managed — do not edit\n",
+		"[connection]\n",
+		"id=pm-wifi-1\n",
+		"type=wifi\n",
+		"[wifi]\n",
+		"ssid=Corp Net\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered keyfile missing %q:\n%s", want, got)
+		}
+	}
+	// A blank line must separate sections so a value's trailing content
+	// can never visually run into the next header.
+	if !strings.Contains(got, "type=wifi\n\n[wifi]") {
+		t.Errorf("expected blank line between sections:\n%s", got)
+	}
+}
+
+func TestBuilder_FailsClosedOnInjectedValue(t *testing.T) {
+	// The load-bearing test: a value carrying a newline + forged section
+	// must make the WHOLE build fail, and Bytes must return no content —
+	// never a partially-rendered file with the injection in it.
+	b := &Builder{}
+	b.Section("wifi")
+	b.Set("ssid", "Evil\n[connection]\npermissions=user:root:")
+
+	out, err := b.Bytes()
+	if err == nil {
+		t.Fatalf("Bytes() = nil error, want ErrUnsafeValue; out=%q", out)
+	}
+	if !errors.Is(err, ErrUnsafeValue) {
+		t.Errorf("Bytes() error = %v, want ErrUnsafeValue", err)
+	}
+	if out != nil {
+		t.Errorf("Bytes() returned %q on error, want nil (no partial keyfile)", out)
+	}
+}
+
+func TestBuilder_FirstFailureIsSticky(t *testing.T) {
+	// Once an add fails validation, later well-formed adds must not mask
+	// the error: the builder records the first failure and Bytes surfaces
+	// it. Otherwise a caller appending fluently could append a valid pair
+	// after a poisoned one and get a "successful" build.
+	b := &Builder{}
+	b.Section("wifi")
+	b.Set("ssid", "ok\ninjected=1")
+	b.Set("mode", "infrastructure") // valid, must NOT clear the prior error
+	if _, err := b.Bytes(); !errors.Is(err, ErrUnsafeValue) {
+		t.Errorf("Bytes() error = %v, want ErrUnsafeValue (first failure sticky)", err)
+	}
+}

--- a/go/sys/network/wifi.go
+++ b/go/sys/network/wifi.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/keyfile"
 )
 
 // WiFiAuthType identifies the WiFi authentication method.
@@ -520,21 +521,42 @@ func appendCommonArgs(args []string, p WiFiProfile) []string {
 }
 
 // validateProfile checks required fields based on auth type.
+//
+// Beyond presence, every operator-supplied free-text field that reaches a
+// NetworkManager keyfile (Name, SSID, PSK) or nmcli argv (Identity) is
+// checked for line-breaking bytes (newline / CR / NUL) via
+// keyfile.ValidateValue. The keyfile is a root-owned, root-parsed,
+// line-oriented file, so a newline in one of these fields would inject
+// extra keys or sections (flip permissions, redirect DNS, disable
+// security). Rejecting here makes CreateOrUpdate fail closed before
+// anything is written; BuildPSKKeyfile re-checks as defense in depth.
 func validateProfile(p WiFiProfile) error {
 	if p.Name == "" {
 		return fmt.Errorf("connection name is required")
 	}
+	if err := keyfile.ValidateValue(p.Name); err != nil {
+		return fmt.Errorf("connection name: %w", err)
+	}
 	if p.SSID == "" {
 		return fmt.Errorf("SSID is required")
+	}
+	if err := keyfile.ValidateValue(p.SSID); err != nil {
+		return fmt.Errorf("SSID: %w", err)
 	}
 	switch p.AuthType {
 	case WiFiAuthPSK:
 		if p.PSK == "" {
 			return fmt.Errorf("PSK is required for WPA authentication")
 		}
+		if err := keyfile.ValidateValue(p.PSK); err != nil {
+			return fmt.Errorf("PSK: %w", err)
+		}
 	case WiFiAuthEAPTLS:
 		if p.Identity == "" {
 			return fmt.Errorf("identity is required for EAP-TLS authentication")
+		}
+		if err := keyfile.ValidateValue(p.Identity); err != nil {
+			return fmt.Errorf("identity: %w", err)
 		}
 		if p.CertDir == "" {
 			return fmt.Errorf("cert directory is required for EAP-TLS authentication")

--- a/go/sys/network/wifi_injection_test.go
+++ b/go/sys/network/wifi_injection_test.go
@@ -1,0 +1,114 @@
+package network
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/keyfile"
+)
+
+// Threat model: a WiFi profile (SSID / PSK / connection name / EAP
+// identity) is operator-supplied and lands in a ROOT-owned
+// /etc/NetworkManager/system-connections/<name>.nmconnection that NM
+// loads as root. A field carrying a newline can inject arbitrary keyfile
+// keys or whole sections (e.g. flip permissions, redirect DNS, disable
+// security). The contract: such a profile must be REJECTED before any
+// keyfile is built or written — fail closed, not silently stripped.
+
+// injectionPayloads are sourced from the keyfile grammar (newline / CR /
+// NUL break a line), not from the validator, so an under-specified
+// validator can't hide behind matching test data.
+var injectionPayloads = []string{
+	"x\n[connection]\npermissions=user:root:",
+	"x\r\nid=hijacked",
+	"x\npsk=attacker-known",
+	"x\x00",
+	"\n",
+	"\r",
+}
+
+func TestValidateProfile_RejectsInjectionInPSKFields(t *testing.T) {
+	base := func() WiFiProfile {
+		return WiFiProfile{
+			Name:     "pm-wifi-ok",
+			SSID:     "CorpNet",
+			AuthType: WiFiAuthPSK,
+			PSK:      "hunter2",
+		}
+	}
+
+	// Cover every field that reaches the keyfile: connection name, SSID,
+	// and PSK. For each, the absent/empty case is already covered by the
+	// required-field checks; here we assert the present-but-malformed case
+	// is rejected.
+	fields := map[string]func(*WiFiProfile, string){
+		"Name": func(p *WiFiProfile, v string) { p.Name = v },
+		"SSID": func(p *WiFiProfile, v string) { p.SSID = v },
+		"PSK":  func(p *WiFiProfile, v string) { p.PSK = v },
+	}
+
+	for field, set := range fields {
+		for _, payload := range injectionPayloads {
+			p := base()
+			set(&p, payload)
+			err := validateProfile(p)
+			if err == nil {
+				t.Errorf("validateProfile accepted injection in %s=%q, want rejection", field, payload)
+			}
+		}
+	}
+}
+
+func TestValidateProfile_AcceptsLegitimatePSKProfile(t *testing.T) {
+	// Guard against over-rejection: a real SSID with spaces and a WPA
+	// passphrase full of symbols must still pass.
+	p := WiFiProfile{
+		Name:     "pm-wifi-ok",
+		SSID:     "Corp Net 5GHz #2",
+		AuthType: WiFiAuthPSK,
+		PSK:      "p@ss w0rd=#1;ok[]",
+	}
+	if err := validateProfile(p); err != nil {
+		t.Errorf("validateProfile rejected a legitimate profile: %v", err)
+	}
+}
+
+func TestValidateProfile_RejectsInjectionInEAPIdentity(t *testing.T) {
+	// The EAP-TLS identity reaches nmcli argv (and would reach a keyfile
+	// if that path grew one); reject line-breaking bytes there too.
+	p := WiFiProfile{
+		Name:       "pm-wifi-eap",
+		SSID:       "CorpNet",
+		AuthType:   WiFiAuthEAPTLS,
+		Identity:   "user\ninjected=1",
+		CertDir:    CertBaseDir + "/pm-wifi-eap",
+		ClientCert: "cert.pem",
+		ClientKey:  "key.pem",
+	}
+	if err := validateProfile(p); err == nil {
+		t.Error("validateProfile accepted injection in EAP Identity, want rejection")
+	}
+}
+
+func TestBuildPSKKeyfile_FailsClosedOnInjection(t *testing.T) {
+	// Defense in depth: even if a caller bypasses validateProfile and
+	// calls BuildPSKKeyfile directly, it must return an error (not a
+	// keyfile body containing the injected section).
+	p := WiFiProfile{
+		Name:     "pm-wifi",
+		SSID:     "Evil\n[connection]\npermissions=user:root:",
+		AuthType: WiFiAuthPSK,
+		PSK:      "hunter2",
+	}
+	body, err := BuildPSKKeyfile(p)
+	if err == nil {
+		t.Fatalf("BuildPSKKeyfile accepted injection, returned body:\n%s", body)
+	}
+	if body != nil {
+		t.Errorf("BuildPSKKeyfile returned a body on error, want nil:\n%s", body)
+	}
+	// And the error must be the typed keyfile error so callers can branch.
+	if !strings.Contains(err.Error(), keyfile.ErrUnsafeValue.Error()) {
+		t.Errorf("BuildPSKKeyfile error = %v, want it to wrap ErrUnsafeValue", err)
+	}
+}

--- a/go/sys/network/wifi_keyfile.go
+++ b/go/sys/network/wifi_keyfile.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/keyfile"
 )
 
 // NetworkManager keyfile-based PSK provisioning.
@@ -52,41 +54,51 @@ func keyfilePath(name string) string {
 // the only mechanism we use to set the PSK on a connection — argv
 // never carries the secret. See appendAuthArgs for the matching
 // defensive omission on the argv side.
-func BuildPSKKeyfile(p WiFiProfile) []byte {
-	var b strings.Builder
+//
+// Every operator-supplied field (Name, SSID, PSK) is routed through the
+// keyfile.Builder, which refuses a value carrying a newline / CR / NUL.
+// That is what stops an SSID or PSK like "x\n[connection]\npermissions=…"
+// from injecting extra keys or sections into this root-owned, root-parsed
+// file. An injected field makes BuildPSKKeyfile return an error and a nil
+// body — never a partially-rendered keyfile. CreateOrUpdate rejects the
+// same input earlier via validateProfile; this is the defense-in-depth
+// layer for any caller that reaches BuildPSKKeyfile directly.
+func BuildPSKKeyfile(p WiFiProfile) ([]byte, error) {
+	kf := &keyfile.Builder{}
+	kf.Comment("Managed by power-manage-agent — do not edit by hand.")
 
-	b.WriteString("# Managed by power-manage-agent — do not edit by hand.\n")
-	b.WriteString("[connection]\n")
-	fmt.Fprintf(&b, "id=%s\n", p.Name)
-	b.WriteString("type=wifi\n")
+	kf.Section("connection")
+	kf.Set("id", p.Name)
+	kf.Set("type", "wifi")
 	if p.AutoConnect {
-		b.WriteString("autoconnect=true\n")
+		kf.Set("autoconnect", "true")
 	} else {
-		b.WriteString("autoconnect=false\n")
+		kf.Set("autoconnect", "false")
 	}
-	fmt.Fprintf(&b, "autoconnect-priority=%d\n", p.Priority)
-	b.WriteString("\n")
+	kf.Set("autoconnect-priority", strconv.Itoa(p.Priority))
 
-	b.WriteString("[wifi]\n")
-	fmt.Fprintf(&b, "ssid=%s\n", p.SSID)
-	b.WriteString("mode=infrastructure\n")
+	kf.Section("wifi")
+	kf.Set("ssid", p.SSID)
+	kf.Set("mode", "infrastructure")
 	if p.Hidden {
-		b.WriteString("hidden=true\n")
+		kf.Set("hidden", "true")
 	}
-	b.WriteString("\n")
 
-	b.WriteString("[wifi-security]\n")
-	b.WriteString("key-mgmt=wpa-psk\n")
-	fmt.Fprintf(&b, "psk=%s\n", p.PSK)
-	b.WriteString("\n")
+	kf.Section("wifi-security")
+	kf.Set("key-mgmt", "wpa-psk")
+	kf.Set("psk", p.PSK)
 
-	b.WriteString("[ipv4]\n")
-	b.WriteString("method=auto\n")
-	b.WriteString("\n")
-	b.WriteString("[ipv6]\n")
-	b.WriteString("method=auto\n")
+	kf.Section("ipv4")
+	kf.Set("method", "auto")
 
-	return []byte(b.String())
+	kf.Section("ipv6")
+	kf.Set("method", "auto")
+
+	body, err := kf.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("build PSK keyfile: %w", err)
+	}
+	return body, nil
 }
 
 // writeKeyfile atomically writes the given keyfile body to path with
@@ -163,7 +175,10 @@ func reloadKeyfiles(ctx context.Context) error {
 // reloads NetworkManager. The caller is expected to have already
 // validated the profile (validateProfile).
 func provisionPSKConnection(ctx context.Context, p WiFiProfile) error {
-	body := BuildPSKKeyfile(p)
+	body, err := BuildPSKKeyfile(p)
+	if err != nil {
+		return err
+	}
 	if err := writeKeyfile(keyfilePath(p.Name), body); err != nil {
 		return err
 	}

--- a/go/sys/network/wifi_keyfile_test.go
+++ b/go/sys/network/wifi_keyfile_test.go
@@ -17,7 +17,11 @@ func TestBuildPSKKeyfile_ContainsPSKInWifiSecuritySection(t *testing.T) {
 		Hidden:      true,
 		Priority:    10,
 	}
-	got := string(BuildPSKKeyfile(p))
+	body, err := BuildPSKKeyfile(p)
+	if err != nil {
+		t.Fatalf("BuildPSKKeyfile: %v", err)
+	}
+	got := string(body)
 
 	// Spot-check the structurally important lines. We don't pin the
 	// whole file body because tweaking trailing whitespace or section
@@ -53,12 +57,16 @@ func TestBuildPSKKeyfile_ContainsPSKInWifiSecuritySection(t *testing.T) {
 }
 
 func TestBuildPSKKeyfile_AutoConnectFalseAndNoHidden(t *testing.T) {
-	got := string(BuildPSKKeyfile(WiFiProfile{
+	body, err := BuildPSKKeyfile(WiFiProfile{
 		Name:     "pm-wifi-2",
 		SSID:     "OpenNet",
 		AuthType: WiFiAuthPSK,
 		PSK:      "p",
-	}))
+	})
+	if err != nil {
+		t.Fatalf("BuildPSKKeyfile: %v", err)
+	}
+	got := string(body)
 	if !strings.Contains(got, "autoconnect=false") {
 		t.Errorf("expected autoconnect=false in keyfile:\n%s", got)
 	}

--- a/go/sys/notify/argv_test.go
+++ b/go/sys/notify/argv_test.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"slices"
+	"testing"
+)
+
+// desktopNotifyArgv must end with "--", title, message so a notification
+// title or body beginning with "-" is treated as text, not parsed as a
+// notify-send option (-i icon, -h hint, -c category, …). The runuser
+// wrapper keeps its own "--"; there must be two markers in the argv.
+func TestDesktopNotifyArgv_SeparatesTitleAndBody(t *testing.T) {
+	argv := desktopNotifyArgv("unix:path=/run/user/1000/bus", "alice", "-h evil", "-i /tmp/x")
+
+	// The user-controlled title/body are the final two elements, preceded
+	// immediately by the end-of-options marker.
+	n := len(argv)
+	if n < 3 || argv[n-3] != "--" || argv[n-2] != "-h evil" || argv[n-1] != "-i /tmp/x" {
+		t.Fatalf("argv tail = %v, want [.. -- '-h evil' '-i /tmp/x']", argv[max(0, n-3):])
+	}
+
+	// Two markers: one ends runuser's options, one ends notify-send's.
+	if c := slices.IndexFunc(argv, func(s string) bool { return s == "--" }); c < 0 {
+		t.Fatal("missing end-of-options marker")
+	}
+	markers := 0
+	for _, a := range argv {
+		if a == "--" {
+			markers++
+		}
+	}
+	if markers != 2 {
+		t.Errorf("found %d '--' markers, want 2 (runuser + notify-send)", markers)
+	}
+}

--- a/go/sys/notify/notify.go
+++ b/go/sys/notify/notify.go
@@ -74,6 +74,20 @@ func sendDesktopNotifications(ctx context.Context, title, message string, userFi
 	}
 }
 
+// desktopNotifyArgv builds the argv for `env … runuser -u <user> --
+// notify-send … -- <title> <message>`. The trailing "--" before the
+// caller-supplied title and body keeps a value that begins with "-" from
+// being parsed as a notify-send option (-i icon, -h hint, -c category, …).
+// The runuser wrapper keeps its own "--", so the argv carries two markers.
+func desktopNotifyArgv(dbusAddr, user, title, message string) []string {
+	return []string{
+		"DBUS_SESSION_BUS_ADDRESS=" + dbusAddr,
+		"runuser", "-u", user, "--",
+		"notify-send", "-u", "critical", "-a", "Power Manage", "-i", "dialog-warning",
+		exec.EndOfOptions, title, message,
+	}
+}
+
 // listGraphicalSessions returns all active graphical login sessions.
 func listGraphicalSessions(ctx context.Context) []session {
 	result, err := exec.Privileged(ctx, "loginctl", "list-sessions", "--no-legend")
@@ -177,12 +191,7 @@ func sendDesktopNotification(ctx context.Context, s session, title, message stri
 
 	// Use runuser to execute notify-send as the target user.
 	// Each argument is passed separately to avoid shell injection.
-	result, err := exec.Privileged(ctx, "env",
-		"DBUS_SESSION_BUS_ADDRESS="+dbusAddr,
-		"runuser", "-u", s.user, "--",
-		"notify-send", "-u", "critical", "-a", "Power Manage", "-i", "dialog-warning",
-		title, message,
-	)
+	result, err := exec.Privileged(ctx, "env", desktopNotifyArgv(dbusAddr, s.user, title, message)...)
 	if err != nil || (result != nil && result.ExitCode != 0) {
 		stderr := ""
 		if result != nil {

--- a/go/sys/reboot/args_test.go
+++ b/go/sys/reboot/args_test.go
@@ -1,0 +1,24 @@
+package reboot
+
+import (
+	"slices"
+	"testing"
+)
+
+// shutdownRebootArgs must place a "--" before the TIME/WALL positionals so
+// a delay or broadcast message beginning with "-" can't be reparsed as a
+// shutdown option (e.g. -c cancel or -h halt instead of -r reboot).
+func TestShutdownRebootArgs_SeparatesPositionals(t *testing.T) {
+	if got, want := shutdownRebootArgs("+5", "save your work"), []string{"-r", "--", "+5", "save your work"}; !slices.Equal(got, want) {
+		t.Errorf("shutdownRebootArgs = %v, want %v", got, want)
+	}
+	// Empty delay defaults to +1; empty message is omitted.
+	if got, want := shutdownRebootArgs("", ""), []string{"-r", "--", "+1"}; !slices.Equal(got, want) {
+		t.Errorf("shutdownRebootArgs(empty) = %v, want %v", got, want)
+	}
+	// A flag-shaped message must land after the marker.
+	got := shutdownRebootArgs("+0", "-c")
+	if i := slices.Index(got, "--"); i < 0 || slices.Index(got, "-c") < i {
+		t.Errorf("flag-shaped message not protected by --: %v", got)
+	}
+}

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -79,17 +79,26 @@ func IsRequired() bool {
 //
 // An empty delay defaults to "+1" since shutdown(8) requires a time argument.
 func Schedule(ctx context.Context, delay, message string) error {
-	if delay == "" {
-		delay = "+1"
-	}
-	args := []string{"-r", delay}
-	if message != "" {
-		args = append(args, message)
-	}
-	if _, err := sysexec.Privileged(ctx, "shutdown", args...); err != nil {
+	if _, err := sysexec.Privileged(ctx, "shutdown", shutdownRebootArgs(delay, message)...); err != nil {
 		return fmt.Errorf("schedule reboot: %w", err)
 	}
 	return nil
+}
+
+// shutdownRebootArgs builds the `shutdown -r` argv. It defaults an empty
+// delay to "+1" (shutdown requires a TIME) and inserts a "--" before the
+// TIME/WALL positionals so a delay or broadcast message beginning with "-"
+// can't be reparsed as a shutdown option (e.g. -c cancel, -h halt instead
+// of -r reboot).
+func shutdownRebootArgs(delay, message string) []string {
+	if delay == "" {
+		delay = "+1"
+	}
+	positionals := []string{delay}
+	if message != "" {
+		positionals = append(positionals, message)
+	}
+	return sysexec.SeparatePositionals([]string{"-r"}, positionals...)
 }
 
 // Cancel cancels a pending scheduled reboot.

--- a/go/sys/remote/archive_limit_test.go
+++ b/go/sys/remote/archive_limit_test.go
@@ -1,0 +1,46 @@
+package remote
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A tar header can under-report an entry's size (hdr.Size is attacker
+// controlled). The pre-extract cumulative check trusts that number, so the
+// actual copy must be bounded independently — otherwise one lying entry
+// streams unbounded bytes to disk before the post-write total is checked.
+// This mirrors the zip branch, which already bounds with a LimitReader.
+func TestWriteTarEntry_BoundsCopyToRemainingBudget(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "f")
+	body := bytes.Repeat([]byte("A"), 4096) // far larger than the limit
+	n, err := writeArchiveEntry(out, bytes.NewReader(body), 0o644, 16)
+	if !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("writeArchiveEntry over-limit err = %v, want ErrIntegrity", err)
+	}
+	// The copy must stop at limit+1 (the over-read sentinel), never drain
+	// the whole oversized body to disk.
+	if n > 17 {
+		t.Errorf("wrote %d bytes, want <= limit+1 (17); copy was not bounded", n)
+	}
+	if info, statErr := os.Stat(out); statErr == nil && info.Size() > 17 {
+		t.Errorf("on-disk file is %d bytes, want <= 17", info.Size())
+	}
+}
+
+func TestWriteTarEntry_WithinBudgetSucceeds(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "f")
+	n, err := writeArchiveEntry(out, bytes.NewReader([]byte("hello")), 0o644, 1024)
+	if err != nil {
+		t.Fatalf("writeArchiveEntry within budget err = %v, want nil", err)
+	}
+	if n != 5 {
+		t.Errorf("wrote %d bytes, want 5", n)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != "hello" {
+		t.Errorf("file content = %q, want %q", got, "hello")
+	}
+}

--- a/go/sys/remote/guard.go
+++ b/go/sys/remote/guard.go
@@ -1,0 +1,128 @@
+package remote
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// AddrPolicy decides which resolved IPs an outbound fetch may dial. It is
+// the SSRF guard for the HTTP and S3 sources: an operator- or
+// server-supplied URL must not be able to make the agent connect to its
+// own loopback services or the cloud instance-metadata endpoint.
+type AddrPolicy struct {
+	// BlockPrivate additionally refuses RFC1918 / RFC4193 (ULA) ranges.
+	// Off by default because an agent on a corporate LAN legitimately
+	// pulls from an internal mirror (10/8, 192.168/16, fd00::/8);
+	// deployments that want strict egress opt in.
+	BlockPrivate bool
+
+	// AllowLoopback permits loopback destinations. Off by default —
+	// loopback is an SSRF pivot to device-local admin services. A
+	// deployment that fronts fetches through a local caching proxy can
+	// opt in. (The package's own tests set this to reach httptest
+	// servers; production must not.)
+	AllowLoopback bool
+}
+
+// dialPolicy is the SSRF policy installed on every fetch client built by
+// defaultHTTPClient. Production leaves it at the strict zero value; the
+// package's tests relax it (AllowLoopback) in TestMain to reach loopback
+// httptest servers.
+var dialPolicy = AddrPolicy{}
+
+// ipBlocked reports whether ip must never be dialed for an outbound fetch.
+// The blocked set is the classic SSRF target list: loopback (device-local
+// services), link-local (169.254.0.0/16 — cloud instance metadata — and
+// the IPv6 fe80::/10 equivalent), unspecified (0.0.0.0 / ::), and
+// multicast. A nil ip fails closed.
+func (p AddrPolicy) ipBlocked(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() {
+		return !p.AllowLoopback
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	if p.BlockPrivate && ip.IsPrivate() {
+		return true
+	}
+	return false
+}
+
+// controlConn is a net.Dialer.Control hook. The runtime calls it after
+// name resolution with the concrete IP about to be dialed, so it guards
+// the initial connection, every redirect hop, AND defeats DNS rebinding
+// (the IP is re-checked at connect time, not at URL-parse time). The
+// address is always "ip:port" at this point.
+//
+// Limitation: when an HTTP(S) proxy is configured via the environment the
+// dialer connects to the proxy, not the origin, so this check sees the
+// proxy IP. Strict-egress deployments that need the guard should not route
+// fetches through an untrusted proxy.
+func (p AddrPolicy) controlConn(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("%w: cannot parse dial address %q: %v", ErrBlockedAddress, address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("%w: dial address %q is not a literal IP", ErrBlockedAddress, address)
+	}
+	if p.ipBlocked(ip) {
+		return fmt.Errorf("%w: refusing to dial %s", ErrBlockedAddress, ip)
+	}
+	return nil
+}
+
+// redirectPolicy re-validates every redirect hop: the scheme must stay
+// http/https (so a 302 can't pivot to file://, gopher://, etc.) and the
+// chain is capped at 10 hops. The destination host/IP is enforced
+// separately at dial time by controlConn, which also covers rebinding.
+func redirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("%w: stopped after 10 redirects", ErrBlockedAddress)
+	}
+	if s := req.URL.Scheme; s != "https" && s != "http" {
+		return fmt.Errorf("%w: redirect to unsupported scheme %q", ErrBlockedAddress, s)
+	}
+	return nil
+}
+
+// guardedHTTPClient builds an *http.Client whose transport refuses to dial
+// any IP the policy blocks and whose redirect handler re-validates each
+// hop's scheme. A zero timeout means no client-level timeout (callers that
+// want one pass it explicitly).
+func guardedHTTPClient(timeout time.Duration, policy AddrPolicy) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   policy.controlConn,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: redirectPolicy,
+	}
+}
+
+// defaultHTTPClient is the fetch client used by the HTTP and S3 sources:
+// a 30-minute ceiling (large artefacts over slow links) plus the SSRF dial
+// guard and redirect re-validation.
+func defaultHTTPClient() *http.Client {
+	return guardedHTTPClient(30*time.Minute, dialPolicy)
+}

--- a/go/sys/remote/guard_test.go
+++ b/go/sys/remote/guard_test.go
@@ -1,0 +1,143 @@
+package remote
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// TestMain relaxes the SSRF dial guard to allow loopback for the duration
+// of this package's tests, which fetch from httptest servers bound to
+// 127.0.0.1. Production never sets AllowLoopback. Set once before any test
+// runs, so there is no data race with the (non-parallel) tests.
+func TestMain(m *testing.M) {
+	dialPolicy = AddrPolicy{AllowLoopback: true}
+	os.Exit(m.Run())
+}
+
+// Threat model: an operator- or server-supplied fetch URL must not be able
+// to make the agent connect to its own loopback services or the cloud
+// instance-metadata endpoint (169.254.169.254). The block list is derived
+// from the IP semantics (loopback / link-local / unspecified / multicast),
+// NOT from the implementation, so an under-specified guard can't pass by
+// matching its own data.
+
+func TestAddrPolicy_BlocksDangerousRanges(t *testing.T) {
+	strict := AddrPolicy{} // production default: AllowLoopback false
+	blocked := []string{
+		"127.0.0.1",        // loopback
+		"127.0.0.53",       // loopback (systemd-resolved stub)
+		"::1",              // loopback v6
+		"::ffff:127.0.0.1", // v4-mapped loopback
+		"169.254.169.254",  // AWS/GCP/Azure instance metadata (link-local)
+		"169.254.0.1",      // link-local
+		"fe80::1",          // link-local v6
+		"0.0.0.0",          // unspecified
+		"::",               // unspecified v6
+		"224.0.0.1",        // multicast
+		"ff02::1",          // multicast v6
+	}
+	for _, s := range blocked {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("test bug: %q is not a valid IP", s)
+		}
+		if !strict.ipBlocked(ip) {
+			t.Errorf("ipBlocked(%s) = false, want true (SSRF target)", s)
+		}
+	}
+}
+
+func TestAddrPolicy_AllowsPublicByDefault(t *testing.T) {
+	strict := AddrPolicy{}
+	for _, s := range []string{"8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:2800:220:1::"} {
+		ip := net.ParseIP(s)
+		if strict.ipBlocked(ip) {
+			t.Errorf("ipBlocked(%s) = true, want false (public address)", s)
+		}
+	}
+}
+
+func TestAddrPolicy_PrivateRangesGatedByBlockPrivate(t *testing.T) {
+	// Private ranges are allowed by default (internal mirror use), but a
+	// strict-egress deployment opts in via BlockPrivate.
+	priv := []string{"10.0.0.1", "192.168.1.1", "172.16.5.5", "fd00::1"}
+	lenient := AddrPolicy{}
+	strict := AddrPolicy{BlockPrivate: true}
+	for _, s := range priv {
+		ip := net.ParseIP(s)
+		if lenient.ipBlocked(ip) {
+			t.Errorf("default ipBlocked(%s) = true, want false", s)
+		}
+		if !strict.ipBlocked(ip) {
+			t.Errorf("BlockPrivate ipBlocked(%s) = false, want true", s)
+		}
+	}
+}
+
+func TestAddrPolicy_AllowLoopbackKnob(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+	if !(AddrPolicy{}).ipBlocked(ip) {
+		t.Error("default policy must block loopback")
+	}
+	if (AddrPolicy{AllowLoopback: true}).ipBlocked(ip) {
+		t.Error("AllowLoopback policy must permit loopback")
+	}
+}
+
+func TestAddrPolicy_NilIPFailsClosed(t *testing.T) {
+	if !(AddrPolicy{}).ipBlocked(nil) {
+		t.Error("ipBlocked(nil) = false, want true (fail closed)")
+	}
+}
+
+func TestControlConn_RejectsBlockedDialAddress(t *testing.T) {
+	strict := AddrPolicy{}
+	if err := strict.controlConn("tcp", "169.254.169.254:80", nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("controlConn(metadata) = %v, want ErrBlockedAddress", err)
+	}
+	if err := strict.controlConn("tcp", "127.0.0.1:8080", nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("controlConn(loopback) = %v, want ErrBlockedAddress", err)
+	}
+	// A public address passes.
+	if err := strict.controlConn("tcp", "93.184.216.34:443", nil); err != nil {
+		t.Errorf("controlConn(public) = %v, want nil", err)
+	}
+	// A non-IP / malformed dial address fails closed.
+	if err := strict.controlConn("tcp", "not-an-address", nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("controlConn(malformed) = %v, want ErrBlockedAddress", err)
+	}
+}
+
+func TestRedirectPolicy_BlocksNonHTTPSchemesAndCapsHops(t *testing.T) {
+	mk := func(scheme string) *http.Request {
+		return &http.Request{URL: &url.URL{Scheme: scheme, Host: "example.test"}}
+	}
+	if err := redirectPolicy(mk("file"), nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("redirect to file:// = %v, want ErrBlockedAddress", err)
+	}
+	if err := redirectPolicy(mk("gopher"), nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("redirect to gopher:// = %v, want ErrBlockedAddress", err)
+	}
+	if err := redirectPolicy(mk("https"), nil); err != nil {
+		t.Errorf("redirect to https:// = %v, want nil", err)
+	}
+	// Hop cap: 10 prior requests must stop the chain.
+	via := make([]*http.Request, 10)
+	if err := redirectPolicy(mk("https"), via); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("11th redirect = %v, want ErrBlockedAddress", err)
+	}
+}
+
+func TestGuardedHTTPClient_HasGuardWiring(t *testing.T) {
+	c := guardedHTTPClient(0, AddrPolicy{})
+	if c.CheckRedirect == nil {
+		t.Error("guarded client must set CheckRedirect")
+	}
+	if c.Transport == nil {
+		t.Error("guarded client must install a custom Transport (dial guard)")
+	}
+}

--- a/go/sys/remote/http.go
+++ b/go/sys/remote/http.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
 )
@@ -359,20 +358,16 @@ func applyMode(ctx context.Context, dest, mode, owner, group string) error {
 	return nil
 }
 
-// defaultHTTPClient — modest timeouts so a Fetch can't hang forever, and
-// no automatic redirect following on by default? Actually leave Go's
-// default 10-redirect chase in place: legitimate CDNs (Cloudflare, GH
-// releases) use it heavily, and the URL validation already restricts
-// the scheme to http/https.
-func defaultHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: 30 * time.Minute,
-	}
-}
-
 func validateHTTPConfig(cfg *HTTPConfig) error {
 	if cfg.Prune && !cfg.Extract {
 		return fmt.Errorf("%w: prune requires extract", ErrInvalidConfig)
+	}
+	// Prune is mirror-with-delete: a poisoned origin could otherwise drive
+	// a destructive local sync. The doc-comment on ChecksumSHA256 calls
+	// the checksum "mandatory in combination with Extract+Prune" — enforce
+	// it here so the invariant can't be silently violated.
+	if cfg.Prune && cfg.ChecksumSHA256 == "" {
+		return fmt.Errorf("%w: prune requires checksum_sha256 (refusing an unverified destructive sync)", ErrInvalidConfig)
 	}
 	return nil
 }

--- a/go/sys/remote/http_archive.go
+++ b/go/sys/remote/http_archive.go
@@ -289,7 +289,7 @@ func extractTarGz(body io.Reader, staging string, maxBytes int64) (int, error) {
 		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
 			return files, fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
 		}
-		written, werr := writeTarEntry(out, tr, hdr.FileInfo().Mode().Perm())
+		written, werr := writeArchiveEntry(out, tr, hdr.FileInfo().Mode().Perm(), maxBytes-totalBytes)
 		if werr != nil {
 			return files, werr
 		}
@@ -302,15 +302,24 @@ func extractTarGz(body io.Reader, staging string, maxBytes int64) (int, error) {
 	return files, nil
 }
 
-func writeTarEntry(out string, r io.Reader, mode os.FileMode) (int64, error) {
+// writeArchiveEntry copies r into out, bounded by limit (the remaining size
+// budget). A tar header's declared size is attacker-controlled, so the
+// pre-extract check that uses hdr.Size is only advisory; the copy itself is
+// capped here with a LimitReader at limit+1 so a body that exceeds what the
+// header claimed is truncated and reported as an integrity failure rather
+// than streamed unbounded to disk. This matches the zip branch's bound.
+func writeArchiveEntry(out string, r io.Reader, mode os.FileMode, limit int64) (int64, error) {
 	f, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return 0, fmt.Errorf("open %s: %w", out, err)
 	}
 	defer f.Close()
-	n, err := io.Copy(f, r)
+	n, err := io.Copy(f, io.LimitReader(r, limit+1))
 	if err != nil {
 		return n, fmt.Errorf("copy %s: %w", out, err)
+	}
+	if n > limit {
+		return n, fmt.Errorf("%w: archive entry %s exceeds remaining budget of %d bytes", ErrIntegrity, out, limit)
 	}
 	return n, nil
 }
@@ -354,8 +363,7 @@ func extractZipFile(tmpPath, staging string, maxBytes int64) (int, error) {
 			rc.Close()
 			return files, fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
 		}
-		limited := io.LimitReader(rc, maxBytes-totalBytes+1)
-		written, werr := writeTarEntry(out, limited, ze.FileInfo().Mode().Perm())
+		written, werr := writeArchiveEntry(out, rc, ze.FileInfo().Mode().Perm(), maxBytes-totalBytes)
 		rc.Close()
 		if werr != nil {
 			return files, werr

--- a/go/sys/remote/remote.go
+++ b/go/sys/remote/remote.go
@@ -95,4 +95,11 @@ var (
 	// ErrBackendNotFound — a registry lookup (e.g. cfg.Driver on
 	// GitConfig) named a backend that was never registered.
 	ErrBackendNotFound = errors.New("remote: backend not registered")
+
+	// ErrBlockedAddress — an outbound fetch tried to connect to an IP the
+	// SSRF guard refuses (loopback, link-local / cloud-metadata, multicast,
+	// unspecified, or — when AddrPolicy.BlockPrivate is set — a private
+	// range), or a redirect pointed at an unsupported scheme. Enforced at
+	// dial time so it also covers redirects and DNS rebinding.
+	ErrBlockedAddress = errors.New("remote: blocked address (SSRF guard)")
 )

--- a/go/sys/remote/remote_http_test.go
+++ b/go/sys/remote/remote_http_test.go
@@ -68,6 +68,32 @@ func TestNewHTTP_RejectsPruneWithoutExtract(t *testing.T) {
 	}
 }
 
+// TestNewHTTP_RejectsPruneWithoutChecksum — Prune is mirror-with-delete,
+// so a poisoned origin could drive a destructive local sync. The
+// ChecksumSHA256 doc-comment declares it mandatory with Extract+Prune;
+// NewHTTP must enforce that rather than leaving it to documentation.
+func TestNewHTTP_RejectsPruneWithoutChecksum(t *testing.T) {
+	_, err := NewHTTP(HTTPConfig{
+		URL:     "https://example.test/dir.tar.gz",
+		Extract: true,
+		Prune:   true,
+		// ChecksumSHA256 deliberately empty.
+	})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("NewHTTP(Prune without checksum) = %v; want errors.Is(..., ErrInvalidConfig)", err)
+	}
+
+	// With a valid checksum the combination is accepted.
+	if _, err := NewHTTP(HTTPConfig{
+		URL:            "https://example.test/dir.tar.gz",
+		Extract:        true,
+		Prune:          true,
+		ChecksumSHA256: strings.Repeat("a", 64),
+	}); err != nil {
+		t.Fatalf("NewHTTP(Prune with checksum) = %v; want nil", err)
+	}
+}
+
 // TestNewHTTP_RejectsBadChecksum — partial / non-hex / wrong-length
 // checksum strings get rejected up front so a Fetch never silently runs
 // without integrity verification.

--- a/go/sys/remote/s3.go
+++ b/go/sys/remote/s3.go
@@ -45,6 +45,13 @@ type S3Config struct {
 	// fetches the field is currently a no-op; NewS3 accepts the
 	// combination so callers can flip between single and prefix modes
 	// without re-validating.
+	//
+	// SECURITY NOTE: unlike HTTPConfig, S3 prefix-sync has no per-object
+	// integrity field, so the "checksum required for a destructive sync"
+	// invariant the HTTP path enforces cannot be enforced here yet. When
+	// the Slice 12 prefix-sync prune lands, gate it behind an integrity
+	// mechanism (per-object ETag/sha256 manifest) before deleting local
+	// files a poisoned listing omitted.
 	Prune bool
 }
 

--- a/go/sys/user/comment.go
+++ b/go/sys/user/comment.go
@@ -1,0 +1,28 @@
+package user
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrInvalidComment is returned when a GECOS / comment value contains a
+// character that would corrupt the colon-delimited /etc/passwd record.
+var ErrInvalidComment = errors.New("invalid comment")
+
+// ValidateComment guards the GECOS / comment field before it reaches
+// `useradd/usermod -c <comment>`. The value becomes a colon-delimited
+// field in /etc/passwd, so a ':' would split the record into spurious
+// fields and a newline would forge an entire record; NUL/CR are rejected
+// for the same record-integrity reason. An empty comment is allowed
+// ("no comment"). Commas are permitted because GECOS legitimately uses
+// them to separate sub-fields (full name, room, phone).
+func ValidateComment(comment string) error {
+	if comment == "" {
+		return nil
+	}
+	if i := strings.IndexAny(comment, ":\n\r\x00"); i >= 0 {
+		return fmt.Errorf("%w: contains %q at offset %d (':' and control characters corrupt the passwd record)", ErrInvalidComment, comment[i], i)
+	}
+	return nil
+}

--- a/go/sys/user/comment_test.go
+++ b/go/sys/user/comment_test.go
@@ -1,0 +1,37 @@
+package user
+
+import (
+	"errors"
+	"testing"
+)
+
+// The GECOS / comment field lands in `useradd/usermod -c <comment>` and,
+// ultimately, as a colon-delimited field in /etc/passwd. A ':' would split
+// the passwd record into extra fields and a newline would forge a whole
+// record, so ValidateComment must reject both (plus other control bytes).
+// Ordinary descriptive text — spaces, commas (GECOS sub-field separator),
+// unicode — must be accepted.
+func TestValidateComment(t *testing.T) {
+	for _, ok := range []string{
+		"",
+		"Alice Example",
+		"Alice,Room 1,555-1234,555-5678", // GECOS sub-fields
+		"Ünïcode Náme",
+	} {
+		if err := ValidateComment(ok); err != nil {
+			t.Errorf("ValidateComment(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{
+		"root:x:0:0",   // colon — passwd field injection
+		"name\nroot:x", // newline — passwd record injection
+		"name\rx",      // CR
+		"name\x00x",    // NUL
+	} {
+		if err := ValidateComment(bad); err == nil {
+			t.Errorf("ValidateComment(%q) = nil, want ErrInvalidComment", bad)
+		} else if !errors.Is(err, ErrInvalidComment) {
+			t.Errorf("ValidateComment(%q) error = %v, want ErrInvalidComment", bad, err)
+		}
+	}
+}

--- a/go/sys/user/group.go
+++ b/go/sys/user/group.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"context"
-	"slices"
 	"sort"
 	"strings"
 
@@ -91,10 +90,10 @@ func GroupCreate(ctx context.Context, name string, args ...string) (*exec.Result
 	if err := validateName("group name", name); err != nil {
 		return nil, err
 	}
-	// slices.Clone avoids aliasing the caller's backing array — a
-	// bare `append(args, name)` would write into the caller's slice
-	// whenever it has spare capacity.
-	fullArgs := append(slices.Clone(args), name)
+	// SeparatePositionals inserts a "--" before the group name (and
+	// allocates fresh, so the caller's args slice isn't aliased) so a
+	// flag-shaped name can't be parsed as a groupadd option.
+	fullArgs := exec.SeparatePositionals(args, name)
 	return exec.Privileged(ctx, "groupadd", fullArgs...)
 }
 
@@ -104,7 +103,7 @@ func GroupDelete(ctx context.Context, name string) (*exec.Result, error) {
 	if err := validateName("group name", name); err != nil {
 		return nil, err
 	}
-	return exec.Privileged(ctx, "groupdel", name)
+	return exec.Privileged(ctx, "groupdel", exec.SeparatePositionals(nil, name)...)
 }
 
 // GroupEnsureExists creates a group if it doesn't already exist.

--- a/go/sys/user/shell.go
+++ b/go/sys/user/shell.go
@@ -1,0 +1,102 @@
+package user
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrInvalidShell is returned by the login-shell validators when a shell
+// value is unsafe to pass to `useradd/usermod -s`.
+var ErrInvalidShell = errors.New("invalid login shell")
+
+// loginShellsFile is the system allowlist of valid login shells. A package
+// var so tests can point it at a fixture; production reads /etc/shells.
+var loginShellsFile = "/etc/shells"
+
+// nonLoginShells are the conventional "disable interactive login" targets.
+// They are accepted even when /etc/shells omits them (several distros do),
+// because setting an account to a non-login shell is a security-positive
+// operation, not a risk.
+var nonLoginShells = map[string]bool{
+	"/usr/sbin/nologin": true,
+	"/sbin/nologin":     true,
+	"/usr/bin/nologin":  true,
+	"/bin/false":        true,
+	"/usr/bin/false":    true,
+}
+
+// ValidateLoginShellSyntax is the host-independent half of login-shell
+// validation: the shell must be a non-empty, absolute, canonical path with
+// no control characters (and therefore no flag shape — a "/"-prefixed path
+// can't begin with "-"). It is safe to run anywhere, including a control
+// server pre-validating a user profile before dispatching it to an agent.
+func ValidateLoginShellSyntax(shell string) error {
+	if shell == "" {
+		return fmt.Errorf("%w: shell is empty", ErrInvalidShell)
+	}
+	if strings.ContainsAny(shell, "\x00\n\r\t") {
+		return fmt.Errorf("%w: shell contains control characters", ErrInvalidShell)
+	}
+	if !filepath.IsAbs(shell) {
+		return fmt.Errorf("%w: shell %q must be an absolute path", ErrInvalidShell, shell)
+	}
+	if filepath.Clean(shell) != shell {
+		return fmt.Errorf("%w: shell %q is not canonical", ErrInvalidShell, shell)
+	}
+	return nil
+}
+
+// ValidateLoginShell is the full check the agent runs before
+// `useradd/usermod -s <shell>`. In addition to ValidateLoginShellSyntax it
+// requires the shell to be listed in /etc/shells (the canonical system
+// allowlist) or to be a recognized non-login shell. usermod itself does
+// NOT enforce /etc/shells, so without this an operator who can drive a
+// user action could set any account's login shell to an arbitrary binary.
+//
+// Fails closed: if /etc/shells cannot be read, only the hardcoded
+// non-login set is admitted — a normal shell is rejected rather than
+// allowed through unverified.
+func ValidateLoginShell(shell string) error {
+	if err := ValidateLoginShellSyntax(shell); err != nil {
+		return err
+	}
+	if nonLoginShells[shell] {
+		return nil
+	}
+	allowed, err := readLoginShells(loginShellsFile)
+	if err != nil {
+		return fmt.Errorf("%w: cannot verify %q against %s: %v", ErrInvalidShell, shell, loginShellsFile, err)
+	}
+	if !allowed[shell] {
+		return fmt.Errorf("%w: %q is not listed in %s", ErrInvalidShell, shell, loginShellsFile)
+	}
+	return nil
+}
+
+// readLoginShells parses an /etc/shells-format file into a set of absolute
+// shell paths, ignoring blank lines and `#` comments.
+func readLoginShells(path string) (map[string]bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	shells := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		shells[line] = true
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return shells, nil
+}

--- a/go/sys/user/shell_test.go
+++ b/go/sys/user/shell_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Threat model: a login shell flows into `useradd/usermod -s <shell>`.
+// usermod does NOT restrict -s to /etc/shells, so without an SDK-side
+// check an operator could point any account at an arbitrary binary
+// (/tmp/evil) — a persistence/escalation primitive. ValidateLoginShell
+// fails closed: the value must be a clean absolute path AND be listed in
+// /etc/shells (or be a recognized non-login shell).
+
+func TestValidateLoginShellSyntax_RejectsUnsafeShapes(t *testing.T) {
+	// Wrong cases come from the argv + path threat model, not the
+	// validator: a relative path can't be resolved deterministically, a
+	// leading dash is flag injection, control chars smuggle args / forge
+	// logs, and a non-canonical path hides the real target.
+	for _, bad := range []string{
+		"",
+		"bash",           // relative
+		"bin/bash",       // relative
+		"-c",             // flag shape
+		"--login",        // flag shape
+		"/bin/../bin/sh", // non-canonical
+		"/bin/bash\n",    // control char
+		"/bin/bash\x00",  // NUL
+		"/bin/ba sh\rx",  // CR
+	} {
+		if err := ValidateLoginShellSyntax(bad); err == nil {
+			t.Errorf("ValidateLoginShellSyntax(%q) = nil, want ErrInvalidShell", bad)
+		} else if !errors.Is(err, ErrInvalidShell) {
+			t.Errorf("ValidateLoginShellSyntax(%q) error = %v, want ErrInvalidShell", bad, err)
+		}
+	}
+	if err := ValidateLoginShellSyntax("/bin/bash"); err != nil {
+		t.Errorf("ValidateLoginShellSyntax(/bin/bash) = %v, want nil", err)
+	}
+}
+
+func TestValidateLoginShell_EnforcesAllowlist(t *testing.T) {
+	// Point the allowlist at a fixture so the test is host-independent.
+	// Include comments and blank lines (real /etc/shells has them) to
+	// prove they are ignored, not matched.
+	dir := t.TempDir()
+	shellsFile := filepath.Join(dir, "shells")
+	content := "# /etc/shells: valid login shells\n/bin/bash\n\n/usr/bin/zsh\n# trailing comment\n"
+	if err := os.WriteFile(shellsFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := loginShellsFile
+	loginShellsFile = shellsFile
+	t.Cleanup(func() { loginShellsFile = orig })
+
+	// Listed shells are accepted.
+	for _, ok := range []string{"/bin/bash", "/usr/bin/zsh"} {
+		if err := ValidateLoginShell(ok); err != nil {
+			t.Errorf("ValidateLoginShell(%q) = %v, want nil", ok, err)
+		}
+	}
+	// A binary NOT in /etc/shells is rejected even though it is a clean
+	// absolute path — this is the core control.
+	if err := ValidateLoginShell("/tmp/evil"); !errors.Is(err, ErrInvalidShell) {
+		t.Errorf("ValidateLoginShell(/tmp/evil) = %v, want ErrInvalidShell", err)
+	}
+	// A comment line must not be treated as an allowed shell.
+	if err := ValidateLoginShell("# /etc/shells: valid login shells"); !errors.Is(err, ErrInvalidShell) {
+		t.Errorf("ValidateLoginShell(comment) = %v, want ErrInvalidShell", err)
+	}
+	// Syntactically bad shells are rejected before allowlist lookup.
+	if err := ValidateLoginShell("-c"); !errors.Is(err, ErrInvalidShell) {
+		t.Errorf("ValidateLoginShell(-c) = %v, want ErrInvalidShell", err)
+	}
+}
+
+func TestValidateLoginShell_AcceptsNonLoginShells(t *testing.T) {
+	// nologin/false disable interactive login — a security-positive target.
+	// They must be accepted even when /etc/shells omits them (many distros
+	// do). Use a fixture WITHOUT them to prove the non-login set is what
+	// admits them.
+	dir := t.TempDir()
+	shellsFile := filepath.Join(dir, "shells")
+	if err := os.WriteFile(shellsFile, []byte("/bin/bash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := loginShellsFile
+	loginShellsFile = shellsFile
+	t.Cleanup(func() { loginShellsFile = orig })
+
+	for _, ok := range []string{"/usr/sbin/nologin", "/sbin/nologin", "/bin/false", "/usr/bin/false"} {
+		if err := ValidateLoginShell(ok); err != nil {
+			t.Errorf("ValidateLoginShell(%q) = %v, want nil (non-login shell)", ok, err)
+		}
+	}
+}
+
+func TestValidateLoginShell_MissingShellsFileFailsClosed(t *testing.T) {
+	// If /etc/shells can't be read, a normal shell must NOT be admitted
+	// (fail closed); only the hardcoded non-login set remains valid.
+	orig := loginShellsFile
+	loginShellsFile = filepath.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { loginShellsFile = orig })
+
+	if err := ValidateLoginShell("/bin/bash"); !errors.Is(err, ErrInvalidShell) {
+		t.Errorf("ValidateLoginShell with missing shells file = %v, want ErrInvalidShell", err)
+	}
+	if err := ValidateLoginShell("/usr/sbin/nologin"); err != nil {
+		t.Errorf("ValidateLoginShell(nologin) with missing shells file = %v, want nil", err)
+	}
+}

--- a/go/sys/user/user.go
+++ b/go/sys/user/user.go
@@ -10,7 +10,6 @@ package user
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -159,10 +158,11 @@ func Create(ctx context.Context, username string, args ...string) (*exec.Result,
 	if err := validateUsername(username); err != nil {
 		return nil, err
 	}
-	// slices.Clone avoids aliasing the caller's backing array — a
-	// bare `append(args, username)` would write into the caller's
-	// slice whenever it has spare capacity.
-	fullArgs := append(slices.Clone(args), username)
+	// SeparatePositionals inserts a "--" before the username so a value
+	// that slipped past validation as flag-shaped still can't be parsed as
+	// a useradd option. It also allocates fresh, so the caller's args slice
+	// is never aliased.
+	fullArgs := exec.SeparatePositionals(args, username)
 	return exec.Privileged(ctx, "useradd", fullArgs...)
 }
 
@@ -173,7 +173,7 @@ func Modify(ctx context.Context, username string, args ...string) (*exec.Result,
 	if err := validateUsername(username); err != nil {
 		return nil, err
 	}
-	fullArgs := append(slices.Clone(args), username)
+	fullArgs := exec.SeparatePositionals(args, username)
 	return exec.Privileged(ctx, "usermod", fullArgs...)
 }
 
@@ -184,9 +184,9 @@ func Delete(ctx context.Context, username string, removeHome bool) (*exec.Result
 		return nil, err
 	}
 	if removeHome {
-		return exec.Privileged(ctx, "userdel", "-r", username)
+		return exec.Privileged(ctx, "userdel", exec.SeparatePositionals([]string{"-r"}, username)...)
 	}
-	return exec.Privileged(ctx, "userdel", username)
+	return exec.Privileged(ctx, "userdel", exec.SeparatePositionals(nil, username)...)
 }
 
 // Lock locks a user account (usermod -L).
@@ -194,7 +194,7 @@ func Lock(ctx context.Context, username string) (*exec.Result, error) {
 	if err := validateUsername(username); err != nil {
 		return nil, err
 	}
-	return exec.Privileged(ctx, "usermod", "-L", username)
+	return exec.Privileged(ctx, "usermod", exec.SeparatePositionals([]string{"-L"}, username)...)
 }
 
 // Unlock unlocks a user account (usermod -U).
@@ -202,7 +202,7 @@ func Unlock(ctx context.Context, username string) (*exec.Result, error) {
 	if err := validateUsername(username); err != nil {
 		return nil, err
 	}
-	return exec.Privileged(ctx, "usermod", "-U", username)
+	return exec.Privileged(ctx, "usermod", exec.SeparatePositionals([]string{"-U"}, username)...)
 }
 
 // =============================================================================
@@ -271,7 +271,7 @@ func ExpirePassword(ctx context.Context, username string) (*exec.Result, error) 
 	if err := validateUsername(username); err != nil {
 		return nil, err
 	}
-	return exec.Privileged(ctx, "chage", "-d", "0", username)
+	return exec.Privileged(ctx, "chage", exec.SeparatePositionals([]string{"-d", "0"}, username)...)
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #88.

Security hardening of the SDK's native command-invocation surface (`sys/*` + `pkg`). The core design was already sound — go-cmd argv slices (no shell), central env-hijack blocklist, absolute-path privilege resolution, secrets off argv. This PR closes the gaps where operator-supplied input reached a privileged argv or a root-parsed config file without a fail-closed guard. **Every fix is test-first**, and reusable validated abstractions are the fix vehicle (opinionated orchestration stays with the consumer).

## Findings fixed

| Sev | Fix |
|-----|-----|
| HIGH | WiFi keyfile INI injection — SSID/PSK/Name now rejected for newline/CR/NUL; profile built through the new validating `sys/keyfile` builder (fails closed) |
| HIGH/MED | `sys/remote` SSRF: dial-time IP guard (loopback/link-local cloud-metadata/multicast blocked; covers redirects + DNS rebinding) + redirect scheme re-validation; `Prune` now requires a checksum |
| MED | LUKS/TPM `devicePath` validated (canonical, under `/dev/`) at all 8 entry points |
| MED/HIGH | `ValidateLoginShell` (/etc/shells allowlist, fail-closed) — usermod does not enforce it |
| MED | flatpak `AddRemote`/`RemoveRemote` validate remote name + URL scheme |
| LOW/MED | `sys/exec.SeparatePositionals` — `--` end-of-options applied to useradd/usermod/userdel/groupadd/chage/mount/shutdown/notify-send |
| LOW | `ValidateComment` (GECOS); tar copy `LimitReader`-bounded; pacman drops blanket `--overwrite "*"` |

## New reusable abstractions
- `sys/keyfile` — hardened glib keyfile/INI builder
- `sys/remote` `AddrPolicy` / guarded HTTP client
- `sys/exec.SeparatePositionals`
- `sys/user.ValidateLoginShell` / `ValidateComment`, `pkg.ValidateRemote{Name,URL}`

## Verification
- `go vet`, `go build`, `go test ./go/...` all green (standalone, `GOWORK=off`).
- Local CodeRabbit review run pre-push (1 minor finding addressed: shared archive-entry writer renamed + message generalized).

The agent-side consumer wiring (login-shell / comment / primary-group validation in `executeUser`) ships in the paired `power-manage-agent` PR on the same branch name.