### PR TITLE
WS13: off-loop action dispatch, inbound validation, transport reuse (agent stream client)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-cmd/cmd v1.4.3
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-playground/validator/v10 v10.30.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.45.0
 )
 
@@ -22,6 +23,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -34,11 +36,13 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go/client.go
+++ b/go/client.go
@@ -17,11 +17,13 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/go-playground/validator/v10"
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/net/http2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/sdk/go/validate"
 )
 
 // Heartbeat interval bounds. The SDK clamps server-supplied values from
@@ -41,8 +43,26 @@ type Client struct {
 	authToken string
 	logger    *slog.Logger
 
+	// httpClient is the underlying transport carrier, retained so the agent
+	// can release its idle connections on reconnect (CloseIdleConnections) and
+	// not leak a transport per reconnect attempt (WS13 #8).
+	httpClient *http.Client
+
+	// validator enforces the inbound `validate` gotags on each server command
+	// before dispatch (WS13 #5) — defence-in-depth against a compromised relay
+	// pushing a malformed-but-non-nil frame. Created in NewClient.
+	validator *validator.Validate
+
 	mu     sync.RWMutex
 	stream *connect.BidiStreamForClient[pm.AgentMessage, pm.ServerMessage]
+
+	// actionCh feeds the per-Run action worker. Server-dispatched actions are
+	// handed to a single worker goroutine (off the receive loop) so a
+	// long-running action can no longer head-of-line-block TerminalStop/Input/
+	// Resize (WS13 #7). A single worker preserves one-at-a-time, in-order
+	// execution; the buffered channel bounds memory. Non-nil only while Run()
+	// is active; guarded by mu.
+	actionCh chan *pm.ActionDispatch
 
 	// sendMu serializes all stream.Send() calls — concurrent writes on a
 	// bidi stream are not safe and can corrupt messages on the wire.
@@ -88,12 +108,20 @@ const (
 	// connect.WithReadMaxBytes in NewClient; the connection that receives
 	// an oversized frame is torn down with a resource-exhausted error.
 	maxInboundMessageBytes = 16 << 20 // 16 MiB
+
+	// actionQueueDepth bounds how many server-dispatched actions can wait for
+	// the single action worker (WS13 #7). Deep enough to absorb any legitimate
+	// burst; a backlog beyond it means a pathological flood, so the excess is
+	// dropped (the server re-dispatches on reconnect) rather than queued
+	// unbounded or allowed to block the receive loop.
+	actionQueueDepth = 256
 )
 
 // NewClient creates a new SDK client.
 func NewClient(serverURL string, opts ...ClientOption) *Client {
 	c := &Client{
 		logger:        slog.Default(),
+		validator:     validate.NewValidator(),
 		invSem:        make(chan struct{}, inventoryDispatchConcurrency),
 		luksRevokeSem: make(chan struct{}, luksRevokeDispatchConcurrency),
 	}
@@ -107,6 +135,7 @@ func NewClient(serverURL string, opts ...ClientOption) *Client {
 	for _, opt := range opts {
 		opt.apply(c, &httpClient)
 	}
+	c.httpClient = httpClient
 
 	// Bound the size of inbound ServerMessages. A compromised or buggy
 	// gateway could otherwise push an arbitrarily large frame and force
@@ -118,6 +147,20 @@ func NewClient(serverURL string, opts ...ClientOption) *Client {
 	c.client = pmv1connect.NewAgentServiceClient(httpClient, serverURL,
 		connect.WithReadMaxBytes(maxInboundMessageBytes))
 	return c
+}
+
+// CloseIdleConnections releases idle keep-alive connections held by this
+// client's transport. The agent calls it when tearing down a connection session
+// before reconnecting (WS13 #8): without it, each reconnect builds a fresh
+// client whose mTLS transport keeps its own idle-connection pool, leaking
+// sockets/file-descriptors across a long-lived reconnect loop. Safe to call on a
+// client with no custom transport (http.DefaultClient.Transport) or a nil
+// client.
+func (c *Client) CloseIdleConnections() {
+	if c == nil || c.httpClient == nil {
+		return
+	}
+	c.httpClient.CloseIdleConnections()
 }
 
 // ClientOption configures the client.
@@ -965,6 +1008,39 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 		})
 	}
 
