### PR TITLE
feat(pkg): argv-hardening validators + exec.SeparatePositionals (sdk#88)

### DIFF
--- a/go/pkg/README.md
+++ b/go/pkg/README.md
@@ -233,6 +233,29 @@ type CommandResult struct {
 | zypper | openSUSE, SLES | `/usr/bin/zypper` | `zypper addlock/removelock` |
 | flatpak | Cross-distro | `/usr/bin/flatpak` | N/A |
 
+## Argument-Hardening Validators
+
+Every value that reaches a package-manager `argv` must be validated against
+its *intent* before the command runs. These exported validators are
+**mandatory** at the argv boundary (the agent's executors call them, and the
+positionals are then passed after an explicit `--` end-of-options separator
+built with `exec.SeparatePositionals`, so a flag-shaped value can never be
+reparsed as an option):
+
+| Validator | Guards | Rule |
+|-----------|--------|------|
+| `ValidatePackageName` / `ValidatePackageNames` | apt/dnf/pacman/zypper/flatpak names | first char alphanumeric, then `[a-zA-Z0-9._+:/@~-]`, ≤256 |
+| `ValidatePackageVersion` | `<name>=<version>` argv | cross-distro EVR grammar, empty = "no pin" |
+| `ValidateRpmPackageName` | `rpm -q` / `rpm -e <NAME>` (NAME read off a crafted `.rpm`) | first char alphanumeric, then `[a-zA-Z0-9._+-]`, ≤256 |
+| `ValidateRepoBaseURL` | dnf `baseurl` / zypper `url` / pacman `server` | **https only**, host required, control-char free (template vars `$releasever`/`$arch` allowed). apt is excluded — its security is the gpg-signed Release file. |
+| `ValidateGpgKeyRef` | dnf/zypper `gpgkey` passed to `rpm --import` | https URL, `file:///abs` path, or absolute path; no `..`, no leading `-`, no `http://`, no `ext::` |
+| `ValidateRemoteName` | flatpak remote alias | first char alphanumeric, then `[a-zA-Z0-9._-]`, ≤128 |
+
+`exec.SeparatePositionals(flags, positionals...)` (in `go/sys/exec`) builds a
+fresh slice, copies `flags`, inserts `--` unconditionally (even with no
+positionals), then appends the positionals — so the caller's `flags` slice is
+never aliased or mutated.
+
 ## Notes
 
 ### Version Formats

--- a/go/pkg/validate.go
+++ b/go/pkg/validate.go
@@ -2,7 +2,9 @@ package pkg
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 // validPackageName is the allowlist every package-name argument must
@@ -92,4 +94,151 @@ func ValidatePackageVersion(version string) error {
 		return fmt.Errorf("invalid package version %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._+:~^-]", version)
 	}
 	return nil
+}
+
+// --- WS8 argv-hardening validators (sdk#88) --------------------------------
+//
+// These guard the package-manager invocation surface that the generic
+// ValidatePackageName does not cover: an RPM %{NAME} read off a crafted
+// .rpm, a dnf/zypper/pacman repository base URL, a dnf/zypper GPG key
+// reference, and a flatpak remote alias. Each is MANDATORY at the argv
+// boundary it protects (see agent/internal/executor) and, in concert
+// with exec.SeparatePositionals, ensures a flag-shaped or
+// metacharacter-bearing value can never be reparsed as an option.
+
+// validRpmPackageName matches a legitimate RPM %{NAME}. The first
+// character MUST be alphanumeric — that single rule kills the option-
+// injection class where a crafted .rpm sets %{NAME} to `-e` or
+// `--eval=%{lua:...}` and `rpm -q`/`rpm -e` reparses it as a flag/macro.
+// RPM names use `[a-zA-Z0-9._+-]` (note '+' for libstdc++); the broader
+// set ValidatePackageName allows (`:/@~`) is not part of an RPM NAME.
+var validRpmPackageName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+-]{0,255}$`)
+
+// ValidateRpmPackageName returns a non-nil error when name is not a
+// safe RPM %{NAME} to pass to `rpm -q`/`rpm -e`. The name a crafted
+// .rpm reports is untrusted; callers MUST validate it before it reaches
+// argv. Mirrors ValidatePackageName / the deb-side validDebPkgName.
+func ValidateRpmPackageName(name string) error {
+	if name == "" {
+		return fmt.Errorf("rpm package name is empty")
+	}
+	if !validRpmPackageName.MatchString(name) {
+		return fmt.Errorf("invalid rpm package name %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._+-]", name)
+	}
+	return nil
+}
+
+// validRemoteName matches a flatpak remote alias (e.g. "flathub",
+// "gnome-nightly"). Same leading-alphanumeric anti-option-injection
+// rule; remote aliases never contain a path separator or whitespace.
+var validRemoteName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$`)
+
+// ValidateRemoteName returns a non-nil error when name is not a safe
+// flatpak remote alias to pass as an operand to `flatpak install`. A
+// flag-shaped remote (`--from=…`) would otherwise be parsed as an
+// option.
+func ValidateRemoteName(name string) error {
+	if name == "" {
+		return fmt.Errorf("flatpak remote name is empty")
+	}
+	if !validRemoteName.MatchString(name) {
+		return fmt.Errorf("invalid flatpak remote name %q: must start with [a-zA-Z0-9] and contain only [a-zA-Z0-9._-]", name)
+	}
+	return nil
+}
+
+// hasCtrlOrSpace reports whether s contains any ASCII control character,
+// whitespace, or DEL. Used to reject config-injection (newlines smuggle
+// extra directives into a repo file) and argv confusion (spaces split a
+// single field into multiple arguments) in URL/ref fields where the
+// generic ValidatePackageName grammar does not apply. r <= ' ' covers
+// NUL through space (incl. \t \n \r); 0x7f is DEL.
+func hasCtrlOrSpace(s string) bool {
+	for _, r := range s {
+		if r <= ' ' || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateRepoBaseURL validates a dnf baseurl / zypper url / pacman
+// server. A repository base URL is where the package manager fetches
+// ROOT-installed packages, so it must be https (no http/ftp/file — the
+// transport is the only thing standing between a MITM and arbitrary
+// root code), a real URL with a host, and free of control characters.
+// Package-manager template variables ($releasever, $arch, $basearch)
+// survive url.Parse and are intentionally allowed.
+//
+// NOTE: apt is deliberately NOT validated through here — apt's security
+// model is the gpg-signed Release file, so an http transport with a
+// trusted key is a legitimate, long-standing configuration.
+func ValidateRepoBaseURL(rawURL string) error {
+	if rawURL == "" {
+		return fmt.Errorf("repository base URL is empty")
+	}
+	if hasCtrlOrSpace(rawURL) {
+		return fmt.Errorf("repository base URL contains whitespace or control characters")
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("repository base URL is not a valid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("repository base URL must use https, got scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("repository base URL has no host")
+	}
+	return nil
+}
+
+// ValidateGpgKeyRef validates a dnf/zypper Gpgkey reference before it
+// reaches `rpm --import`. Accepted iff it is (a) an https URL with a
+// host, (b) a file:// absolute path (file:///… — empty host, no `..`),
+// or (c) a bare absolute filesystem path (no `..`). Everything else is
+// refused: a leading '-' (option injection into `rpm --import`),
+// plaintext http (MITM of the trust anchor itself), rpm's `ext::`
+// external transport (which executes a command), and relative or
+// traversing paths.
+func ValidateGpgKeyRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("gpg key ref is empty")
+	}
+	if hasCtrlOrSpace(ref) {
+		return fmt.Errorf("gpg key ref contains whitespace or control characters")
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("gpg key ref %q is flag-shaped (leading '-')", ref)
+	}
+	switch {
+	case strings.HasPrefix(ref, "https://"):
+		u, err := url.Parse(ref)
+		if err != nil {
+			return fmt.Errorf("gpg key ref is not a valid URL: %w", err)
+		}
+		if u.Host == "" {
+			return fmt.Errorf("gpg key https ref has no host")
+		}
+		return nil
+	case strings.HasPrefix(ref, "file://"):
+		u, err := url.Parse(ref)
+		if err != nil {
+			return fmt.Errorf("gpg key ref is not a valid URL: %w", err)
+		}
+		if u.Host != "" {
+			return fmt.Errorf("gpg key file ref must be file:///absolute/path (no host)")
+		}
+		if !strings.HasPrefix(u.Path, "/") || strings.Contains(u.Path, "..") {
+			return fmt.Errorf("gpg key file ref must be an absolute path with no '..'")
+		}
+		return nil
+	case strings.HasPrefix(ref, "/"):
+		if strings.Contains(ref, "..") {
+			return fmt.Errorf("gpg key path ref must not contain '..'")
+		}
+		return nil
+	default:
+		return fmt.Errorf("gpg key ref %q must be an https URL, a file:// absolute path, or an absolute filesystem path", ref)
+	}
 }

--- a/go/pkg/validate_test.go
+++ b/go/pkg/validate_test.go
@@ -93,3 +93,178 @@ func TestValidatePackageName_LengthCap(t *testing.T) {
 		t.Errorf("257-char name accepted; expected rejection")
 	}
 }
