### PR TITLE
fix(ts-client): accept trust_email_assertions in create/updateIdentityProvider facade

### DIFF
--- a/ts/client.ts
+++ b/ts/client.ts
@@ -1693,6 +1693,7 @@ export class ApiClient {
 		scopes?: string[];
 		autoCreateUsers?: boolean;
 		autoLinkByEmail?: boolean;
+		trustEmailAssertions?: boolean;
 		defaultRoleId?: string;
 		disablePasswordForLinked?: boolean;
 		groupClaim?: string;
@@ -1733,6 +1734,7 @@ export class ApiClient {
 		scopes?: string[];
 		autoCreateUsers?: boolean;
 		autoLinkByEmail?: boolean;
+		trustEmailAssertions?: boolean;
 		defaultRoleId?: string;
 		disablePasswordForLinked?: boolean;
 		groupClaim?: string;


### PR DESCRIPTION
Follow-up to #98: the proto field was added but the hand-written `ApiClient` facade (`ts/client.ts`) types each IdP method's `data` param inline, so web callers (which use the facade via `$pmSdk`) couldn't pass `trustEmailAssertions`. Adds the optional field to both `createIdentityProvider` and `updateIdentityProvider`.