### PR TITLE
fix: make agent-update expected_sha256 + checksum_url optional (operator choice)

### DIFF
--- a/gen/go/pm/v1/actions.pb.go
+++ b/gen/go/pm/v1/actions.pb.go
@@ -3924,16 +3924,27 @@ type AgentUpdateArch struct {
 	// Direct download URL for the agent binary (HTTPS only)
 	// @gotags: validate:"required,url,startswith=https://"
 	BinaryUrl string `protobuf:"bytes,1,opt,name=binary_url,json=binaryUrl,proto3" json:"binary_url,omitempty" validate:"required,url,startswith=https://"`
-	// URL to the SHA256 checksum file for the binary (HTTPS only)
-	// @gotags: validate:"required,url,startswith=https://"
-	ChecksumUrl string `protobuf:"bytes,2,opt,name=checksum_url,json=checksumUrl,proto3" json:"checksum_url,omitempty" validate:"required,url,startswith=https://"`
-	// Expected SHA-256 of the binary, lowercase hex. This is the
-	// AUTHORITATIVE integrity gate for the self-update swap: it travels
-	// inside the CA-signed action, so the agent verifies the downloaded
-	// binary against a hash bound to the control server's signature rather
-	// than a checksum file fetched from the (untrusted) download origin.
-	// @gotags: validate:"required,len=64,hexadecimal"
-	ExpectedSha256 string `protobuf:"bytes,3,opt,name=expected_sha256,json=expectedSha256,proto3" json:"expected_sha256,omitempty" validate:"required,len=64,hexadecimal"`
+	// URL to a SHA256SUMS-style checksum file for the binary (HTTPS only).
+	// The DEFAULT integrity source: with it set (and expected_sha256
+	// unset) the agent fetches and verifies against this file, which lets
+	// an action point binary_url + checksum_url at "latest" release assets
+	// and have the fleet track new releases hands-off. Authenticity here is
+	// origin-trust (TLS + the operator's release host); an operator can
+	// host the checksum file on a SEPARATE host from the binary to mitigate
+	// the single-origin risk. At least one of checksum_url / expected_sha256
+	// must be set (enforced by the server validator).
+	// @gotags: validate:"omitempty,url,startswith=https://"
+	ChecksumUrl string `protobuf:"bytes,2,opt,name=checksum_url,json=checksumUrl,proto3" json:"checksum_url,omitempty" validate:"omitempty,url,startswith=https://"`
+	// Optional pinned SHA-256 of the binary, lowercase hex. When set it is
+	// the AUTHORITATIVE integrity gate and OVERRIDES checksum_url: it
+	// travels inside the CA-signed action, so the agent verifies the
+	// downloaded binary against a hash bound to the control server's
+	// signature rather than a checksum file fetched from the download
+	// origin. Use it to pin an exact binary (staged rollouts) or for
+	// stronger authenticity; leave it unset to track "latest" via
+	// checksum_url.
+	// @gotags: validate:"omitempty,len=64,hexadecimal"
+	ExpectedSha256 string `protobuf:"bytes,3,opt,name=expected_sha256,json=expectedSha256,proto3" json:"expected_sha256,omitempty" validate:"omitempty,len=64,hexadecimal"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }

--- a/gen/ts/pm/v1/actions_pb.ts
+++ b/gen/ts/pm/v1/actions_pb.ts
@@ -1879,20 +1879,31 @@ export type AgentUpdateArch = Message<"pm.v1.AgentUpdateArch"> & {
   binaryUrl: string;
 
   /**
-   * URL to the SHA256 checksum file for the binary (HTTPS only)
-   * @gotags: validate:"required,url,startswith=https://"
+   * URL to a SHA256SUMS-style checksum file for the binary (HTTPS only).
+   * The DEFAULT integrity source: with it set (and expected_sha256
+   * unset) the agent fetches and verifies against this file, which lets
+   * an action point binary_url + checksum_url at "latest" release assets
+   * and have the fleet track new releases hands-off. Authenticity here is
+   * origin-trust (TLS + the operator's release host); an operator can
+   * host the checksum file on a SEPARATE host from the binary to mitigate
+   * the single-origin risk. At least one of checksum_url / expected_sha256
+   * must be set (enforced by the server validator).
+   * @gotags: validate:"omitempty,url,startswith=https://"
    *
    * @generated from field: string checksum_url = 2;
    */
   checksumUrl: string;
 
   /**
-   * Expected SHA-256 of the binary, lowercase hex. This is the
-   * AUTHORITATIVE integrity gate for the self-update swap: it travels
-   * inside the CA-signed action, so the agent verifies the downloaded
-   * binary against a hash bound to the control server's signature rather
-   * than a checksum file fetched from the (untrusted) download origin.
-   * @gotags: validate:"required,len=64,hexadecimal"
+   * Optional pinned SHA-256 of the binary, lowercase hex. When set it is
+   * the AUTHORITATIVE integrity gate and OVERRIDES checksum_url: it
+   * travels inside the CA-signed action, so the agent verifies the
+   * downloaded binary against a hash bound to the control server's
+   * signature rather than a checksum file fetched from the download
+   * origin. Use it to pin an exact binary (staged rollouts) or for
+   * stronger authenticity; leave it unset to track "latest" via
+   * checksum_url.
+   * @gotags: validate:"omitempty,len=64,hexadecimal"
    *
    * @generated from field: string expected_sha256 = 3;
    */

--- a/proto/pm/v1/actions.proto
+++ b/proto/pm/v1/actions.proto
@@ -913,16 +913,27 @@ message AgentUpdateArch {
   // @gotags: validate:"required,url,startswith=https://"
   string binary_url = 1;
 
-  // URL to the SHA256 checksum file for the binary (HTTPS only)
-  // @gotags: validate:"required,url,startswith=https://"
+  // URL to a SHA256SUMS-style checksum file for the binary (HTTPS only).
+  // The DEFAULT integrity source: with it set (and expected_sha256
+  // unset) the agent fetches and verifies against this file, which lets
+  // an action point binary_url + checksum_url at "latest" release assets
+  // and have the fleet track new releases hands-off. Authenticity here is
+  // origin-trust (TLS + the operator's release host); an operator can
+  // host the checksum file on a SEPARATE host from the binary to mitigate
+  // the single-origin risk. At least one of checksum_url / expected_sha256
+  // must be set (enforced by the server validator).
+  // @gotags: validate:"omitempty,url,startswith=https://"
   string checksum_url = 2;
 
-  // Expected SHA-256 of the binary, lowercase hex. This is the
-  // AUTHORITATIVE integrity gate for the self-update swap: it travels
-  // inside the CA-signed action, so the agent verifies the downloaded
-  // binary against a hash bound to the control server's signature rather
-  // than a checksum file fetched from the (untrusted) download origin.
-  // @gotags: validate:"required,len=64,hexadecimal"
+  // Optional pinned SHA-256 of the binary, lowercase hex. When set it is
+  // the AUTHORITATIVE integrity gate and OVERRIDES checksum_url: it
+  // travels inside the CA-signed action, so the agent verifies the
+  // downloaded binary against a hash bound to the control server's
+  // signature rather than a checksum file fetched from the download
+  // origin. Use it to pin an exact binary (staged rollouts) or for
+  // stronger authenticity; leave it unset to track "latest" via
+  // checksum_url.
+  // @gotags: validate:"omitempty,len=64,hexadecimal"
   string expected_sha256 = 3;
 }
 


### PR DESCRIPTION
WS7 follow-up. The required `expected_sha256` from #101 forced version-pinning and **broke the hands-off update workflow**: pointing `binary_url`/`checksum_url` at `releases/latest/...` to track new releases no longer works — a pinned hash + a `latest` URL actively *fails every update* (the new bytes don't match the old hash). An admin would have to bump the hash and re-sign on every release.

Both fields are now `omitempty`:
- **`checksum_url` (default)** — track `latest`, verify against the operator's checksum file. Authenticity is origin-trust (the action is CA-signed, so only an origin-manipulated hash is a concern; an operator can host the checksum file on a **separate host** to mitigate the single-origin risk).
- **`expected_sha256` (opt-in)** — an exact pinned hash inside the CA-signed action (staged rollouts / stronger authenticity); overrides `checksum_url` when set.

The **"at least one of `checksum_url` / `expected_sha256`"** invariant (so an update never runs with no integrity check — does not reopen the deb/rpm/appimage mandatory-checksum, which is separate) is a cross-field rule proto can't express; it's enforced by the **server validator** and the **agent** (companion PRs in `power-manage-server` / `power-manage-agent`). CodeRabbit flagged exactly this — the companion PRs satisfy it.

`go test` green, `gofmt` clean. Part of the sdk→server→agent set.