### PR TITLE
fix(fs,client,exec): symlink-safe writes, deny-by-default RemoveDir, bounded fan-out (WS6)

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -56,12 +56,34 @@ type Client struct {
 	// to reset its ticker when Welcome arrives with a new interval.
 	// Non-nil only while Run() is active; guarded by mu.
 	heartbeatUpdate chan time.Duration
+
+	// invSem and luksRevokeSem bound how many server-originated
+	// RequestInventory / RevokeLuksDeviceKey handlers run concurrently.
+	// Each spawns a goroutine (inventory forks osquery; revoke does a
+	// request-response on the stream), so an unbounded flood from a
+	// compromised or buggy gateway could exhaust memory and goroutines.
+	// Acquisition is non-blocking: excess is DROPPED, not queued (WS6
+	// #11). Initialised by NewClient.
+	invSem        chan struct{}
+	luksRevokeSem chan struct{}
 }
+
+const (
+	// inventoryDispatchConcurrency bounds concurrent server-originated
+	// inventory collections. One full osquery scan at a time is the
+	// realistic need; 2 gives a little slack without risking exhaustion.
+	inventoryDispatchConcurrency = 2
+	// luksRevokeDispatchConcurrency bounds concurrent LUKS device-key
+	// revocations dispatched from the server.
+	luksRevokeDispatchConcurrency = 2
+)
 
 // NewClient creates a new SDK client.
 func NewClient(serverURL string, opts ...ClientOption) *Client {
 	c := &Client{
-		logger: slog.Default(),
+		logger:        slog.Default(),
+		invSem:        make(chan struct{}, inventoryDispatchConcurrency),
+		luksRevokeSem: make(chan struct{}, luksRevokeDispatchConcurrency),
 	}
 
 	httpClient := http.DefaultClient
@@ -1029,16 +1051,27 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 				c.logger.Warn("dropping RequestInventory with nil payload", "message_id", msg.Id)
 				return nil
 			}
-			go func() {
-				// Server-originated: verify the signature (inside the handler)
-				// before collecting. A forged RequestInventory from a
-				// compromised gateway yields nil and never runs osquery.
-				if inv := invHandler.OnRequestInventory(ctx, p.RequestInventory); inv != nil {
-					if err := c.SendInventory(ctx, inv); err != nil {
-						c.logger.Warn("failed to send inventory", "error", err)
+			req := p.RequestInventory
+			// Bound concurrency: drop (don't queue) when already at
+			// capacity so a flood cannot spawn unbounded osquery forks.
+			select {
+			case c.invSem <- struct{}{}:
+				go func() {
+					defer func() { <-c.invSem }()
+					// Server-originated: verify the signature (inside the
+					// handler) before collecting. A forged RequestInventory
+					// from a compromised gateway yields nil and never runs
+					// osquery.
+					if inv := invHandler.OnRequestInventory(ctx, req); inv != nil {
+						if err := c.SendInventory(ctx, inv); err != nil {
+							c.logger.Warn("failed to send inventory", "error", err)
+						}
 					}
-				}
-			}()
+				}()
+			default:
+				c.logger.Warn("dropping RequestInventory: inventory collection already at capacity",
+					"message_id", msg.Id, "limit", inventoryDispatchConcurrency)
+			}
 		}
 
 	case *pm.ServerMessage_LogQuery:
@@ -1068,14 +1101,23 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			// Run in goroutine: the handler calls GetLuksKey which sends
 			// a request on the stream and waits for a response. Processing
 			// that response requires this receive loop to keep running.
-			go func() {
-				// Pass the full message so the handler can verify the CA
-				// signature binding action_id before the destructive wipe.
-				success, errMsg := luksHandler.OnRevokeLuksDeviceKey(ctx, req)
-				if err := c.SendRevokeLuksDeviceKeyResult(ctx, actionID, success, errMsg); err != nil {
-					c.logger.Warn("failed to send LUKS revocation result", "action_id", actionID, "error", err)
-				}
-			}()
+			// Bound concurrency and drop overflow so a flood cannot spawn
+			// unbounded goroutines (WS6 #11).
+			select {
+			case c.luksRevokeSem <- struct{}{}:
+				go func() {
+					defer func() { <-c.luksRevokeSem }()
+					// Pass the full message so the handler can verify the CA
+					// signature binding action_id before the destructive wipe.
+					success, errMsg := luksHandler.OnRevokeLuksDeviceKey(ctx, req)
+					if err := c.SendRevokeLuksDeviceKeyResult(ctx, actionID, success, errMsg); err != nil {
+						c.logger.Warn("failed to send LUKS revocation result", "action_id", actionID, "error", err)
+					}
+				}()
+			default:
+				c.logger.Warn("dropping RevokeLuksDeviceKey: revocation already at capacity",
+					"message_id", msg.Id, "action_id", actionID, "limit", luksRevokeDispatchConcurrency)
+			}
 		}
 
 	case *pm.ServerMessage_TerminalStart:

--- a/go/client_dispatch_test.go
+++ b/go/client_dispatch_test.go
@@ -1,0 +1,152 @@
+package sdk
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS6 #11: dispatchServerMessage spawned an UNBOUNDED goroutine for every
+// RequestInventory and every RevokeLuksDeviceKey. A compromised or buggy
+// gateway could flood the agent with these and exhaust memory/goroutines
+// (each inventory collection forks osquery). The fix bounds in-flight
+// handlers with a small semaphore and DROPS overflow rather than queuing
+// it unboundedly.
+//
+// These tests pin: at most `cap` handlers run concurrently, and the
+// EXCESS is dropped (not run later) — fire N >> cap and exactly `cap`
+// ever enter the handler.
+
+// blockingFanoutHandler implements StreamHandler + InventoryHandler +
+// LuksHandler. The fan-out handlers block on `release` so the test can
+// observe peak concurrency before letting them finish.
+type blockingFanoutHandler struct {
+	release  chan struct{}
+	inFlight int32
+	maxSeen  int32
+	entered  int32
+}
+
+func (h *blockingFanoutHandler) enter() {
+	cur := atomic.AddInt32(&h.inFlight, 1)
+	atomic.AddInt32(&h.entered, 1)
+	for {
+		old := atomic.LoadInt32(&h.maxSeen)
+		if cur <= old || atomic.CompareAndSwapInt32(&h.maxSeen, old, cur) {
+			break
+		}
+	}
+	<-h.release
+	atomic.AddInt32(&h.inFlight, -1)
+}
+
+func (h *blockingFanoutHandler) OnWelcome(ctx context.Context, w *pm.Welcome) error { return nil }
+func (h *blockingFanoutHandler) OnAction(ctx context.Context, envelope, signature []byte) (*pm.ActionResult, error) {
+	return nil, nil
+}
+func (h *blockingFanoutHandler) OnQuery(ctx context.Context, q *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (h *blockingFanoutHandler) OnError(ctx context.Context, e *pm.Error) error { return nil }
+
+func (h *blockingFanoutHandler) CollectInventory(ctx context.Context) *pm.DeviceInventory {
+	return nil // agent-initiated path; unused by these dispatch tests
+}
+
+func (h *blockingFanoutHandler) OnRequestInventory(ctx context.Context, req *pm.RequestInventory) *pm.DeviceInventory {
+	h.enter()
+	return nil // nil → dispatch skips SendInventory (no stream in test)
+}
+
+func (h *blockingFanoutHandler) OnRevokeLuksDeviceKey(ctx context.Context, req *pm.RevokeLuksDeviceKey) (bool, string) {
+	h.enter()
+	return false, "blocked"
+}
+
+func waitForCond(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within deadline")
+}
+
+func TestDispatchServerMessage_InventoryConcurrencyBounded(t *testing.T) {
+	c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+	h := &blockingFanoutHandler{release: make(chan struct{})}
+
+	const fired = 50
+	for i := 0; i < fired; i++ {
+		msg := &pm.ServerMessage{
+			Id: "m",
+			Payload: &pm.ServerMessage_RequestInventory{
+				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000"},
+			},
+		}
+		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+	}
+
+	cap := inventoryDispatchConcurrency
+	if cap < 1 {
+		t.Fatalf("inventoryDispatchConcurrency = %d, want >= 1", cap)
+	}
+	// Wait until the bounded set of handlers has entered, then settle so
+	// any (erroneously) unbounded extra goroutines would also enter and
+	// inflate maxSeen/entered before we assert.
+	waitForCond(t, func() bool { return atomic.LoadInt32(&h.entered) >= int32(cap) })
+	time.Sleep(100 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&h.maxSeen); got != int32(cap) {
+		t.Errorf("peak concurrent inventory handlers = %d, want %d", got, cap)
+	}
+	if got := atomic.LoadInt32(&h.entered); got != int32(cap) {
+		t.Errorf("total inventory handlers entered = %d, want %d (excess of %d must be dropped)", got, cap, fired-cap)
+	}
+
+	close(h.release)
+	waitForCond(t, func() bool { return atomic.LoadInt32(&h.inFlight) == 0 })
+}
+
+func TestDispatchServerMessage_LuksRevokeConcurrencyBounded(t *testing.T) {
+	c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+	h := &blockingFanoutHandler{release: make(chan struct{})}
+
+	const fired = 50
+	for i := 0; i < fired; i++ {
+		msg := &pm.ServerMessage{
+			Id: "m",
+			Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
+				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000"},
+			},
+		}
+		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+	}
+
+	cap := luksRevokeDispatchConcurrency
+	if cap < 1 {
+		t.Fatalf("luksRevokeDispatchConcurrency = %d, want >= 1", cap)
+	}
+	waitForCond(t, func() bool { return atomic.LoadInt32(&h.entered) >= int32(cap) })
+	time.Sleep(100 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&h.maxSeen); got != int32(cap) {
+		t.Errorf("peak concurrent luks-revoke handlers = %d, want %d", got, cap)
+	}
+	if got := atomic.LoadInt32(&h.entered); got != int32(cap) {
+		t.Errorf("total luks-revoke handlers entered = %d, want %d (excess dropped)", got, cap)
+	}
+
+	close(h.release)
+	waitForCond(t, func() bool { return atomic.LoadInt32(&h.inFlight) == 0 })
+}

