### PR TITLE
feat(osquery): refuse known-sensitive tables on the convenience table path (WS17a #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ oq := osquery.New()                                // lazy-init, detects install
 rows, err := oq.Query(ctx, "os_version", nil, 0)   // query a table
 ```
 
+The convenience **table** path (`Query`/`QueryTable` with a table name) refuses a
+curated deny-list of credential-bearing tables — `shadow`, `process_envs`,
+`crontab`, `shell_history`, `sudoers` — before any SQL is built or run, so a
+compromised control server cannot exfiltrate them through the agent's privileged
+osquery. The deny-list is defense-in-depth on top of the CA-signed osquery
+RPC; the signed `RawSql` path is the operator's explicit escape hatch and is
+intentionally **not** gated.
+
 #### `sys/encryption` — Disk Encryption
 
 ```go

--- a/go/sys/osquery/osquery.go
+++ b/go/sys/osquery/osquery.go
@@ -18,6 +18,28 @@ import (
 // validTableName matches only safe osquery table names (alphanumeric + underscore).
 var validTableName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// sensitiveTables are osquery tables that can expose credential material or
+// other high-value secrets — password-hash metadata (shadow), secrets in
+// process environments (process_envs), scheduled commands (crontab), shell
+// history (shell_history), and sudoers policy (sudoers). They all pass
+// validTableName, so the shape-only check is not enough: the convenience table
+// path refuses them so a compromised control server cannot exfiltrate them
+// through the agent's privileged osquery. The signed RawSql escape hatch is
+// intentionally NOT gated here — it is the operator's explicit, CA-signed path.
+var sensitiveTables = map[string]bool{
+	"shadow":        true,
+	"process_envs":  true,
+	"crontab":       true,
+	"shell_history": true,
+	"sudoers":       true,
+}
+
+// isSensitiveTable reports whether name is on the curated deny-list. Comparison
+// is case- and whitespace-insensitive so trivial variants cannot slip past.
+func isSensitiveTable(name string) bool {
+	return sensitiveTables[strings.ToLower(strings.TrimSpace(name))]
+}
+
 var (
 	// ErrNotInstalled is returned when osquery is not installed on the system.
 	ErrNotInstalled = errors.New("osquery is not installed")
@@ -125,6 +147,13 @@ func (c *Client) Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResul
 				Error:   fmt.Sprintf("invalid table name: %q", query.Table),
 			}, nil
 		}
+		if isSensitiveTable(query.Table) {
+			return &pb.OSQueryResult{
+				QueryId: query.QueryId,
+				Success: false,
+				Error:   fmt.Sprintf("table %q is not permitted", query.Table),
+			}, nil
+		}
 		sql = fmt.Sprintf("SELECT * FROM %s", query.Table)
 	}
 
@@ -171,10 +200,18 @@ func (c *Client) QueryTable(ctx context.Context, tableName string) ([]*pb.OSQuer
 		if !validTableName.MatchString(tableName) {
 			return nil, fmt.Errorf("invalid table name: %q", tableName)
 		}
+		if isSensitiveTable(tableName) {
+			return nil, fmt.Errorf("table %q is not permitted", tableName)
+		}
 		sql = fmt.Sprintf("SELECT * FROM %s", tableName)
 	}
 	return c.QuerySQL(ctx, sql)
 }
