### PR TITLE
test: shared cryptotest fixtures for CA/cert generation (WS16b DRY)

### DIFF
--- a/go/client_loopback_test.go
+++ b/go/client_loopback_test.go
@@ -2,18 +2,11 @@ package sdk
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -26,6 +19,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
 
 // agentLoopback wires an in-process AgentService handler behind an h2c
@@ -570,10 +564,9 @@ func (h *welcomeRecordingHandler) OnError(ctx context.Context, e *pm.Error) erro
 // ---------------------------------------------------------------------------
 
 func TestWithMTLSFromPEM_ClientPresentsCertificate(t *testing.T) {
-	caCert, caKey := mustGenCA(t)
-	serverCertPEM, serverKeyPEM := mustGenCert(t, caCert, caKey, "127.0.0.1", true)
-	clientCertPEM, clientKeyPEM := mustGenCert(t, caCert, caKey, "device-client", false)
-	caPEM := mustEncodeCert(caCert)
+	caPEM, caKey, caCert := cryptotest.GenCA(t, "test-ca")
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "127.0.0.1", true)
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "device-client", false)
 
 	caPool := x509.NewCertPool()
 	if !caPool.AppendCertsFromPEM(caPEM) {
@@ -663,66 +656,3 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { retu
 // ---------------------------------------------------------------------------
 // Cert generation helpers
 // ---------------------------------------------------------------------------
-
-func mustGenCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("ca key: %v", err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("create ca: %v", err)
-	}
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		t.Fatalf("parse ca: %v", err)
-	}
-	return cert, key
-}
-
-func mustGenCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, name string, isServer bool) (certPEM, keyPEM []byte) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("leaf key: %v", err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(time.Now().UnixNano()),
-		Subject:      pkix.Name{CommonName: name},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-	}
-	if isServer {
-		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
-		tmpl.DNSNames = []string{"localhost"}
-	} else {
-		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
-	if err != nil {
-		t.Fatalf("create cert: %v", err)
-	}
-	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		t.Fatalf("marshal key: %v", err)
-	}
-	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-	return certPEM, keyPEM
-}
-
-func mustEncodeCert(cert *x509.Certificate) []byte {
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-}

--- a/go/crypto/cert_test.go
+++ b/go/crypto/cert_test.go
@@ -1,76 +1,19 @@
 package crypto
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/sha256"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/hex"
-	"encoding/pem"
-	"math/big"
 	"testing"