+	// Action worker (WS13 #7): server-dispatched actions execute on this single
+	// goroutine, off the receive loop, so a long-running action cannot
+	// head-of-line-block terminal control frames. One worker = one-at-a-time,
+	// in-order execution; the buffered channel bounds memory. Published on the
+	// Client so dispatchServerMessage can enqueue; cleared + drained on Run exit.
+	actionCh := make(chan *pm.ActionDispatch, actionQueueDepth)
+	workerCtx, cancelWorker := context.WithCancel(ctx)
+	c.mu.Lock()
+	c.actionCh = actionCh
+	c.mu.Unlock()
+	var actionWG sync.WaitGroup
+	actionWG.Add(1)
+	go func() {
+		defer actionWG.Done()
+		for disp := range actionCh {
+			// Skip queued actions once the connection is going down rather than
+			// half-applying system state during teardown; the server
+			// re-dispatches unacked actions on reconnect.
+			if workerCtx.Err() != nil {
+				continue
+			}
+			c.runDispatchedAction(workerCtx, disp, handler)
+		}
+	}()
+	defer func() {
+		c.mu.Lock()
+		c.actionCh = nil
+		c.mu.Unlock()
+		cancelWorker()
+		close(actionCh)
+		actionWG.Wait()
+	}()
+
 	// Channel to receive messages from blocking Receive call
 	type receiveResult struct {
 		msg *pm.ServerMessage
@@ -1073,6 +1149,59 @@ func (c *Client) safeGo(label string, fn func()) {
 // crash-loop the agent (Run treats a returned error as fatal and tears the
 // connection down). Genuine fatal stream send/receive errors still return
 // as errors — only handler PANICS become non-fatal.
+// validateInbound runs the shared `validate` gotags on a concrete inbound
+// command payload (WS13 #5) — defence-in-depth so a compromised relay can't push
+// a malformed-but-non-nil frame (out-of-range PTY dims, non-ULID session id,
+// empty action envelope) past the SDK boundary into a handler.
+func (c *Client) validateInbound(payload any) error {
+	if c.validator == nil {
+		return nil
+	}
+	if msg, ok := validate.Struct(c.validator, payload); !ok {
+		return errors.New(msg)
+	}
+	return nil
+}
+
+// currentActionCh returns the per-Run action worker channel, or nil when Run()
+// is not active (e.g. dispatchServerMessage driven directly by a unit test).
+func (c *Client) currentActionCh() chan *pm.ActionDispatch {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.actionCh
+}
+
+// runDispatchedAction executes one server-dispatched action and sends its
+// result. Run on the single action worker goroutine (or inline as a test
+// fallback). A panic is recovered (one bad action can't crash the agent); an
+// infrastructure error is logged, not propagated — off the receive loop there is
+// no connection to tear down, and an action *failure* already comes back as a
+// FAILED ActionResult rather than an error.
+func (c *Client) runDispatchedAction(ctx context.Context, disp *pm.ActionDispatch, handler StreamHandler) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("recovered panic while executing dispatched action (non-fatal)", "panic", fmt.Sprintf("%v", r))
+		}
+	}()
+	var result *pm.ActionResult
+	var err error
+	if streamingHandler, ok := handler.(StreamingHandler); ok {
+		sendChunk := func(chunk *pm.OutputChunk) error { return c.SendOutputChunk(ctx, chunk) }
+		result, err = streamingHandler.OnActionWithStreaming(ctx, disp.Envelope, disp.Signature, sendChunk)
+	} else {
+		result, err = handler.OnAction(ctx, disp.Envelope, disp.Signature)
+	}
+	if err != nil {
+		c.logger.Error("action handler error", "error", err)
+		return
+	}
+	if result != nil {
+		if err := c.SendActionResult(ctx, result); err != nil {
+			c.logger.Warn("failed to send action result", "error", err)
+		}
+	}
+}
+
 func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessage, handler StreamHandler) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1111,33 +1240,37 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			c.logger.Warn("dropping Action with nil dispatch payload", "message_id", msg.Id)
 			return nil
 		}
