### PR TITLE
Harden agent stream dispatch loop: per-message recover, nil-guards, inbound size bound + fan-out cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ client.Run(ctx, handler)
 
 Features: mTLS authentication, automatic heartbeat, action result reporting, live output streaming, security alerts.
 
+#### Stream-loop robustness
+
+The receive loop is hardened against a compromised or buggy gateway:
+
+- **Inbound size bound.** `NewClient` wires `connect.WithReadMaxBytes(maxInboundMessageBytes)` (16 MiB). An over-large `ServerMessage` is refused with a resource-exhausted error and the connection is torn down cleanly (the loop reconnects) instead of allocating the frame — closing an OOM/DoS vector.
+- **Per-message panic isolation.** `dispatchServerMessage` runs each message under a scoped `recover()`: a panic inside any handler method is caught, logged, and turned into a non-fatal dropped frame so one bad handler invocation cannot crash-loop the whole agent (fleet DoS). Genuine fatal stream send/receive errors still propagate.
+- **Bounded, panic-safe goroutine fan-out.** The server-originated `RequestInventory` and `RevokeLuksDeviceKey` legs (and the inventory ticker) run through `safeGo` — a spawned goroutine with its own deferred `recover()` — and are gated behind bounded semaphores so a flood of frames cannot spawn unbounded goroutines or crash the process from a goroutine panic.
+- **Malformed-oneof nil-guards.** A `ServerMessage` whose inner oneof payload is nil (e.g. a `ServerMessage_Action` with a nil `ActionDispatch`) is logged and dropped, never dereferenced.
+
 ### Certificate Renewal
 
 `go/client.go` also provides a standalone `RenewCertificate` function for certificate rotation:

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Features: mTLS authentication, automatic heartbeat, action result reporting, liv
 
 The receive loop is hardened against a compromised or buggy gateway:
 
-- **Inbound size bound.** `NewClient` wires `connect.WithReadMaxBytes(maxInboundMessageBytes)` (16 MiB). An over-large `ServerMessage` is refused with a resource-exhausted error and the connection is torn down cleanly (the loop reconnects) instead of allocating the frame — closing an OOM/DoS vector.
-- **Per-message panic isolation.** `dispatchServerMessage` runs each message under a scoped `recover()`: a panic inside any handler method is caught, logged, and turned into a non-fatal dropped frame so one bad handler invocation cannot crash-loop the whole agent (fleet DoS). Genuine fatal stream send/receive errors still propagate.
+- **Inbound size bound.** `NewClient` wires `connect.WithReadMaxBytes(maxInboundMessageBytes)` (16 MiB). An over-large `ServerMessage` is refused with a resource-exhausted error and `Run` returns cleanly; the caller's reconnect loop (the agent connection loop) re-establishes the stream, instead of allocating the frame — closing an OOM/DoS vector.
+- **Per-message panic isolation.** `dispatchServerMessage` runs each message under a scoped `recover()`: a panic inside any handler method is caught, logged, and turned into a non-fatal dropped frame so one bad handler invocation cannot crash-loop the whole agent (fleet DoS). Genuine fatal stream send/receive errors still propagate (they return from `Run`, leaving reconnection to the caller).
 - **Bounded, panic-safe goroutine fan-out.** The server-originated `RequestInventory` and `RevokeLuksDeviceKey` legs (and the inventory ticker) run through `safeGo` — a spawned goroutine with its own deferred `recover()` — and are gated behind bounded semaphores so a flood of frames cannot spawn unbounded goroutines or crash the process from a goroutine panic.
 - **Malformed-oneof nil-guards.** A `ServerMessage` whose inner oneof payload is nil (e.g. a `ServerMessage_Action` with a nil `ActionDispatch`) is logged and dropped, never dereferenced.
 

--- a/go/client.go
+++ b/go/client.go
@@ -893,9 +893,12 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 		}
 	}()
 