--- a/go/sys/exec/capped_buffer.go
+++ b/go/sys/exec/capped_buffer.go
@@ -1,0 +1,99 @@
+package exec
+
+import (
+	"io"
+	"sync"
+)
+
+// truncationMarker is appended once to a CappedBuffer's rendered output
+// when input exceeded the cap. It matches the marker exec.Run uses for
+// its own captured streams so downstream consumers see one convention.
+const truncationMarker = "\n[output truncated]"
+
+// CappedBuffer is a concurrency-safe io.Writer that accumulates at most
+// `cap` bytes and then discards the rest, recording that truncation
+// happened. It is the shared bound the agent wraps per-user command
+// output buffers in, so a child process emitting unbounded output cannot
+// exhaust the root agent's memory (WS6 #14).
+//
+// Write always reports the FULL len(p) as consumed and a nil error, even
+// when bytes are dropped, so an io.Copy feeding it from a child's pipe
+// never observes a short write (which it would treat as ErrShortWrite and
+// abort, potentially wedging the child on a full pipe). Overflow is
+// silently dropped; String/Bytes append the truncation marker so the
+// loss is visible to a human reader.
+type CappedBuffer struct {
+	mu        sync.Mutex
+	buf       []byte
+	cap       int
+	truncated bool
+}
+
+// NewCappedBuffer returns a CappedBuffer that retains at most cap bytes.
+func NewCappedBuffer(cap int) *CappedBuffer {
+	if cap < 0 {
+		cap = 0
+	}
+	return &CappedBuffer{cap: cap}
+}
+
+// Write appends as much of p as fits under the cap and discards the rest,
+// marking the buffer truncated if anything was dropped. It always returns
+// (len(p), nil).
+func (b *CappedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	remaining := b.cap - len(b.buf)
+	if remaining <= 0 {
+		if len(p) > 0 {
+			b.truncated = true
+		}
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		b.buf = append(b.buf, p[:remaining]...)
+		b.truncated = true
+		return len(p), nil
+	}
+	b.buf = append(b.buf, p...)
+	return len(p), nil
+}
+
+// Truncated reports whether any input was dropped because of the cap.
+func (b *CappedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+// String returns the retained output, with a single truncation marker
+// appended if input was dropped.
+func (b *CappedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.truncated {
+		return string(b.buf) + truncationMarker
+	}
+	return string(b.buf)
+}
+
+// Bytes returns the retained output (with the truncation marker appended
+// if input was dropped). The returned slice is a copy; callers may retain
+// it without aliasing the buffer.
+func (b *CappedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.truncated {
+		out := make([]byte, 0, len(b.buf)+len(truncationMarker))
+		out = append(out, b.buf...)
+		out = append(out, truncationMarker...)
+		return out
+	}
+	out := make([]byte, len(b.buf))
+	copy(out, b.buf)
+	return out
+}
+
+// compile-time guard: CappedBuffer satisfies io.Writer.
+var _ io.Writer = (*CappedBuffer)(nil)

--- a/go/sys/exec/capped_buffer_test.go
+++ b/go/sys/exec/capped_buffer_test.go
@@ -1,0 +1,111 @@
+package exec
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// WS6 #14: per-user command execution buffered child output into an
+// unbounded bytes.Buffer, so a child that emits gigabytes pins the root
+// agent's memory. CappedBuffer is the shared, bounded io.Writer the agent
+// wraps those buffers in — it accumulates up to a cap, then discards the
+// rest and marks the output truncated, matching the "[output truncated]"
+// convention the exec.Run capture already uses.
+//
+// Contract:
+//   - under the cap: content is preserved verbatim, not marked truncated;
+//   - over the cap: stored content never exceeds the cap, a single
+//     truncation marker is appended, and Truncated() reports true;
+//   - Write ALWAYS reports the full len(p) consumed and a nil error, so
+//     an io.Copy feeding it from a child pipe never sees a short write
+//     and the child is drained (not wedged on a blocked pipe).
+func TestCappedBuffer_UnderCap(t *testing.T) {
+	b := NewCappedBuffer(100)
+	n, err := b.Write([]byte("hello world"))
+	if err != nil || n != len("hello world") {
+		t.Fatalf("Write = (%d,%v), want (%d,nil)", n, err, len("hello world"))
+	}
+	if b.Truncated() {
+		t.Errorf("Truncated() = true, want false")
+	}
+	if got := b.String(); got != "hello world" {
+		t.Errorf("String() = %q, want %q", got, "hello world")
+	}
+}
+
+func TestCappedBuffer_OverCapTruncatesAndMarks(t *testing.T) {
+	const cap = 64
+	b := NewCappedBuffer(cap)
+
+	big := strings.Repeat("A", cap*4)
+	n, err := b.Write([]byte(big))
+	if err != nil {
+		t.Fatalf("Write err = %v", err)
+	}
+	// Write must report the full input consumed even though we dropped
+	// the overflow — otherwise io.Copy treats it as ErrShortWrite.
+	if n != len(big) {
+		t.Errorf("Write n = %d, want %d (full input reported consumed)", n, len(big))
+	}
+	if !b.Truncated() {
+		t.Errorf("Truncated() = false, want true")
+	}
+
+	out := b.String()
+	if !strings.HasSuffix(out, "[output truncated]") {
+		t.Errorf("String() = %q, want trailing truncation marker", out)
+	}
+	// The retained 'A' run must not exceed the cap (marker excluded).
+	body := strings.TrimSuffix(out, "\n[output truncated]")
+	if len(body) > cap {
+		t.Errorf("retained body = %d bytes, want <= cap %d", len(body), cap)
+	}
+	if strings.Count(body, "A") != len(body) {
+		t.Errorf("retained body contains unexpected bytes: %q", body)
+	}
+}
+
+// Truncation across MULTIPLE writes: the cap is on cumulative bytes, and
+// the marker is appended exactly once regardless of how many writes
+// crossed the boundary.
+func TestCappedBuffer_MultiWriteCumulativeCap(t *testing.T) {
+	const cap = 10
+	b := NewCappedBuffer(cap)
+	for i := 0; i < 5; i++ {
+		if _, err := b.Write([]byte("XXXXX")); err != nil { // 25 bytes total
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	out := b.String()
+	if strings.Count(out, "[output truncated]") != 1 {
+		t.Errorf("marker count = %d, want exactly 1 in %q", strings.Count(out, "[output truncated]"), out)
+	}
+	body := strings.TrimSuffix(out, "\n[output truncated]")
+	if len(body) > cap {
+		t.Errorf("retained = %d, want <= %d", len(body), cap)
+	}
+}
+
+// CappedBuffer is written from os/exec's stdout/stderr copy goroutines;
+// it must be safe under concurrent writers.
+func TestCappedBuffer_ConcurrentWritesSafe(t *testing.T) {
+	b := NewCappedBuffer(1 << 16)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = b.Write([]byte("line\n"))
+			}
+		}()
+	}
+	wg.Wait()
+	// No assertion on exact content (interleaving is nondeterministic);
+	// the race detector is the real check. Sanity: it did not panic and
+	// produced something.
+	if b.String() == "" {
+		t.Errorf("expected some buffered output")
+	}
+}

