### PR TITLE
test: ed25519 fail-closed + byte-tampered sig + hard-failing protovalidate request-field gate (WS17b)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,24 +63,12 @@ jobs:
       - name: go test (excludes integration-tagged files)
         run: go test -race -short ./...
 
-  # Proto-tag completeness checker. Reports every field across
-  # proto/pm/v1/ that lacks a validate: tag. Soft-fail today so the
-  # large historical backlog (~580 fields per the 2026-06-06 audit)
-  # doesn't block unrelated work; promote to hard-fail in a follow-up
-  # once the backlog is down to zero.
-  proto-validate-coverage:
-    name: Proto validate-tag coverage (soft-fail)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Run completeness checker
-        run: go run ./test/protovalidatecoverage ./proto/pm/v1
+  # NOTE: the validate-tag coverage gate is now the Go test
+  # TestEveryBoundableRequestFieldCarriesValidateTag (test/protovalidatecoverage/
+  # coverage_test.go). It hard-fails when a bound-able *Request* field lacks a
+  # validate tag and runs under the `go test` job above, so the previous
+  # soft-fail `go run ./test/protovalidatecoverage` job has been removed (it
+  # always exited 0 and counted response fields the gate intentionally exempts).
 
   proto-lint:
     name: Proto lint + format

--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -1962,12 +1962,17 @@ type CreateUserRequest struct {
 	// @gotags: validate:"required,min=8"
 	Password string `protobuf:"bytes,2,opt,name=password,proto3" json:"password,omitempty" validate:"required,min=8"`
 	// Role IDs to assign to the new user. If empty, the default "User" role is assigned.
-	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty"`
+	// @gotags: validate:"omitempty,dive,ulid"
+	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,dive,ulid"`
 	// Optional profile fields
-	DisplayName       string `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	GivenName         string `protobuf:"bytes,5,opt,name=given_name,json=givenName,proto3" json:"given_name,omitempty"`
-	FamilyName        string `protobuf:"bytes,6,opt,name=family_name,json=familyName,proto3" json:"family_name,omitempty"`
-	PreferredUsername string `protobuf:"bytes,7,opt,name=preferred_username,json=preferredUsername,proto3" json:"preferred_username,omitempty"`
+	// @gotags: validate:"omitempty,max=255"
+	DisplayName string `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,max=255"
+	GivenName string `protobuf:"bytes,5,opt,name=given_name,json=givenName,proto3" json:"given_name,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,max=255"
+	FamilyName string `protobuf:"bytes,6,opt,name=family_name,json=familyName,proto3" json:"family_name,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,max=64"
+	PreferredUsername string `protobuf:"bytes,7,opt,name=preferred_username,json=preferredUsername,proto3" json:"preferred_username,omitempty" validate:"omitempty,max=64"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -2516,10 +2521,13 @@ func (x *UpdateUserResponse) GetUser() *User {
 type UpdateUserProfileRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @gotags: validate:"required,ulid"
-	Id          string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" validate:"required,ulid"`
-	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	GivenName   string `protobuf:"bytes,3,opt,name=given_name,json=givenName,proto3" json:"given_name,omitempty"`
-	FamilyName  string `protobuf:"bytes,4,opt,name=family_name,json=familyName,proto3" json:"family_name,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" validate:"required,ulid"`
+	// @gotags: validate:"omitempty,max=255"
+	DisplayName string `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,max=255"
+	GivenName string `protobuf:"bytes,3,opt,name=given_name,json=givenName,proto3" json:"given_name,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,max=255"
+	FamilyName string `protobuf:"bytes,4,opt,name=family_name,json=familyName,proto3" json:"family_name,omitempty" validate:"omitempty,max=255"`
 	// @gotags: validate:"omitempty,max=64"
 	PreferredUsername string `protobuf:"bytes,5,opt,name=preferred_username,json=preferredUsername,proto3" json:"preferred_username,omitempty" validate:"omitempty,max=64"`
 	// @gotags: validate:"omitempty,max=2048"
@@ -3179,8 +3187,9 @@ type ListDevicesRequest struct {
 	// UNSPECIFIED (0) means "no status filter"; ONLINE / OFFLINE narrow
 	// the listing to that single status.
 	// @gotags: validate:"omitempty,gte=0,lte=2"
-	StatusFilter  DeviceStatus      `protobuf:"varint,3,opt,name=status_filter,json=statusFilter,proto3,enum=pm.v1.DeviceStatus" json:"status_filter,omitempty" validate:"omitempty,gte=0,lte=2"`
-	LabelFilter   map[string]string `protobuf:"bytes,4,rep,name=label_filter,json=labelFilter,proto3" json:"label_filter,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	StatusFilter DeviceStatus `protobuf:"varint,3,opt,name=status_filter,json=statusFilter,proto3,enum=pm.v1.DeviceStatus" json:"status_filter,omitempty" validate:"omitempty,gte=0,lte=2"`
+	// @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
+	LabelFilter   map[string]string `protobuf:"bytes,4,rep,name=label_filter,json=labelFilter,proto3" json:"label_filter,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" validate:"omitempty,dive,keys,max=64,endkeys,max=1024"`
 	MyDevicesOnly bool              `protobuf:"varint,5,opt,name=my_devices_only,json=myDevicesOnly,proto3" json:"my_devices_only,omitempty"` // when true, only return devices assigned to the authenticated user
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -12305,10 +12314,11 @@ type ListExecutionsRequest struct {
 	// @gotags: validate:"omitempty"
 	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty" validate:"omitempty"`
 	// @gotags: validate:"omitempty,ulid"
-	DeviceId      string          `protobuf:"bytes,3,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"omitempty,ulid"` // optional filter
-	StatusFilter  ExecutionStatus `protobuf:"varint,4,opt,name=status_filter,json=statusFilter,proto3,enum=pm.v1.ExecutionStatus" json:"status_filter,omitempty"`
-	TypeFilter    ActionType      `protobuf:"varint,5,opt,name=type_filter,json=typeFilter,proto3,enum=pm.v1.ActionType" json:"type_filter,omitempty"` // optional action type filter
-	Search        string          `protobuf:"bytes,6,opt,name=search,proto3" json:"search,omitempty"`                                                  // searches action name and device hostname
+	DeviceId     string          `protobuf:"bytes,3,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"omitempty,ulid"` // optional filter
+	StatusFilter ExecutionStatus `protobuf:"varint,4,opt,name=status_filter,json=statusFilter,proto3,enum=pm.v1.ExecutionStatus" json:"status_filter,omitempty"`
+	TypeFilter   ActionType      `protobuf:"varint,5,opt,name=type_filter,json=typeFilter,proto3,enum=pm.v1.ActionType" json:"type_filter,omitempty"` // optional action type filter
+	// @gotags: validate:"omitempty,max=255"
+	Search        string `protobuf:"bytes,6,opt,name=search,proto3" json:"search,omitempty" validate:"omitempty,max=255"` // searches action name and device hostname
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -13798,7 +13808,8 @@ type GetDeviceInventoryRequest struct {
 	// @gotags: validate:"required,ulid"
 	DeviceId string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"required,ulid"`
 	// Optional: filter to specific tables (empty = all)
-	TableNames    []string `protobuf:"bytes,2,rep,name=table_names,json=tableNames,proto3" json:"table_names,omitempty"`
+	// @gotags: validate:"omitempty,dive,max=128"
+	TableNames    []string `protobuf:"bytes,2,rep,name=table_names,json=tableNames,proto3" json:"table_names,omitempty" validate:"omitempty,dive,max=128"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -17076,17 +17087,24 @@ type CreateIdentityProviderRequest struct {
 	// @gotags: validate:"required,min=1"
 	ClientSecret string `protobuf:"bytes,5,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty" validate:"required,min=1"`
 	// @gotags: validate:"required,url"
-	IssuerUrl                string            `protobuf:"bytes,6,opt,name=issuer_url,json=issuerUrl,proto3" json:"issuer_url,omitempty" validate:"required,url"`
-	AuthorizationUrl         string            `protobuf:"bytes,7,opt,name=authorization_url,json=authorizationUrl,proto3" json:"authorization_url,omitempty"`
-	TokenUrl                 string            `protobuf:"bytes,8,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
-	UserinfoUrl              string            `protobuf:"bytes,9,opt,name=userinfo_url,json=userinfoUrl,proto3" json:"userinfo_url,omitempty"`
-	Scopes                   []string          `protobuf:"bytes,10,rep,name=scopes,proto3" json:"scopes,omitempty"`
-	AutoCreateUsers          bool              `protobuf:"varint,11,opt,name=auto_create_users,json=autoCreateUsers,proto3" json:"auto_create_users,omitempty"`
-	AutoLinkByEmail          bool              `protobuf:"varint,12,opt,name=auto_link_by_email,json=autoLinkByEmail,proto3" json:"auto_link_by_email,omitempty"`
-	DefaultRoleId            string            `protobuf:"bytes,13,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
-	DisablePasswordForLinked bool              `protobuf:"varint,14,opt,name=disable_password_for_linked,json=disablePasswordForLinked,proto3" json:"disable_password_for_linked,omitempty"`
-	GroupClaim               string            `protobuf:"bytes,15,opt,name=group_claim,json=groupClaim,proto3" json:"group_claim,omitempty"`
-	GroupMapping             map[string]string `protobuf:"bytes,16,rep,name=group_mapping,json=groupMapping,proto3" json:"group_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	IssuerUrl string `protobuf:"bytes,6,opt,name=issuer_url,json=issuerUrl,proto3" json:"issuer_url,omitempty" validate:"required,url"`
+	// @gotags: validate:"omitempty,url"
+	AuthorizationUrl string `protobuf:"bytes,7,opt,name=authorization_url,json=authorizationUrl,proto3" json:"authorization_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,url"
+	TokenUrl string `protobuf:"bytes,8,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,url"
+	UserinfoUrl string `protobuf:"bytes,9,opt,name=userinfo_url,json=userinfoUrl,proto3" json:"userinfo_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,dive,max=255"
+	Scopes          []string `protobuf:"bytes,10,rep,name=scopes,proto3" json:"scopes,omitempty" validate:"omitempty,dive,max=255"`
+	AutoCreateUsers bool     `protobuf:"varint,11,opt,name=auto_create_users,json=autoCreateUsers,proto3" json:"auto_create_users,omitempty"`
+	AutoLinkByEmail bool     `protobuf:"varint,12,opt,name=auto_link_by_email,json=autoLinkByEmail,proto3" json:"auto_link_by_email,omitempty"`
+	// @gotags: validate:"omitempty,ulid"
+	DefaultRoleId            string `protobuf:"bytes,13,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty" validate:"omitempty,ulid"`
+	DisablePasswordForLinked bool   `protobuf:"varint,14,opt,name=disable_password_for_linked,json=disablePasswordForLinked,proto3" json:"disable_password_for_linked,omitempty"`
+	// @gotags: validate:"omitempty,max=255"
+	GroupClaim string `protobuf:"bytes,15,opt,name=group_claim,json=groupClaim,proto3" json:"group_claim,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
+	GroupMapping map[string]string `protobuf:"bytes,16,rep,name=group_mapping,json=groupMapping,proto3" json:"group_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" validate:"omitempty,dive,keys,max=255,endkeys,max=255"`
 	// See IdentityProvider.trust_email_assertions. Default false (secure).
 	TrustEmailAssertions bool `protobuf:"varint,17,opt,name=trust_email_assertions,json=trustEmailAssertions,proto3" json:"trust_email_assertions,omitempty"`
 	unknownFields        protoimpl.UnknownFields
@@ -17494,22 +17512,32 @@ type UpdateIdentityProviderRequest struct {
 	// @gotags: validate:"required,ulid"
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"required,min=1,max=64"
-	Name     string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" validate:"required,min=1,max=64"`
-	Enabled  bool   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	ClientId string `protobuf:"bytes,4,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	Name    string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" validate:"required,min=1,max=64"`
+	Enabled bool   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// @gotags: validate:"omitempty,max=255"
+	ClientId string `protobuf:"bytes,4,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty" validate:"omitempty,max=255"`
 	// If empty, the existing secret is kept.
-	ClientSecret             string            `protobuf:"bytes,5,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
-	IssuerUrl                string            `protobuf:"bytes,6,opt,name=issuer_url,json=issuerUrl,proto3" json:"issuer_url,omitempty"`
-	AuthorizationUrl         string            `protobuf:"bytes,7,opt,name=authorization_url,json=authorizationUrl,proto3" json:"authorization_url,omitempty"`
-	TokenUrl                 string            `protobuf:"bytes,8,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty"`
-	UserinfoUrl              string            `protobuf:"bytes,9,opt,name=userinfo_url,json=userinfoUrl,proto3" json:"userinfo_url,omitempty"`
-	Scopes                   []string          `protobuf:"bytes,10,rep,name=scopes,proto3" json:"scopes,omitempty"`
-	AutoCreateUsers          bool              `protobuf:"varint,11,opt,name=auto_create_users,json=autoCreateUsers,proto3" json:"auto_create_users,omitempty"`
-	AutoLinkByEmail          bool              `protobuf:"varint,12,opt,name=auto_link_by_email,json=autoLinkByEmail,proto3" json:"auto_link_by_email,omitempty"`
-	DefaultRoleId            string            `protobuf:"bytes,13,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
-	DisablePasswordForLinked bool              `protobuf:"varint,14,opt,name=disable_password_for_linked,json=disablePasswordForLinked,proto3" json:"disable_password_for_linked,omitempty"`
-	GroupClaim               string            `protobuf:"bytes,15,opt,name=group_claim,json=groupClaim,proto3" json:"group_claim,omitempty"`
-	GroupMapping             map[string]string `protobuf:"bytes,16,rep,name=group_mapping,json=groupMapping,proto3" json:"group_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// @gotags: validate:"omitempty,max=4096"
+	ClientSecret string `protobuf:"bytes,5,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty" validate:"omitempty,max=4096"`
+	// @gotags: validate:"omitempty,url"
+	IssuerUrl string `protobuf:"bytes,6,opt,name=issuer_url,json=issuerUrl,proto3" json:"issuer_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,url"
+	AuthorizationUrl string `protobuf:"bytes,7,opt,name=authorization_url,json=authorizationUrl,proto3" json:"authorization_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,url"
+	TokenUrl string `protobuf:"bytes,8,opt,name=token_url,json=tokenUrl,proto3" json:"token_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,url"
+	UserinfoUrl string `protobuf:"bytes,9,opt,name=userinfo_url,json=userinfoUrl,proto3" json:"userinfo_url,omitempty" validate:"omitempty,url"`
+	// @gotags: validate:"omitempty,dive,max=255"
+	Scopes          []string `protobuf:"bytes,10,rep,name=scopes,proto3" json:"scopes,omitempty" validate:"omitempty,dive,max=255"`
+	AutoCreateUsers bool     `protobuf:"varint,11,opt,name=auto_create_users,json=autoCreateUsers,proto3" json:"auto_create_users,omitempty"`
+	AutoLinkByEmail bool     `protobuf:"varint,12,opt,name=auto_link_by_email,json=autoLinkByEmail,proto3" json:"auto_link_by_email,omitempty"`
+	// @gotags: validate:"omitempty,ulid"
+	DefaultRoleId            string `protobuf:"bytes,13,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty" validate:"omitempty,ulid"`
+	DisablePasswordForLinked bool   `protobuf:"varint,14,opt,name=disable_password_for_linked,json=disablePasswordForLinked,proto3" json:"disable_password_for_linked,omitempty"`
+	// @gotags: validate:"omitempty,max=255"
+	GroupClaim string `protobuf:"bytes,15,opt,name=group_claim,json=groupClaim,proto3" json:"group_claim,omitempty" validate:"omitempty,max=255"`
+	// @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
+	GroupMapping map[string]string `protobuf:"bytes,16,rep,name=group_mapping,json=groupMapping,proto3" json:"group_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" validate:"omitempty,dive,keys,max=255,endkeys,max=255"`
 	// See IdentityProvider.trust_email_assertions. Default false (secure).
 	TrustEmailAssertions bool `protobuf:"varint,17,opt,name=trust_email_assertions,json=trustEmailAssertions,proto3" json:"trust_email_assertions,omitempty"`
 	unknownFields        protoimpl.UnknownFields
@@ -17853,7 +17881,8 @@ func (x *AuthMethodProvider) GetProviderType() IdentityProviderType {
 type ListAuthMethodsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional email to check user-specific auth methods.
-	Email         string `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	// @gotags: validate:"omitempty,email,max=254"
+	Email         string `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty" validate:"omitempty,email,max=254"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -20136,14 +20165,19 @@ func (x *SearchDateFilter) GetEnd() int64 {
 
 type SearchRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	Query string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	// @gotags: validate:"omitempty,max=1024"
+	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty" validate:"omitempty,max=1024"`
 	// UNSPECIFIED (0) means "all scopes".
 	// @gotags: validate:"omitempty,gte=0,lte=10"
-	Scope         SearchScope         `protobuf:"varint,2,opt,name=scope,proto3,enum=pm.v1.SearchScope" json:"scope,omitempty" validate:"omitempty,gte=0,lte=10"`
-	PageSize      int32               `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	PageToken     string              `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
-	DateFilters   []*SearchDateFilter `protobuf:"bytes,5,rep,name=date_filters,json=dateFilters,proto3" json:"date_filters,omitempty"`
-	TagFilters    map[string]string   `protobuf:"bytes,6,rep,name=tag_filters,json=tagFilters,proto3" json:"tag_filters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // field → value(s), pipe-separated for OR (e.g. "completed|failed")
+	Scope SearchScope `protobuf:"varint,2,opt,name=scope,proto3,enum=pm.v1.SearchScope" json:"scope,omitempty" validate:"omitempty,gte=0,lte=10"`
+	// Matches the handler's effective clamp ([1,200], else default 50).
+	// @gotags: validate:"omitempty,gte=0,lte=200"
+	PageSize int32 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty" validate:"omitempty,gte=0,lte=200"`
+	// @gotags: validate:"omitempty,max=4096"
+	PageToken   string              `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty" validate:"omitempty,max=4096"`
+	DateFilters []*SearchDateFilter `protobuf:"bytes,5,rep,name=date_filters,json=dateFilters,proto3" json:"date_filters,omitempty"`
+	// @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
+	TagFilters    map[string]string `protobuf:"bytes,6,rep,name=tag_filters,json=tagFilters,proto3" json:"tag_filters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" validate:"omitempty,dive,keys,max=64,endkeys,max=1024"` // field → value(s), pipe-separated for OR (e.g. "completed|failed")
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/ts/pm/v1/control_pb.ts
+++ b/gen/ts/pm/v1/control_pb.ts
@@ -979,6 +979,7 @@ export type CreateUserRequest = Message<"pm.v1.CreateUserRequest"> & {
 
   /**
    * Role IDs to assign to the new user. If empty, the default "User" role is assigned.
+   * @gotags: validate:"omitempty,dive,ulid"
    *
    * @generated from field: repeated string role_ids = 3;
    */
@@ -986,22 +987,29 @@ export type CreateUserRequest = Message<"pm.v1.CreateUserRequest"> & {
 
   /**
    * Optional profile fields
+   * @gotags: validate:"omitempty,max=255"
    *
    * @generated from field: string display_name = 4;
    */
   displayName: string;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string given_name = 5;
    */
   givenName: string;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string family_name = 6;
    */
   familyName: string;
 
   /**
+   * @gotags: validate:"omitempty,max=64"
+   *
    * @generated from field: string preferred_username = 7;
    */
   preferredUsername: string;
@@ -1236,16 +1244,22 @@ export type UpdateUserProfileRequest = Message<"pm.v1.UpdateUserProfileRequest">
   id: string;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string display_name = 2;
    */
   displayName: string;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string given_name = 3;
    */
   givenName: string;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string family_name = 4;
    */
   familyName: string;
@@ -1590,6 +1604,8 @@ export type ListDevicesRequest = Message<"pm.v1.ListDevicesRequest"> & {
   statusFilter: DeviceStatus;
 
   /**
+   * @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
+   *
    * @generated from field: map<string, string> label_filter = 4;
    */
   labelFilter: { [key: string]: string };
@@ -5941,6 +5957,8 @@ export type ListExecutionsRequest = Message<"pm.v1.ListExecutionsRequest"> & {
   typeFilter: ActionType;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * searches action name and device hostname
    *
    * @generated from field: string search = 6;
@@ -6678,6 +6696,7 @@ export type GetDeviceInventoryRequest = Message<"pm.v1.GetDeviceInventoryRequest
 
   /**
    * Optional: filter to specific tables (empty = all)
+   * @gotags: validate:"omitempty,dive,max=128"
    *
    * @generated from field: repeated string table_names = 2;
    */
@@ -8288,21 +8307,29 @@ export type CreateIdentityProviderRequest = Message<"pm.v1.CreateIdentityProvide
   issuerUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string authorization_url = 7;
    */
   authorizationUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string token_url = 8;
    */
   tokenUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string userinfo_url = 9;
    */
   userinfoUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,dive,max=255"
+   *
    * @generated from field: repeated string scopes = 10;
    */
   scopes: string[];
@@ -8318,6 +8345,8 @@ export type CreateIdentityProviderRequest = Message<"pm.v1.CreateIdentityProvide
   autoLinkByEmail: boolean;
 
   /**
+   * @gotags: validate:"omitempty,ulid"
+   *
    * @generated from field: string default_role_id = 13;
    */
   defaultRoleId: string;
@@ -8328,11 +8357,15 @@ export type CreateIdentityProviderRequest = Message<"pm.v1.CreateIdentityProvide
   disablePasswordForLinked: boolean;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string group_claim = 15;
    */
   groupClaim: string;
 
   /**
+   * @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
+   *
    * @generated from field: map<string, string> group_mapping = 16;
    */
   groupMapping: { [key: string]: string };
@@ -8482,38 +8515,51 @@ export type UpdateIdentityProviderRequest = Message<"pm.v1.UpdateIdentityProvide
   enabled: boolean;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string client_id = 4;
    */
   clientId: string;
 
   /**
    * If empty, the existing secret is kept.
+   * @gotags: validate:"omitempty,max=4096"
    *
    * @generated from field: string client_secret = 5;
    */
   clientSecret: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string issuer_url = 6;
    */
   issuerUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string authorization_url = 7;
    */
   authorizationUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string token_url = 8;
    */
   tokenUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,url"
+   *
    * @generated from field: string userinfo_url = 9;
    */
   userinfoUrl: string;
 
   /**
+   * @gotags: validate:"omitempty,dive,max=255"
+   *
    * @generated from field: repeated string scopes = 10;
    */
   scopes: string[];
@@ -8529,6 +8575,8 @@ export type UpdateIdentityProviderRequest = Message<"pm.v1.UpdateIdentityProvide
   autoLinkByEmail: boolean;
 
   /**
+   * @gotags: validate:"omitempty,ulid"
+   *
    * @generated from field: string default_role_id = 13;
    */
   defaultRoleId: string;
@@ -8539,11 +8587,15 @@ export type UpdateIdentityProviderRequest = Message<"pm.v1.UpdateIdentityProvide
   disablePasswordForLinked: boolean;
 
   /**
+   * @gotags: validate:"omitempty,max=255"
+   *
    * @generated from field: string group_claim = 15;
    */
   groupClaim: string;
 
   /**
+   * @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
+   *
    * @generated from field: map<string, string> group_mapping = 16;
    */
   groupMapping: { [key: string]: string };
@@ -8645,6 +8697,7 @@ export const AuthMethodProviderSchema: GenMessage<AuthMethodProvider> = /*@__PUR
 export type ListAuthMethodsRequest = Message<"pm.v1.ListAuthMethodsRequest"> & {
   /**
    * Optional email to check user-specific auth methods.
+   * @gotags: validate:"omitempty,email,max=254"
    *
    * @generated from field: string email = 1;
    */
@@ -9680,6 +9733,8 @@ export const SearchDateFilterSchema: GenMessage<SearchDateFilter> = /*@__PURE__*
  */
 export type SearchRequest = Message<"pm.v1.SearchRequest"> & {
   /**
+   * @gotags: validate:"omitempty,max=1024"
+   *
    * @generated from field: string query = 1;
    */
   query: string;
@@ -9693,11 +9748,16 @@ export type SearchRequest = Message<"pm.v1.SearchRequest"> & {
   scope: SearchScope;
 
   /**
+   * Matches the handler's effective clamp ([1,200], else default 50).
+   * @gotags: validate:"omitempty,gte=0,lte=200"
+   *
    * @generated from field: int32 page_size = 3;
    */
   pageSize: number;
 
   /**
+   * @gotags: validate:"omitempty,max=4096"
+   *
    * @generated from field: string page_token = 4;
    */
   pageToken: string;
@@ -9708,6 +9768,8 @@ export type SearchRequest = Message<"pm.v1.SearchRequest"> & {
   dateFilters: SearchDateFilter[];
 
   /**
+   * @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
+   *
    * field → value(s), pipe-separated for OR (e.g. "completed|failed")
    *
    * @generated from field: map<string, string> tag_filters = 6;

--- a/go/verify/verify_test.go
+++ b/go/verify/verify_test.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -9,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 )
@@ -159,8 +161,22 @@ func TestVerify_ByteTamperedSignature(t *testing.T) {
 	}
 	tampered := append([]byte(nil), sig...)
 	tampered[len(tampered)-1] ^= 0x01
-	if err := verifier.Verify(payload, tampered); err == nil {
+	err = verifier.Verify(payload, tampered)
+	if err == nil {
 		t.Fatal("expected error for byte-tampered signature")
+	}
+	// Pin that the rejection comes from the cryptographic comparison
+	// (ecdsa.VerifyASN1), not an ASN.1 parse error — a no-op verifier that only
+	// rejected malformed DER would pass the tail flip but fail this assertion.
+	if !strings.Contains(err.Error(), "invalid ECDSA signature") {
+		t.Errorf("error = %q, want it to name the invalid ECDSA signature (crypto compare)", err)
+	}
+	// A second flip in the middle of the DER guards against a verifier that only
+	// inspects trailing bytes.
+	mid := append([]byte(nil), sig...)
+	mid[len(mid)/2] ^= 0x01
+	if err := verifier.Verify(payload, mid); err == nil {
+		t.Fatal("expected error for a mid-signature byte flip")
 	}
 }
 
@@ -199,6 +215,66 @@ func TestVerify_WrongKey(t *testing.T) {
 	}
 	if err := verifier.Verify([]byte("envelope"), sig); err == nil {
 		t.Fatal("expected error when verifying with the wrong CA")
+	}
+}
+
+// generateTestEd25519CA creates a self-signed ed25519 CA certificate + key.
+// ed25519 is deliberately NOT a supported signing algorithm for action
+// envelopes (only ECDSA and RSA are) — these fixtures drive the fail-closed
+// unsupported-key branches.
+func generateTestEd25519CA(t *testing.T) (certPEM []byte, priv ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Ed25519 CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	if err != nil {
+		t.Fatalf("create ed25519 CA certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), priv
+}
+
+// TestVerifier_RejectsEd25519Key pins the fail-closed unsupported-key contract:
+// a verifier built from an ed25519 cert must refuse to verify (anything other
+// than ECDSA/RSA is rejected), naming the unsupported key type rather than
+// silently treating the signature as valid.
+func TestVerifier_RejectsEd25519Key(t *testing.T) {
+	certPEM, _ := generateTestEd25519CA(t)
+	verifier, err := NewActionVerifier(certPEM)
+	if err != nil {
+		t.Fatalf("NewActionVerifier(ed25519): %v", err)
+	}
+	err = verifier.Verify([]byte("envelope-bytes"), []byte("any-signature-bytes"))
+	if err == nil {
+		t.Fatal("ed25519 verifier must fail closed, not accept the signature")
+	}
+	if !strings.Contains(err.Error(), "unsupported public key type") {
+		t.Errorf("error = %q, want it to name the unsupported public key type", err)
+	}
+}
+
+// TestSigner_RejectsEd25519Key pins the sign-side fail-closed branch: an
+// ActionSigner over an ed25519 key must refuse to sign rather than emit a
+// signature no agent verifier could check.
+func TestSigner_RejectsEd25519Key(t *testing.T) {
+	_, priv := generateTestEd25519CA(t)
+	signer := NewActionSigner(priv) // ed25519.PrivateKey satisfies crypto.Signer
+	_, err := signer.Sign([]byte("envelope-bytes"))
+	if err == nil {
+		t.Fatal("ed25519 signer must fail closed, not produce a signature")
+	}
+	if !strings.Contains(err.Error(), "unsupported key type") {
+		t.Errorf("error = %q, want it to name the unsupported key type", err)
 	}
 }
 

--- a/proto/pm/v1/control.proto
+++ b/proto/pm/v1/control.proto
@@ -276,11 +276,16 @@ message CreateUserRequest {
   // @gotags: validate:"required,min=8"
   string password = 2;
   // Role IDs to assign to the new user. If empty, the default "User" role is assigned.
+  // @gotags: validate:"omitempty,dive,ulid"
   repeated string role_ids = 3;
   // Optional profile fields
+  // @gotags: validate:"omitempty,max=255"
   string display_name = 4;
+  // @gotags: validate:"omitempty,max=255"
   string given_name = 5;
+  // @gotags: validate:"omitempty,max=255"
   string family_name = 6;
+  // @gotags: validate:"omitempty,max=64"
   string preferred_username = 7;
 }
 
@@ -340,8 +345,11 @@ message UpdateUserResponse {
 message UpdateUserProfileRequest {
   // @gotags: validate:"required,ulid"
   string id = 1;
+  // @gotags: validate:"omitempty,max=255"
   string display_name = 2;
+  // @gotags: validate:"omitempty,max=255"
   string given_name = 3;
+  // @gotags: validate:"omitempty,max=255"
   string family_name = 4;
   // @gotags: validate:"omitempty,max=64"
   string preferred_username = 5;
@@ -430,6 +438,7 @@ message ListDevicesRequest {
   // the listing to that single status.
   // @gotags: validate:"omitempty,gte=0,lte=2"
   DeviceStatus status_filter = 3;
+  // @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
   map<string, string> label_filter = 4;
   bool my_devices_only = 5; // when true, only return devices assigned to the authenticated user
 }
@@ -1570,6 +1579,7 @@ message ListExecutionsRequest {
   string device_id = 3; // optional filter
   ExecutionStatus status_filter = 4;
   ActionType type_filter = 5; // optional action type filter
+  // @gotags: validate:"omitempty,max=255"
   string search = 6; // searches action name and device hostname
 }
 
@@ -1788,6 +1798,7 @@ message GetDeviceInventoryRequest {
   // @gotags: validate:"required,ulid"
   string device_id = 1;
   // Optional: filter to specific tables (empty = all)
+  // @gotags: validate:"omitempty,dive,max=128"
   repeated string table_names = 2;
 }
 
@@ -2217,15 +2228,22 @@ message CreateIdentityProviderRequest {
   string client_secret = 5;
   // @gotags: validate:"required,url"
   string issuer_url = 6;
+  // @gotags: validate:"omitempty,url"
   string authorization_url = 7;
+  // @gotags: validate:"omitempty,url"
   string token_url = 8;
+  // @gotags: validate:"omitempty,url"
   string userinfo_url = 9;
+  // @gotags: validate:"omitempty,dive,max=255"
   repeated string scopes = 10;
   bool auto_create_users = 11;
   bool auto_link_by_email = 12;
+  // @gotags: validate:"omitempty,ulid"
   string default_role_id = 13;
   bool disable_password_for_linked = 14;
+  // @gotags: validate:"omitempty,max=255"
   string group_claim = 15;
+  // @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
   map<string, string> group_mapping = 16;
   // See IdentityProvider.trust_email_assertions. Default false (secure).
   bool trust_email_assertions = 17;
@@ -2263,19 +2281,29 @@ message UpdateIdentityProviderRequest {
   // @gotags: validate:"required,min=1,max=64"
   string name = 2;
   bool enabled = 3;
+  // @gotags: validate:"omitempty,max=255"
   string client_id = 4;
   // If empty, the existing secret is kept.
+  // @gotags: validate:"omitempty,max=4096"
   string client_secret = 5;
+  // @gotags: validate:"omitempty,url"
   string issuer_url = 6;
+  // @gotags: validate:"omitempty,url"
   string authorization_url = 7;
+  // @gotags: validate:"omitempty,url"
   string token_url = 8;
+  // @gotags: validate:"omitempty,url"
   string userinfo_url = 9;
+  // @gotags: validate:"omitempty,dive,max=255"
   repeated string scopes = 10;
   bool auto_create_users = 11;
   bool auto_link_by_email = 12;
+  // @gotags: validate:"omitempty,ulid"
   string default_role_id = 13;
   bool disable_password_for_linked = 14;
+  // @gotags: validate:"omitempty,max=255"
   string group_claim = 15;
+  // @gotags: validate:"omitempty,dive,keys,max=255,endkeys,max=255"
   map<string, string> group_mapping = 16;
   // See IdentityProvider.trust_email_assertions. Default false (secure).
   bool trust_email_assertions = 17;
@@ -2304,6 +2332,7 @@ message AuthMethodProvider {
 
 message ListAuthMethodsRequest {
   // Optional email to check user-specific auth methods.
+  // @gotags: validate:"omitempty,email,max=254"
   string email = 1;
 }
 
@@ -2564,13 +2593,18 @@ message SearchDateFilter {
 }
 
 message SearchRequest {
+  // @gotags: validate:"omitempty,max=1024"
   string query = 1;
   // UNSPECIFIED (0) means "all scopes".
   // @gotags: validate:"omitempty,gte=0,lte=10"
   SearchScope scope = 2;
+  // Matches the handler's effective clamp ([1,200], else default 50).
+  // @gotags: validate:"omitempty,gte=0,lte=200"
   int32 page_size = 3;
+  // @gotags: validate:"omitempty,max=4096"
   string page_token = 4;
   repeated SearchDateFilter date_filters = 5;
+  // @gotags: validate:"omitempty,dive,keys,max=64,endkeys,max=1024"
   map<string, string> tag_filters = 6; // field → value(s), pipe-separated for OR (e.g. "completed|failed")
 }
 

--- a/test/protovalidatecoverage/coverage_test.go
+++ b/test/protovalidatecoverage/coverage_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	_ "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestEveryBoundableRequestFieldCarriesValidateTag is the hard CI gate (it
+// replaces the advisory os.Exit(0) scanner in main.go): every *bound-able*
+// field of every `*Request` message type must carry a non-empty
+// `validate:"..."` struct tag, so a new request field cannot reach a handler
+// unvalidated.
+//
+// "Bound-able" is decided BY GO KIND (self-discovering, no name allow-list):
+//   - REQUIRED: string, []byte, repeated/map of scalars, and BUILTIN integers
+//     — these carry meaningful proto3 constraints (max length, dive bounds,
+//     min/max value, ulid/format).
+//   - EXEMPT: proto3 scalar bool / enum (a named integer type) / float, nested
+//     messages and *Timestamp (pointers), repeated/map of messages, and oneof
+//     wrappers — proto3 gives these no presence and no length/format to bound,
+//     so a tag would be a no-op. (A proto3 `optional` scalar generates a
+//     pointer and is treated as a message here; add a tag if one is wanted.)
+//
+// The list of violations is printed so a failure is actionable.
+func TestEveryBoundableRequestFieldCarriesValidateTag(t *testing.T) {
+	var requestTypes int
+	var missing []string
+
+	protoregistry.GlobalTypes.RangeMessages(func(mt protoreflect.MessageType) bool {
+		name := string(mt.Descriptor().Name())
+		if !strings.HasSuffix(name, "Request") {
+			return true
+		}
+		requestTypes++
+		goType := reflect.TypeOf(mt.Zero().Interface()).Elem()
+		for i := 0; i < goType.NumField(); i++ {
+			f := goType.Field(i)
+			if f.Tag.Get("protobuf") == "" {
+				continue // internal state / oneof wrapper / sizeCache
+			}
+			if !tagRequiredForKind(f.Type) {
+				continue
+			}
+			if strings.TrimSpace(f.Tag.Get("validate")) == "" {
+				missing = append(missing, name+"."+f.Name+" ("+f.Type.String()+")")
+			}
+		}
+		return true
+	})
+
+	// Matches-zero guard: a registry that surfaced no request types (a generated
+	// import that silently dropped, or a refactor) would otherwise let this pass
+	// vacuously.
+	if requestTypes == 0 {
+		t.Fatal("no *Request message types discovered — the generated pm package did not register; the gate would pass vacuously")
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%d bound-able request field(s) are missing a validate: tag — add a `// @gotags: validate:\"...\"` marker in the .proto and regenerate:\n  %s",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+}
+
+// tagRequiredForKind reports whether a request field of this Go type must carry
+// a validate tag. See the test doc for the rationale.
+func tagRequiredForKind(ft reflect.Type) bool {
+	switch ft.Kind() {
+	case reflect.String:
+		return true
+	case reflect.Slice:
+		if ft.Elem().Kind() == reflect.Uint8 {
+			return true // bytes
+		}
+		return isScalarKind(ft.Elem().Kind()) // repeated scalar/string; repeated message exempt
+	case reflect.Map:
+		return isScalarKind(ft.Elem().Kind()) // map of scalar values; map of message exempt
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		// A builtin integer (PkgPath == "") is bound-able (min/max). A NAMED
+		// integer type is a proto enum — no proto3 presence/format to bound.
+		return ft.PkgPath() == ""
+	default:
+		// bool, float, ptr (message / *Timestamp / proto3-optional), interface
+		// (oneof), struct.
+		return false
+	}
+}
+
+func isScalarKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	}
+	return false
+}

--- a/test/protovalidatecoverage/main.go
+++ b/test/protovalidatecoverage/main.go
@@ -1,11 +1,15 @@
 // Command protovalidatecoverage scans .proto files under the supplied
-// directory and reports fields that lack a `validate:` constraint
-// declared via the @gotags marker (protoc-go-inject-tag convention).
+// directory and prints a human-readable summary of fields that lack a
+// `validate:` constraint declared via the @gotags marker
+// (protoc-go-inject-tag convention), across ALL messages (requests AND
+// responses) for triage.
 //
-// Today it exits 0 and writes a summary to stdout so it can be wired
-// into CI as a soft signal without breaking unrelated PRs. Once the
-// historical backlog is down to zero the CI step that calls this
-// program should drop its `continue-on-error: true`.
+// It is a reporting tool only — it always exits 0. The authoritative CI gate
+// is the Go test TestEveryBoundableRequestFieldCarriesValidateTag in
+// coverage_test.go, which hard-fails when a bound-able *Request* field is
+// missing a validate tag and runs under the normal `go test ./...` job. This
+// binary stays useful for spotting untagged RESPONSE fields (which the gate
+// deliberately does not require) when triaging coverage by hand.
 //
 // Usage:
 //
@@ -126,9 +130,8 @@ func main() {
 		}
 	}
 
-	// Soft-fail today (continue-on-error in CI). Once the backlog is
-	// zero, flip the exit code below to a hard failure and drop the
-	// continue-on-error from .github/workflows/test.yml.
+	// Reporting tool only — always exits 0. The hard gate is the Go test
+	// TestEveryBoundableRequestFieldCarriesValidateTag (request fields, type-aware).
 	os.Exit(0)
 }
 


### PR DESCRIPTION
WS17b sdk arm.

## verify (#10, #20)
- `TestVerifier_RejectsEd25519Key` / `TestSigner_RejectsEd25519Key` drive the unsupported-key default branches with a self-signed ed25519 cert/key and assert the "unsupported … key type" message — the agent rejects a non-ECDSA/RSA CA rather than silently accepting.
- `TestVerify_ByteTamperedSignature` now asserts the rejection names "invalid ECDSA signature" (crypto compare, not an ASN.1 parse) and adds a mid-signature flip.

## protovalidate hard gate (#4)
Replaces the advisory `os.Exit(0)` scanner with `TestEveryBoundableRequestFieldCarriesValidateTag`: self-discovers every `*Request` type via the proto registry and requires a `validate:` tag on each **bound-able** field, decided **by Go kind** (no name allow-list) — string/bytes/repeated-or-map-of-scalar/builtin-integer require a tag; proto3 scalar bool/enum/float/message/`*Timestamp`/oneof are exempt (proto3 gives them no presence and no length/format to validate). A matches-zero guard fails if the registry surfaces no request types.

Tags the **33** previously-untagged bound-able request fields with intent-sourced constraints (string `max=`, OIDC URLs `url`, email `email`, ids `ulid`, repeated `dive`, maps keyed bounds, `SearchRequest.page_size` matching the handler's [1,200] clamp). The scanner binary stays as a human-readable summary (incl. response fields the gate exempts); the soft-fail CI job is removed since the Go test runs under the normal `go test` gate.

Verified RED-before-green (gate flagged exactly the 33; removing it found 0 untagged). Full sdk suite + archtest green; local CodeRabbit review clean.

The server consumes the new tags when it bumps its SDK pin (WS17b server PR); the validation interceptor then enforces them.

Closes #120