-	// Inventory: send on connect + every 24 hours
+	// Inventory: send on connect + every 24 hours. safeGo guards the
+	// loop so a panic in the agent-initiated CollectInventory path cannot
+	// crash the whole agent process (a panic in a bare goroutine is
+	// unrecoverable by the parent).
 	if invHandler, ok := handler.(InventoryHandler); ok {
-		go func() {
+		c.safeGo("inventory-ticker", func() {
 			// sendWithRetry sends inventory with up to 3 attempts at
 			// 1s/3s/9s backoff. The 24-hour ticker means a single
 			// transient send failure (network blip on connect) would
@@ -939,7 +942,7 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	// Channel to receive messages from blocking Receive call
@@ -1020,13 +1023,53 @@ func (c *Client) applyWelcomeHeartbeat(w *pm.Welcome) {
 	}
 }
 
+// safeGo runs fn in a new goroutine with a deferred recover so a panic
+// in a server-originated fan-out handler (inventory, LUKS revoke,
+// inventory ticker) cannot crash the whole agent process. A panic in a
+// goroutine is unrecoverable by the parent, so each spawned goroutine
+// must guard itself. label identifies the leg in the log line.
+func (c *Client) safeGo(label string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Error("recovered panic in stream dispatch goroutine",
+					"leg", label, "panic", fmt.Sprintf("%v", r))
+			}
+		}()
+		fn()
+	}()
+}
+
 // dispatchServerMessage routes a single ServerMessage to the appropriate
 // handler method. Extracted from Run for testability — call sites that
 // need a fake stream or hand-built messages can drive this directly.
 // Returns a non-nil error only for fatal stream errors that should tear
 // down the connection; per-message handler failures (LUKS, terminal,
 // etc.) are wrapped before returning so callers see what failed.
-func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessage, handler StreamHandler) error {
+//
+// The per-message body runs under a deferred recover(): a panic inside ANY
+// handler method is caught, logged, and turned into a NON-fatal outcome
+// (dispatch returns nil) so one buggy or hostile handler invocation cannot
+// crash-loop the agent (Run treats a returned error as fatal and tears the
+// connection down). Genuine fatal stream send/receive errors still return
+// as errors — only handler PANICS become non-fatal.
+func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessage, handler StreamHandler) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var payloadType string
+			if msg != nil {
+				payloadType = fmt.Sprintf("%T", msg.Payload)
+			}
+			var msgID string
+			if msg != nil {
+				msgID = msg.Id
+			}
+			c.logger.Error("recovered panic while dispatching ServerMessage; dropping frame (non-fatal)",
+				"message_id", msgID, "payload_type", payloadType, "panic", fmt.Sprintf("%v", r))
+			// Non-fatal: keep the receive loop alive.
+			retErr = nil
+		}
+	}()
 	switch p := msg.Payload.(type) {
 	case *pm.ServerMessage_Welcome:
 		c.applyWelcomeHeartbeat(p.Welcome)
@@ -1089,7 +1132,9 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			// capacity so a flood cannot spawn unbounded osquery forks.
 			select {
 			case c.invSem <- struct{}{}:
-				go func() {
+				// safeGo: a panic in OnRequestInventory runs in this spawned
+				// goroutine and would otherwise crash the whole agent.
+				c.safeGo("inventory", func() {
 					defer func() { <-c.invSem }()
 					// Server-originated: verify the signature (inside the
 					// handler) before collecting. A forged RequestInventory
@@ -1100,7 +1145,7 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 							c.logger.Warn("failed to send inventory", "error", err)
 						}
 					}
-				}()
+				})
 			default:
 				c.logger.Warn("dropping RequestInventory: inventory collection already at capacity",
 					"message_id", msg.Id, "limit", inventoryDispatchConcurrency)
