### PR TITLE
test(arch): constant-time secret-compare fitness function

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,23 @@ Proto definitions are in `proto/pm/v1/`. Generated Go code lives in `gen/`. Go l
 - Always handle errors -- never silently ignore them.
 - Proto files follow the Buf style guide.
 
+## Guardrails (architectural fitness functions)
+
+`go/archtest/` holds build-failing invariant tests that run in the normal
+`go test ./...` path:
+
+- **`TestSecretComparesAreConstantTime`** — the SDK is the action-signing and
+  encryption boundary (`go/verify`, `go/crypto`). Compare secrets/MACs/
+  tokens/signatures/fingerprints with `subtle.ConstantTimeCompare`/
+  `hmac.Equal`, never `==`/`bytes.Equal`.
+
+The clock guard (`TestNoUnabstractedTimeNow`) is intentionally **not** applied
+to the SDK: it has no time-*decision* logic — its `time.Now()` uses are
+external-command duration measurement and ULID seeding, where injecting a
+clock buys no testability. The guard ships a documented, no-stale-guarded
+allowlist for genuine exceptions; **prefer fixing the code over adding one**.
+Rationale: the server repo's `docs/adr/0002-architectural-fitness-functions.md`.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the AGPL-3.0 license.

--- a/go/archtest/archtest.go
+++ b/go/archtest/archtest.go
@@ -1,0 +1,147 @@
+// Package archtest holds architectural fitness functions for the SDK:
+// self-discovering, module-wide invariant tests that fail the build when
+// a known code smell is reintroduced or a good pattern is broken.
+//
+// # Scope for the SDK
+//
+// The SDK is a library (proto-generated code, crypto/signing helpers,
+// package-manager exec abstraction). The guard that matters most here is
+// the constant-time secret-comparison lock, because sdk/go/verify and
+// sdk/go/crypto are the action-signing and encryption boundary.
+//
+// Guards from the server archtest suite that do NOT apply to the SDK and
+// are intentionally absent:
+//
+//   - No-dynamic-SQL / projection-write: the SDK has no database.
+//   - Unabstracted-clock: the SDK has no time-DECISION logic. Its only
+//     time.Now() uses are external-command duration measurement in
+//     sdk/go/pkg (intrinsically real wall-clock — injecting a fake clock
+//     is meaningless there) and ULID timestamp seeding. Neither is a
+//     testability-relevant decision, so a clock seam buys nothing.
+//
+// Standard library only (go/parser, go/ast, go/token, go/printer) — no
+// golang.org/x/tools dependency. Every guard walks the module tree,
+// asserts it inspected a non-empty set (cannot pass vacuously), and ships
+// a no-stale-entry-guarded allowlist for true exceptions.
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goFile is a parsed Go source file with its module-relative path.
+type goFile struct {
+	rel  string
+	fset *token.FileSet
+	ast  *ast.File
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// containing go.mod (the SDK module root).
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// walkGoFiles parses every .go file under root whose module-relative,
+// slash-separated path satisfies keep. Test files and vendor/testdata/.git
+// are always skipped; keep narrows further (callers exclude generated and
+// the archtest package itself).
+func walkGoFiles(t *testing.T, root string, keep func(rel string) bool) []*goFile {
+	t.Helper()
+	var out []*goFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "testdata", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(rel, "_test.go") || !keep(rel) {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", rel, perr)
+		}
+		out = append(out, &goFile{rel: rel, fset: fset, ast: f})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+func (gf *goFile) line(n ast.Node) int { return gf.fset.Position(n.Pos()).Line }
+
+// render returns the gofmt-style source of an AST node, whitespace
+// collapsed, for stable allowlist keys and readable messages.
+func render(fset *token.FileSet, n ast.Node) string {
+	var b strings.Builder
+	if err := printer.Fprint(&b, fset, n); err != nil {
+		return "<unprintable node>"
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// allowlist couples intentionally-exempt sites with their justifications
+// and fails the build for any entry that no longer matches a site.
+type allowlist struct {
+	reason map[string]string
+	used   map[string]bool
+}
+
+func newAllowlist(reasons map[string]string) *allowlist {
+	return &allowlist{reason: reasons, used: make(map[string]bool)}
+}
+
+func (a *allowlist) exempt(key string) bool {
+	if _, ok := a.reason[key]; ok {
+		a.used[key] = true
+		return true
+	}
+	return false
+}
+
+func (a *allowlist) assertNoStale(t *testing.T) {
+	t.Helper()
+	for key := range a.reason {
+		if !a.used[key] {
+			t.Errorf("stale allowlist entry never matched any site (remove it or fix the key): %q", key)
+		}
+	}
+}

--- a/go/archtest/astutil.go
+++ b/go/archtest/astutil.go
@@ -1,0 +1,79 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// identName returns the most specific name an expression is known by: the
+// identifier, or the trailing selector field (foo.Bar -> "Bar").
+func identName(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		return x.Sel.Name
+	case *ast.StarExpr:
+		return identName(x.X)
+	case *ast.ParenExpr:
+		return identName(x.X)
+	}
+	return ""
+}
+
+// isPresenceComparand reports whether an operand is a nil / empty-string /
+// zero literal — i.e. the comparison is a presence check, not a
+// secret-value comparison.
+func isPresenceComparand(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "nil"
+	case *ast.BasicLit:
+		switch x.Kind {
+		case token.STRING:
+			if s, err := strconv.Unquote(x.Value); err == nil {
+				return s == ""
+			}
+		case token.INT, token.FLOAT:
+			return x.Value == "0" || x.Value == "0.0"
+		}
+	case *ast.CallExpr:
+		if len(x.Args) == 1 {
+			return isPresenceComparand(x.Args[0])
+		}
+	}
+	return false
+}
+
+// secretNameRe matches identifiers that hold secret material. The full
+// "signature"/"hmac" forms are used (bare "sig"/"mac" collide with
+// "assign"/"format"). A match is a violation only when it is not metadata
+// (secretMetaSuffixes) and not a presence check.
+var secretNameRe = regexp.MustCompile(`(?i)(token|secret|hmac|signature|fingerprint|password|passwd|digest|apikey)`)
+
+// secretMetaSuffixes name fields that describe a secret rather than carry
+// its bytes (TokenType, KeyID, SignatureSize, ...).
+var secretMetaSuffixes = []string{
+	"type", "kind", "id", "name", "len", "length", "count", "version",
+	"expiry", "expiresat", "at", "format", "algorithm", "algo", "method",
+	"status", "enabled", "disabled", "index", "idx", "field", "size",
+}
+
+// looksLikeSecretOperand reports whether an operand names secret material
+// that must be compared in constant time.
+func looksLikeSecretOperand(e ast.Expr) bool {
+	name := identName(e)
+	if name == "" || !secretNameRe.MatchString(name) {
+		return false
+	}
+	lower := strings.ToLower(name)
+	for _, suf := range secretMetaSuffixes {
+		if strings.HasSuffix(lower, suf) {
+			return false
+		}
+	}
+	return true
+}

--- a/go/archtest/secret_compare_test.go
+++ b/go/archtest/secret_compare_test.go
@@ -1,0 +1,84 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// secretCompareAllowlist lists comparisons that match the secret-name
+// heuristic but are not timing-sensitive secret-value compares. Each entry
+// is justified; assertNoStale fails the build if one stops matching.
+// Keyed by "<module-rel path> :: <rendered expression>".
+var secretCompareAllowlist = map[string]string{}
+
+// TestSecretComparesAreConstantTime forbids comparing secret material
+// (tokens, MACs, signatures, fingerprints, password/digest bytes) with
+// == / != / bytes.Equal in the SDK — the action-signing and encryption
+// boundary (sdk/go/verify, sdk/go/crypto). The correct primitives are
+// subtle.ConstantTimeCompare and hmac.Equal. Presence checks and metadata
+// fields are excluded.
+func TestSecretComparesAreConstantTime(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		// Skip generated proto code and the archtest package itself.
+		return !strings.HasPrefix(rel, "gen/") && !strings.HasPrefix(rel, "go/archtest/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero SDK Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(secretCompareAllowlist)
+	sawComparison := false
+	sawSecretName := false
+
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.BinaryExpr:
+				if x.Op == token.EQL || x.Op == token.NEQ {
+					sawComparison = true
+					checkSecretCompare(t, gf, x, x.X, x.Y, allow, &sawSecretName)
+				}
+			case *ast.CallExpr:
+				if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+					if id, ok := sel.X.(*ast.Ident); ok && id.Name == "bytes" && sel.Sel.Name == "Equal" && len(x.Args) == 2 {
+						sawComparison = true
+						checkSecretCompare(t, gf, x, x.Args[0], x.Args[1], allow, &sawSecretName)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if !sawComparison {
+		t.Fatal("matches-zero guard: found no equality comparisons — the AST walk is not reaching real code")
+	}
+	if !sawSecretName {
+		t.Fatal("matches-zero guard: the secret-name detector matched no identifier anywhere — the regex/scoping is dead, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+func checkSecretCompare(t *testing.T, gf *goFile, node ast.Node, lhs, rhs ast.Expr, allow *allowlist, sawSecretName *bool) {
+	t.Helper()
+	lSecret := looksLikeSecretOperand(lhs)
+	rSecret := looksLikeSecretOperand(rhs)
+	if lSecret || rSecret {
+		*sawSecretName = true
+	}
+	if !lSecret && !rSecret {
+		return
+	}
+	if isPresenceComparand(lhs) || isPresenceComparand(rhs) {
+		return
+	}
+	key := gf.rel + " :: " + render(gf.fset, node)
+	if allow.exempt(key) {
+		return
+	}
+	t.Errorf("non-constant-time secret compare at %s:%d — %s\n  compares secret material with ==/!=/bytes.Equal, which leaks length and content via timing. Use subtle.ConstantTimeCompare or hmac.Equal. If this is metadata (not secret bytes), add a justified, guarded entry to secretCompareAllowlist.",
+		gf.rel, gf.line(node), render(gf.fset, node))
+}


### PR DESCRIPTION
## Summary
Adds a self-discovering architectural fitness function (`go/archtest`) that fails the build if any secret/MAC/token/signature/fingerprint/digest value is compared with `==`/`!=`/`bytes.Equal` instead of `subtle.ConstantTimeCompare`/`hmac.Equal`. Locks the constant-time-compare discipline at the SDK's action-signing and encryption boundary (`go/verify`, `go/crypto`).

## Design
- Pure-stdlib AST (no `golang.org/x/tools` dependency).
- Presence-aware (`== nil` / `== ""` excluded) and metadata-aware (`TokenType`, `KeyID`, `SignatureSize` excluded).
- **Matches-zero guarded** — fails if it scans zero files or matches no secret-named identifier anywhere, so it can never pass vacuously.
- **No-stale-entry-guarded allowlist** — an allowlisted exception that no longer exists fails the build.

Green against current `main`. Part of WS0 of the security hardening workplan.

The clock fitness function applied to the server/agent repos is intentionally **not** applied here — the SDK has no time-decision logic (only external-command duration measurement and ULID seeding). See server repo ADR 0002.

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide with architectural standards and guidelines for SDK development.

* **Tests**
  * Added automated architectural checks to enforce constant-time operations for sensitive comparisons and maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->