--- a/go/sys/fs/fchown_dir_test.go
+++ b/go/sys/fs/fchown_dir_test.go
@@ -1,0 +1,115 @@
+//go:build unix
+
+package fs
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// WS6 #5: directory chmod/chown was path-based, so it re-resolved the
+// path on every call and dereferenced a final-component symlink. A user
+// who controls a managed directory could swap it for a symlink between a
+// check and the chmod/chown, redirecting a root-run permission change
+// onto the symlink's target (e.g. /etc, /root). SetDirPermissionsNoFollow
+// closes the class: it opens the directory with O_NOFOLLOW|O_DIRECTORY
+// and applies fchmod/fchown through the fd, so a symlink at the path
+// fails the open (ELOOP) instead of being dereferenced.
+//
+// Contract:
+//   - correct: a real directory → mode and ownership applied via the fd;
+//   - present-but-wrong: the path is a symlink → ELOOP, NOTHING applied
+//     to the symlink's target;
+//   - absent: the path does not exist → error.
+func TestSetDirPermissionsNoFollow_RealDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "managed")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := SetDirPermissionsNoFollow(dir, 0o750, -1, -1); err != nil {
+		t.Fatalf("SetDirPermissionsNoFollow: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o750 {
+		t.Errorf("mode = %v, want 0750", perm)
+	}
+}
+
+func TestSetDirPermissionsNoFollow_AppliesOwnershipToSelf(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "owned")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("current user: %v", err)
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+
+	if err := SetDirPermissionsNoFollow(dir, 0o700, uid, gid); err != nil {
+		t.Fatalf("SetDirPermissionsNoFollow: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fileUID(t, info); got != uid {
+		t.Errorf("uid = %d, want %d", got, uid)
+	}
+}
+
+func TestSetDirPermissionsNoFollow_RefusesSymlink(t *testing.T) {
+	root := t.TempDir()
+
+	// The victim directory whose mode an attacker hopes to change by
+	// planting a symlink where a managed dir is expected.
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	link := filepath.Join(root, "managed")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := SetDirPermissionsNoFollow(link, 0o777, -1, -1)
+	if err == nil {
+		t.Fatalf("SetDirPermissionsNoFollow on a symlink: want error, got nil")
+	}
+
+	// The victim's mode must be unchanged — the symlink was not followed.
+	info, statErr := os.Stat(victim)
+	if statErr != nil {
+		t.Fatalf("stat victim: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("victim mode = %v, want 0700 (unchanged) — symlink was dereferenced", perm)
+	}
+}
+
+func TestSetDirPermissionsNoFollow_RefusesNonDir(t *testing.T) {
+	// A regular file is not a directory: O_DIRECTORY must reject it
+	// rather than chmod'ing it.
+	f := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := SetDirPermissionsNoFollow(f, 0o700, -1, -1); err == nil {
+		t.Fatalf("SetDirPermissionsNoFollow on a regular file: want error, got nil")
+	}
+}
+
+func TestSetDirPermissionsNoFollow_Missing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope")
+	if err := SetDirPermissionsNoFollow(missing, 0o700, -1, -1); err == nil {
+		t.Fatalf("SetDirPermissionsNoFollow on a missing path: want error, got nil")
+	}
+}

--- a/go/sys/fs/fd_test_helpers_test.go
+++ b/go/sys/fs/fd_test_helpers_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package fs
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// fileUID returns the owning uid of info, failing the test if the
+// platform stat shape is unavailable.
+func fileUID(t *testing.T, info os.FileInfo) int {
+	t.Helper()
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("FileInfo.Sys() is not *syscall.Stat_t")
+	}
+	return int(st.Uid)
+}
+
+// fileGID returns the owning gid of info.
+func fileGID(t *testing.T, info os.FileInfo) int {
+	t.Helper()
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("FileInfo.Sys() is not *syscall.Stat_t")
+	}
+	return int(st.Gid)
+}

--- a/go/sys/fs/fd_test_helpers_test.go
+++ b/go/sys/fs/fd_test_helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"syscall"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // fileUID returns the owning uid of info, failing the test if the
@@ -19,12 +21,15 @@ func fileUID(t *testing.T, info os.FileInfo) int {
 	return int(st.Uid)
 }
 
-// fileGID returns the owning gid of info.
-func fileGID(t *testing.T, info os.FileInfo) int {
+// useRootBackend forces the Root privilege backend for the duration of a
+// test (restored on cleanup) so the fd-based, symlink-safe code paths in
+// WriteFileAtomic / RemoveDir are exercised even though the test process
+// is not actually root. The operations themselves run against
+// test-user-owned temp dirs, so they succeed without real privilege; only
+// the path SELECTION (fd vs sudo escalation) is what the backend gates.
+func useRootBackend(t *testing.T) {
 	t.Helper()
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		t.Fatalf("FileInfo.Sys() is not *syscall.Stat_t")
-	}
-	return int(st.Gid)
+	prev := exec.CurrentPrivilegeBackend()
+	exec.SetPrivilegeBackend(exec.PrivilegeBackendRoot)
+	t.Cleanup(func() { exec.SetPrivilegeBackend(prev) })
 }

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -10,7 +10,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -178,39 +180,61 @@ func SetPermissions(ctx context.Context, path, mode, owner, group string) error 
 	return nil
 }
 
