### PR TITLE
feat(internal): add gateway_id to InternalService device-origin requests

### DIFF
--- a/gen/go/pm/v1/internal.pb.go
+++ b/gen/go/pm/v1/internal.pb.go
@@ -27,7 +27,15 @@ const (
 type InternalSyncActionsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,ulid"
-	DeviceId      string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
+	DeviceId string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
+	// gateway_id is the calling gateway's self-asserted identity, cross-checked
+	// by control against the authenticated device→gateway routing binding (the
+	// gateway peer cert is shared and carries no per-gateway identity). Optional
+	// on the wire: single-gateway deployments without a wired resolver bypass the
+	// binding; when a resolver is wired, control rejects an empty or mismatched
+	// gateway_id. See the server gateway↔control device-origin binding ADR.
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,2,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -69,13 +77,24 @@ func (x *InternalSyncActionsRequest) GetDeviceId() string {
 	return ""
 }
 
+func (x *InternalSyncActionsRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
+	}
+	return ""
+}
+
 // InternalValidateLuksTokenRequest wraps ValidateLuksTokenRequest.
 type InternalValidateLuksTokenRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,ulid"
 	DeviceId string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"required,min=1,max=256"
-	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required,min=1,max=256"`
+	Token string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required,min=1,max=256"`
+	// gateway_id cross-checked against the device→gateway binding (see
+	// InternalSyncActionsRequest.gateway_id).
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,3,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -124,13 +143,24 @@ func (x *InternalValidateLuksTokenRequest) GetToken() string {
 	return ""
 }
 
+func (x *InternalValidateLuksTokenRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
+	}
+	return ""
+}
+
 // InternalGetLuksKeyRequest includes device_id (from mTLS) and action_id.
 type InternalGetLuksKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,ulid"
 	DeviceId string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"required,ulid"
-	ActionId      string `protobuf:"bytes,2,opt,name=action_id,json=actionId,proto3" json:"action_id,omitempty" validate:"required,ulid"`
+	ActionId string `protobuf:"bytes,2,opt,name=action_id,json=actionId,proto3" json:"action_id,omitempty" validate:"required,ulid"`
+	// gateway_id cross-checked against the device→gateway binding (see
+	// InternalSyncActionsRequest.gateway_id).
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,3,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -179,6 +209,13 @@ func (x *InternalGetLuksKeyRequest) GetActionId() string {
 	return ""
 }
 
+func (x *InternalGetLuksKeyRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
+	}
+	return ""
+}
+
 // InternalStoreLuksKeyRequest includes device_id (from mTLS) and key data.
 type InternalStoreLuksKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -195,8 +232,12 @@ type InternalStoreLuksKeyRequest struct {
 	// rotation. Stored on the event as the lowercase string form.
 	// @gotags: validate:"required"
 	RotationReason RotationReason `protobuf:"varint,5,opt,name=rotation_reason,json=rotationReason,proto3,enum=pm.v1.RotationReason" json:"rotation_reason,omitempty" validate:"required"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// gateway_id cross-checked against the device→gateway binding (see
+	// InternalSyncActionsRequest.gateway_id).
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,6,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *InternalStoreLuksKeyRequest) Reset() {
@@ -262,6 +303,13 @@ func (x *InternalStoreLuksKeyRequest) GetRotationReason() RotationReason {
 		return x.RotationReason
 	}
 	return RotationReason_ROTATION_REASON_UNSPECIFIED
+}
+
+func (x *InternalStoreLuksKeyRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
+	}
+	return ""
 }
 
 // LpsPasswordRotation represents a single password rotation entry the
@@ -362,7 +410,11 @@ type InternalStoreLpsPasswordsRequest struct {
 	// @gotags: validate:"required,ulid"
 	ActionId string `protobuf:"bytes,2,opt,name=action_id,json=actionId,proto3" json:"action_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"required,min=1,dive"
-	Rotations     []*LpsPasswordRotation `protobuf:"bytes,3,rep,name=rotations,proto3" json:"rotations,omitempty" validate:"required,min=1,dive"`
+	Rotations []*LpsPasswordRotation `protobuf:"bytes,3,rep,name=rotations,proto3" json:"rotations,omitempty" validate:"required,min=1,dive"`
+	// gateway_id cross-checked against the device→gateway binding (see
+	// InternalSyncActionsRequest.gateway_id).
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,4,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -416,6 +468,13 @@ func (x *InternalStoreLpsPasswordsRequest) GetRotations() []*LpsPasswordRotation
 		return x.Rotations
 	}
 	return nil