-	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
-
-// genCA creates a self-signed CA cert (PEM) + its key.
-func genCA(t *testing.T, cn string) ([]byte, *ecdsa.PrivateKey, *x509.Certificate) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("ca key: %v", err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: cn},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("create ca: %v", err)
-	}
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		t.Fatalf("parse ca: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
-}
-
-// genSubCA creates a CA cert (PEM) signed BY parent — a cross-signed /
-// successor CA, the legitimate-rotation continuity case.
-func genSubCA(t *testing.T, cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) []byte {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("subca key: %v", err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(2),
-		Subject:               pkix.Name{CommonName: cn},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
-	if err != nil {
-		t.Fatalf("create subca: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-}
 
 // TestCAFingerprintFromPEM pins that the fingerprint is the lowercase hex
 // SHA-256 of the certificate DER — byte-identical to the server's
 // ca.FingerprintFromPEM, so an operator-supplied pin (derived from the
 // control CA, e.g. `openssl x509 -outform DER | sha256sum`) matches.
 func TestCAFingerprintFromPEM(t *testing.T) {
-	caPEM, _, caCert := genCA(t, "fp-ca")
+	caPEM, _, caCert := cryptotest.GenCA(t, "fp-ca")
 	want := hex.EncodeToString(func() []byte { s := sha256.Sum256(caCert.Raw); return s[:] }())
 
 	got, err := CAFingerprintFromPEM(caPEM)
@@ -102,9 +45,9 @@ func TestCAFingerprintFromPEM(t *testing.T) {
 // adopted if it is byte-identical to, or cross-signed by, the enrolled
 // CA. An unrelated CA (the trust-anchor-swap attack) is refused.
 func TestVerifyCAContinuity(t *testing.T) {
-	oldPEM, oldKey, oldCert := genCA(t, "old-ca")
-	successorPEM := genSubCA(t, "successor-ca", oldCert, oldKey)
-	unrelatedPEM, _, _ := genCA(t, "attacker-ca")
+	oldPEM, oldKey, oldCert := cryptotest.GenCA(t, "old-ca")
+	successorPEM := cryptotest.GenSubCA(t, "successor-ca", oldCert, oldKey)
+	unrelatedPEM, _, _ := cryptotest.GenCA(t, "attacker-ca")
 
 	t.Run("byte-identical accepted", func(t *testing.T) {
 		if err := VerifyCAContinuity(oldPEM, oldPEM); err != nil {

--- a/go/cryptotest/cryptotest.go
+++ b/go/cryptotest/cryptotest.go
@@ -1,0 +1,136 @@
+// Package cryptotest provides shared X.509 test fixtures so the sdk and agent
+// test suites do not each re-implement ECDSA P-256 certificate construction
+// (WS16b DRY). It is a regular (non-_test) package so it can be imported across
+// packages and repos; it therefore deliberately uses FIXED validity bounds
+// rather than time.Now() — the module's clock seam forbids time.Now() outside
+// _test files, and a wide fixed window is "valid now" for any realistic test
+// run while staying within the ASN.1 GeneralizedTime range.
+package cryptotest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Fixed validity window: valid for any realistic test run, comfortably within
+// ASN.1 range. No time.Now() so this importable package stays within the
+// module clock seam.
+var (
+	notBefore = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter  = time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+// serialCounter hands out unique-per-process serial numbers so multiple certs
+// generated in one test run don't collide (the previous per-site builders used
+// time.Now().UnixNano(), which the clock seam forbids here).
+var serialCounter atomic.Int64
+
+func nextSerial() *big.Int { return big.NewInt(serialCounter.Add(1)) }
+
+// GenCA returns a self-signed test CA: its PEM-encoded certificate, its private
+// key, and the parsed certificate (for signing leaves / building pools).
+func GenCA(t testing.TB, commonName string) (caPEM []byte, key *ecdsa.PrivateKey, cert *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          nextSerial(),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create ca: %v", err)
+	}
+	cert, err = x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), key, cert
+}
+
+// CAPEM is a convenience for tests that only need a fresh CA certificate blob.
+func CAPEM(t testing.TB, commonName string) []byte {
+	t.Helper()
+	pemBytes, _, _ := GenCA(t, commonName)
+	return pemBytes
+}
+
+// GenSubCA returns a sub-CA certificate PEM signed by parent/parentKey.
+func GenSubCA(t testing.TB, commonName string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("subca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          nextSerial(),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("create subca: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// GenLeaf issues a leaf certificate (server or client) signed by ca/caKey and
+// returns the PEM-encoded certificate and key. Server leaves carry localhost
+// SANs (127.0.0.1, ::1, localhost) so they work for httptest TLS servers.
+func GenLeaf(t testing.TB, ca *x509.Certificate, caKey *ecdsa.PrivateKey, commonName string, server bool) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: nextSerial(),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	if server {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+		tmpl.DNSNames = []string{"localhost"}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// EncodeCertPEM PEM-encodes an already-parsed certificate.
+func EncodeCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}


### PR DESCRIPTION
## WS16b DRY — shared cert/CSR test fixtures (closes #116)

ECDSA P-256 CA/cert generation was re-implemented in three test sites (sdk `client_loopback_test.go`, sdk `crypto/cert_test.go`, agent `cert_rotation_test.go`). This adds a shared exported **`sdk/go/cryptotest`** package (`GenCA`/`GenSubCA`/`GenLeaf`/`CAPEM`/`EncodeCertPEM`) and routes the two **sdk** sites through it; the agent site migrates in a follow-up PR (it consumes this package after a go.mod bump).

- `cryptotest` is a regular (non-`_test`) package so it's importable across packages and repos. It deliberately uses **fixed validity bounds** (`time.Date`, not `time.Now`) and a per-process serial counter, so the importable helper stays within the module's clock seam (which forbids `time.Now()` outside `_test` files) — verified by the archtest guard.
- Net: removes the duplicated `mustGenCA`/`mustGenCert`/`mustEncodeCert` and `genCA`/`genSubCA` builders.

Gates: `gofmt`/`go vet`/`staticcheck` clean; `go test ./go/ ./go/crypto/ ./go/cryptotest/` green; archtest (clock-seam) green; local CodeRabbit: **no findings**.

Part of the security/RBAC hardening work plan (WS16b).