-// WriteFileAtomic writes content to a file with the specified permissions
-// using a write-then-rename sequence: it tees content to a predictable temp
-// path (path + ".pm-tmp"), chmod/chowns it, then mvs it into place.
-//
-// The mv-into-place at the end is what gives concurrent readers a consistent
-// view (they see either the old file or the new one, never a half-written
-// one). It does NOT guarantee fsync-level durability — the temp file is not
-// fsynced before the rename, and the parent directory is not fsynced after.
-// The temp path is also predictable, so this is not a defense against an
-// attacker who can create files in the target directory; for that, use
-// AtomicWriteFile in atomic_write.go (which uses os.CreateTemp with a
-// random suffix and proper fsync sequencing).
-func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group string) error {
-	tmpPath := path + ".pm-tmp"
-
-	// Write content to temp file
-	if err := WriteFile(ctx, tmpPath, content); err != nil {
-		Remove(ctx, tmpPath) // cleanup
-		return fmt.Errorf("write file %s: %w", tmpPath, err)
+// parseFileMode parses an octal mode string ("0644", "640") into an
+// os.FileMode. An empty string defaults to 0644 (the conventional mode
+// for a managed config file), so the resulting inode always carries a
+// deterministic mode rather than depending on the process umask.
+func parseFileMode(mode string) (os.FileMode, error) {
+	if mode == "" {
+		return 0o644, nil
 	}
+	v, err := strconv.ParseUint(mode, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid file mode %q: %w", mode, err)
+	}
+	return os.FileMode(v), nil
+}
 
-	// Set permissions on temp file before moving
-	if err := SetPermissions(ctx, tmpPath, mode, owner, group); err != nil {
-		Remove(ctx, tmpPath) // cleanup
+// WriteFileAtomic writes content to a file with the specified permissions
+// and ownership, atomically and WITHOUT following symlinks.
+//
+// It routes the write through SafeReplaceFile: a same-directory temp file
+// with a RANDOM suffix, opened O_NOFOLLOW, fchmod'd, fsync'd, and renamed
+// into place. Ownership is then applied through an O_NOFOLLOW fd
+// (FchownNoFollow). The previous implementation tee'd content to a
+// PREDICTABLE temp path (path + ".pm-tmp") via the privilege backend;
+// because `tee` follows symlinks, a local attacker who could create
+// entries in the target directory could pre-plant `<target>.pm-tmp` as a
+// symlink and redirect the root agent's write to an arbitrary file — a
+// root arbitrary-file-write privesc (WS6 #2). The predictable name is
+// gone entirely and every step is symlink-aware.
+//
+// The agent runs as root, so the underlying syscalls operate with root
+// privilege directly (no privilege-backend escalation per op). ctx is
+// honoured for early cancellation before the write begins.
+func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group string) error {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-
-	// Atomic move into place
-	if _, err := exec.Privileged(ctx, "mv", "-f", "--", tmpPath, path); err != nil {
-		Remove(ctx, tmpPath) // cleanup
-		return fmt.Errorf("move file into place: %w", err)
+	if err := ValidatePath(path); err != nil {
+		return err
 	}
-
+	perm, err := parseFileMode(mode)
+	if err != nil {
+		return err
+	}
+	if err := SafeReplaceFile(path, []byte(content), perm, true); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	if owner != "" || group != "" {
+		uid, gid, err := ResolveOwnership(owner, group)
+		if err != nil {
+			return err
+		}
+		if err := FchownNoFollow(path, uid, gid); err != nil {
+			return fmt.Errorf("set ownership on %s: %w", path, err)
+		}
+	}
 	return nil
 }
 
@@ -332,8 +356,26 @@ var dangerousPaths = map[string]bool{
 	"/root":  true,
 }
 
-// RemoveDir removes a directory and its contents via the privilege backend (rm -rf).
-// It validates the path to prevent accidental removal of critical system directories.
+// RemoveDir removes a directory and its contents WITHOUT following any
+// symlink (intermediate component, leaf, or descendant) and refuses any
+// target at or under a security-relevant system prefix.
+//
+// Two hardenings over the previous `rm -rf` implementation:
+//
+//   - Deny-by-default (WS6 #12): the old guard was a top-level-only
+//     exact-match denylist, so `/etc/sudoers.d`, `/home/alice`,
+//     `/var/lib/anything` slipped through to a root `rm -rf`.
+//     IsUnderProtectedPrefix refuses the whole subtree of every
+//     protected root.
+//   - Symlink-refusing fd-anchored delete (WS6 #4): `rm -rf <path>`
+//     re-resolves the path, so a component swapped for a symlink after
+//     validation could redirect the recursive delete. removeDirSecure
+//     walks the path by openat(O_NOFOLLOW) handles, never re-resolving a
+//     string, so a swapped component aborts the operation.
+//
+// The agent (root) reuses IsUnderProtectedPrefix in its directory action
+// to additionally require the target be under a configured managed prefix
+// (a true allowlist); this SDK guard is the defense-in-depth floor.
 func RemoveDir(ctx context.Context, path string) error {
 	if err := ValidatePath(path); err != nil {
 		return err
@@ -342,11 +384,10 @@ func RemoveDir(ctx context.Context, path string) error {
 	if !filepath.IsAbs(clean) {
 		return fmt.Errorf("path must be absolute: %s", path)
 	}
-	if dangerousPaths[clean] {
+	if IsUnderProtectedPrefix(clean) {
 		return fmt.Errorf("refusing to remove protected path: %s", clean)
 	}
-	_, err := exec.Privileged(ctx, "rm", "-rf", "--", clean)
-	return err
+	return removeDirSecure(ctx, clean)
 }
 
 // =============================================================================

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -196,22 +196,24 @@ func parseFileMode(mode string) (os.FileMode, error) {
 }
 
 // WriteFileAtomic writes content to a file with the specified permissions
-// and ownership, atomically and WITHOUT following symlinks.
+// and ownership, atomically.
 //
-// It routes the write through SafeReplaceFile: a same-directory temp file
-// with a RANDOM suffix, opened O_NOFOLLOW, fchmod'd, fsync'd, and renamed
-// into place. Ownership is then applied through an O_NOFOLLOW fd
-// (FchownNoFollow). The previous implementation tee'd content to a
-// PREDICTABLE temp path (path + ".pm-tmp") via the privilege backend;
-// because `tee` follows symlinks, a local attacker who could create
-// entries in the target directory could pre-plant `<target>.pm-tmp` as a
-// symlink and redirect the root agent's write to an arbitrary file — a
-// root arbitrary-file-write privesc (WS6 #2). The predictable name is
-// gone entirely and every step is symlink-aware.
+// When the active privilege backend is Root — i.e. the process is already
+// root, which is how the deployed agent runs — the write takes the
+// TOCTOU-safe, fd-based path (writeFileAtomicRoot): a random-suffix
+// same-directory temp opened O_NOFOLLOW, fchmod'd, fsync'd, renamed into
+// place, then chowned through an O_NOFOLLOW fd. This closes WS6 #2: the
+// previous implementation tee'd content to a PREDICTABLE temp path
+// (path + ".pm-tmp"), and because `tee` follows symlinks a local attacker
+// who could create entries in the target directory could pre-plant
+// `<target>.pm-tmp` as a symlink and redirect the root agent's write to
+// an arbitrary file — a root arbitrary-file-write privesc.
 //
-// The agent runs as root, so the underlying syscalls operate with root
-// privilege directly (no privilege-backend escalation per op). ctx is
-// honoured for early cancellation before the write begins.
+// When the backend is sudo/doas (a non-root caller, e.g. CI integration
+// or a dev tool), the escalated path is used: it cannot openat as root,
+// so it shells the write through the privilege backend as before. That
+// path is NOT symlink-safe, but the security-relevant consumer — the root
+// agent — never takes it.
 func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -219,6 +221,15 @@ func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group stri
 	if err := ValidatePath(path); err != nil {
 		return err
 	}
+	if exec.CurrentPrivilegeBackend() == exec.PrivilegeBackendRoot {
+		return writeFileAtomicRoot(path, content, mode, owner, group)
+	}
+	return writeFileAtomicEscalated(ctx, path, content, mode, owner, group)
+}
+
+// writeFileAtomicRoot is the fd-based, symlink-safe path (WS6 #2). Runs
+// the syscalls directly with the process's own (root) privilege.
+func writeFileAtomicRoot(path, content, mode, owner, group string) error {
 	perm, err := parseFileMode(mode)
 	if err != nil {
 		return err
@@ -234,6 +245,26 @@ func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group stri
 		if err := FchownNoFollow(path, uid, gid); err != nil {
 			return fmt.Errorf("set ownership on %s: %w", path, err)
 		}
+	}
+	return nil
+}
+
+// writeFileAtomicEscalated is the legacy privilege-backend (sudo/doas)
+// path for non-root callers. Predictable temp + `tee`/`mv`; not
+// symlink-safe (see WriteFileAtomic's doc for why that is acceptable).
+func writeFileAtomicEscalated(ctx context.Context, path, content, mode, owner, group string) error {
+	tmpPath := path + ".pm-tmp"
+	if err := WriteFile(ctx, tmpPath, content); err != nil {
+		Remove(ctx, tmpPath)
+		return fmt.Errorf("write file %s: %w", tmpPath, err)
+	}
+	if err := SetPermissions(ctx, tmpPath, mode, owner, group); err != nil {
+		Remove(ctx, tmpPath)
+		return err
+	}
+	if _, err := exec.Privileged(ctx, "mv", "-f", "--", tmpPath, path); err != nil {
+		Remove(ctx, tmpPath)
+		return fmt.Errorf("move file into place: %w", err)
 	}
 	return nil
 }
@@ -384,10 +415,19 @@ func RemoveDir(ctx context.Context, path string) error {
 	if !filepath.IsAbs(clean) {
 		return fmt.Errorf("path must be absolute: %s", path)
 	}
+	// Deny-by-default applies regardless of backend (WS6 #12).
 	if IsUnderProtectedPrefix(clean) {
 		return fmt.Errorf("refusing to remove protected path: %s", clean)
 	}
-	return removeDirSecure(ctx, clean)
+	// Root (the deployed agent): symlink-refusing fd-anchored delete
+	// (WS6 #4). Non-root callers cannot openat as root, so they fall back
+	// to the privilege-backend `rm -rf` (not symlink-safe, but not the
+	// root agent's path).
+	if exec.CurrentPrivilegeBackend() == exec.PrivilegeBackendRoot {
+		return removeDirSecure(ctx, clean)
+	}
+	_, err := exec.Privileged(ctx, "rm", "-rf", "--", clean)
+	return err
 }
 
 // =============================================================================

--- a/go/sys/fs/fs_test.go
+++ b/go/sys/fs/fs_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -133,29 +132,20 @@ func TestWriteFileAtomic(t *testing.T) {
 
 func TestWriteFileAtomicCleansUpOnError(t *testing.T) {
 	ctx := context.Background()
+	// Use a directory that doesn't exist as parent for the temp file.
+	// This integration job runs non-root with sudo, so WriteFileAtomic
+	// takes the escalated (privilege-backend) path, which uses the
+	// predictable `.pm-tmp` temp name. The fd-based root path's no-leftover
+	// guarantee is covered by the unit test
+	// TestWriteFileAtomic_RefusesSymlinkPlantedTempTarget.
+	path := "/tmp/pm-nonexistent-dir-12345/file.txt"
+	tmpFile := path + ".pm-tmp"
 
-	// Target an EXISTING directory so the final rename fails (a file
-	// cannot be renamed over a directory), exercising the cleanup path.
-	// The random-suffix temp (`.<base>.tmp-*`, created in the parent dir)
-	// must not be left behind. The predictable `.pm-tmp` name no longer
-	// exists at all after the SafeReplaceFile migration (WS6 #2).
-	dir := tmpPath(t, "cleanup")
-	if err := fs.Mkdir(ctx, dir, true); err != nil {
-		t.Fatalf("Mkdir failed: %v", err)
-	}
-	defer fs.RemoveDir(ctx, dir)
-
-	if err := fs.WriteFileAtomic(ctx, dir, "content", "0644", "root", "root"); err == nil {
-		t.Fatal("WriteFileAtomic onto an existing directory should fail")
-	}
-
-	tempGlob := filepath.Join(filepath.Dir(dir), "."+filepath.Base(dir)+".tmp-*")
-	matches, _ := filepath.Glob(tempGlob)
-	if len(matches) != 0 {
-		t.Errorf("temp files left behind after error: %v", matches)
-		for _, m := range matches {
-			_ = os.Remove(m)
-		}
+	_ = fs.WriteFileAtomic(ctx, path, "content", "0644", "root", "root")
+	// The temp file should not be left behind
+	if fs.FileExists(ctx, tmpFile) {
+		t.Error("temp file should be cleaned up after error")
+		fs.Remove(ctx, tmpFile)
 	}
 }
 

--- a/go/sys/fs/fs_test.go
+++ b/go/sys/fs/fs_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -132,15 +133,29 @@ func TestWriteFileAtomic(t *testing.T) {
 
 func TestWriteFileAtomicCleansUpOnError(t *testing.T) {
 	ctx := context.Background()
-	// Use a directory that doesn't exist as parent for the temp file
-	path := "/tmp/pm-nonexistent-dir-12345/file.txt"
-	tmpFile := path + ".pm-tmp"
 
-	_ = fs.WriteFileAtomic(ctx, path, "content", "0644", "root", "root")
-	// The temp file should not be left behind
-	if fs.FileExists(ctx, tmpFile) {
-		t.Error("temp file should be cleaned up after error")
-		fs.Remove(ctx, tmpFile)
+	// Target an EXISTING directory so the final rename fails (a file
+	// cannot be renamed over a directory), exercising the cleanup path.
+	// The random-suffix temp (`.<base>.tmp-*`, created in the parent dir)
+	// must not be left behind. The predictable `.pm-tmp` name no longer
+	// exists at all after the SafeReplaceFile migration (WS6 #2).
+	dir := tmpPath(t, "cleanup")
+	if err := fs.Mkdir(ctx, dir, true); err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	defer fs.RemoveDir(ctx, dir)
+
+	if err := fs.WriteFileAtomic(ctx, dir, "content", "0644", "root", "root"); err == nil {
+		t.Fatal("WriteFileAtomic onto an existing directory should fail")
+	}
+
+	tempGlob := filepath.Join(filepath.Dir(dir), "."+filepath.Base(dir)+".tmp-*")
+	matches, _ := filepath.Glob(tempGlob)
+	if len(matches) != 0 {
+		t.Errorf("temp files left behind after error: %v", matches)
+		for _, m := range matches {
+			_ = os.Remove(m)
+		}
 	}
 }
 

--- a/go/sys/fs/ownership_resolve_test.go
+++ b/go/sys/fs/ownership_resolve_test.go
@@ -1,0 +1,69 @@
+//go:build unix
+
+package fs
+
+import (
+	"os/user"
+	"strconv"
+	"testing"
+)
+
+// ResolveOwnership maps owner/group NAMES to numeric ids for the fd-based
+// fchown helpers. An empty name resolves to -1 ("leave unchanged", the
+// chown(2) sentinel); an unknown name is an error (fail closed — never
+// fall back to root/0 or to "leave unchanged" silently, which would let a
+// typo widen ownership).
+func TestResolveOwnership(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("current user: %v", err)
+	}
+	wantUID, _ := strconv.Atoi(u.Uid)
+	wantGID, _ := strconv.Atoi(u.Gid)
+	g, gErr := user.LookupGroupId(u.Gid)
+
+	t.Run("both empty leaves unchanged", func(t *testing.T) {
+		uid, gid, err := ResolveOwnership("", "")
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if uid != -1 || gid != -1 {
+			t.Errorf("got (%d,%d), want (-1,-1)", uid, gid)
+		}
+	})
+
+	t.Run("known owner only", func(t *testing.T) {
+		uid, gid, err := ResolveOwnership(u.Username, "")
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if uid != wantUID || gid != -1 {
+			t.Errorf("got (%d,%d), want (%d,-1)", uid, gid, wantUID)
+		}
+	})
+
+	t.Run("known owner and group", func(t *testing.T) {
+		if gErr != nil {
+			t.Skipf("cannot resolve current group: %v", gErr)
+		}
+		uid, gid, err := ResolveOwnership(u.Username, g.Name)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if uid != wantUID || gid != wantGID {
+			t.Errorf("got (%d,%d), want (%d,%d)", uid, gid, wantUID, wantGID)
+		}
+	})
+
+	t.Run("unknown owner is an error", func(t *testing.T) {
+		if _, _, err := ResolveOwnership("pm-ws6-no-such-user-zzz", ""); err == nil {
+			t.Errorf("ResolveOwnership(unknown user): want error, got nil")
+		}
+	})
+
+	t.Run("unknown group is an error", func(t *testing.T) {
+		if _, _, err := ResolveOwnership("", "pm-ws6-no-such-group-zzz"); err == nil {
+			t.Errorf("ResolveOwnership(unknown group): want error, got nil")
+		}
+	})
+}

--- a/go/sys/fs/protected.go
+++ b/go/sys/fs/protected.go
@@ -1,6 +1,9 @@
 package fs
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // IsProtectedPath returns true if path is a system directory that should
 // never be deleted. The path is cleaned and resolved to absolute before checking.
@@ -30,4 +33,70 @@ var extraProtectedPaths = map[string]bool{
 	"/srv":    true,
 	"/tmp":    true,
 	"/snap":   true, // snap-based distributions (Ubuntu)
+}
+
+// protectedPrefixRoots are directory subtrees that a managed directory
+// delete must NEVER touch at ANY depth. Unlike IsProtectedPath (an exact
+// top-level match), IsUnderProtectedPrefix refuses these roots AND
+// everything beneath them — so /etc/sudoers.d, /home/alice/.ssh,
+// /var/lib/postgresql, /boot/efi, /usr/bin are all refused, closing the
+// "one level down slips through to rm -rf" gap (WS6 #12).
+//
+// The set is deliberately broad: deletion of anything under the OS,
+// package-manager, bootloader, persistent-state, or user-home trees is a
+// privilege-escalation / data-destruction vector when an attacker can
+// influence the target path. /var itself is refused (see
+// protectedExactPaths) but /var/log/<app> and /var/cache/<app> are left
+// deletable for managed app data; only /var/lib is locked as a subtree.
+var protectedPrefixRoots = []string{
+	"/etc",
+	"/boot",
+	"/usr",
+	"/home",
+	"/root",
+	"/var/lib",
+	"/bin",
+	"/sbin",
+	"/lib",
+	"/lib64",
+	"/lib32",
+	"/libx32",
+	"/proc",
+	"/sys",
+	"/dev",
+	"/run",
+}
+
+// protectedExactPaths are refused only as an exact match — the directory
+// itself must never be removed, but children outside the prefix roots
+// above remain deletable (e.g. /var is locked, /var/log/<app> is not).
+var protectedExactPaths = map[string]bool{
+	"/":    true,
+	"/var": true,
+}
+
+// IsUnderProtectedPrefix reports whether path is at or under a
+// security-relevant system prefix that a managed directory delete must
+// refuse. The path is cleaned and resolved to absolute before checking,
+// so traversal tricks (/etc/../etc/sudoers.d) and relative inputs cannot
+// dodge the guard. This is the deny-by-default predicate RemoveDir uses
+// and that the agent's directory action reuses (WS6 #4, #12).
+func IsUnderProtectedPrefix(path string) bool {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		abs, err := filepath.Abs(clean)
+		if err != nil {
+			return true // err on the side of caution
+		}
+		clean = abs
+	}
+	if protectedExactPaths[clean] {
+		return true
+	}
+	for _, root := range protectedPrefixRoots {
+		if clean == root || strings.HasPrefix(clean, root+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/go/sys/fs/remove_dir_other.go
+++ b/go/sys/fs/remove_dir_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package fs
+
+import (
+	"context"
+	"errors"
+)
+
+// removeDirSecure is unix-only: the fd-anchored, symlink-refusing
+// recursive delete relies on openat/unlinkat semantics that do not exist
+// on non-unix platforms. The agent targets Linux, so this stub merely
+// keeps the package buildable elsewhere (e.g. cross-platform `go vet`).
+func removeDirSecure(_ context.Context, _ string) error {
+	return errors.New("fs: secure directory removal is not supported on this platform")
+}

--- a/go/sys/fs/remove_dir_test.go
+++ b/go/sys/fs/remove_dir_test.go
@@ -58,6 +58,7 @@ func TestIsUnderProtectedPrefix(t *testing.T) {
 // Using real system paths is safe precisely because the refusal happens
 // in the predicate, before any unlink.
 func TestRemoveDir_RefusesProtectedPrefixes(t *testing.T) {
+	useRootBackend(t)
 	for _, p := range []string{
 		"/etc/sudoers.d/power-manage",
 		"/etc/cron.d",
@@ -77,6 +78,7 @@ func TestRemoveDir_RefusesProtectedPrefixes(t *testing.T) {
 // Positive path: a managed tree under a non-protected prefix is removed
 // recursively. Runs as the test user against t.TempDir(); no root needed.
 func TestRemoveDir_DeletesManagedTree(t *testing.T) {
+	useRootBackend(t)
 	root := t.TempDir()
 	target := filepath.Join(root, "managed")
 	sub := filepath.Join(target, "a", "b")
@@ -104,6 +106,7 @@ func TestRemoveDir_DeletesManagedTree(t *testing.T) {
 // symlink fails the open instead of redirecting `rm -rf` into another
 // tree.
 func TestRemoveDir_RefusesSymlinkedComponent(t *testing.T) {
+	useRootBackend(t)
 	root := t.TempDir()
 
 	// A victim tree the attacker hopes RemoveDir will descend into.
@@ -135,6 +138,7 @@ func TestRemoveDir_RefusesSymlinkedComponent(t *testing.T) {
 // asked to delete a DIRECTORY; a symlink is not one and must not be
 // dereferenced (nor silently unlinked as if it were the target dir).
 func TestRemoveDir_RefusesSymlinkTarget(t *testing.T) {
+	useRootBackend(t)
 	root := t.TempDir()
 	victim := filepath.Join(root, "victim")
 	if err := os.MkdirAll(victim, 0o755); err != nil {

--- a/go/sys/fs/remove_dir_test.go
+++ b/go/sys/fs/remove_dir_test.go
@@ -1,0 +1,154 @@
+//go:build unix
+
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WS6 #12: RemoveDir guarded recursive `rm -rf` with a TOP-LEVEL-ONLY
+// denylist (an exact-match map of `/etc`, `/home`, …). A path one level
+// down — `/etc/sudoers.d`, `/home/alice`, `/var/lib/anything` — slipped
+// straight through to a root `rm -rf`. The fix is deny-by-default across
+// the whole subtree of every security-relevant prefix.
+//
+// The must-refuse set below is sourced from INTENT (the security-relevant
+// system prefixes a managed directory action must never be able to wipe),
+// NOT from the implementation's list — so a prefix silently dropped from
+// the code fails this test.
+func TestIsUnderProtectedPrefix(t *testing.T) {
+	refuse := []string{
+		"/",
+		"/etc", "/etc/sudoers.d", "/etc/sudoers.d/power-manage",
+		"/etc/cron.d", "/etc/cron.d/job", "/etc/systemd/system",
+		"/boot", "/boot/efi", "/boot/efi/EFI",
+		"/var", "/var/lib", "/var/lib/anything", "/var/lib/postgresql/data",
+		"/home", "/home/alice", "/home/alice/.ssh",
+		"/root", "/root/.ssh",
+		"/usr", "/usr/bin", "/usr/lib/systemd",
+		"/bin", "/sbin", "/lib", "/lib64",
+		"/proc", "/sys", "/dev", "/run",
+		// non-clean inputs must normalise before the check
+		"/etc/../etc/sudoers.d", "/home/./bob",
+	}
+	for _, p := range refuse {
+		if !IsUnderProtectedPrefix(p) {
+			t.Errorf("IsUnderProtectedPrefix(%q) = false, want true (protected)", p)
+		}
+	}
+
+	allow := []string{
+		"/tmp/managed", "/tmp/foo/bar",
+		"/srv/app/data",
+		"/opt/myapp/cache",
+		"/var/log/myapp", // /var itself is protected but /var/log/* is not
+		"/data/managed",
+	}
+	for _, p := range allow {
+		if IsUnderProtectedPrefix(p) {
+			t.Errorf("IsUnderProtectedPrefix(%q) = true, want false (deletable)", p)
+		}
+	}
+}
+
+// RemoveDir must refuse a protected path BEFORE touching the filesystem.
+// Using real system paths is safe precisely because the refusal happens
+// in the predicate, before any unlink.
+func TestRemoveDir_RefusesProtectedPrefixes(t *testing.T) {
+	for _, p := range []string{
+		"/etc/sudoers.d/power-manage",
+		"/etc/cron.d",
+		"/boot/efi",
+		"/var/lib/anything",
+		"/home/alice",
+		"/root/.ssh",
+		"/usr/local",
+	} {
+		err := RemoveDir(context.Background(), p)
+		if err == nil {
+			t.Errorf("RemoveDir(%q) = nil, want refusal", p)
+		}
+	}
+}
+
+// Positive path: a managed tree under a non-protected prefix is removed
+// recursively. Runs as the test user against t.TempDir(); no root needed.
+func TestRemoveDir_DeletesManagedTree(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "managed")
+	sub := filepath.Join(target, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := RemoveDir(context.Background(), target); err != nil {
+		t.Fatalf("RemoveDir: %v", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Errorf("target still exists after RemoveDir: %v", err)
+	}
+	// The parent (the non-protected managed root) is left intact.
+	if _, err := os.Stat(root); err != nil {
+		t.Errorf("RemoveDir removed more than its target: %v", err)
+	}
+}
+
+// WS6 #4: a symlinked INTERMEDIATE component must abort the delete — the
+// fd-anchored walk opens each component O_NOFOLLOW, so a swapped-in
+// symlink fails the open instead of redirecting `rm -rf` into another
+// tree.
+func TestRemoveDir_RefusesSymlinkedComponent(t *testing.T) {
+	root := t.TempDir()
+
+	// A victim tree the attacker hopes RemoveDir will descend into.
+	victim := filepath.Join(root, "victim")
+	if err := os.MkdirAll(filepath.Join(victim, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	victimFile := filepath.Join(victim, "sub", "keep.txt")
+	if err := os.WriteFile(victimFile, []byte("KEEP"), 0o644); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	// `link` is a symlink standing in for what should be a real dir.
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := RemoveDir(context.Background(), filepath.Join(link, "sub"))
+	if err == nil {
+		t.Fatalf("RemoveDir through a symlinked component: want error, got nil")
+	}
+	if _, statErr := os.Stat(victimFile); statErr != nil {
+		t.Errorf("victim was deleted through a symlinked component: %v", statErr)
+	}
+}
+
+// The leaf target being a symlink must also be refused — RemoveDir is
+// asked to delete a DIRECTORY; a symlink is not one and must not be
+// dereferenced (nor silently unlinked as if it were the target dir).
+func TestRemoveDir_RefusesSymlinkTarget(t *testing.T) {
+	root := t.TempDir()
+	victim := filepath.Join(root, "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := RemoveDir(context.Background(), link); err == nil {
+		t.Fatalf("RemoveDir on a symlink target: want error, got nil")
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Errorf("victim removed via symlink leaf: %v", err)
+	}
+}

--- a/go/sys/fs/remove_dir_unix.go
+++ b/go/sys/fs/remove_dir_unix.go
@@ -1,0 +1,136 @@
+//go:build unix
+
+package fs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// removeDirSecure removes the directory at path (already validated,
+// cleaned, absolute, and confirmed NOT under a protected prefix by
+// RemoveDir) without ever following a symlink — neither an intermediate
+// path component nor the leaf nor any descendant. This closes the
+// resolve-then-string-reopen TOCTOU that a plain `rm -rf <path>` left
+// open (WS6 #4): a `rm -rf` re-resolves the whole path, so a component
+// swapped for a symlink after validation could redirect the recursive
+// delete into another tree (e.g. /etc, a user's home).
+//
+// The approach is openat-anchored:
+//   - walk the parent's components from "/" with O_NOFOLLOW|O_DIRECTORY,
+//     so a symlinked intermediate component fails the open (ELOOP);
+//   - require the leaf to be a real directory (a symlinked leaf is
+//     refused, not unlinked-as-if-the-dir and not dereferenced);
+//   - recurse with unlinkat/openat anchored on directory fds, so every
+//     descendant is reached by handle, not by re-resolved path.
+func removeDirSecure(ctx context.Context, path string) error {
+	parent := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	pfd, err := openNoFollowChain(parent)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(pfd)
+
+	var st unix.Stat_t
+	if err := unix.Fstatat(pfd, base, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	switch st.Mode & unix.S_IFMT {
+	case unix.S_IFLNK:
+		return fmt.Errorf("refusing to remove symlink %s", path)
+	case unix.S_IFDIR:
+		// ok
+	default:
+		return fmt.Errorf("refusing to remove non-directory %s", path)
+	}
+
+	return removeAtRecursive(ctx, pfd, base)
+}
+
+// openNoFollowChain opens dir by walking its components from the
+// filesystem root, opening each with O_NOFOLLOW|O_DIRECTORY so no
+// symlinked component is ever traversed. The caller must Close the fd.
+func openNoFollowChain(dir string) (int, error) {
+	clean := filepath.Clean(dir)
+
+	fd, err := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open /: %w", err)
+	}
+	if clean == "/" {
+		return fd, nil
+	}
+
+	rest := strings.TrimPrefix(clean, "/")
+	for _, comp := range strings.Split(rest, "/") {
+		if comp == "" || comp == "." {
+			continue
+		}
+		next, openErr := unix.Openat(fd, comp, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return -1, fmt.Errorf("open component %q of %s without following symlinks: %w", comp, dir, openErr)
+		}
+		fd = next
+	}
+	return fd, nil
+}
+
+// removeAtRecursive removes name under dirfd. A directory is recursed
+// into via an O_NOFOLLOW openat and rmdir'd; anything else — including a
+// symlink — is unlinkat'd WITHOUT being followed.
+func removeAtRecursive(ctx context.Context, dirfd int, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	var st unix.Stat_t
+	if err := unix.Fstatat(dirfd, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("stat %s: %w", name, err)
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFDIR {
+		// Regular file, symlink, device, fifo, … — unlink the entry
+		// itself; never traverse into it.
+		if err := unix.Unlinkat(dirfd, name, 0); err != nil {
+			return fmt.Errorf("unlink %s: %w", name, err)
+		}
+		return nil
+	}
+
+	cfd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open dir %s: %w", name, err)
+	}
+	// os.NewFile takes ownership of cfd for the Readdirnames call; we keep
+	// using cfd for unlinkat on the children BEFORE closing f, then close
+	// f exactly once (which closes cfd).
+	f := os.NewFile(uintptr(cfd), name)
+	children, readErr := f.Readdirnames(-1)
+	if readErr != nil {
+		_ = f.Close()
+		return fmt.Errorf("read dir %s: %w", name, readErr)
+	}
+	for _, child := range children {
+		if child == "." || child == ".." {
+			continue
+		}
+		if err := removeAtRecursive(ctx, cfd, child); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close dir %s: %w", name, err)
+	}
+	if err := unix.Unlinkat(dirfd, name, unix.AT_REMOVEDIR); err != nil {
+		return fmt.Errorf("rmdir %s: %w", name, err)
+	}
+	return nil
+}

--- a/go/sys/fs/safe_fd_unix.go
+++ b/go/sys/fs/safe_fd_unix.go
@@ -5,6 +5,8 @@ package fs
 import (
 	"fmt"
 	"os"
+	"os/user"
+	"strconv"
 	"syscall"
 )
 
@@ -74,4 +76,88 @@ func FchownNoFollow(path string, uid, gid int) error {
 		return fmt.Errorf("fchown %s: %w", path, err)
 	}
 	return nil
+}
+
+// SetDirPermissionsNoFollow applies mode and ownership to a DIRECTORY
+// through an O_NOFOLLOW|O_DIRECTORY fd, so the operation acts on the
+// inode that was opened and a later path swap cannot redirect it. This is
+// the TOCTOU-closing replacement for path-based dir chmod/chown (WS6 #5).
+//
+//   - A symlink at path fails the open (ELOOP) instead of being
+//     dereferenced — a user who can swap a managed directory for a
+//     symlink to /etc or /root cannot redirect a root-run chmod/chown
+//     onto the target.
+//   - A non-directory fails the open (ENOTDIR).
+//   - uid and/or gid of -1 leaves that id unchanged (chown(2) sentinel);
+//     when both are -1 the chown is skipped entirely.
+//
+// The mode is always applied; callers that do not want to change the mode
+// should pass the directory's existing mode.
+func SetDirPermissionsNoFollow(path string, mode os.FileMode, uid, gid int) error {
+	f, err := OpenRealDir(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Chmod(mode); err != nil {
+		return fmt.Errorf("fchmod dir %s: %w", path, err)
+	}
+	if uid != -1 || gid != -1 {
+		if err := f.Chown(uid, gid); err != nil {
+			return fmt.Errorf("fchown dir %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// ResolveOwnership maps owner/group NAMES to numeric uid/gid for the
+// fd-based fchown helpers. An empty name yields -1 ("leave unchanged",
+// the chown(2) sentinel). A name is resolved against the user/group
+// database first and falls back to a numeric id (matching chown(1), which
+// accepts raw ids); a value that is neither a known name nor a number is
+// an error. Callers MUST fail closed on that error rather than silently
+// widening or narrowing ownership.
+func ResolveOwnership(owner, group string) (uid, gid int, err error) {
+	uid, gid = -1, -1
+	if owner != "" {
+		uid, err = resolveID(owner, func(name string) (string, error) {
+			u, lookupErr := user.Lookup(name)
+			if lookupErr != nil {
+				return "", lookupErr
+			}
+			return u.Uid, nil
+		})
+		if err != nil {
+			return -1, -1, fmt.Errorf("resolve owner %q: %w", owner, err)
+		}
+	}
+	if group != "" {
+		gid, err = resolveID(group, func(name string) (string, error) {
+			g, lookupErr := user.LookupGroup(name)
+			if lookupErr != nil {
+				return "", lookupErr
+			}
+			return g.Gid, nil
+		})
+		if err != nil {
+			return -1, -1, fmt.Errorf("resolve group %q: %w", group, err)
+		}
+	}
+	return uid, gid, nil
+}
+
+// resolveID resolves a name to a numeric id via lookup, falling back to
+// parsing the name as a raw numeric id.
+func resolveID(name string, lookup func(string) (string, error)) (int, error) {
+	if idStr, lookupErr := lookup(name); lookupErr == nil {
+		id, parseErr := strconv.Atoi(idStr)
+		if parseErr != nil {
+			return -1, fmt.Errorf("parse id %q: %w", idStr, parseErr)
+		}
+		return id, nil
+	}
+	if id, parseErr := strconv.Atoi(name); parseErr == nil {
+		return id, nil
+	}
+	return -1, fmt.Errorf("unknown name and not a numeric id")
 }

--- a/go/sys/fs/safe_replace_file_action_test.go
+++ b/go/sys/fs/safe_replace_file_action_test.go
@@ -1,0 +1,155 @@
+//go:build unix
+
+package fs
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// WS6 #2: WriteFileAtomic used a PREDICTABLE temp name (path+".pm-tmp")
+// and wrote it with a privilege-backend `tee`, which FOLLOWS symlinks.
+// A local attacker who can create entries in the target directory could
+// pre-plant `<target>.pm-tmp` as a symlink to any root-writable file and
+// redirect the root agent's write there — an arbitrary-file-write → root
+// privesc. The fix routes the write through SafeReplaceFile: a
+// RANDOM-suffix same-directory temp opened O_NOFOLLOW, fchmod'd, then
+// renamed into place. The predictable name is gone entirely, so a planted
+// symlink at the old name is never touched.
+//
+// Design intent pinned here:
+//   - the predictable `<target>.pm-tmp` path is NEVER written through;
+//   - no leftover temp (`.<base>.tmp-*`) lingers on success;
+//   - the final inode is a real regular file with the requested content
+//     and mode.
+func TestWriteFileAtomic_RefusesSymlinkPlantedTempTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "managed.conf")
+
+	// Sentinel in a separate tree that the attacker hopes to clobber by
+	// planting a symlink at the OLD predictable temp path.
+	sentinelDir := t.TempDir()
+	sentinel := filepath.Join(sentinelDir, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	planted := target + ".pm-tmp"
+	if err := os.Symlink(sentinel, planted); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	const content = "managed content\n"
+	if err := WriteFileAtomic(context.Background(), target, content, "0644", "", ""); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	// The planted symlink target must be untouched — the write must not
+	// have followed `<target>.pm-tmp`.
+	got, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Fatalf("sentinel was modified through the planted .pm-tmp symlink: %q", string(got))
+	}
+
+	// The real target holds the new content as a regular file.
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("lstat target: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("target is a symlink, want a regular file")
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("target is not a regular file: %v", info.Mode())
+	}
+	gotTarget, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(gotTarget) != content {
+		t.Errorf("target content = %q, want %q", string(gotTarget), content)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("target mode = %v, want 0644", perm)
+	}
+
+	// No predictable name was created and no random temp lingers.
+	matches, _ := filepath.Glob(filepath.Join(dir, ".managed.conf.tmp-*"))
+	if len(matches) != 0 {
+		t.Errorf("leftover temp files: %v", matches)
+	}
+}
+
+// WriteFileAtomic must refuse to write THROUGH a symlink planted at the
+// final target path: a symlink at `target` must be replaced by the real
+// regular file (rename-over), never dereferenced so the write lands on
+// the symlink's victim. Pins that the new inode is real and the victim
+// is untouched.
+func TestWriteFileAtomic_TargetSymlinkNotDereferenced(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "managed.conf")
+
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "victim")
+	if err := os.WriteFile(victim, []byte("VICTIM"), 0o644); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	if err := os.Symlink(victim, target); err != nil {
+		t.Fatalf("plant target symlink: %v", err)
+	}
+
+	if err := WriteFileAtomic(context.Background(), target, "new\n", "0644", "", ""); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	if got, _ := os.ReadFile(victim); string(got) != "VICTIM" {
+		t.Fatalf("victim modified through target symlink deref: %q", string(got))
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("lstat target: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("target still a symlink after write")
+	}
+}
+
+// The correct path with explicit ownership: resolving the owner/group
+// NAMES to ids and applying them through an fd (no path-based chown that
+// could follow a swapped symlink). Run against the current user so it
+// works without root.
+func TestWriteFileAtomic_AppliesOwnershipToSelf(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "owned.conf")
+
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("current user: %v", err)
+	}
+	g, err := user.LookupGroupId(u.Gid)
+	if err != nil {
+		t.Skipf("cannot resolve current group: %v", err)
+	}
+
+	if err := WriteFileAtomic(context.Background(), target, "x\n", "0640", u.Username, g.Name); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o640 {
+		t.Errorf("mode = %v, want 0640", perm)
+	}
+	wantUID, _ := strconv.Atoi(u.Uid)
+	if uid := fileUID(t, info); uid != wantUID {
+		t.Errorf("uid = %d, want %d", uid, wantUID)
+	}
+}

--- a/go/sys/fs/safe_replace_file_action_test.go
+++ b/go/sys/fs/safe_replace_file_action_test.go
@@ -27,6 +27,7 @@ import (
 //   - the final inode is a real regular file with the requested content
 //     and mode.
 func TestWriteFileAtomic_RefusesSymlinkPlantedTempTarget(t *testing.T) {
+	useRootBackend(t)
 	dir := t.TempDir()
 	target := filepath.Join(dir, "managed.conf")
 
@@ -92,6 +93,7 @@ func TestWriteFileAtomic_RefusesSymlinkPlantedTempTarget(t *testing.T) {
 // the symlink's victim. Pins that the new inode is real and the victim
 // is untouched.
 func TestWriteFileAtomic_TargetSymlinkNotDereferenced(t *testing.T) {
+	useRootBackend(t)
 	dir := t.TempDir()
 	target := filepath.Join(dir, "managed.conf")
 
@@ -125,6 +127,7 @@ func TestWriteFileAtomic_TargetSymlinkNotDereferenced(t *testing.T) {
 // could follow a swapped symlink). Run against the current user so it
 // works without root.
 func TestWriteFileAtomic_AppliesOwnershipToSelf(t *testing.T) {
+	useRootBackend(t)
 	dir := t.TempDir()
 	target := filepath.Join(dir, "owned.conf")
 


### PR DESCRIPTION
Advances `manchtools/power-manage-sdk#88`. The SDK half of **WS6** (agent local privesc / file & dir symlink-TOCTOU + bounded fan-out). The agent half (LUKS daemon socket, executor wiring, store 0600, install.sh) follows in a separate `power-manage-agent` PR that bumps this SDK.

The agent runs as **root** (`User=root`; backend auto-selects `PrivilegeBackendRoot`), so these helpers now operate via direct fd syscalls instead of escalating string-path commands per op — which is what makes the symlink-aware defenses possible.

## Findings closed
| # | sev | fix |
|---|-----|-----|
| 2 | high | `WriteFileAtomic` → `SafeReplaceFile` (random-suffix `O_NOFOLLOW` temp + fd chown). Kills the predictable `.pm-tmp` symlink-following `tee` write — a root arbitrary-file-write. |
| 5 | med | `SetDirPermissionsNoFollow`: fd-based dir chmod/chown (`O_NOFOLLOW|O_DIRECTORY`), no final-component symlink deref. |
| 4 | med | `RemoveDir`: openat-anchored, symlink-refusing recursive delete — no string re-resolution; a swapped intermediate component aborts. |
| 12 | low | `RemoveDir`: deny-by-default `IsUnderProtectedPrefix` (whole subtree of every protected prefix) replaces the top-level-only exact-match denylist. |
| 11 | low | `dispatchServerMessage`: bound `RequestInventory` / `RevokeLuksDeviceKey` goroutine fan-out (semaphore, drop overflow). |
| 14 | low | `exec.CappedBuffer`: shared bounded `io.Writer` for per-user output (consumed agent-side). |

Plus `ResolveOwnership` (fail-closed name→uid/gid) used by the fd chown helpers.

## Tests
All written **RED first**: planted-symlink temp/target defenses, fd-based dir-perm symlink refusal, deny-by-default subtree refusal (must-reject set sourced from intent, not the impl list), fd-anchored delete refusing symlinked components, bounded concurrency under a 50-message flood, capped-buffer truncation. `go test -race ./...` green; `go vet` + `gofmt` clean; local CodeRabbit review clean.

## Follow-up (out of scope, reported not fixed)
`go/sys/network/wifi.go` stages EAP-TLS certs in a predictable `CertDir + ".tmp"` dir — same predictable-temp class as #2 but a different, config-driven (root-owned `CertDir`) surface and not one of WS6's 19 findings. Flagging for a separate charter rather than folding an un-tested change in here.