### PR TITLE
test(crypto,encryption): bind keyPEM to CSR pubkey + pin LUKS tmpfs key-file (sdk#106)

### DIFF
--- a/go/crypto/csr_test.go
+++ b/go/crypto/csr_test.go
@@ -74,6 +74,19 @@ func TestGenerateCSR(t *testing.T) {
 	if key.Curve != elliptic.P256() {
 		t.Fatalf("key curve = %v, want P-256", key.Curve.Params().Name)
 	}
+
+	// The returned private key MUST be the one that signed the CSR — its
+	// public half must equal the CSR's embedded public key. A GenerateCSR
+	// bug that signs with key-A but returns key-B (the key-swap path the
+	// other assertions cannot catch) would leave the agent unable to use
+	// the issued certificate. (#5)
+	csrPub, ok := csr.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("CSR public key type = %T, want *ecdsa.PublicKey", csr.PublicKey)
+	}
+	if key.PublicKey.X.Cmp(csrPub.X) != 0 || key.PublicKey.Y.Cmp(csrPub.Y) != 0 {
+		t.Fatal("returned keyPEM does not match the CSR's embedded public key")
+	}
 }
 
 func TestGenerateCSR_DifferentHostnames(t *testing.T) {

--- a/go/sys/encryption/luks_test.go
+++ b/go/sys/encryption/luks_test.go
@@ -6,6 +6,36 @@ import (
 	"testing"
 )
 
+// TestWriteKeyFile_TmpfsAnd0600 pins the no-argv-secret directive: a LUKS
+// passphrase reaches cryptsetup via a tmpfs (/dev/shm) --key-file at mode
+// 0600, never on the command line where it would be world-readable in
+// /proc/<pid>/cmdline.
+func TestWriteKeyFile_TmpfsAnd0600(t *testing.T) {
+	path, err := writeKeyFile("secret-passphrase")
+	if err != nil {
+		t.Skipf("writeKeyFile needs %s (tmpfs): %v", keyFileDir, err)
+	}
+	t.Cleanup(func() { cleanupKeyFile(path) })
+
+	if !strings.HasPrefix(path, keyFileDir+"/") {
+		t.Errorf("key file %q is not under the tmpfs dir %q", path, keyFileDir)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("key file mode = %v, want 0600", info.Mode().Perm())
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read key file: %v", err)
+	}
+	if string(b) != "secret-passphrase" {
+		t.Error("key file content does not match the passphrase")
+	}
+}
+
 // ─── GeneratePassphrase tests ────────────────────────────────────────────────
 
 func TestGeneratePassphrase_MinWords(t *testing.T) {


### PR DESCRIPTION
Closes #106. WS10 test hardening — no production code change, both pin existing correct behavior.

- **TestGenerateCSR** now asserts the returned `keyPEM`'s public half equals the CSR's embedded public key (finding #5) — catches a `GenerateCSR` bug that would sign with one key and return another.
- **TestWriteKeyFile_TmpfsAnd0600** pins the no-argv-secret directive: a LUKS passphrase reaches `cryptsetup` via a `/dev/shm` (tmpfs) `--key-file` at mode 0600, never on argv.

(The `SetPassword` stdin no-argv pin was intentionally skipped — `PrivilegeBackend` is an int selector with no injectable exec-capture seam, and the password is fed via the stdin `Reader` with argv `[chpasswd]` by construction.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced CSR generation testing to verify that generated private keys properly correspond with their embedded public keys.
* Added validation test for key file creation, ensuring proper file permissions and content accuracy in secure storage environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->