@@ -1138,7 +1183,9 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			// unbounded goroutines (WS6 #11).
 			select {
 			case c.luksRevokeSem <- struct{}{}:
-				go func() {
+				// safeGo: a panic in OnRevokeLuksDeviceKey runs in this
+				// spawned goroutine and would otherwise crash the agent.
+				c.safeGo("luks-revoke", func() {
 					defer func() { <-c.luksRevokeSem }()
 					// Pass the full message so the handler can verify the CA
 					// signature binding action_id before the destructive wipe.
@@ -1146,7 +1193,7 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 					if err := c.SendRevokeLuksDeviceKeyResult(ctx, actionID, success, errMsg); err != nil {
 						c.logger.Warn("failed to send LUKS revocation result", "action_id", actionID, "error", err)
 					}
-				}()
+				})
 			default:
 				c.logger.Warn("dropping RevokeLuksDeviceKey: revocation already at capacity",
 					"message_id", msg.Id, "action_id", actionID, "limit", luksRevokeDispatchConcurrency)

--- a/go/client.go
+++ b/go/client.go
@@ -1072,12 +1072,26 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 	}()
 	switch p := msg.Payload.(type) {
 	case *pm.ServerMessage_Welcome:
+		if p.Welcome == nil {
+			c.logger.Warn("dropping Welcome with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		c.applyWelcomeHeartbeat(p.Welcome)
 		if err := handler.OnWelcome(ctx, p.Welcome); err != nil {
 			return fmt.Errorf("handle welcome: %w", err)
 		}
 
 	case *pm.ServerMessage_Action:
+		// Malformed-oneof guard: a compromised/buggy gateway could deliver a
+		// ServerMessage_Action whose inner ActionDispatch is nil. Reading
+		// p.Action.Envelope/.Signature on a nil p.Action is a nil-pointer
+		// dereference. Drop it non-fatally — every real Action on the wire
+		// carries the signed envelope + signature.
+		if p.Action == nil {
+			c.logger.Warn("dropping Action with nil dispatch payload", "message_id", msg.Id)
+			return nil
+		}
+
 		var actionResult *pm.ActionResult
 		var err error
 
@@ -1102,6 +1116,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_Query:
+		if p.Query == nil {
+			c.logger.Warn("dropping Query with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		queryResult, err := handler.OnQuery(ctx, p.Query)
 		if err != nil {
 			return fmt.Errorf("handle query: %w", err)
@@ -1113,6 +1131,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_Error:
+		if p.Error == nil {
+			c.logger.Warn("dropping Error with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if err := handler.OnError(ctx, p.Error); err != nil {
 			return fmt.Errorf("handle error: %w", err)
 		}
@@ -1153,6 +1175,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_LogQuery:
+		if p.LogQuery == nil {
+			c.logger.Warn("dropping LogQuery with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if lqHandler, ok := handler.(LogQueryHandler); ok {
 			result, err := lqHandler.OnLogQuery(ctx, p.LogQuery)
 			if err != nil {
@@ -1201,6 +1227,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_TerminalStart:
+		if p.TerminalStart == nil {
+			c.logger.Warn("dropping TerminalStart with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalStart(ctx, p.TerminalStart); err != nil {
 				return fmt.Errorf("handle terminal start: %w", err)
@@ -1211,6 +1241,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_TerminalInput:
+		if p.TerminalInput == nil {
+			c.logger.Warn("dropping TerminalInput with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalInput(ctx, p.TerminalInput); err != nil {
 				return fmt.Errorf("handle terminal input: %w", err)
@@ -1218,6 +1252,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_TerminalResize:
+		if p.TerminalResize == nil {
+			c.logger.Warn("dropping TerminalResize with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalResize(ctx, p.TerminalResize); err != nil {
 				return fmt.Errorf("handle terminal resize: %w", err)
@@ -1225,6 +1263,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_TerminalStop:
+		if p.TerminalStop == nil {
+			c.logger.Warn("dropping TerminalStop with nil payload", "message_id", msg.Id)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalStop(ctx, p.TerminalStop); err != nil {
 				return fmt.Errorf("handle terminal stop: %w", err)

--- a/go/client.go
+++ b/go/client.go
@@ -76,6 +76,18 @@ const (
 	// luksRevokeDispatchConcurrency bounds concurrent LUKS device-key
 	// revocations dispatched from the server.
 	luksRevokeDispatchConcurrency = 2
+
+	// maxInboundMessageBytes bounds the size of a single inbound
+	// ServerMessage the agent will decode. The agent only ever receives
+	// small control frames (actions, queries, terminal I/O chunks capped
+	// at 64 KiB, LUKS request-response) — none legitimately approach this
+	// size. Without a bound, a compromised or buggy gateway could push a
+	// multi-gigabyte frame and force the agent to allocate it, an OOM /
+	// DoS vector. 16 MiB is comfortably above any real frame yet refuses
+	// a frame whose only purpose is to exhaust memory. Enforced via
+	// connect.WithReadMaxBytes in NewClient; the connection that receives
+	// an oversized frame is torn down with a resource-exhausted error.
+	maxInboundMessageBytes = 16 << 20 // 16 MiB
 )
 
 // NewClient creates a new SDK client.
@@ -96,7 +108,15 @@ func NewClient(serverURL string, opts ...ClientOption) *Client {
 		opt.apply(c, &httpClient)
 	}
 
-	c.client = pmv1connect.NewAgentServiceClient(httpClient, serverURL)
+	// Bound the size of inbound ServerMessages. A compromised or buggy
+	// gateway could otherwise push an arbitrarily large frame and force
+	// the agent to allocate it (OOM/DoS). connect.WithReadMaxBytes makes
+	// the connection that receives an oversized frame fail with a
+	// resource-exhausted error and tear down cleanly, rather than
+	// allocate. The long-lived bidi stream is unaffected for normal
+	// (small) control frames.
+	c.client = pmv1connect.NewAgentServiceClient(httpClient, serverURL,
+		connect.WithReadMaxBytes(maxInboundMessageBytes))
 	return c
 }
 

--- a/go/client_dispatch_robust_test.go
+++ b/go/client_dispatch_robust_test.go
@@ -1,0 +1,345 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS15 #2 — stream-dispatch robustness.
+//
+// The SDK Client drives the agent's long-lived bidi stream. Run() treats a
+// non-nil return from dispatchServerMessage as FATAL and tears the connection
+// down. The design intent of WS15:
+//
+//   - A panic inside ANY handler method (including the spawned goroutine
+//     fan-out legs) must be caught and turned into a NON-fatal, logged drop —
+//     one bad handler invocation must not crash-loop the whole agent (fleet
+//     DoS). It must NOT propagate as the returned error.
+//   - A malformed Action oneof (nil inner Action/envelope) on the wire must be
+//     dropped, never dereferenced. Intent: "every Action on the wire carries an
+//     id ULID and a signed envelope"; an Action that doesn't is malformed and
+//     is refused, not crashed on.
+//   - The inbound ServerMessage size must be bounded so the client refuses an
+//     over-large frame (resource-exhausted) rather than allocating it.
+
+// ---------------------------------------------------------------------------
+// #2 — handler panic recovery
+// ---------------------------------------------------------------------------
+
+// panicStreamingHandler is a StreamingHandler whose OnActionWithStreaming
+// signals it actually ran (via `ran`) and then panics. The signal proves the
+// recover happens AFTER the handler body executed, not because the handler was
+// skipped — a test that passes by never reaching the handler proves nothing.
+type panicStreamingHandler struct {
+	ran          chan struct{}
+	panicAction  bool
+	panicInv     bool
+	panicRevoke  bool
+	normalResult *pm.ActionResult
+	mu           sync.Mutex
+	closed       bool
+}
+
+func (h *panicStreamingHandler) signalRan() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.closed {
+		close(h.ran)
+		h.closed = true
+	}
+}
+
+func (h *panicStreamingHandler) OnWelcome(ctx context.Context, w *pm.Welcome) error { return nil }
+func (h *panicStreamingHandler) OnAction(ctx context.Context, envelope, signature []byte) (*pm.ActionResult, error) {
+	return h.normalResult, nil
+}
+func (h *panicStreamingHandler) OnQuery(ctx context.Context, q *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (h *panicStreamingHandler) OnError(ctx context.Context, e *pm.Error) error { return nil }
+
+func (h *panicStreamingHandler) OnActionWithStreaming(ctx context.Context, envelope, signature []byte, sendChunk func(*pm.OutputChunk) error) (*pm.ActionResult, error) {
+	if h.panicAction {
+		h.signalRan()
+		panic("boom: handler exploded mid-dispatch")
+	}
+	return h.normalResult, nil
+}
+
+func (h *panicStreamingHandler) CollectInventory(ctx context.Context) *pm.DeviceInventory { return nil }
+func (h *panicStreamingHandler) OnRequestInventory(ctx context.Context, req *pm.RequestInventory) *pm.DeviceInventory {
+	if h.panicInv {
+		h.signalRan()
+		panic("boom: inventory handler exploded")
+	}
+	return nil
+}
+func (h *panicStreamingHandler) OnRevokeLuksDeviceKey(ctx context.Context, req *pm.RevokeLuksDeviceKey) (bool, string) {
+	if h.panicRevoke {
+		h.signalRan()
+		panic("boom: revoke handler exploded")
+	}
+	return false, ""
+}
+
+// validActionMessage builds a well-formed Action ServerMessage. The envelope
+// bytes are advisory for these dispatch tests (the panic handler never reads
+// them) but must be non-nil so the dispatch path that reads p.Action.Envelope
+// does not itself crash.
+func validActionMessage(t *testing.T) *pm.ServerMessage {
+	t.Helper()
+	env := &pm.SignedActionEnvelope{
+		ActionId:   &pm.ActionId{Value: "01HQ0000000000000000000000"},
+		ActionType: pm.ActionType_ACTION_TYPE_SHELL,
+	}
+	b, err := proto.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return &pm.ServerMessage{
+		Id: NewULID(),
+		Payload: &pm.ServerMessage_Action{
+			Action: &pm.ActionDispatch{Envelope: b, Signature: []byte("sig")},
+		},
+	}
+}
+
+func TestDispatch_HandlerPanic_Recovered_LoopSurvives(t *testing.T) {
+	t.Run("correct: handler returns normally, no recovery", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{})}
+		// No stream is connected, so a returned ActionResult would try to
+		// Send and fail; keep it nil so the happy path returns clean nil.
+		if err := c.dispatchServerMessage(context.Background(), validActionMessage(t), h); err != nil {
+			t.Fatalf("normal dispatch returned error: %v", err)
+		}
+	})
+
+	t.Run("the bug: handler panic must be caught and turned non-fatal", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{}), panicAction: true}
+
+		// RED today: the panic escapes dispatchServerMessage (no recover),
+		// crashing the test goroutine. After the fix, the panic is recovered
+		// and dispatch returns nil (NON-fatal — Run must keep the loop alive).
+		err := c.dispatchServerMessage(context.Background(), validActionMessage(t), h)
+		if err != nil {
+			t.Fatalf("recovered handler panic must be non-fatal (nil), got: %v", err)
+		}
+		// Prove the handler actually ran (so we recovered AFTER the body, not
+		// because the handler was skipped).
+		select {
+		case <-h.ran:
+		default:
+			t.Fatal("handler never ran — recovery proved nothing")
+		}
+	})
+
+	t.Run("fan-out leg: inventory goroutine panic must not crash the process", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{}), panicInv: true}
+		msg := &pm.ServerMessage{
+			Id: NewULID(),
+			Payload: &pm.ServerMessage_RequestInventory{
+				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000"},
+			},
+		}
+		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+			t.Fatalf("dispatch returned error: %v", err)
+		}
+		// The handler runs in a spawned goroutine; wait for it to enter and
+		// panic. A missing recover crashes the whole test binary (RED).
+		select {
+		case <-h.ran:
+		case <-time.After(2 * time.Second):
+			t.Fatal("inventory handler never ran")
+		}
+		// Give the recovered goroutine a moment to unwind cleanly.
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	t.Run("fan-out leg: luks-revoke goroutine panic must not crash the process", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{}), panicRevoke: true}
+		msg := &pm.ServerMessage{
+			Id: NewULID(),
+			Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
+				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000"},
+			},
+		}
+		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+			t.Fatalf("dispatch returned error: %v", err)
+		}
+		select {
+		case <-h.ran:
+		case <-time.After(2 * time.Second):
+			t.Fatal("revoke handler never ran")
+		}
+		time.Sleep(50 * time.Millisecond)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// #2 — malformed Action oneof (nil inner) must be dropped, never dereferenced
+// ---------------------------------------------------------------------------
+
+func TestDispatch_Action_NilEnvelope_NoPanic(t *testing.T) {
+	t.Run("correct: well-formed Action dispatches without error", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{})}
+		if err := c.dispatchServerMessage(context.Background(), validActionMessage(t), h); err != nil {
+			t.Fatalf("well-formed Action errored: %v", err)
+		}
+	})
+
+	t.Run("absent: nil inner Action must be dropped, not dereferenced", func(t *testing.T) {
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{})}
+		// ServerMessage_Action with a nil inner ActionEnvelope. The dispatch
+		// path reads p.Action.Envelope / p.Action.Signature; a nil p.Action is
+		// a nil-pointer dereference today (RED → panic).
+		msg := &pm.ServerMessage{
+			Id:      NewULID(),
+			Payload: &pm.ServerMessage_Action{Action: nil},
+		}
+		err := c.dispatchServerMessage(context.Background(), msg, h)
+		if err != nil {
+			t.Fatalf("nil Action must be dropped non-fatally, got: %v", err)
+		}
+		// The handler must NOT have been invoked on a malformed Action.
+		select {
+		case <-h.ran:
+			t.Fatal("handler was invoked on a malformed (nil) Action")
+		default:
+		}
+	})
+
+	t.Run("present-but-wrong: Action with nil Id reaches handler safely", func(t *testing.T) {
+		// Intent: an Action on the wire carries an Id ULID. A malformed Action
+		// missing the Id must not crash dispatch. The SDK passes the envelope
+		// bytes/signature straight through; with a nil-inner-Action guard plus
+		// the handler's own fail-closed verify, this is a clean non-fatal path.
+		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
+		h := &panicStreamingHandler{ran: make(chan struct{})}
+		msg := &pm.ServerMessage{
+			Id: NewULID(),
+			// ActionEnvelope present but with nil envelope bytes — a malformed
+			// wire Action. Must not panic; dispatch stays non-fatal.
+			Payload: &pm.ServerMessage_Action{Action: &pm.ActionDispatch{Envelope: nil, Signature: nil}},
+		}
+		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
+			t.Fatalf("malformed Action (nil envelope bytes) must be non-fatal, got: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// inbound message-size bound
+// ---------------------------------------------------------------------------
+
+// TestRun_InboundMessageSizeBounded proves the client refuses an over-large
+// inbound ServerMessage (resource-exhausted) instead of allocating it, and
+// that a message within the limit still round-trips. Asserting BOTH sides
+// (limit+1 fails AND a normal message succeeds) means the test cannot pass
+// against an unbounded client OR a client whose limit is absurdly small.
+func TestRun_InboundMessageSizeBounded(t *testing.T) {
+	if maxInboundMessageBytes <= 0 {
+		t.Fatalf("maxInboundMessageBytes = %d, want a positive bound", maxInboundMessageBytes)
+	}
+
+	t.Run("within limit: normal message round-trips", func(t *testing.T) {
+		l := newAgentLoopback(t)
+		welcomeOnce := func(ctx context.Context, s *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) error {
+			if _, err := s.Receive(); err != nil {
+				return err
+			}
+			if err := s.Send(&pm.ServerMessage{
+				Id:      NewULID(),
+				Payload: &pm.ServerMessage_Welcome{Welcome: &pm.Welcome{ServerVersion: "test"}},
+			}); err != nil {
+				return err
+			}
+			for {
+				if _, err := s.Receive(); err != nil {
+					return nil
+				}
+			}
+		}
+		l.handler.onStream = welcomeOnce
+
+		c := l.newClient(WithAuth("device", "tok"))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.Connect(ctx); err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		defer c.Close()
+		if err := c.SendHello(ctx, "h", "v"); err != nil {
+			t.Fatalf("SendHello: %v", err)
+		}
+		msg, err := c.Receive(ctx)
+		if err != nil {
+			t.Fatalf("Receive within limit failed: %v", err)
+		}
+		if msg.GetWelcome() == nil {
+			t.Fatalf("expected Welcome, got %T", msg.Payload)
+		}
+	})
+
+	t.Run("over limit: oversized inbound frame is refused (resource exhausted)", func(t *testing.T) {
+		l := newAgentLoopback(t)
+		oversize := func(ctx context.Context, s *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) error {
+			if _, err := s.Receive(); err != nil {
+				return err
+			}
+			// A LogQueryResult whose Logs field exceeds the inbound bound by a
+			// comfortable margin. The wire frame is therefore > maxInboundMessageBytes.
+			big := make([]byte, maxInboundMessageBytes+(1<<20))
+			for i := range big {
+				big[i] = 'a'
+			}
+			_ = s.Send(&pm.ServerMessage{
+				Id: NewULID(),
+				Payload: &pm.ServerMessage_Error{
+					Error: &pm.Error{Code: "x", Message: string(big)},
+				},
+			})
+			for {
+				if _, err := s.Receive(); err != nil {
+					return nil
+				}
+			}
+		}
+		l.handler.onStream = oversize
+
+		c := l.newClient(WithAuth("device", "tok"))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.Connect(ctx); err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		defer c.Close()
+		if err := c.SendHello(ctx, "h", "v"); err != nil {
+			t.Fatalf("SendHello: %v", err)
+		}
+		_, err := c.Receive(ctx)
+		if err == nil {
+			t.Fatal("oversized inbound frame was accepted; expected a resource-exhausted error")
+		}
+		var connectErr *connect.Error
+		if !errors.As(err, &connectErr) {
+			t.Fatalf("want a *connect.Error for the oversized frame, got %T: %v", err, err)
+		}
+		if connectErr.Code() != connect.CodeResourceExhausted {
+			t.Fatalf("oversized frame code = %v, want %v", connectErr.Code(), connect.CodeResourceExhausted)
+		}
+	})
+}

--- a/go/client_dispatch_robust_test.go
+++ b/go/client_dispatch_robust_test.go
@@ -202,7 +202,12 @@ func TestDispatch_Action_NilEnvelope_NoPanic(t *testing.T) {
 
 	t.Run("absent: nil inner Action must be dropped, not dereferenced", func(t *testing.T) {
 		c := NewClient("https://gw.invalid", WithAuth("01HZZZZZZZZZZZZZZZZZZZZZZZZ", ""))
-		h := &panicStreamingHandler{ran: make(chan struct{})}
+		// panicAction:true makes the "handler must NOT have been invoked"
+		// assertion BINDING: if the nil-guard regressed and the handler were
+		// reached, signalRan() closes h.ran (before the recovered panic), so
+		// the select below fires t.Fatal. Without the flag the handler returns
+		// silently and the assertion could never catch a leak.
+		h := &panicStreamingHandler{ran: make(chan struct{}), panicAction: true}
 		// ServerMessage_Action with a nil inner ActionEnvelope. The dispatch
 		// path reads p.Action.Envelope / p.Action.Signature; a nil p.Action is
 		// a nil-pointer dereference today (RED → panic).


### PR DESCRIPTION
Closes manchtools/power-manage-sdk#109

## What

WS15 (agent stream-loop robustness), SDK leg. Hardens the agent's bidi receive loop against a compromised or buggy gateway (the MITM/relay actor in the trust model).

### Changes

1. **Per-message panic recovery** (`fix(client)`). `dispatchServerMessage` now runs each message under a scoped `recover()`: a panic inside any handler method is caught, logged, and turned into a NON-fatal dropped frame so one bad handler invocation cannot crash-loop the agent (`Run` treats a returned error as fatal). Only handler *panics* become non-fatal; genuine fatal stream send/receive errors still propagate. A `safeGo` helper (deferred recover + log) wraps the inventory ticker and the `RequestInventory` / `RevokeLuksDeviceKey` goroutine fan-out legs so a panic in a spawned goroutine cannot crash the process.
2. **Malformed-oneof nil-guards** (`fix(client)`). A `ServerMessage` whose inner oneof payload is nil (e.g. `ServerMessage_Action` with a nil `ActionDispatch`, or any of Welcome/Query/Error/LogQuery/Terminal* variants) is logged and dropped non-fatally before any handler is invoked — never dereferenced.
3. **Inbound size bound** (`feat(client)`). `NewAgentServiceClient` is wired with `connect.WithReadMaxBytes(maxInboundMessageBytes)` (16 MiB). An oversized inbound frame fails with a resource-exhausted error and the connection tears down cleanly (the loop reconnects) instead of being allocated (OOM/DoS).

### Tests

`client_dispatch_robust_test.go` pins all three. Each was confirmed RED for the intended reason before the fix (panic unwinds the goroutine; nil-pointer deref reading the inner payload; oversized frame accepted). Correct / absent / present-but-wrong coverage; the panic handler signals via a channel that it actually ran so recovery proves it wraps real dispatch, not a skipped handler. Both sides of the size bound asserted (limit+1 fails resource-exhausted, within-limit round-trips) so the test cannot pass against an unbounded client.

### Notes

- No proto/sqlc changes — the wire types are unchanged; this is pure receive-loop hardening.
- The agent leg (terminal Cols/Rows bounds, fail-closed maintenance window, gateway-URL guard, etc.) ships separately in sdk→agent order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added stream-loop robustness documentation covering receive-loop hardening behaviors.

* **Bug Fixes**
  * Implemented inbound message size limits to prevent resource exhaustion from oversized frames.
  * Added panic recovery mechanisms to prevent client crashes from handler errors.
  * Added defensive validation for malformed server payloads to prevent crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->