+
+// execPrivileged runs the osquery binary under the privilege backend. It is a
+// package var so tests can record (and refuse) execution, proving the
+// sensitive-table deny-list short-circuits BEFORE any query is run.
+var execPrivileged = sysexec.Privileged
 
 // execQuery executes an osquery command via sudo and returns the output.
 func (c *Client) execQuery(ctx context.Context, query string) (string, error) {
@@ -191,7 +228,7 @@ func (c *Client) execQuery(ctx context.Context, query string) (string, error) {
 		args = append(args, "--json", query)
 	}
 
-	result, err := sysexec.Privileged(ctx, c.binaryPath, args...)
+	result, err := execPrivileged(ctx, c.binaryPath, args...)
 	if err != nil {
 		stderr := ""
 		if result != nil {

--- a/go/sys/osquery/osquery_sensitive_test.go
+++ b/go/sys/osquery/osquery_sensitive_test.go
@@ -1,0 +1,91 @@
+package osquery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// The non-raw Query() table path must refuse known-sensitive tables even though
+// they match validTableName, and must do so BEFORE building or running any SQL.
+// The sensitive cases are sourced from intent (credential-bearing osquery
+// tables), not from the validTableName regex. The execPrivileged seam records
+// every execution so the test can prove the deny path runs zero queries.
+func TestQuery_DeniesSensitiveTables(t *testing.T) {
+	orig := execPrivileged
+	t.Cleanup(func() { execPrivileged = orig })
+
+	var executed []string // args actually sent to the osquery binary
+	execPrivileged = func(ctx context.Context, name string, args ...string) (*sysexec.Result, error) {
+		executed = append(executed, strings.Join(args, " "))
+		return &sysexec.Result{Stdout: "[]"}, nil // valid empty JSON result set
+	}
+
+	c := &Client{binaryPath: "/usr/bin/osqueryi"}
+	ctx := context.Background()
+
+	// present-but-wrong: each sensitive table is regex-valid but policy-forbidden.
+	for table := range sensitiveTables {
+		res, err := c.Query(ctx, &pb.OSQuery{QueryId: "q", Table: table})
+		if err != nil {
+			t.Fatalf("Query(%q) returned a transport error: %v", table, err)
+		}
+		if res.Success {
+			t.Errorf("Query(%q) succeeded; a sensitive table must be refused", table)
+		}
+		if !strings.Contains(res.Error, table) || !strings.Contains(res.Error, "not permitted") {
+			t.Errorf("Query(%q) error = %q, want it to name the table as not permitted", table, res.Error)
+		}
+	}
+	if len(executed) != 0 {
+		t.Errorf("a denied table must execute no query, but %d ran: %v", len(executed), executed)
+	}
+
+	// ABSENT: empty table and empty RawSql → the existing invalid-name rejection.
+	res, err := c.Query(ctx, &pb.OSQuery{QueryId: "q", Table: ""})
+	if err != nil {
+		t.Fatalf("Query(empty) transport error: %v", err)
+	}
+	if res.Success || !strings.Contains(res.Error, "invalid table name") {
+		t.Errorf("empty table = %+v, want the invalid-name rejection", res)
+	}
+
+	// correct: a benign table builds and runs SELECT * FROM <table> exactly once.
+	executed = nil
+	res, err = c.Query(ctx, &pb.OSQuery{QueryId: "q", Table: "os_version"})
+	if err != nil {
+		t.Fatalf("Query(os_version) error: %v", err)
+	}
+	if !res.Success {
+		t.Errorf("a non-sensitive table must be queryable, got %+v", res)
+	}
+	if len(executed) != 1 || !strings.Contains(executed[0], "SELECT * FROM os_version") {
+		t.Errorf("expected exactly one os_version query, got %v", executed)
+	}
+}
+
+// Self-discovering guard: the deny-list must be non-empty, every member must be
+// enforced by isSensitiveTable (including case/whitespace variants), and sample
+// benign tables must stay queryable. Adding a table to sensitiveTables is
+// automatically covered; emptying the set or dropping enforcement fails here.
+func TestSensitiveTables_PolicyNonEmptyAndEnforced(t *testing.T) {
+	if len(sensitiveTables) == 0 {
+		t.Fatal("the sensitive-table deny-list must not be empty")
+	}
+	for table := range sensitiveTables {
+		if !isSensitiveTable(table) {
+			t.Errorf("%q is in sensitiveTables but isSensitiveTable returns false", table)
+		}
+		if !isSensitiveTable(strings.ToUpper(table)) || !isSensitiveTable(" "+table+" ") {
+			t.Errorf("%q case/whitespace variants must also be refused", table)
+		}
+	}
+	for _, benign := range []string{"os_version", "uptime", "system_info"} {
+		if isSensitiveTable(benign) {
+			t.Errorf("%q is a benign table and must stay queryable", benign)
+		}
+	}
+}


### PR DESCRIPTION
## What

The non-raw `osquery.Client.Query`/`QueryTable` table path built `SELECT * FROM <table>` for any name matching `validTableName` (`^[a-zA-Z_][a-zA-Z0-9_]*$`). That shape-only check let credential-bearing tables through — `shadow`, `process_envs`, `crontab`, `shell_history`, `sudoers`.

This adds a curated `sensitiveTables` deny-list consulted on the convenience table path (after `validTableName`), refusing those tables **before any SQL is built or executed**. The signed `RawSql` escape hatch is intentionally **not** gated — it is the operator's explicit, CA-signed path (same posture as WS4 raw-SQL signing).

## Why

osquery actions are CA-signed (WS4), so the threat model here is a compromised control server / malicious operator exfiltrating credential material via the agent's privileged (root) osquery. The deny-list is defense-in-depth on top of signing.

## Tests

- `TestQuery_DeniesSensitiveTables` — each sensitive table is refused (regex-valid, policy-forbidden), the `execPrivileged` seam records **zero** executions on the deny path, the empty-table invalid-name rejection still fires, and a benign table (`os_version`) builds + runs exactly one query.
- `TestSensitiveTables_PolicyNonEmptyAndEnforced` — self-discovering guard: the deny set is non-empty, every member (incl. case/whitespace variants) is enforced, and sample benign tables stay queryable.

Verified RED-before-green (removing the `Query()` gate makes every sensitive table succeed). Full sdk suite + archtest green.

Closes #118
Part of WS17a (agent power-manage-agent#133, finding #1). The agent-side osquery action consumes this once its SDK pin is bumped; this PR is independently mergeable.