### PR TITLE
feat: enrollment CA-pin field + bounded bootstrap transport + VerifyCAContinuity (sdk#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ result, _ := sdk.RenewCertificate(ctx, controlURL, csrPEM, currentCertPEM)
 
 The agent presents its current (still valid) certificate and a new CSR. The Control Server verifies the certificate, checks the fingerprint against the database, signs the new CSR, and returns the active CA certificate. If the CA has been rotated, the agent should update its stored CA certificate.
 
+**Bootstrap transport hardening.** `RegisterAgent` and `RenewCertificate` are the unauthenticated bootstrap calls; their default HTTP client is bounded (request timeout + TLS 1.3 floor) so a hung or malicious control endpoint cannot wedge enrollment/renewal. Proxy support is retained for enterprise deployments (the channel is TLS-authenticated and the optional enrollment CA-pin catches a wrong-CA outcome). A `ClientOption` (the mTLS variants) overrides the client entirely.
+
+**Enrollment trust helpers** (`go/crypto`):
+
+```go
+fp, _ := crypto.CAFingerprintFromPEM(caPEM)        // lowercase-hex SHA-256 of the CA DER
+err := crypto.VerifyCAContinuity(oldCAPEM, newCAPEM) // accept only an identical or cross-signed CA
+```
+
+`CAFingerprintFromPEM` is byte-identical to the control server's `ca.FingerprintFromPEM`, so an operator-supplied out-of-band pin (e.g. `openssl x509 -in ca.crt -outform DER | sha256sum`) matches what the agent derives from the registration-returned CA. `VerifyCAContinuity` guards certificate rotation: a returned CA is adopted only when it is byte-identical to, or cross-signed by, the enrolled CA — refusing an unrelated trust-anchor swap.
+
 ### Package Manager Library
 
 `go/pkg/` abstracts five Linux package managers behind a unified interface with a builder API:

--- a/gen/go/pm/v1/device_auth.pb.go
+++ b/gen/go/pm/v1/device_auth.pb.go
@@ -24,11 +24,25 @@ const (
 type EnrollRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,url"
-	ServerUrl string `protobuf:"bytes,1,opt,name=server_url,json=serverUrl,proto3" json:"server_url,omitempty" validate:"required,url"` // Control server URL
+	ServerUrl string `protobuf:"bytes,1,opt,name=server_url,json=serverUrl,proto3" json:"server_url,omitempty" validate:"required,url"` // Control server URL (https only — enforced agent-side)
 	// @gotags: validate:"required"
-	Token         string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required"` // Registration token from web UI
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Token string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty" validate:"required"` // Registration token from web UI
+	// Optional out-of-band CA fingerprint pin: the 64-char hex SHA-256 of
+	// the control CA certificate DER. When set, the agent verifies the CA
+	// returned by registration matches this pin BEFORE trusting it,
+	// defending against a first-enrollment trust-anchor swap. Delivered by
+	// the operator alongside the token (e.g. power-manage://…?token=…&pin=…).
+	// Absent = trust-on-first-use (accepted residual). Case-insensitive:
+	// the enroll CLI strips colons and lowercases the operator's value
+	// (openssl emits uppercase, colon-separated) and the agent compares
+	// with EqualFold, so the `hexadecimal` tag is intentionally permissive
+	// on case. Field 3 (formerly the removed skip_verify bool) is reused in
+	// place — EnrollRequest only crosses the local enrollment socket within
+	// one agent binary, so there is no cross-version wire concern.
+	// @gotags: validate:"omitempty,len=64,hexadecimal"
+	CaFingerprintPin string `protobuf:"bytes,3,opt,name=ca_fingerprint_pin,json=caFingerprintPin,proto3" json:"ca_fingerprint_pin,omitempty" validate:"omitempty,len=64,hexadecimal"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *EnrollRequest) Reset() {
@@ -71,6 +85,13 @@ func (x *EnrollRequest) GetServerUrl() string {
 func (x *EnrollRequest) GetToken() string {
 	if x != nil {
 		return x.Token
+	}
+	return ""
+}
+
+func (x *EnrollRequest) GetCaFingerprintPin() string {
+	if x != nil {
+		return x.CaFingerprintPin
 	}
 	return ""
 }
@@ -240,11 +261,12 @@ var File_pm_v1_device_auth_proto protoreflect.FileDescriptor
 
 const file_pm_v1_device_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x17pm/v1/device_auth.proto\x12\x05pm.v1\"W\n" +
+	"\x17pm/v1/device_auth.proto\x12\x05pm.v1\"r\n" +
 	"\rEnrollRequest\x12\x1d\n" +
 	"\n" +
 	"server_url\x18\x01 \x01(\tR\tserverUrl\x12\x14\n" +
-	"\x05token\x18\x02 \x01(\tR\x05tokenJ\x04\b\x03\x10\x04R\vskip_verify\"]\n" +
+	"\x05token\x18\x02 \x01(\tR\x05token\x12,\n" +
+	"\x12ca_fingerprint_pin\x18\x03 \x01(\tR\x10caFingerprintPin\"]\n" +
 	"\x0eEnrollResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x1b\n" +
 	"\tdevice_id\x18\x02 \x01(\tR\bdeviceId\x12\x14\n" +

--- a/gen/ts/pm/v1/device_auth_pb.ts
+++ b/gen/ts/pm/v1/device_auth_pb.ts
@@ -10,7 +10,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file pm/v1/device_auth.proto.
  */
 export const file_pm_v1_device_auth: GenFile = /*@__PURE__*/
-  fileDesc("ChdwbS92MS9kZXZpY2VfYXV0aC5wcm90bxIFcG0udjEiRQoNRW5yb2xsUmVxdWVzdBISCgpzZXJ2ZXJfdXJsGAEgASgJEg0KBXRva2VuGAIgASgJSgQIAxAEUgtza2lwX3ZlcmlmeSJDCg5FbnJvbGxSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEhEKCWRldmljZV9pZBgCIAEoCRINCgVlcnJvchgDIAEoCSIcChpHZXRFbnJvbGxtZW50U3RhdHVzUmVxdWVzdCJCChtHZXRFbnJvbGxtZW50U3RhdHVzUmVzcG9uc2USEAoIZW5yb2xsZWQYASABKAgSEQoJZGV2aWNlX2lkGAIgASgJMqgBChFEZXZpY2VBdXRoU2VydmljZRI1CgZFbnJvbGwSFC5wbS52MS5FbnJvbGxSZXF1ZXN0GhUucG0udjEuRW5yb2xsUmVzcG9uc2USXAoTR2V0RW5yb2xsbWVudFN0YXR1cxIhLnBtLnYxLkdldEVucm9sbG1lbnRTdGF0dXNSZXF1ZXN0GiIucG0udjEuR2V0RW5yb2xsbWVudFN0YXR1c1Jlc3BvbnNlQjpaOGdpdGh1Yi5jb20vbWFuY2h0b29scy9wb3dlci1tYW5hZ2Uvc2RrL2dlbi9nby9wbS92MTtwbXYxYgZwcm90bzM");
+  fileDesc("ChdwbS92MS9kZXZpY2VfYXV0aC5wcm90bxIFcG0udjEiTgoNRW5yb2xsUmVxdWVzdBISCgpzZXJ2ZXJfdXJsGAEgASgJEg0KBXRva2VuGAIgASgJEhoKEmNhX2ZpbmdlcnByaW50X3BpbhgDIAEoCSJDCg5FbnJvbGxSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEhEKCWRldmljZV9pZBgCIAEoCRINCgVlcnJvchgDIAEoCSIcChpHZXRFbnJvbGxtZW50U3RhdHVzUmVxdWVzdCJCChtHZXRFbnJvbGxtZW50U3RhdHVzUmVzcG9uc2USEAoIZW5yb2xsZWQYASABKAgSEQoJZGV2aWNlX2lkGAIgASgJMqgBChFEZXZpY2VBdXRoU2VydmljZRI1CgZFbnJvbGwSFC5wbS52MS5FbnJvbGxSZXF1ZXN0GhUucG0udjEuRW5yb2xsUmVzcG9uc2USXAoTR2V0RW5yb2xsbWVudFN0YXR1cxIhLnBtLnYxLkdldEVucm9sbG1lbnRTdGF0dXNSZXF1ZXN0GiIucG0udjEuR2V0RW5yb2xsbWVudFN0YXR1c1Jlc3BvbnNlQjpaOGdpdGh1Yi5jb20vbWFuY2h0b29scy9wb3dlci1tYW5hZ2Uvc2RrL2dlbi9nby9wbS92MTtwbXYxYgZwcm90bzM");
 
 /**
  * @generated from message pm.v1.EnrollRequest
@@ -19,7 +19,7 @@ export type EnrollRequest = Message<"pm.v1.EnrollRequest"> & {
   /**
    * @gotags: validate:"required,url"
    *
-   * Control server URL
+   * Control server URL (https only — enforced agent-side)
    *
    * @generated from field: string server_url = 1;
    */
@@ -33,6 +33,25 @@ export type EnrollRequest = Message<"pm.v1.EnrollRequest"> & {
    * @generated from field: string token = 2;
    */
   token: string;
+
+  /**
+   * Optional out-of-band CA fingerprint pin: the 64-char hex SHA-256 of
+   * the control CA certificate DER. When set, the agent verifies the CA
+   * returned by registration matches this pin BEFORE trusting it,
+   * defending against a first-enrollment trust-anchor swap. Delivered by
+   * the operator alongside the token (e.g. power-manage://…?token=…&pin=…).
+   * Absent = trust-on-first-use (accepted residual). Case-insensitive:
+   * the enroll CLI strips colons and lowercases the operator's value
+   * (openssl emits uppercase, colon-separated) and the agent compares
+   * with EqualFold, so the `hexadecimal` tag is intentionally permissive
+   * on case. Field 3 (formerly the removed skip_verify bool) is reused in
+   * place — EnrollRequest only crosses the local enrollment socket within
+   * one agent binary, so there is no cross-version wire concern.
+   * @gotags: validate:"omitempty,len=64,hexadecimal"
+   *
+   * @generated from field: string ca_fingerprint_pin = 3;
+   */
+  caFingerprintPin: string;
 };
 
 /**

--- a/go/client.go
+++ b/go/client.go
@@ -86,6 +86,11 @@ func NewClient(serverURL string, opts ...ClientOption) *Client {
 		luksRevokeSem: make(chan struct{}, luksRevokeDispatchConcurrency),
 	}
 
+	// http.DefaultClient (no Timeout) is correct here: the agent client
+	// drives a long-lived bidi stream, and a whole-request timeout would
+	// kill it. In production NewClient is always given a WithMTLS* option
+	// that replaces this anyway. (The unary RegisterAgent/RenewCertificate
+	// bootstrap calls use the bounded bootstrapHTTPClient instead.)
 	httpClient := http.DefaultClient
 	for _, opt := range opts {
 		opt.apply(c, &httpClient)
@@ -281,6 +286,34 @@ func WithH2C() ClientOption {
 	}}
 }
 
+// bootstrapHTTPClient is the default client for the unauthenticated
+// RegisterAgent / RenewCertificate bootstrap calls. Unlike
+// http.DefaultClient it has a bounded Timeout (a hung or malicious
+// control endpoint must not be able to wedge enrollment/renewal forever)
+// and a TLS 1.3 floor. Proxy support is deliberately retained
+// (http.ProxyFromEnvironment): the agent runs as root under systemd with
+// a controlled environment, the channel is TLS-authenticated, and the
+// optional enrollment CA-pin catches a wrong-CA outcome — so honoring an
+// enterprise proxy is the right trade-off over breaking proxied
+// deployments. Overridable via ClientOption (the renewal mTLS variants
+// replace the client entirely).
+func bootstrapHTTPClient() *http.Client {
+	transport := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13},
+	}
+	// Preserve HTTP/2 parity with http.DefaultClient for the https
+	// control endpoint; falls back to HTTP/1.1 if configuration fails
+	// (unary register/renew works over either).
+	if err := http2.ConfigureTransport(transport); err != nil {
+		slog.Default().Warn("bootstrap: failed to configure HTTP/2 transport; falling back to HTTP/1.1", "error", err)
+	}
+	return &http.Client{
+		Timeout:   60 * time.Second,
+		Transport: transport,
+	}
+}
+
 // RegisterAgentResult contains the result of agent registration.
 type RegisterAgentResult struct {
 	DeviceID    string
@@ -295,7 +328,7 @@ type RegisterAgentResult struct {
 // Returns the gateway URL that the agent should use for streaming.
 func RegisterAgent(ctx context.Context, controlURL string, token, hostname, agentVersion string, csr []byte, opts ...ClientOption) (*RegisterAgentResult, error) {
 	c := &Client{}
-	httpClient := http.DefaultClient
+	httpClient := bootstrapHTTPClient()
 	for _, opt := range opts {
 		opt.apply(c, &httpClient)
 	}
@@ -333,7 +366,7 @@ type RenewCertificateResult struct {
 // The agent presents its current certificate for identity verification.
 func RenewCertificate(ctx context.Context, controlURL string, csr, currentCert []byte, opts ...ClientOption) (*RenewCertificateResult, error) {
 	c := &Client{}
-	httpClient := http.DefaultClient
+	httpClient := bootstrapHTTPClient()
 	for _, opt := range opts {
 		opt.apply(c, &httpClient)
 	}

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -2,7 +2,9 @@ package sdk
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +13,27 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
+
+// TestBootstrapHTTPClient_Bounded pins the transport hardening for the
+// unauthenticated RegisterAgent/RenewCertificate bootstrap calls
+// (sdk#104): a bounded timeout (no hang/DoS) and a TLS 1.3 floor.
+// RegisterAgent and RenewCertificate use this as their default client.
+func TestBootstrapHTTPClient_Bounded(t *testing.T) {
+	c := bootstrapHTTPClient()
+	if c.Timeout == 0 {
+		t.Error("bootstrap client has no Timeout (a hung control endpoint could wedge enrollment)")
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", c.Transport)
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("bootstrap transport has no TLSClientConfig")
+	}
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Errorf("TLS MinVersion = %#x, want TLS 1.3 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS13)
+	}
+}
 
 // fakeTerminalHandler is a minimal StreamHandler+TerminalHandler that
 // records every call so dispatch tests can assert against it.

--- a/go/crypto/cert.go
+++ b/go/crypto/cert.go
@@ -1,0 +1,71 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+)
+
+// CAFingerprintFromPEM returns the lowercase-hex SHA-256 of the
+// certificate's DER bytes. It is byte-for-byte identical to the control
+// server's ca.FingerprintFromPEM, so an operator-delivered pin computed
+// from the control CA (e.g. `openssl x509 -in ca.crt -outform DER |
+// sha256sum`) matches what the agent derives from the CA returned at
+// registration. This is the out-of-band trust anchor for the optional
+// enrollment CA-pin.
+func CAFingerprintFromPEM(certPEM []byte) (string, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode certificate PEM")
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// VerifyCAContinuity reports whether newCAPEM is an acceptable rotation
+// of oldCAPEM: it must be byte-identical to the enrolled CA, OR be a CA
+// that is cross-signed by (chains to) the enrolled CA. An unrelated CA
+// is refused — that is the trust-anchor swap an attacker (or a
+// compromised/MITM'd control origin) would attempt at certificate
+// renewal. A hard CA swap (a new self-signed root not cross-signed by
+// the old one) is intentionally refused too: it requires re-enrollment,
+// not silent adoption over the renewal channel.
+func VerifyCAContinuity(oldCAPEM, newCAPEM []byte) error {
+	if len(newCAPEM) == 0 {
+		return fmt.Errorf("new CA is empty")
+	}
+	oldBlock, _ := pem.Decode(oldCAPEM)
+	if oldBlock == nil {
+		return fmt.Errorf("enrolled CA: failed to decode PEM")
+	}
+	newBlock, _ := pem.Decode(newCAPEM)
+	if newBlock == nil {
+		return fmt.Errorf("new CA: failed to decode PEM")
+	}
+
+	// The overwhelmingly common case — renewal returns the same CA.
+	if bytes.Equal(oldBlock.Bytes, newBlock.Bytes) {
+		return nil
+	}
+
+	oldCert, err := x509.ParseCertificate(oldBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("enrolled CA: %w", err)
+	}
+	newCert, err := x509.ParseCertificate(newBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("new CA: %w", err)
+	}
+
+	// Continuity: the new CA must be signed by the enrolled CA.
+	// CheckSignatureFrom verifies the signature AND that oldCert is a CA
+	// permitted to sign certificates (IsCA + BasicConstraints + CertSign
+	// key usage), so an unrelated self-signed CA fails here.
+	if err := newCert.CheckSignatureFrom(oldCert); err != nil {
+		return fmt.Errorf("new CA does not chain to the enrolled CA: %w", err)
+	}
+	return nil
+}

--- a/go/crypto/cert_test.go
+++ b/go/crypto/cert_test.go
@@ -1,0 +1,137 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// genCA creates a self-signed CA cert (PEM) + its key.
+func genCA(t *testing.T, cn string) ([]byte, *ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create ca: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
+}
+
+// genSubCA creates a CA cert (PEM) signed BY parent — a cross-signed /
+// successor CA, the legitimate-rotation continuity case.
+func genSubCA(t *testing.T, cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("subca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("create subca: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestCAFingerprintFromPEM pins that the fingerprint is the lowercase hex
+// SHA-256 of the certificate DER — byte-identical to the server's
+// ca.FingerprintFromPEM, so an operator-supplied pin (derived from the
+// control CA, e.g. `openssl x509 -outform DER | sha256sum`) matches.
+func TestCAFingerprintFromPEM(t *testing.T) {
+	caPEM, _, caCert := genCA(t, "fp-ca")
+	want := hex.EncodeToString(func() []byte { s := sha256.Sum256(caCert.Raw); return s[:] }())
+
+	got, err := CAFingerprintFromPEM(caPEM)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("fingerprint = %q, want %q", got, want)
+	}
+	if len(got) != 64 {
+		t.Errorf("fingerprint length = %d, want 64", len(got))
+	}
+	for _, c := range got {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Fatalf("fingerprint %q is not lowercase hex", got)
+		}
+	}
+
+	// ABSENT / malformed inputs fail.
+	if _, err := CAFingerprintFromPEM(nil); err == nil {
+		t.Error("empty PEM accepted; want error")
+	}
+	if _, err := CAFingerprintFromPEM([]byte("not a pem")); err == nil {
+		t.Error("non-PEM accepted; want error")
+	}
+}
+
+// TestVerifyCAContinuity pins the rotation guard: a returned CA is only
+// adopted if it is byte-identical to, or cross-signed by, the enrolled
+// CA. An unrelated CA (the trust-anchor-swap attack) is refused.
+func TestVerifyCAContinuity(t *testing.T) {
+	oldPEM, oldKey, oldCert := genCA(t, "old-ca")
+	successorPEM := genSubCA(t, "successor-ca", oldCert, oldKey)
+	unrelatedPEM, _, _ := genCA(t, "attacker-ca")
+
+	t.Run("byte-identical accepted", func(t *testing.T) {
+		if err := VerifyCAContinuity(oldPEM, oldPEM); err != nil {
+			t.Errorf("identical CA rejected: %v", err)
+		}
+	})
+	t.Run("cross-signed successor accepted", func(t *testing.T) {
+		if err := VerifyCAContinuity(oldPEM, successorPEM); err != nil {
+			t.Errorf("cross-signed successor CA rejected: %v", err)
+		}
+	})
+	t.Run("unrelated CA refused", func(t *testing.T) {
+		if err := VerifyCAContinuity(oldPEM, unrelatedPEM); err == nil {
+			t.Error("unrelated CA accepted; want refusal (trust-anchor swap)")
+		}
+	})
+	t.Run("empty new CA refused", func(t *testing.T) {
+		if err := VerifyCAContinuity(oldPEM, nil); err == nil {
+			t.Error("empty new CA accepted; want error")
+		}
+	})
+	t.Run("malformed PEM refused", func(t *testing.T) {
+		if err := VerifyCAContinuity(oldPEM, []byte("garbage")); err == nil {
+			t.Error("malformed new CA accepted; want error")
+		}
+		if err := VerifyCAContinuity([]byte("garbage"), oldPEM); err == nil {
+			t.Error("malformed old CA accepted; want error")
+		}
+	})
+}

--- a/go/url.go
+++ b/go/url.go
@@ -1,0 +1,43 @@
+package sdk
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateHTTPSURL returns a non-nil error unless raw is a well-formed
+// https://host URL. It parses rather than prefix-checks so every corner
+// a bare "starts with https://" test misses fails closed:
+//
+//   - non-https schemes (http, ftp, h2c, the empty scheme)
+//   - case variants (HTTP://, Https://) and leading whitespace
+//   - opaque forms (https:foo — Opaque != "")
+//   - hostless URLs (https:)
+//   - embedded user info (https://user:pass@host) and fragments
+//
+// It is the single source for the agent's https-only trust boundaries —
+// the enrollment server_url and the gateway URL — so a cleartext or
+// malformed endpoint is refused before any network call.
+func ValidateHTTPSURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	if strings.ToLower(u.Scheme) != "https" {
+		return fmt.Errorf("URL must use https, got scheme %q", u.Scheme)
+	}
+	if u.Opaque != "" {
+		return fmt.Errorf("URL must be https://host, not an opaque URL")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	if u.User != nil {
+		return fmt.Errorf("URL must not contain user info")
+	}
+	if u.Fragment != "" || u.RawFragment != "" {
+		return fmt.Errorf("URL must not contain a fragment")
+	}
+	return nil
+}

--- a/go/url_test.go
+++ b/go/url_test.go
@@ -1,0 +1,44 @@
+package sdk
+
+import "testing"
+
+// TestValidateHTTPSURL pins the https-only trust-boundary rule. Invalid
+// cases are sourced from intent (a cleartext/opaque/hostless/credential-
+// bearing endpoint must fail closed), not from the parser under test.
+func TestValidateHTTPSURL(t *testing.T) {
+	accept := []string{
+		"https://control.example.com",
+		"https://control.example.com:8081",
+		"https://control.example.com:8081/path",
+		"  https://control.example.com  ", // leading/trailing whitespace trimmed
+		"Https://control.example.com",     // case-variant scheme normalizes to https
+	}
+	for _, u := range accept {
+		t.Run("ok/"+u, func(t *testing.T) {
+			if err := ValidateHTTPSURL(u); err != nil {
+				t.Errorf("ValidateHTTPSURL(%q) = %v, want nil", u, err)
+			}
+		})
+	}
+
+	reject := []string{
+		"",                           // ABSENT
+		"http://control.example.com", // cleartext
+		"HTTP://control.example.com", // case variant of cleartext
+		"h2c://control.example.com",  // wrong scheme
+		"ftp://x",                    // wrong scheme
+		"control.example.com",        // scheme-less
+		"https:foo",                  // opaque
+		"https:",                     // scheme, no host
+		"https://",                   // no host
+		"https://user:pass@host",     // embedded credentials
+		"https://host#frag",          // fragment
+	}
+	for _, u := range reject {
+		t.Run("reject/"+u, func(t *testing.T) {
+			if err := ValidateHTTPSURL(u); err == nil {
+				t.Errorf("ValidateHTTPSURL(%q) = nil, want error", u)
+			}
+		})
+	}
+}

--- a/proto/pm/v1/device_auth.proto
+++ b/proto/pm/v1/device_auth.proto
@@ -27,11 +27,23 @@ service DeviceAuthService {
 
 message EnrollRequest {
   // @gotags: validate:"required,url"
-  string server_url = 1; // Control server URL
+  string server_url = 1; // Control server URL (https only — enforced agent-side)
   // @gotags: validate:"required"
   string token = 2; // Registration token from web UI
-  reserved 3; // was bool skip_verify; removed in 2026.05 (TLS bypass is not supported)
-  reserved "skip_verify";
+  // Optional out-of-band CA fingerprint pin: the 64-char hex SHA-256 of
+  // the control CA certificate DER. When set, the agent verifies the CA
+  // returned by registration matches this pin BEFORE trusting it,
+  // defending against a first-enrollment trust-anchor swap. Delivered by
+  // the operator alongside the token (e.g. power-manage://…?token=…&pin=…).
+  // Absent = trust-on-first-use (accepted residual). Case-insensitive:
+  // the enroll CLI strips colons and lowercases the operator's value
+  // (openssl emits uppercase, colon-separated) and the agent compares
+  // with EqualFold, so the `hexadecimal` tag is intentionally permissive
+  // on case. Field 3 (formerly the removed skip_verify bool) is reused in
+  // place — EnrollRequest only crosses the local enrollment socket within
+  // one agent binary, so there is no cross-version wire concern.
+  // @gotags: validate:"omitempty,len=64,hexadecimal"
+  string ca_fingerprint_pin = 3;
 }
 
 message EnrollResponse {


### PR DESCRIPTION
Advances `manchtools/power-manage-sdk#104`. Supports WS9 agent enrollment hardening (the chosen scope: optional out-of-band CA pin + transport hardening — **no** server-signed enrollment artifact).

## What
- **`EnrollRequest.ca_fingerprint_pin`** (optional, 64-hex) — the operator-delivered OOB pin the agent verifies the registration-returned CA against *before* trusting it (first-enrollment trust-anchor-swap defense). Reuses field 3 in place (the message only crosses the local enrollment socket within one binary, so there's no cross-version wire concern). Case-insensitive by design — the enroll CLI strips colons + lowercases the operator's value and the agent compares with `EqualFold`.
- **Bounded bootstrap transport** — `RegisterAgent` / `RenewCertificate` default to a client with a request **timeout** and a **TLS 1.3 floor** (was `http.DefaultClient` — no timeout, TLS 1.2). Proxy support retained (TLS + the optional pin already protect the channel; don't break proxied enterprise deployments). `NewClient` keeps the no-timeout client — a whole-request timeout would kill its long-lived bidi stream.
- **`crypto.CAFingerprintFromPEM`** — lowercase-hex SHA-256 of the CA DER, byte-identical to the server's `ca.FingerprintFromPEM`, so an operator pin from `openssl x509 -outform DER | sha256sum` matches.
- **`crypto.VerifyCAContinuity`** — a rotated CA is accepted only if byte-identical to, or cross-signed by, the enrolled CA; an unrelated CA is refused (the trust-anchor swap on renewal). The control server returns the same CA on every renewal today, so this never refuses a legitimate renewal.

## Tests
- `crypto/cert_test.go`: fingerprint matches `hex(sha256(DER))`; continuity accepts identical + cross-signed, refuses unrelated/empty/malformed.
- `client_test.go`: bootstrap client has a timeout + TLS 1.3 floor.

cr clean (1 minor proto-comment finding folded). gen/go + gen/ts regenerated.