### PR TITLE
fix(client,exec): honor ctx in stream Send* + SIGKILL-escalate cancelled children (WS16 #1/#6)

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -64,9 +64,13 @@ type Client struct {
 	// is active; guarded by mu.
 	actionCh chan *pm.ActionDispatch
 
-	// sendMu serializes all stream.Send() calls — concurrent writes on a
-	// bidi stream are not safe and can corrupt messages on the wire.
-	sendMu sync.Mutex
+	// sendSem is a buffered-1 channel used as a ctx-aware send lock. It
+	// serializes all stream.Send() calls — concurrent writes on a bidi
+	// stream are not safe and can corrupt messages on the wire — while
+	// letting a sender abandon its claim on its own ctx deadline instead of
+	// blocking indefinitely behind a stalled send (WS16 #1). Initialised by
+	// NewClient.
+	sendSem chan struct{}
 
 	// pendingMu protects pendingRequests for LUKS request-response correlation.
 	pendingMu       sync.Mutex
@@ -122,6 +126,7 @@ func NewClient(serverURL string, opts ...ClientOption) *Client {
 	c := &Client{
 		logger:        slog.Default(),
 		validator:     validate.NewValidator(),
+		sendSem:       make(chan struct{}, 1),
 		invSem:        make(chan struct{}, inventoryDispatchConcurrency),
 		luksRevokeSem: make(chan struct{}, luksRevokeDispatchConcurrency),
 	}
@@ -571,10 +576,19 @@ func (c *Client) Connect(ctx context.Context) error {
 	return nil
 }
 
-// send serializes all writes to the bidirectional stream.
+// send serializes all writes to the bidirectional stream and honors ctx.
 // Multiple goroutines (heartbeat, inventory, result sender) may call Send
 // methods concurrently; without serialization this can corrupt messages.
-func (c *Client) send(msg *pm.AgentMessage) error {
+//
+// Both the send-lock acquisition AND the underlying stream.Send observe ctx,
+// so a stalled peer (a full HTTP/2 flow-control window with no draining) can
+// no longer wedge a sender — or every other sender queued behind it — past
+// its own deadline (WS16 #1). At most one stream.Send is ever in flight: the
+// send slot is held until the in-flight Send actually returns, even if the
+// caller has already given up on ctx, so the on-wire serialization guarantee
+// is preserved. A send that is abandoned on ctx stays pending until the
+// stream is torn down (Close / run-ctx cancel on reconnect), which resets it.
+func (c *Client) send(ctx context.Context, msg *pm.AgentMessage) error {
 	c.mu.RLock()
 	stream := c.stream
 	c.mu.RUnlock()
@@ -583,9 +597,38 @@ func (c *Client) send(msg *pm.AgentMessage) error {
 		return errors.New("not connected")
 	}
 
-	c.sendMu.Lock()
-	defer c.sendMu.Unlock()
-	return stream.Send(msg)
+	// Refuse up front if the caller's ctx is already done — don't queue
+	// behind the send lock just to fail.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Acquire the send slot ctx-aware: a waiting sender abandons its claim on
+	// its own deadline instead of starving behind a stalled send.
+	select {
+	case c.sendSem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Run the blocking Send while holding the slot. The slot is released only
+	// when stream.Send actually returns (in the goroutine), so a second Send
+	// can never start concurrently with an abandoned one — no on-wire
+	// corruption. errCh is buffered so the goroutine never blocks publishing
+	// its result even after we have returned on ctx.
+	errCh := make(chan error, 1)
+	go func() {
+		err := stream.Send(msg)
+		<-c.sendSem
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // SendHello sends a hello message to the server.
@@ -595,7 +638,7 @@ func (c *Client) SendHello(ctx context.Context, hostname, agentVersion string) e
 	authToken := c.authToken
 	c.mu.RUnlock()
 
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_Hello{
 			Hello: &pm.Hello{
@@ -611,7 +654,7 @@ func (c *Client) SendHello(ctx context.Context, hostname, agentVersion string) e
 
 // SendHeartbeat sends a heartbeat message to the server.
 func (c *Client) SendHeartbeat(ctx context.Context, hb *pm.Heartbeat) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_Heartbeat{
 			Heartbeat: hb,
@@ -621,7 +664,7 @@ func (c *Client) SendHeartbeat(ctx context.Context, hb *pm.Heartbeat) error {
 
 // SendActionResult sends an action result to the server.
 func (c *Client) SendActionResult(ctx context.Context, result *pm.ActionResult) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_ActionResult{
 			ActionResult: result,
@@ -631,7 +674,7 @@ func (c *Client) SendActionResult(ctx context.Context, result *pm.ActionResult) 
 
 // SendOutputChunk sends an output chunk during action execution.
 func (c *Client) SendOutputChunk(ctx context.Context, chunk *pm.OutputChunk) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_OutputChunk{
 			OutputChunk: chunk,
@@ -641,7 +684,7 @@ func (c *Client) SendOutputChunk(ctx context.Context, chunk *pm.OutputChunk) err
 
 // SendQueryResult sends an OS query result to the server.
 func (c *Client) SendQueryResult(ctx context.Context, result *pm.OSQueryResult) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_QueryResult{
 			QueryResult: result,
@@ -651,7 +694,7 @@ func (c *Client) SendQueryResult(ctx context.Context, result *pm.OSQueryResult) 
 
 // SendLogQueryResult sends a log query result to the server.
 func (c *Client) SendLogQueryResult(ctx context.Context, result *pm.LogQueryResult) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_LogQueryResult{
 			LogQueryResult: result,
@@ -661,7 +704,7 @@ func (c *Client) SendLogQueryResult(ctx context.Context, result *pm.LogQueryResu
 
 // SendSecurityAlert sends a security alert to the server for audit logging.
 func (c *Client) SendSecurityAlert(ctx context.Context, alert *pm.SecurityAlert) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_SecurityAlert{
 			SecurityAlert: alert,
@@ -675,7 +718,7 @@ func (c *Client) SendInventory(ctx context.Context, inventory *pm.DeviceInventor
 		return nil
 	}
 
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_Inventory{
 			Inventory: inventory,
@@ -687,7 +730,7 @@ func (c *Client) SendInventory(ctx context.Context, inventory *pm.DeviceInventor
 // session back to the server. The TerminalHandler is responsible for
 // chunking PTY reads to fit the proto's 64KB max data size.
 func (c *Client) SendTerminalOutput(ctx context.Context, out *pm.TerminalOutput) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_TerminalOutput{
 			TerminalOutput: out,
@@ -701,7 +744,7 @@ func (c *Client) SendTerminalOutput(ctx context.Context, out *pm.TerminalOutput)
 // and ERROR for any failure that ends the session before STARTED or
 // in flight.
 func (c *Client) SendTerminalStateChange(ctx context.Context, change *pm.TerminalStateChange) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_TerminalStateChange{
 			TerminalStateChange: change,
@@ -716,7 +759,7 @@ func (c *Client) GetLuksKey(ctx context.Context, actionID string) (string, error
 	ch := c.registerPending(id)
 	defer c.unregisterPending(id)
 
-	if err := c.send(&pm.AgentMessage{
+	if err := c.send(ctx, &pm.AgentMessage{
 		Id: id,
 		Payload: &pm.AgentMessage_GetLuksKey{
 			GetLuksKey: &pm.GetLuksKeyRequest{
@@ -748,7 +791,7 @@ func (c *Client) StoreLuksKey(ctx context.Context, actionID, devicePath, passphr
 	ch := c.registerPending(id)
 	defer c.unregisterPending(id)
 
-	if err := c.send(&pm.AgentMessage{
+	if err := c.send(ctx, &pm.AgentMessage{
 		Id: id,
 		Payload: &pm.AgentMessage_StoreLuksKey{
 			StoreLuksKey: &pm.StoreLuksKeyRequest{
@@ -782,7 +825,7 @@ func (c *Client) StoreLuksKey(ctx context.Context, actionID, devicePath, passphr
 
 // SendRevokeLuksDeviceKeyResult sends the result of a LUKS device key revocation back to the server.
 func (c *Client) SendRevokeLuksDeviceKeyResult(ctx context.Context, actionID string, success bool, errMsg string) error {
-	return c.send(&pm.AgentMessage{
+	return c.send(ctx, &pm.AgentMessage{
 		Id: NewULID(),
 		Payload: &pm.AgentMessage_RevokeLuksDeviceKeyResult{
 			RevokeLuksDeviceKeyResult: &pm.RevokeLuksDeviceKeyResult{

--- a/go/client_send_ctx_test.go
+++ b/go/client_send_ctx_test.go
@@ -1,0 +1,207 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// WS16 finding #1: the Send* methods take a ctx but (*Client).send ignored
+// it and held sendMu for the whole stream.Send. A single stalled send (peer
+// not draining the HTTP/2 flow-control window) therefore wedged sendMu and
+// blocked every other sender past its own deadline; the terminal-send 5s ctx
+// was cosmetic. These tests pin that a Send must surface its ctx deadline as
+// a ctx error — both when the call is itself the wedged writer and when it is
+// merely queued behind one — without reintroducing on-wire corruption
+// (TestConcurrentSend_PreservesEveryMessage must stay green).
+
+// newStalledLoopback returns a loopback whose server accepts the stream but
+// NEVER calls Receive, so the client's HTTP/2 send window fills and stays
+// full: the next large write blocks at the transport layer indefinitely.
+func newStalledLoopback(t *testing.T) *agentLoopback {
+	t.Helper()
+	l := newAgentLoopback(t)
+	l.handler.onStream = func(ctx context.Context, _ *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) error {
+		// Hold the stream open without ever draining the inbound side.
+		<-ctx.Done()
+		return nil
+	}
+	return l
+}
+
+// connectCancellable connects the client over a cancellable ctx and registers
+// cleanup that cancels it (resetting the underlying HTTP/2 stream so any send
+// wedged on a full flow-control window unblocks) before closing the client.
+// This mirrors production: the agent's run ctx cancel on shutdown/reconnect is
+// what tears down a stalled stream — Close alone cannot wake a flow-control
+// wait.
+func connectCancellable(t *testing.T, c *Client) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := c.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		done := make(chan struct{})
+		go func() { _ = c.Close(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			// Best-effort: the httptest server cleanup will finish teardown.
+		}
+	})
+}
+
+// bigTerminalOutput is intentionally far larger than the ~64 KiB HTTP/2
+// flow-control window so a single Send to a non-draining peer blocks mid-write.
+func bigTerminalOutput() *pm.TerminalOutput {
+	return &pm.TerminalOutput{
+		SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+		Data:      make([]byte, 2<<20), // 2 MiB
+	}
+}
+
+func TestSendTerminalOutput_HonorsContextDeadline_WhenPeerNotDraining(t *testing.T) {
+	l := newStalledLoopback(t)
+	c := l.newClient(WithAuth("device-x", "tok"))
+
+	connectCancellable(t, c)
+
+	// present-but-WRONG: an already-cancelled ctx must be refused up front,
+	// before attempting the wedged send. Bounded so the buggy (ctx-ignoring)
+	// path surfaces as a fast failure rather than a 10-minute hang.
+	t.Run("already cancelled returns Canceled before sending", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		done := make(chan error, 1)
+		go func() { done <- c.SendTerminalOutput(cctx, bigTerminalOutput()) }()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("want context.Canceled, got %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("already-cancelled SendTerminalOutput blocked instead of refusing — finding #1 (ctx ignored)")
+		}
+	})
+
+	// correct (the headline case): the call is itself the writer that wedges
+	// on the full window; it must return its own deadline error within
+	// roughly the timeout, not block forever.
+	t.Run("deadline surfaces as DeadlineExceeded", func(t *testing.T) {
+		done := make(chan error, 1)
+		start := time.Now()
+		go func() {
+			sctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			done <- c.SendTerminalOutput(sctx, bigTerminalOutput())
+		}()
+
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("want context.DeadlineExceeded, got %v", err)
+			}
+			if elapsed := time.Since(start); elapsed > 2*time.Second {
+				t.Errorf("send took %v, expected to abort near the 200ms deadline", elapsed)
+			}
+		case <-time.After(4 * time.Second):
+			t.Fatal("SendTerminalOutput blocked far past its ctx deadline — finding #1 (ctx ignored / sendMu wedged)")
+		}
+	})
+}
+
+func TestSend_DoesNotSerializeAllTrafficBehindOneStalledSend(t *testing.T) {
+	l := newStalledLoopback(t)
+	c := l.newClient(WithAuth("device-x", "tok"))
+
+	connectCancellable(t, c)
+
+	// A long-lived blocker saturates the window and holds the send slot.
+	blockerDone := make(chan struct{})
+	go func() {
+		defer close(blockerDone)
+		// context.Background(): with the bug this blocks forever holding
+		// sendMu; with the fix it holds the send slot until the stream is
+		// torn down at Close, which is fine — the point is the victim below
+		// must not inherit this wait.
+		_ = c.SendTerminalOutput(context.Background(), bigTerminalOutput())
+	}()
+
+	// Give the blocker time to fill the window and claim the slot.
+	time.Sleep(150 * time.Millisecond)
+
+	// The victim is small but must still honor its own short deadline rather
+	// than block behind the stalled blocker.
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		vctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+		done <- c.SendHeartbeat(vctx, &pm.Heartbeat{})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("want context.DeadlineExceeded for the queued victim, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("victim send took %v, expected to abort near its 150ms deadline", elapsed)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("queued SendHeartbeat inherited the blocker's stall — finding #1 (one stalled send serializes all traffic)")
+	}
+}
+
+func TestSendTerminalStateChange_HonorsContextDeadline(t *testing.T) {
+	l := newStalledLoopback(t)
+	c := l.newClient(WithAuth("device-x", "tok"))
+
+	connectCancellable(t, c)
+
+	// Saturate the window with a blocker so the state-change send is queued
+	// behind a stall — the exact shape of the F053 EXITED path (terminal.go
+	// passes a 5s ctx that was ignored).
+	go func() { _ = c.SendTerminalOutput(context.Background(), bigTerminalOutput()) }()
+	time.Sleep(150 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		sctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+		done <- c.SendTerminalStateChange(sctx, &pm.TerminalStateChange{
+			SessionId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			State:     pm.TerminalSessionState_TERMINAL_SESSION_STATE_EXITED,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("want context.DeadlineExceeded, got %v", err)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("SendTerminalStateChange ignored its ctx deadline — finding #1 (F053 fix is cosmetic)")
+	}
+}
+
+// TestSend_DrainingPeer_NoRegression proves the ctx plumbing does not break
+// the normal path: against a draining server a Background-ctx send still
+// succeeds (ABSENT deadline → nil).
+func TestSend_DrainingPeer_NoRegression(t *testing.T) {
+	l := newAgentLoopback(t) // default handler drains via Receive
+	c := l.newClient(WithAuth("device-x", "tok"))
+
+	connectCancellable(t, c)
+
+	if err := c.SendHeartbeat(context.Background(), &pm.Heartbeat{}); err != nil {
+		t.Fatalf("SendHeartbeat against a draining peer should succeed, got %v", err)
+	}
+}

--- a/go/sys/exec/exec.go
+++ b/go/sys/exec/exec.go
@@ -7,9 +7,50 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"syscall"
+	"time"
 
 	"github.com/go-cmd/cmd"
 )
+
+// killGrace bounds how long a cancelled child has to exit on SIGTERM before
+// its process group is escalated to SIGKILL. A package var (not const) so
+// tests can shorten it. WS16 #6: without escalation a SIGTERM-ignoring child
+// pins the reaping goroutine until the child exits on its own — or forever.
+var killGrace = 5 * time.Second
+
+// awaitStatusOrKill waits for a cancelled command's final status. It SIGTERMs
+// the process group (Stop, idempotent), and if the child has not exited within
+// killGrace it escalates to SIGKILL on the whole group, then reads the status
+// under a second bounded grace so a wedged child can never pin the caller
+// forever. go-cmd starts children with Setpgid, so -pid targets the group.
+func awaitStatusOrKill(c *cmd.Cmd, statusChan <-chan cmd.Status) cmd.Status {
+	_ = c.Stop() // SIGTERM the process group (no-op if already stopped/exited)
+
+	term := time.NewTimer(killGrace)
+	defer term.Stop()
+	select {
+	case status := <-statusChan:
+		return status
+	case <-term.C:
+	}
+
+	if pid := c.Status().PID; pid > 0 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+
+	kill := time.NewTimer(killGrace)
+	defer kill.Stop()
+	select {
+	case status := <-statusChan:
+		return status
+	case <-kill.C:
+		// Even SIGKILL could not be reaped within grace (e.g. an
+		// uninterruptible D-state). Return a best-effort snapshot rather
+		// than block the caller forever.
+		return c.Status()
+	}
+}
 
 // Run executes a command and returns its output.
 func Run(ctx context.Context, name string, args ...string) (*Result, error) {
@@ -205,13 +246,24 @@ func runStreamingWithEnv(ctx context.Context, name string, args []string, env []
 				}
 				recordLine(StreamStderr, line)
 			case <-ctx.Done():
-				c.Stop()
+				// Stop draining; awaitStatusOrKill below owns the SIGTERM →
+				// SIGKILL escalation so a SIGTERM-ignoring child can't pin us.
 				return
 			}
 		}
 	}()
 
-	status := <-statusChan
+	var (
+		status cmd.Status
+		runErr error
+	)
+	select {
+	case status = <-statusChan:
+		runErr = status.Error
+	case <-ctx.Done():
+		status = awaitStatusOrKill(c, statusChan)
+		runErr = ctx.Err()
+	}
 	<-done
 
 	stdoutStr := stdoutBuf.String()
@@ -227,7 +279,7 @@ func runStreamingWithEnv(ctx context.Context, name string, args []string, env []
 		ExitCode: status.Exit,
 		Stdout:   stdoutStr,
 		Stderr:   stderrStr,
-	}, status.Error
+	}, runErr
 }
 
 func runWithOptions(ctx context.Context, name string, args []string, stdin io.Reader, dir string) (*Result, error) {
@@ -254,8 +306,7 @@ func runWithOptions(ctx context.Context, name string, args []string, stdin io.Re
 		}
 		return result, nil
 	case <-ctx.Done():
-		c.Stop()
-		status := <-statusChan
+		status := awaitStatusOrKill(c, statusChan)
 		return statusToResult(status), ctx.Err()
 	}
 }

--- a/go/sys/exec/exec_kill_test.go
+++ b/go/sys/exec/exec_kill_test.go
@@ -1,0 +1,147 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// WS16 finding #6: on ctx cancel/timeout both exec wrappers SIGTERM'd the
+// child's process group but never escalated to SIGKILL, and then blocked
+// reading the status channel. A SIGTERM-ignoring child therefore pinned the
+// reaping goroutine until the child exited on its own (or forever). These
+// tests pin that a cancelled, SIGTERM-ignoring child is SIGKILLed after a
+// bounded grace and the call returns promptly — for BOTH wrappers
+// (runStreamingWithEnv via RunStreaming, runWithOptions via Run).
+
+// readChildPID reads the pgid-leader PID the child shell wrote ($$).
+func readChildPID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		b, err := os.ReadFile(pidFile)
+		if err == nil {
+			if pid, perr := strconv.Atoi(strings.TrimSpace(string(b))); perr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child never wrote its PID to %s", pidFile)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// assertProcessGroupGone polls until kill(-pid, 0) reports ESRCH (the whole
+// group is gone). SIGKILL delivery + reaping is asynchronous.
+func assertProcessGroupGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := syscall.Kill(-pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d still alive after grace (kill(-pid,0)=%v) — SIGKILL never delivered", pid, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// sigtermIgnoringScript writes its pgid-leader PID, traps+ignores SIGTERM in
+// the shell, and loops re-spawning sleep so the GROUP stays alive across a
+// SIGTERM. A bare `sleep 30` would NOT work: the group SIGTERM also hits the
+// sleep child (default disposition → it dies), the script completes and the
+// shell exits — SIGKILL would never be exercised. The restart loop keeps the
+// shell (which ignores SIGTERM) running until SIGKILL tears down the group.
+func sigtermIgnoringScript(pidFile string) string {
+	return fmt.Sprintf(`echo $$ > %s; trap "" TERM; while true; do sleep 30; done`, pidFile)
+}
+
+func TestRunStreaming_SIGKILLsChildThatIgnoresSIGTERM(t *testing.T) {
+	restore := killGrace
+	killGrace = 200 * time.Millisecond
+	defer func() { killGrace = restore }()
+
+	pidFile := t.TempDir() + "/pid"
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	type res struct{ err error }
+	done := make(chan res, 1)
+	start := time.Now()
+	go func() {
+		_, err := RunStreaming(ctx, "sh", []string{"-c", sigtermIgnoringScript(pidFile)}, nil, "", nil)
+		done <- res{err}
+	}()
+
+	select {
+	case r := <-done:
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Errorf("RunStreaming took %v; SIGTERM-ignoring child was not SIGKILLed after grace", elapsed)
+		}
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Errorf("err = %v, want context.DeadlineExceeded on cancel", r.err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("RunStreaming pinned on a SIGTERM-ignoring child — finding #6 (no SIGKILL escalation)")
+	}
+
+	assertProcessGroupGone(t, readChildPID(t, pidFile))
+}
+
+func TestRun_SIGKILLsChildThatIgnoresSIGTERM(t *testing.T) {
+	restore := killGrace
+	killGrace = 200 * time.Millisecond
+	defer func() { killGrace = restore }()
+
+	pidFile := t.TempDir() + "/pid"
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	type res struct{ err error }
+	done := make(chan res, 1)
+	start := time.Now()
+	go func() {
+		_, err := Run(ctx, "sh", "-c", sigtermIgnoringScript(pidFile))
+		done <- res{err}
+	}()
+
+	select {
+	case r := <-done:
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Errorf("Run took %v; SIGTERM-ignoring child was not SIGKILLed after grace", elapsed)
+		}
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Errorf("err = %v, want context.DeadlineExceeded on cancel", r.err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Run pinned on a SIGTERM-ignoring child — finding #6 (no SIGKILL escalation)")
+	}
+
+	assertProcessGroupGone(t, readChildPID(t, pidFile))
+}
+
+// TestRun_WellBehavedChildReapsOnSIGTERM is the correct-path control: a child
+// that honors SIGTERM reaps at cancel, well before the SIGKILL grace, and the
+// call still returns ctx.Err().
+func TestRun_WellBehavedChildReapsOnSIGTERM(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := Run(ctx, "sleep", "30") // default disposition: dies on SIGTERM
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("well-behaved child took %v to reap on SIGTERM", elapsed)
+	}
+}


### PR DESCRIPTION
## WS16 error-discipline — SDK (findings #1, #6)

### #1 — `(*Client).send` honors ctx (closes #113)
Every `Send*` method already accepted a `ctx` but `send` ignored it and held `sendMu` for the whole `stream.Send`. A single stalled send (peer not draining the HTTP/2 flow-control window) wedged `sendMu` and blocked **every** other sender past its own deadline; the terminal-send 5s ctx (F053) was cosmetic.

- `send` now observes `ctx` for both the send-lock acquisition **and** the underlying `stream.Send`.
- `sendMu` → a buffered-1 **ctx-aware send slot**, held until the in-flight `stream.Send` actually returns. At most one Send is ever on the wire, so the on-wire serialization guarantee is preserved (`TestConcurrentSend_PreservesEveryMessage` stays green); a waiting/abandoned sender returns its own `ctx.Err()` instead of starving.

### #6 — exec wrappers SIGKILL-escalate cancelled children (closes #114)
On ctx cancel both `runStreamingWithEnv` and `runWithOptions` SIGTERM'd the process group then blocked reading status — a SIGTERM-ignoring child pinned the goroutine forever.

- New `awaitStatusOrKill`: SIGTERM → bounded `killGrace` → **SIGKILL the process group** → read status under a second bounded grace.
- The streaming wrapper now returns `ctx.Err()` on the cancel path, consistent with `runWithOptions`.

### Tests (red-first)
- `go/client_send_ctx_test.go` — non-draining loopback wedges the window; pins ctx-deadline surfacing for the wedged writer **and** a queued victim, plus an already-cancelled fast-refuse and a draining-peer no-regression. `TestConcurrentSend` kept green.
- `go/sys/exec/exec_kill_test.go` — a `trap "" TERM` shell that re-spawns sleep; asserts the call returns near deadline and the **process group is gone** (ESRCH). Verified the escalation is genuinely required by substituting SIGTERM and observing the group survive (a bare `sleep 30` would exit on SIGTERM and never exercise SIGKILL — caught in local review).

Gates: `gofmt`, `go vet`, `staticcheck`, full `go test ./...` green; local CodeRabbit review clean after fixing the script finding above.

Part of the security/RBAC hardening work plan (WS16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Client requests now properly honor timeout deadlines when the server is unresponsive, preventing indefinite hangs while processing concurrent requests.
  * Process termination is more reliable, automatically escalating to forceful shutdown if graceful termination is ignored.

* **Tests**
  * Added comprehensive tests for timeout handling and process termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->