-
-		var actionResult *pm.ActionResult
-		var err error
-
-		// Check if handler supports streaming
-		if streamingHandler, ok := handler.(StreamingHandler); ok {
-			// Create a callback that sends output chunks
-			sendChunk := func(chunk *pm.OutputChunk) error {
-				return c.SendOutputChunk(ctx, chunk)
+		if err := c.validateInbound(p.Action); err != nil {
+			c.logger.Warn("dropping invalid Action", "message_id", msg.Id, "error", err)
+			return nil
+		}
+		// Off-loop (WS13 #7): hand the action to the single per-Run worker so a
+		// long-running action can't head-of-line-block TerminalStop/Input/Resize
+		// on the receive loop. The worker preserves one-at-a-time, in-order
+		// execution and sends the result via the sendMu-serialized SendActionResult.
+		if ch := c.currentActionCh(); ch != nil {
+			select {
+			case ch <- p.Action:
+			default:
+				// A full queue means a pathological flood (a legit gateway never
+				// has actionQueueDepth actions outstanding). Drop with a loud
+				// warning rather than block the receive loop; the server
+				// re-dispatches unacked actions on reconnect.
+				c.logger.Warn("action queue full; dropping dispatched action", "message_id", msg.Id, "depth", actionQueueDepth)
 			}
-			actionResult, err = streamingHandler.OnActionWithStreaming(ctx, p.Action.Envelope, p.Action.Signature, sendChunk)
-		} else {
-			actionResult, err = handler.OnAction(ctx, p.Action.Envelope, p.Action.Signature)
+			return nil
 		}
-
-		if err != nil {
-			return fmt.Errorf("handle action: %w", err)
-		}
-		if actionResult != nil {
-			if err := c.SendActionResult(ctx, actionResult); err != nil {
-				return fmt.Errorf("send action result: %w", err)
-			}
-		}
+		// Fallback: no worker (dispatchServerMessage driven directly, e.g. a unit
+		// test, outside Run) — execute inline so behaviour is preserved.
+		c.runDispatchedAction(ctx, p.Action, handler)
 
 	case *pm.ServerMessage_Query:
 		if p.Query == nil {
 			c.logger.Warn("dropping Query with nil payload", "message_id", msg.Id)
+			return nil
+		}
+		if err := c.validateInbound(p.Query); err != nil {
+			c.logger.Warn("dropping invalid Query", "message_id", msg.Id, "error", err)
 			return nil
 		}
 		queryResult, err := handler.OnQuery(ctx, p.Query)
@@ -1251,6 +1384,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			c.logger.Warn("dropping TerminalStart with nil payload", "message_id", msg.Id)
 			return nil
 		}
+		if err := c.validateInbound(p.TerminalStart); err != nil {
+			c.logger.Warn("dropping invalid TerminalStart", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalStart(ctx, p.TerminalStart); err != nil {
 				return fmt.Errorf("handle terminal start: %w", err)
@@ -1265,6 +1402,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			c.logger.Warn("dropping TerminalInput with nil payload", "message_id", msg.Id)
 			return nil
 		}
+		if err := c.validateInbound(p.TerminalInput); err != nil {
+			c.logger.Warn("dropping invalid TerminalInput", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalInput(ctx, p.TerminalInput); err != nil {
 				return fmt.Errorf("handle terminal input: %w", err)
@@ -1276,6 +1417,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			c.logger.Warn("dropping TerminalResize with nil payload", "message_id", msg.Id)
 			return nil
 		}
+		if err := c.validateInbound(p.TerminalResize); err != nil {
+			c.logger.Warn("dropping invalid TerminalResize", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if termHandler, ok := handler.(TerminalHandler); ok {
 			if err := termHandler.OnTerminalResize(ctx, p.TerminalResize); err != nil {
 				return fmt.Errorf("handle terminal resize: %w", err)
@@ -1285,6 +1430,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 	case *pm.ServerMessage_TerminalStop:
 		if p.TerminalStop == nil {
 			c.logger.Warn("dropping TerminalStop with nil payload", "message_id", msg.Id)
+			return nil
+		}
+		if err := c.validateInbound(p.TerminalStop); err != nil {
+			c.logger.Warn("dropping invalid TerminalStop", "message_id", msg.Id, "error", err)
 			return nil
 		}
 		if termHandler, ok := handler.(TerminalHandler); ok {

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -109,7 +109,7 @@ func makeTerminalMsg(name string) *pm.ServerMessage {
 	case "TerminalStart":
 		msg.Payload = &pm.ServerMessage_TerminalStart{
 			TerminalStart: &pm.TerminalStart{
-				SessionId: "01ABCDEF",
+				SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 				TtyUser:   "pm-tty-test",
 				Cols:      80,
 				Rows:      24,
@@ -118,14 +118,14 @@ func makeTerminalMsg(name string) *pm.ServerMessage {
 	case "TerminalInput":
 		msg.Payload = &pm.ServerMessage_TerminalInput{
 			TerminalInput: &pm.TerminalInput{
-				SessionId: "01ABCDEF",
+				SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 				Data:      []byte("ls -la\n"),
 			},
 		}
 	case "TerminalResize":
 		msg.Payload = &pm.ServerMessage_TerminalResize{
 			TerminalResize: &pm.TerminalResize{
-				SessionId: "01ABCDEF",
+				SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 				Cols:      120,
 				Rows:      40,
 			},
@@ -133,7 +133,7 @@ func makeTerminalMsg(name string) *pm.ServerMessage {
 	case "TerminalStop":
 		msg.Payload = &pm.ServerMessage_TerminalStop{
 			TerminalStop: &pm.TerminalStop{
-				SessionId: "01ABCDEF",
+				SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
 				Reason:    "admin terminate",
 			},
 		}
@@ -159,8 +159,8 @@ func TestDispatch_Terminal_Routing(t *testing.T) {
 				if len(h.startCalls) != 1 {
 					t.Fatalf("OnTerminalStart calls = %d, want 1", len(h.startCalls))
 				}
-				if h.startCalls[0].SessionId != "01ABCDEF" {
-					t.Errorf("session_id = %q, want 01ABCDEF", h.startCalls[0].SessionId)
+				if h.startCalls[0].SessionId != "01ARZ3NDEKTSV4RRFFQ69G5FAV" {
+					t.Errorf("session_id = %q, want 01ARZ3NDEKTSV4RRFFQ69G5FAV", h.startCalls[0].SessionId)
 				}
 				if h.startCalls[0].TtyUser != "pm-tty-test" {
 					t.Errorf("tty_user = %q, want pm-tty-test", h.startCalls[0].TtyUser)

--- a/go/client_ws13_test.go
+++ b/go/client_ws13_test.go
@@ -78,7 +78,11 @@ func TestDispatch_ActionRunsOffLoop_DoesNotBlockTerminal(t *testing.T) {
 			c.runDispatchedAction(context.Background(), d, h)
 		}
 	}()
-	defer func() { close(actionCh); wg.Wait() }()
+	// Cleanup closes h.release here (not at the end) so an early assertion
+	// failure can't leave the worker blocked in OnActionWithStreaming and hang
+	// wg.Wait(). Closed exactly once, on every exit path. Order matters: unblock
+	// the action, then end the channel range, then wait.
+	defer func() { close(h.release); close(actionCh); wg.Wait() }()
 
 	// Dispatch a long-running action — returns immediately (enqueued off-loop).
 	actionMsg := &pm.ServerMessage{Id: NewULID(), Payload: &pm.ServerMessage_Action{
@@ -98,8 +102,7 @@ func TestDispatch_ActionRunsOffLoop_DoesNotBlockTerminal(t *testing.T) {
 	}}
 	require.NoError(t, c.dispatchServerMessage(context.Background(), stopMsg, h))
 	require.Len(t, h.stopCalls, 1, "TerminalStop must be handled while a long action is still in-flight (off-loop)")
-
-	close(h.release) // let the action finish so the worker drains cleanly
+	// h.release is closed by the deferred cleanup above (safe on any exit path).
 }
 
 // TestDispatch_DropsInvalidInbound pins WS13 #5: a command frame that violates

--- a/go/client_ws13_test.go
+++ b/go/client_ws13_test.go
@@ -1,0 +1,136 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+const testULID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+// recordingTransport records CloseIdleConnections calls so the #8 seam can be
+// verified without a real network.
+type recordingTransport struct{ closeCalls int }
+
+func (r *recordingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("recordingTransport: no real requests")
+}
+func (r *recordingTransport) CloseIdleConnections() { r.closeCalls++ }
+
+// TestClient_CloseIdleConnections pins WS13 #8: CloseIdleConnections releases the
+// transport's idle connections (so a reconnect loop doesn't leak transports) and
+// is nil-safe.
+func TestClient_CloseIdleConnections(t *testing.T) {
+	rt := &recordingTransport{}
+	c := NewClient("https://gw.example", WithHTTPClient(&http.Client{Transport: rt}))
+
+	c.CloseIdleConnections()
+	require.Equal(t, 1, rt.closeCalls, "CloseIdleConnections must release the underlying transport's idle connections")
+
+	var nilClient *Client
+	require.NotPanics(t, func() { nilClient.CloseIdleConnections() }, "must be nil-safe")
+}
+
+// offLoopHandler is a StreamingHandler whose action blocks until released, plus a
+// TerminalHandler (via the embedded fake) so the off-loop test can prove a
+// TerminalStop is handled while an action is still in-flight.
+type offLoopHandler struct {
+	*fakeTerminalHandler
+	started chan struct{}
+	release chan struct{}
+}
+
+func (h *offLoopHandler) OnActionWithStreaming(ctx context.Context, envelope, signature []byte, sendChunk func(*pm.OutputChunk) error) (*pm.ActionResult, error) {
+	close(h.started)
+	<-h.release
+	return &pm.ActionResult{}, nil
+}
+
+// TestDispatch_ActionRunsOffLoop_DoesNotBlockTerminal pins WS13 #7: a
+// long-running action is executed off the receive loop, so a TerminalStop
+// dispatched while it is in-flight is still handled promptly (no head-of-line
+// block). Against the old inline dispatch this would hang.
+func TestDispatch_ActionRunsOffLoop_DoesNotBlockTerminal(t *testing.T) {
+	c := newTestClient()
+
+	// Stand up the per-Run action worker the way Run() does.
+	actionCh := make(chan *pm.ActionDispatch, actionQueueDepth)
+	c.mu.Lock()
+	c.actionCh = actionCh
+	c.mu.Unlock()
+	h := &offLoopHandler{
+		fakeTerminalHandler: &fakeTerminalHandler{},
+		started:             make(chan struct{}),
+		release:             make(chan struct{}),
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for d := range actionCh {
+			c.runDispatchedAction(context.Background(), d, h)
+		}
+	}()
+	defer func() { close(actionCh); wg.Wait() }()
+
+	// Dispatch a long-running action — returns immediately (enqueued off-loop).
+	actionMsg := &pm.ServerMessage{Id: NewULID(), Payload: &pm.ServerMessage_Action{
+		Action: &pm.ActionDispatch{Envelope: []byte{0x01}, Signature: []byte{0x01}},
+	}}
+	require.NoError(t, c.dispatchServerMessage(context.Background(), actionMsg, h))
+
+	select {
+	case <-h.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("action never started on the worker")
+	}
+
+	// While the action is blocked, a TerminalStop must still be handled.
+	stopMsg := &pm.ServerMessage{Id: NewULID(), Payload: &pm.ServerMessage_TerminalStop{
+		TerminalStop: &pm.TerminalStop{SessionId: testULID, Reason: "stop"},
+	}}
+	require.NoError(t, c.dispatchServerMessage(context.Background(), stopMsg, h))
+	require.Len(t, h.stopCalls, 1, "TerminalStop must be handled while a long action is still in-flight (off-loop)")
+
+	close(h.release) // let the action finish so the worker drains cleanly
+}
+
+// TestDispatch_DropsInvalidInbound pins WS13 #5: a command frame that violates
+// the inbound `validate` gotags (out-of-range PTY dims, non-ULID session id) is
+// dropped before the handler; a conformant frame reaches it.
+func TestDispatch_DropsInvalidInbound(t *testing.T) {
+	ctx := context.Background()
+	start := func(sid, tty string, cols, rows uint32) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: NewULID(), Payload: &pm.ServerMessage_TerminalStart{
+			TerminalStart: &pm.TerminalStart{SessionId: sid, TtyUser: tty, Cols: cols, Rows: rows},
+		}}
+	}
+
+	t.Run("cols=0 dropped (gt=0)", func(t *testing.T) {
+		c := newTestClient()
+		h := &fakeTerminalHandler{}
+		require.NoError(t, c.dispatchServerMessage(ctx, start(testULID, "pm-tty-x", 0, 24), h))
+		require.Empty(t, h.startCalls, "a TerminalStart with cols=0 must be dropped by inbound validation")
+	})
+
+	t.Run("non-ULID session id dropped", func(t *testing.T) {
+		c := newTestClient()
+		h := &fakeTerminalHandler{}
+		require.NoError(t, c.dispatchServerMessage(ctx, start("not-a-ulid", "pm-tty-x", 80, 24), h))
+		require.Empty(t, h.startCalls, "a TerminalStart with a non-ULID session id must be dropped")
+	})
+
+	t.Run("conformant frame reaches the handler", func(t *testing.T) {
+		c := newTestClient()
+		h := &fakeTerminalHandler{}
+		require.NoError(t, c.dispatchServerMessage(ctx, start(testULID, "pm-tty-x", 80, 24), h))
+		require.Len(t, h.startCalls, 1, "a valid TerminalStart must reach the handler")
+	})
+}


### PR DESCRIPTION
WS13 (sdk portion) — closes #111. Three deltas on the agent stream client, on top of the WS15 stream-loop hardening (#110).

- **#7 off-loop action dispatch.** A server-dispatched action ran INLINE on the receive loop, head-of-line-blocking TerminalStop/Input/Resize. Actions now execute on a single per-`Run` worker goroutine (off-loop), preserving one-at-a-time, in-order execution. A buffered channel (`actionQueueDepth=256`) bounds memory; a pathological backlog is dropped (the server re-dispatches on reconnect) rather than blocking the loop. `dispatchServerMessage` falls back to inline execution when no worker is active (direct-dispatch unit tests).
- **#5 inbound validation.** Each inbound command payload is validated against its `validate` gotags (the shared go-playground validator — `ulid`, `gt=0,lte=65535`, `required`) before dispatch, so a malformed-but-non-nil frame from a compromised relay is dropped non-fatally.
- **#8 transport reuse.** `Client.CloseIdleConnections()` lets the agent release the prior client's idle connections on reconnect, so the reconnect loop doesn't leak a transport per attempt.

Tests: off-loop (a TerminalStop is handled while an action is in-flight), inbound-validation drop (cols=0 / non-ULID dropped, conformant reaches the handler), `CloseIdleConnections` seam. Existing terminal-routing fixtures updated to realistic ULID session ids (the loose 8-char fixtures failed the now-enforced `ulid` rule). cr-clean (one test-hang-on-failure finding fixed).

Part of WS13; server portion in power-manage-server#428, agent offline-store bound in power-manage-agent#120. The agent side (#8 call site + #2 terminal-setup ctx) follows once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CloseIdleConnections()` method for explicit idle connection management.
  * Improved concurrent operation handling to prevent long-running actions from blocking terminal message processing.

* **Bug Fixes**
  * Enhanced inbound message validation to gracefully drop invalid payloads instead of failing fatally.

* **Tests**
  * Added comprehensive test coverage for connection lifecycle and message validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->