+}
+
+func (x *InternalStoreLpsPasswordsRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
+	}
+	return ""
 }
 
 type InternalStoreLpsPasswordsResponse struct {
@@ -611,7 +670,11 @@ func (x *InternalValidateTerminalTokenResponse) GetRows() uint32 {
 type VerifyDeviceRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,ulid"
-	DeviceId      string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
+	DeviceId string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
+	// gateway_id cross-checked against the device→gateway binding (see
+	// InternalSyncActionsRequest.gateway_id).
+	// @gotags: validate:"omitempty,max=256"
+	GatewayId     string `protobuf:"bytes,2,opt,name=gateway_id,json=gatewayId,proto3" json:"gateway_id,omitempty" validate:"omitempty,max=256"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -649,6 +712,13 @@ func (*VerifyDeviceRequest) Descriptor() ([]byte, []int) {
 func (x *VerifyDeviceRequest) GetDeviceId() string {
 	if x != nil {
 		return x.DeviceId
+	}
+	return ""
+}
+
+func (x *VerifyDeviceRequest) GetGatewayId() string {
+	if x != nil {
+		return x.GatewayId
 	}
 	return ""
 }
@@ -977,15 +1047,21 @@ var File_pm_v1_internal_proto protoreflect.FileDescriptor
 
 const file_pm_v1_internal_proto_rawDesc = "" +
 	"\n" +
-	"\x14pm/v1/internal.proto\x12\x05pm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11pm/v1/agent.proto\x1a\x12pm/v1/common.proto\"9\n" +
+	"\x14pm/v1/internal.proto\x12\x05pm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11pm/v1/agent.proto\x1a\x12pm/v1/common.proto\"X\n" +
 	"\x1aInternalSyncActionsRequest\x12\x1b\n" +
-	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"U\n" +
+	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x02 \x01(\tR\tgatewayId\"t\n" +
 	" InternalValidateLuksTokenRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x14\n" +
-	"\x05token\x18\x02 \x01(\tR\x05token\"U\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x03 \x01(\tR\tgatewayId\"t\n" +
 	"\x19InternalGetLuksKeyRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1b\n" +
-	"\taction_id\x18\x02 \x01(\tR\bactionId\"\xd8\x01\n" +
+	"\taction_id\x18\x02 \x01(\tR\bactionId\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x03 \x01(\tR\tgatewayId\"\xf7\x01\n" +
 	"\x1bInternalStoreLuksKeyRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1b\n" +
 	"\taction_id\x18\x02 \x01(\tR\bactionId\x12\x1f\n" +
@@ -994,17 +1070,21 @@ const file_pm_v1_internal_proto_rawDesc = "" +
 	"\n" +
 	"passphrase\x18\x04 \x01(\tR\n" +
 	"passphrase\x12>\n" +
-	"\x0frotation_reason\x18\x05 \x01(\x0e2\x15.pm.v1.RotationReasonR\x0erotationReason\"\x9b\x01\n" +
+	"\x0frotation_reason\x18\x05 \x01(\x0e2\x15.pm.v1.RotationReasonR\x0erotationReason\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x06 \x01(\tR\tgatewayId\"\x9b\x01\n" +
 	"\x13LpsPasswordRotation\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1a\n" +
 	"\bpassword\x18\x02 \x01(\tR\bpassword\x12\x1d\n" +
 	"\n" +
 	"rotated_at\x18\x03 \x01(\tR\trotatedAt\x12-\n" +
-	"\x06reason\x18\x04 \x01(\x0e2\x15.pm.v1.RotationReasonR\x06reason\"\x96\x01\n" +
+	"\x06reason\x18\x04 \x01(\x0e2\x15.pm.v1.RotationReasonR\x06reason\"\xb5\x01\n" +
 	" InternalStoreLpsPasswordsRequest\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1b\n" +
 	"\taction_id\x18\x02 \x01(\tR\bactionId\x128\n" +
-	"\trotations\x18\x03 \x03(\v2\x1a.pm.v1.LpsPasswordRotationR\trotations\"#\n" +
+	"\trotations\x18\x03 \x03(\v2\x1a.pm.v1.LpsPasswordRotationR\trotations\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x04 \x01(\tR\tgatewayId\"#\n" +
 	"!InternalStoreLpsPasswordsResponse\"[\n" +
 	"$InternalValidateTerminalTokenRequest\x12\x1d\n" +
 	"\n" +
@@ -1015,9 +1095,11 @@ const file_pm_v1_internal_proto_rawDesc = "" +
 	"\tdevice_id\x18\x02 \x01(\tR\bdeviceId\x12\x19\n" +
 	"\btty_user\x18\x03 \x01(\tR\attyUser\x12\x12\n" +
 	"\x04cols\x18\x04 \x01(\rR\x04cols\x12\x12\n" +
-	"\x04rows\x18\x05 \x01(\rR\x04rows\"2\n" +
+	"\x04rows\x18\x05 \x01(\rR\x04rows\"Q\n" +
 	"\x13VerifyDeviceRequest\x12\x1b\n" +
-	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"\x16\n" +
+	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\x12\x1d\n" +
+	"\n" +
+	"gateway_id\x18\x02 \x01(\tR\tgatewayId\"\x16\n" +
 	"\x14VerifyDeviceResponse\"\x8d\x02\n" +
 	"\x1aGatewayTerminalSessionInfo\x12\x1d\n" +
 	"\n" +

--- a/gen/ts/pm/v1/internal_pb.ts
+++ b/gen/ts/pm/v1/internal_pb.ts
@@ -16,7 +16,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file pm/v1/internal.proto.
  */
 export const file_pm_v1_internal: GenFile = /*@__PURE__*/
-  fileDesc("ChRwbS92MS9pbnRlcm5hbC5wcm90bxIFcG0udjEiLwoaSW50ZXJuYWxTeW5jQWN0aW9uc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJIkQKIEludGVybmFsVmFsaWRhdGVMdWtzVG9rZW5SZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRINCgV0b2tlbhgCIAEoCSJBChlJbnRlcm5hbEdldEx1a3NLZXlSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRIRCglhY3Rpb25faWQYAiABKAkinAEKG0ludGVybmFsU3RvcmVMdWtzS2V5UmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkSEQoJYWN0aW9uX2lkGAIgASgJEhMKC2RldmljZV9wYXRoGAMgASgJEhIKCnBhc3NwaHJhc2UYBCABKAkSLgoPcm90YXRpb25fcmVhc29uGAUgASgOMhUucG0udjEuUm90YXRpb25SZWFzb24idAoTTHBzUGFzc3dvcmRSb3RhdGlvbhIQCgh1c2VybmFtZRgBIAEoCRIQCghwYXNzd29yZBgCIAEoCRISCgpyb3RhdGVkX2F0GAMgASgJEiUKBnJlYXNvbhgEIAEoDjIVLnBtLnYxLlJvdGF0aW9uUmVhc29uIncKIEludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRIRCglhY3Rpb25faWQYAiABKAkSLQoJcm90YXRpb25zGAMgAygLMhoucG0udjEuTHBzUGFzc3dvcmRSb3RhdGlvbiIjCiFJbnRlcm5hbFN0b3JlTHBzUGFzc3dvcmRzUmVzcG9uc2UiSQokSW50ZXJuYWxWYWxpZGF0ZVRlcm1pbmFsVG9rZW5SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkSDQoFdG9rZW4YAiABKAkieQolSW50ZXJuYWxWYWxpZGF0ZVRlcm1pbmFsVG9rZW5SZXNwb25zZRIPCgd1c2VyX2lkGAEgASgJEhEKCWRldmljZV9pZBgCIAEoCRIQCgh0dHlfdXNlchgDIAEoCRIMCgRjb2xzGAQgASgNEgwKBHJvd3MYBSABKA0iKAoTVmVyaWZ5RGV2aWNlUmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkiFgoUVmVyaWZ5RGV2aWNlUmVzcG9uc2UizAEKGkdhdGV3YXlUZXJtaW5hbFNlc3Npb25JbmZvEhIKCnNlc3Npb25faWQYASABKAkSDwoHdXNlcl9pZBgCIAEoCRIRCglkZXZpY2VfaWQYAyABKAkSEAoIdHR5X3VzZXIYBCABKAkSLgoKc3RhcnRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASNAoQbGFzdF9hY3Rpdml0eV9hdBgGIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiJAoiTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zUmVxdWVzdCJaCiNMaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXNwb25zZRIzCghzZXNzaW9ucxgBIAMoCzIhLnBtLnYxLkdhdGV3YXlUZXJtaW5hbFNlc3Npb25JbmZvIkwKJlRlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb25SZXF1ZXN0EhIKCnNlc3Npb25faWQYASABKAkSDgoGcmVhc29uGAIgASgJIjgKJ1Rlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb25SZXNwb25zZRINCgVmb3VuZBgBIAEoCDKeBQoPSW50ZXJuYWxTZXJ2aWNlEkcKDFZlcmlmeURldmljZRIaLnBtLnYxLlZlcmlmeURldmljZVJlcXVlc3QaGy5wbS52MS5WZXJpZnlEZXZpY2VSZXNwb25zZRJRChBQcm94eVN5bmNBY3Rpb25zEiEucG0udjEuSW50ZXJuYWxTeW5jQWN0aW9uc1JlcXVlc3QaGi5wbS52MS5TeW5jQWN0aW9uc1Jlc3BvbnNlEmMKFlByb3h5VmFsaWRhdGVMdWtzVG9rZW4SJy5wbS52MS5JbnRlcm5hbFZhbGlkYXRlTHVrc1Rva2VuUmVxdWVzdBogLnBtLnYxLlZhbGlkYXRlTHVrc1Rva2VuUmVzcG9uc2USTgoPUHJveHlHZXRMdWtzS2V5EiAucG0udjEuSW50ZXJuYWxHZXRMdWtzS2V5UmVxdWVzdBoZLnBtLnYxLkdldEx1a3NLZXlSZXNwb25zZRJUChFQcm94eVN0b3JlTHVrc0tleRIiLnBtLnYxLkludGVybmFsU3RvcmVMdWtzS2V5UmVxdWVzdBobLnBtLnYxLlN0b3JlTHVrc0tleVJlc3BvbnNlEmsKFlByb3h5U3RvcmVMcHNQYXNzd29yZHMSJy5wbS52MS5JbnRlcm5hbFN0b3JlTHBzUGFzc3dvcmRzUmVxdWVzdBooLnBtLnYxLkludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXNwb25zZRJ3ChpQcm94eVZhbGlkYXRlVGVybWluYWxUb2tlbhIrLnBtLnYxLkludGVybmFsVmFsaWRhdGVUZXJtaW5hbFRva2VuUmVxdWVzdBosLnBtLnYxLkludGVybmFsVmFsaWRhdGVUZXJtaW5hbFRva2VuUmVzcG9uc2UyiQIKDkdhdGV3YXlTZXJ2aWNlEnQKG0xpc3RHYXRld2F5VGVybWluYWxTZXNzaW9ucxIpLnBtLnYxLkxpc3RHYXRld2F5VGVybWluYWxTZXNzaW9uc1JlcXVlc3QaKi5wbS52MS5MaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXNwb25zZRKAAQofVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvbhItLnBtLnYxLlRlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb25SZXF1ZXN0Gi4ucG0udjEuVGVybWluYXRlR2F0ZXdheVRlcm1pbmFsU2Vzc2lvblJlc3BvbnNlQjpaOGdpdGh1Yi5jb20vbWFuY2h0b29scy9wb3dlci1tYW5hZ2Uvc2RrL2dlbi9nby9wbS92MTtwbXYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_pm_v1_agent, file_pm_v1_common]);
+  fileDesc("ChRwbS92MS9pbnRlcm5hbC5wcm90bxIFcG0udjEiQwoaSW50ZXJuYWxTeW5jQWN0aW9uc1JlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJEhIKCmdhdGV3YXlfaWQYAiABKAkiWAogSW50ZXJuYWxWYWxpZGF0ZUx1a3NUb2tlblJlcXVlc3QSEQoJZGV2aWNlX2lkGAEgASgJEg0KBXRva2VuGAIgASgJEhIKCmdhdGV3YXlfaWQYAyABKAkiVQoZSW50ZXJuYWxHZXRMdWtzS2V5UmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkSEQoJYWN0aW9uX2lkGAIgASgJEhIKCmdhdGV3YXlfaWQYAyABKAkisAEKG0ludGVybmFsU3RvcmVMdWtzS2V5UmVxdWVzdBIRCglkZXZpY2VfaWQYASABKAkSEQoJYWN0aW9uX2lkGAIgASgJEhMKC2RldmljZV9wYXRoGAMgASgJEhIKCnBhc3NwaHJhc2UYBCABKAkSLgoPcm90YXRpb25fcmVhc29uGAUgASgOMhUucG0udjEuUm90YXRpb25SZWFzb24SEgoKZ2F0ZXdheV9pZBgGIAEoCSJ0ChNMcHNQYXNzd29yZFJvdGF0aW9uEhAKCHVzZXJuYW1lGAEgASgJEhAKCHBhc3N3b3JkGAIgASgJEhIKCnJvdGF0ZWRfYXQYAyABKAkSJQoGcmVhc29uGAQgASgOMhUucG0udjEuUm90YXRpb25SZWFzb24iiwEKIEludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRIRCglhY3Rpb25faWQYAiABKAkSLQoJcm90YXRpb25zGAMgAygLMhoucG0udjEuTHBzUGFzc3dvcmRSb3RhdGlvbhISCgpnYXRld2F5X2lkGAQgASgJIiMKIUludGVybmFsU3RvcmVMcHNQYXNzd29yZHNSZXNwb25zZSJJCiRJbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlcXVlc3QSEgoKc2Vzc2lvbl9pZBgBIAEoCRINCgV0b2tlbhgCIAEoCSJ5CiVJbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlc3BvbnNlEg8KB3VzZXJfaWQYASABKAkSEQoJZGV2aWNlX2lkGAIgASgJEhAKCHR0eV91c2VyGAMgASgJEgwKBGNvbHMYBCABKA0SDAoEcm93cxgFIAEoDSI8ChNWZXJpZnlEZXZpY2VSZXF1ZXN0EhEKCWRldmljZV9pZBgBIAEoCRISCgpnYXRld2F5X2lkGAIgASgJIhYKFFZlcmlmeURldmljZVJlc3BvbnNlIswBChpHYXRld2F5VGVybWluYWxTZXNzaW9uSW5mbxISCgpzZXNzaW9uX2lkGAEgASgJEg8KB3VzZXJfaWQYAiABKAkSEQoJZGV2aWNlX2lkGAMgASgJEhAKCHR0eV91c2VyGAQgASgJEi4KCnN0YXJ0ZWRfYXQYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEjQKEGxhc3RfYWN0aXZpdHlfYXQYBiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIiQKIkxpc3RHYXRld2F5VGVybWluYWxTZXNzaW9uc1JlcXVlc3QiWgojTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zUmVzcG9uc2USMwoIc2Vzc2lvbnMYASADKAsyIS5wbS52MS5HYXRld2F5VGVybWluYWxTZXNzaW9uSW5mbyJMCiZUZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uUmVxdWVzdBISCgpzZXNzaW9uX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSI4CidUZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uUmVzcG9uc2USDQoFZm91bmQYASABKAgyngUKD0ludGVybmFsU2VydmljZRJHCgxWZXJpZnlEZXZpY2USGi5wbS52MS5WZXJpZnlEZXZpY2VSZXF1ZXN0GhsucG0udjEuVmVyaWZ5RGV2aWNlUmVzcG9uc2USUQoQUHJveHlTeW5jQWN0aW9ucxIhLnBtLnYxLkludGVybmFsU3luY0FjdGlvbnNSZXF1ZXN0GhoucG0udjEuU3luY0FjdGlvbnNSZXNwb25zZRJjChZQcm94eVZhbGlkYXRlTHVrc1Rva2VuEicucG0udjEuSW50ZXJuYWxWYWxpZGF0ZUx1a3NUb2tlblJlcXVlc3QaIC5wbS52MS5WYWxpZGF0ZUx1a3NUb2tlblJlc3BvbnNlEk4KD1Byb3h5R2V0THVrc0tleRIgLnBtLnYxLkludGVybmFsR2V0THVrc0tleVJlcXVlc3QaGS5wbS52MS5HZXRMdWtzS2V5UmVzcG9uc2USVAoRUHJveHlTdG9yZUx1a3NLZXkSIi5wbS52MS5JbnRlcm5hbFN0b3JlTHVrc0tleVJlcXVlc3QaGy5wbS52MS5TdG9yZUx1a3NLZXlSZXNwb25zZRJrChZQcm94eVN0b3JlTHBzUGFzc3dvcmRzEicucG0udjEuSW50ZXJuYWxTdG9yZUxwc1Bhc3N3b3Jkc1JlcXVlc3QaKC5wbS52MS5JbnRlcm5hbFN0b3JlTHBzUGFzc3dvcmRzUmVzcG9uc2USdwoaUHJveHlWYWxpZGF0ZVRlcm1pbmFsVG9rZW4SKy5wbS52MS5JbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlcXVlc3QaLC5wbS52MS5JbnRlcm5hbFZhbGlkYXRlVGVybWluYWxUb2tlblJlc3BvbnNlMokCCg5HYXRld2F5U2VydmljZRJ0ChtMaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnMSKS5wbS52MS5MaXN0R2F0ZXdheVRlcm1pbmFsU2Vzc2lvbnNSZXF1ZXN0GioucG0udjEuTGlzdEdhdGV3YXlUZXJtaW5hbFNlc3Npb25zUmVzcG9uc2USgAEKH1Rlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb24SLS5wbS52MS5UZXJtaW5hdGVHYXRld2F5VGVybWluYWxTZXNzaW9uUmVxdWVzdBouLnBtLnYxLlRlcm1pbmF0ZUdhdGV3YXlUZXJtaW5hbFNlc3Npb25SZXNwb25zZUI6WjhnaXRodWIuY29tL21hbmNodG9vbHMvcG93ZXItbWFuYWdlL3Nkay9nZW4vZ28vcG0vdjE7cG12MWIGcHJvdG8z", [file_google_protobuf_timestamp, file_pm_v1_agent, file_pm_v1_common]);
 
 /**
  * InternalSyncActionsRequest wraps SyncActionsRequest with the device_id
@@ -31,6 +31,19 @@ export type InternalSyncActionsRequest = Message<"pm.v1.InternalSyncActionsReque
    * @generated from field: string device_id = 1;
    */
   deviceId: string;
+
+  /**
+   * gateway_id is the calling gateway's self-asserted identity, cross-checked
+   * by control against the authenticated device→gateway routing binding (the
+   * gateway peer cert is shared and carries no per-gateway identity). Optional
+   * on the wire: single-gateway deployments without a wired resolver bypass the
+   * binding; when a resolver is wired, control rejects an empty or mismatched
+   * gateway_id. See the server gateway↔control device-origin binding ADR.
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 2;
+   */
+  gatewayId: string;
 };
 
 /**
@@ -59,6 +72,15 @@ export type InternalValidateLuksTokenRequest = Message<"pm.v1.InternalValidateLu
    * @generated from field: string token = 2;
    */
   token: string;
+
+  /**
+   * gateway_id cross-checked against the device→gateway binding (see
+   * InternalSyncActionsRequest.gateway_id).
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 3;
+   */
+  gatewayId: string;
 };
 
 /**
@@ -87,6 +109,15 @@ export type InternalGetLuksKeyRequest = Message<"pm.v1.InternalGetLuksKeyRequest
    * @generated from field: string action_id = 2;
    */
   actionId: string;
+
+  /**
+   * gateway_id cross-checked against the device→gateway binding (see
+   * InternalSyncActionsRequest.gateway_id).
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 3;
+   */
+  gatewayId: string;
 };
 
 /**
@@ -139,6 +170,15 @@ export type InternalStoreLuksKeyRequest = Message<"pm.v1.InternalStoreLuksKeyReq
    * @generated from field: pm.v1.RotationReason rotation_reason = 5;
    */
   rotationReason: RotationReason;
+
+  /**
+   * gateway_id cross-checked against the device→gateway binding (see
+   * InternalSyncActionsRequest.gateway_id).
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 6;
+   */
+  gatewayId: string;
 };
 
 /**
@@ -233,6 +273,15 @@ export type InternalStoreLpsPasswordsRequest = Message<"pm.v1.InternalStoreLpsPa
    * @generated from field: repeated pm.v1.LpsPasswordRotation rotations = 3;
    */
   rotations: LpsPasswordRotation[];
+
+  /**
+   * gateway_id cross-checked against the device→gateway binding (see
+   * InternalSyncActionsRequest.gateway_id).
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 4;
+   */
+  gatewayId: string;
 };
 
 /**
@@ -360,6 +409,15 @@ export type VerifyDeviceRequest = Message<"pm.v1.VerifyDeviceRequest"> & {
    * @generated from field: string device_id = 1;
    */
   deviceId: string;
+
+  /**
+   * gateway_id cross-checked against the device→gateway binding (see
+   * InternalSyncActionsRequest.gateway_id).
+   * @gotags: validate:"omitempty,max=256"
+   *
+   * @generated from field: string gateway_id = 2;
+   */
+  gatewayId: string;
 };
 
 /**

--- a/go/internal_gateway_binding_test.go
+++ b/go/internal_gateway_binding_test.go
@@ -1,0 +1,59 @@
+package sdk
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestInternalServiceDeviceIDRequestsCarryGatewayID is the self-discovering
+// charter for the gateway↔control device-origin binding (server#403 / WS2): the
+// control server can only confine a gateway to its own devices if every
+// InternalService request that names a `device_id` ALSO carries the calling
+// gateway's `gateway_id` to cross-check against the device→gateway routing
+// binding. This walks the live InternalService descriptor (not a hardcoded
+// list), so a NEW device-origin RPC added without a gateway_id field fails here
+// rather than silently shipping an unbindable credential-bearing request.
+//
+// Requests that authenticate by other means (e.g. ValidateTerminalToken, which
+// carries session_id + token, no device_id) are correctly excluded by the
+// device_id-presence rule — no special-casing.
+func TestInternalServiceDeviceIDRequestsCarryGatewayID(t *testing.T) {
+	svc := pmv1.File_pm_v1_internal_proto.Services().ByName("InternalService")
+	if svc == nil {
+		t.Fatal("InternalService descriptor must resolve")
+	}
+
+	methods := svc.Methods()
+	if methods.Len() == 0 {
+		t.Fatal("matches-zero guard: InternalService exposes no methods")
+	}
+
+	// foundDeviceID counts requests the walk actually reached that carry a
+	// device_id — the matches-zero guard. It is deliberately SEPARATE from the
+	// pass/fail of the gateway_id check: if every device_id request were missing
+	// gateway_id (the exact regression this guards), a counter that only
+	// incremented on success would hit zero and misreport "no device_id request
+	// exists" instead of the real failures.
+	foundDeviceID := 0
+	for i := 0; i < methods.Len(); i++ {
+		req := methods.Get(i).Input()
+		if req.Fields().ByName("device_id") == nil {
+			continue // not a device-id-keyed request; binds via another credential
+		}
+		foundDeviceID++
+		gw := req.Fields().ByName("gateway_id")
+		if gw == nil {
+			t.Errorf("%s carries device_id but no gateway_id — every device-origin InternalService request must bind to the calling gateway (WS2)", req.FullName())
+			continue
+		}
+		if gw.Kind() != protoreflect.StringKind {
+			t.Errorf("%s.gateway_id must be a string, got %s", req.FullName(), gw.Kind())
+		}
+	}
+	if foundDeviceID == 0 {
+		t.Fatal("matches-zero guard: no InternalService request carries device_id — the parity check is dead and would pass vacuously")
+	}
+}

--- a/proto/pm/v1/internal.proto
+++ b/proto/pm/v1/internal.proto
@@ -59,6 +59,14 @@ service InternalService {
 message InternalSyncActionsRequest {
   // @gotags: validate:"required,ulid"
   string device_id = 1;
+  // gateway_id is the calling gateway's self-asserted identity, cross-checked
+  // by control against the authenticated device→gateway routing binding (the
+  // gateway peer cert is shared and carries no per-gateway identity). Optional
+  // on the wire: single-gateway deployments without a wired resolver bypass the
+  // binding; when a resolver is wired, control rejects an empty or mismatched
+  // gateway_id. See the server gateway↔control device-origin binding ADR.
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 2;
 }
 
 // InternalValidateLuksTokenRequest wraps ValidateLuksTokenRequest.
@@ -67,6 +75,10 @@ message InternalValidateLuksTokenRequest {
   string device_id = 1;
   // @gotags: validate:"required,min=1,max=256"
   string token = 2;
+  // gateway_id cross-checked against the device→gateway binding (see
+  // InternalSyncActionsRequest.gateway_id).
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 3;
 }
 
 // InternalGetLuksKeyRequest includes device_id (from mTLS) and action_id.
@@ -75,6 +87,10 @@ message InternalGetLuksKeyRequest {
   string device_id = 1;
   // @gotags: validate:"required,ulid"
   string action_id = 2;
+  // gateway_id cross-checked against the device→gateway binding (see
+  // InternalSyncActionsRequest.gateway_id).
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 3;
 }
 
 // InternalStoreLuksKeyRequest includes device_id (from mTLS) and key data.
@@ -92,6 +108,10 @@ message InternalStoreLuksKeyRequest {
   // rotation. Stored on the event as the lowercase string form.
   // @gotags: validate:"required"
   RotationReason rotation_reason = 5;
+  // gateway_id cross-checked against the device→gateway binding (see
+  // InternalSyncActionsRequest.gateway_id).
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 6;
 }
 
 // LpsPasswordRotation represents a single password rotation entry the
@@ -131,6 +151,10 @@ message InternalStoreLpsPasswordsRequest {
   string action_id = 2;
   // @gotags: validate:"required,min=1,dive"
   repeated LpsPasswordRotation rotations = 3;
+  // gateway_id cross-checked against the device→gateway binding (see
+  // InternalSyncActionsRequest.gateway_id).
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 4;
 }
 
 message InternalStoreLpsPasswordsResponse {}
@@ -177,6 +201,10 @@ message InternalValidateTerminalTokenResponse {
 message VerifyDeviceRequest {
   // @gotags: validate:"required,ulid"
   string device_id = 1;
+  // gateway_id cross-checked against the device→gateway binding (see
+  // InternalSyncActionsRequest.gateway_id).
+  // @gotags: validate:"omitempty,max=256"
+  string gateway_id = 2;
 }
 
 // VerifyDeviceResponse indicates whether the device is valid for connection.


### PR DESCRIPTION
Adds an optional `string gateway_id` to every `InternalService` request carrying a `device_id`: `InternalSyncActionsRequest`, `InternalValidateLuksTokenRequest`, `InternalGetLuksKeyRequest`, `InternalStoreLuksKeyRequest`, `InternalStoreLpsPasswordsRequest`, `VerifyDeviceRequest`.

## Why

The gateway peer-class mTLS cert is shared and carries no per-gateway identity, so the control server cannot derive *which* gateway is calling. The request self-asserts its `gateway_id`; control cross-checks it against the device→gateway routing binding written under the agent's own mTLS identity, and rejects any `(device_id, gateway_id)` mismatch — so a compromised gateway can no longer read/overwrite another device's LUKS/LPS secrets or forge device-attributed events. The enforcement lands server-side (`manchtools/power-manage-server#403`); this PR is the additive wire contract.

## Notes

- Optional on the wire (`validate:"omitempty,max=256"`): single-gateway deployments without a wired resolver bypass the binding; the control handler rejects an empty or mismatched `gateway_id` only when a resolver is wired.
- `InternalValidateTerminalTokenRequest` is intentionally excluded — it authenticates by `session_id` + token, not `device_id`.
- Additive, next-free field numbers, no `reserved`. `make generate` regenerated Go + TS.
- `TestInternalServiceDeviceIDRequestsCarryGatewayID` self-discovers the `InternalService` descriptor and fails if a new `device_id`-carrying request omits `gateway_id` (matches-zero guarded on a separate device_id counter).

Closes #93. Advances `manchtools/power-manage-server#403`.