+
+// --- WS8 argv-hardening validators (sdk#88) ---------------------------------
+
+// TestValidateRpmPackageName_Accepts pins the legitimate RPM %{NAME}
+// shapes ValidateRpmPackageName must let through. The name comes from
+// `rpm -qp --qf %{NAME}` on a downloaded .rpm, so a regression that
+// rejects any of these breaks a real install/remove.
+func TestValidateRpmPackageName_Accepts(t *testing.T) {
+	cases := []string{
+		"bash",
+		"kernel-core",
+		"libstdc++",      // RPM names carry '+'
+		"python3.11",     // dotted version segment in the name
+		"NetworkManager", // mixed case
+		"2048-cli",       // digit-leading is allowed; first char is alphanumeric
+		"glibc-langpack-en",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateRpmPackageName(name); err != nil {
+				t.Errorf("legitimate rpm name rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRpmPackageName_RejectsOptionInjection sources every
+// invalid case from intent — a crafted .rpm can set %{NAME} to
+// anything, and a name that begins with '-'/'=' or carries a
+// metacharacter is option/argv confusion against `rpm -q`/`rpm -e`.
+func TestValidateRpmPackageName_RejectsOptionInjection(t *testing.T) {
+	cases := []string{
+		"",                               // ABSENT
+		"-e",                             // leading dash → option to rpm
+		"--eval=%{lua:os.execute('id')}", // rpm macro evaluation via option
+		"=evil",                          // leading '='
+		" bash",                          // leading space
+		"bash ",                          // trailing space
+		"foo bar",                        // embedded space → argv confusion
+		"pkg;rm -rf /",                   // shell metachar
+		"pkg|cat",
+		"$(reboot)",
+		"`reboot`",
+		"pkg\nmalicious",               // newline
+		"pkg\x00",                      // NUL
+		"a" + strings.Repeat("b", 256), // length cap (257 chars)
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateRpmPackageName(name); err == nil {
+				t.Errorf("expected rejection of %q", name)
+			}
+		})
+	}
+}
+
+// TestValidateRepoBaseURL_Accepts pins the legitimate dnf baseurl /
+// zypper url / pacman server shapes — including the package-manager
+// template variables that must survive validation.
+func TestValidateRepoBaseURL_Accepts(t *testing.T) {
+	cases := []string{
+		"https://dnf.example.com/fedora/$releasever",
+		"https://arch.example.com/os/$arch",
+		"https://mirror.example.com/repo/$basearch/os",
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			if err := ValidateRepoBaseURL(u); err != nil {
+				t.Errorf("legitimate base URL rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRepoBaseURL_Rejects sources invalid cases from intent: a
+// repository base URL fetches root-installed packages, so it MUST be
+// https (no http/ftp/file), MUST be a real URL with a host, and MUST
+// NOT be flag-shaped or carry control characters.
+func TestValidateRepoBaseURL_Rejects(t *testing.T) {
+	cases := []string{
+		"",                   // ABSENT
+		"http://mirror/repo", // plaintext http → MITM of root packages
+		"ftp://x/repo",       // wrong scheme
+		"file:///etc",        // local file masquerading as a repo
+		"-o/tmp/x",           // flag-shaped, no scheme
+		"https://a\nb",       // control char (config injection)
+		"https://",           // no host
+		"not-a-url",          // no scheme/host
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			if err := ValidateRepoBaseURL(u); err == nil {
+				t.Errorf("expected rejection of %q", u)
+			}
+		})
+	}
+}
+
+// TestValidateGpgKeyRef_Accepts pins the exact allowed shapes for a
+// dnf/zypper Gpgkey: an https URL, a file:// absolute path, or a bare
+// absolute filesystem path. These are what `rpm --import` legitimately
+// consumes.
+func TestValidateGpgKeyRef_Accepts(t *testing.T) {
+	cases := []string{
+		"https://dnf.example.com/RPM-GPG-KEY",
+		"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foo",
+		"/etc/pki/rpm-gpg/RPM-GPG-KEY-foo",
+	}
+	for _, ref := range cases {
+		t.Run(ref, func(t *testing.T) {
+			if err := ValidateGpgKeyRef(ref); err != nil {
+				t.Errorf("legitimate gpg key ref rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateGpgKeyRef_Rejects sources invalid cases from intent: a
+// key ref must be https / file:// / absolute path — never a flag, never
+// plaintext http (MITM of the trust anchor), never an rpm transport
+// like ext::, never a relative or traversing path.
+func TestValidateGpgKeyRef_Rejects(t *testing.T) {
+	cases := []string{
+		"",                        // ABSENT
+		"-",                       // flag-shaped
+		"--import=/etc/shadow",    // option injection into rpm --import
+		"http://evil/key",         // plaintext http → MITM the key
+		"ext::sh -c id",           // rpm "external" transport → command exec
+		"relative/key",            // relative path
+		"file://../../etc/passwd", // file:// with traversal
+		"/etc/../etc/shadow",      // absolute path with traversal
+		"https://a\nhttps://b",    // control char
+	}
+	for _, ref := range cases {
+		t.Run(ref, func(t *testing.T) {
+			if err := ValidateGpgKeyRef(ref); err == nil {
+				t.Errorf("expected rejection of %q", ref)
+			}
+		})
+	}
+}
+
+// TestValidateRemoteName_Accepts pins the flatpak remote-alias shapes
+// (configured remote names like "flathub") that must pass.
+func TestValidateRemoteName_Accepts(t *testing.T) {
+	cases := []string{"flathub", "fedora", "gnome-nightly", "flathub-beta"}
+	for _, n := range cases {
+		t.Run(n, func(t *testing.T) {
+			if err := ValidateRemoteName(n); err != nil {
+				t.Errorf("legitimate remote name rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRemoteName_Rejects sources invalid cases from intent: a
+// flatpak remote name is an operand to `flatpak install`, so a
+// flag-shaped or space/control-bearing value is argv confusion.
+func TestValidateRemoteName_Rejects(t *testing.T) {
+	cases := []string{
+		"",            // ABSENT
+		"--from=evil", // flag-shaped
+		"-x",
+		"a b",      // embedded space
+		"re\nmote", // control char
+		"a/b",      // path separator is not a remote alias
+	}
+	for _, n := range cases {
+		t.Run(n, func(t *testing.T) {
+			if err := ValidateRemoteName(n); err == nil {
+				t.Errorf("expected rejection of %q", n)
+			}
+		})
+	}
+}

--- a/go/sys/exec/argv.go
+++ b/go/sys/exec/argv.go
@@ -1,0 +1,25 @@
+package exec
+
+// EndOfOptions is the POSIX "--" token. Everything after it on a
+// command line is treated as an operand, never an option.
+const EndOfOptions = "--"
+
+// SeparatePositionals builds an argv slice that places positionals
+// after an explicit EndOfOptions ("--") separator, so a value that
+// happens to be flag-shaped (a package name like "-e", a flatpak
+// remote like "--from") can never be reparsed by the invoked program
+// as an option. The "--" is ALWAYS inserted, even when there are no
+// positionals — terminating the option list is harmless and keeps the
+// invariant unconditional (callers never have to reason about the
+// empty case).
+//
+// The result is a freshly-allocated slice; the caller's flags slice is
+// never aliased or appended into, so a reused flag list stays
+// pristine across calls.
+func SeparatePositionals(flags []string, positionals ...string) []string {
+	out := make([]string, 0, len(flags)+1+len(positionals))
+	out = append(out, flags...)
+	out = append(out, EndOfOptions)
+	out = append(out, positionals...)
+	return out
+}

--- a/go/sys/exec/argv_test.go
+++ b/go/sys/exec/argv_test.go
@@ -1,0 +1,96 @@
+package exec
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSeparatePositionals_InsertsEndOfOptions pins the core contract:
+// the "--" end-of-options token is always inserted between the flags
+// and the positional operands, so a flag-shaped operand (a package
+// name like "-e", a remote like "--from") can never be reparsed by the
+// invoked program as an option.
+func TestSeparatePositionals_InsertsEndOfOptions(t *testing.T) {
+	cases := []struct {
+		name        string
+		flags       []string
+		positionals []string
+		want        []string
+	}{
+		{
+			name:        "rpm query",
+			flags:       []string{"-q"},
+			positionals: []string{"bash"},
+			want:        []string{"-q", "--", "bash"},
+		},
+		{
+			name:        "rpm erase with flag-shaped name stays an operand",
+			flags:       []string{"-e"},
+			positionals: []string{"--eval=evil"},
+			want:        []string{"-e", "--", "--eval=evil"},
+		},
+		{
+			name:        "flatpak install with remote+appid",
+			flags:       []string{"install", "-y", "--noninteractive", "--system"},
+			positionals: []string{"flathub", "org.videolan.VLC"},
+			want:        []string{"install", "-y", "--noninteractive", "--system", "--", "flathub", "org.videolan.VLC"},
+		},
+		{
+			name:        "no flags",
+			flags:       nil,
+			positionals: []string{"x"},
+			want:        []string{"--", "x"},
+		},
+		{
+			name:        "no positionals still terminates options",
+			flags:       []string{"-q"},
+			positionals: nil,
+			want:        []string{"-q", "--"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SeparatePositionals(tc.flags, tc.positionals...)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("SeparatePositionals(%v, %v) = %v, want %v", tc.flags, tc.positionals, got, tc.want)
+			}
+			// The "--" must sit before every positional: its index must
+			// be strictly less than the index of any operand.
+			sep := -1
+			for i, a := range got {
+				if a == EndOfOptions {
+					sep = i
+					break
+				}
+			}
+			if sep < 0 {
+				t.Fatalf("result %v contains no %q separator", got, EndOfOptions)
+			}
+			for _, p := range tc.positionals {
+				idx := -1
+				for i := sep + 1; i < len(got); i++ {
+					if got[i] == p {
+						idx = i
+						break
+					}
+				}
+				if idx < 0 {
+					t.Errorf("positional %q does not appear after the %q separator", p, EndOfOptions)
+				}
+			}
+		})
+	}
+}
+
+// TestSeparatePositionals_DoesNotMutateFlags guards against the helper
+// aliasing/appending into the caller's flags slice — a classic
+// append-to-shared-backing-array bug that would corrupt a reused flag
+// list across calls.
+func TestSeparatePositionals_DoesNotMutateFlags(t *testing.T) {
+	flags := []string{"-q"}
+	_ = SeparatePositionals(flags, "bash")
+	_ = SeparatePositionals(flags, "curl")
+	if !reflect.DeepEqual(flags, []string{"-q"}) {
+		t.Fatalf("input flags were mutated: %v", flags)
+	}
+}


### PR DESCRIPTION
Implements `manchtools/power-manage-sdk#88` — adds the missing argv validators so package-manager invocations validate against intent, and a `--` end-of-options helper so a flag-shaped value can never be reparsed as an option.

## What

- `pkg.ValidateRpmPackageName` — an RPM `%{NAME}` read off a (possibly crafted) `.rpm` must start alphanumeric and use `[a-zA-Z0-9._+-]`. Kills option/macro injection into `rpm -q`/`rpm -e` (e.g. a `.rpm` whose name is `--eval=%{lua:...}`).
- `pkg.ValidateRepoBaseURL` — dnf `baseurl` / zypper `url` / pacman `server` must be **https** with a host (package-manager template vars `$releasever`/`$arch` survive). apt is intentionally excluded — its security model is the gpg-signed Release file, so http+gpg is legitimate.
- `pkg.ValidateGpgKeyRef` — a dnf/zypper `Gpgkey` passed to `rpm --import` is restricted to an https URL, a `file:///abs` path, or an absolute path; no `..`, no leading `-`, no `http://`, no rpm `ext::` external transport.
- `pkg.ValidateRemoteName` — a flatpak remote alias is a leading-alphanumeric operand.
- `exec.SeparatePositionals(flags, positionals...)` + `exec.EndOfOptions` — returns a fresh slice with `--` always inserted before operands, without mutating the caller's `flags`.

## Tests

- `go/pkg/validate_test.go`: accept/reject tables for each validator, with the **invalid cases sourced from intent** (leading `-`/`=`, metacharacters, control chars, `http://`, `ext::`, traversal), plus the `ABSENT` (empty) case.
- `go/sys/exec/argv_test.go`: `--` is always inserted and precedes every operand; the caller's `flags` slice is never mutated.

All green; `go vet`, `gofmt`, and the `archtest` fitness functions pass. The agent PR consumes these next (advances the same issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validators for secure package manager inputs including RPM package names, repository URLs, GPG key references, and remote aliases
  * Improved argument construction to prevent option injection by enforcing separation between flags and positional arguments

* **Documentation**
  * Added guide documenting argument-hardening validators and their validation rules

* **Tests**
  * Comprehensive test coverage for new validators and argument handling logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->