### PR TITLE
test(verify,client): strict-mTLS pinning coverage + shared cryptotest CA fixtures

### DIFF
--- a/go/client_loopback_test.go
+++ b/go/client_loopback_test.go
@@ -572,37 +572,14 @@ func TestWithMTLSFromPEM_ClientPresentsCertificate(t *testing.T) {
 	if !caPool.AppendCertsFromPEM(caPEM) {
 		t.Fatal("AppendCertsFromPEM(ca)")
 	}
-	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
-	if err != nil {
-		t.Fatalf("server keypair: %v", err)
-	}
-
-	handler := &recordingControlHandler{}
-	handler.registerFn = func(req *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
-		return connect.NewResponse(&pm.RegisterResponse{
-			DeviceId: &pm.DeviceId{Value: "ok"},
-		}), nil
-	}
-	path, h := pmv1connect.NewControlServiceHandler(handler)
-	mux := http.NewServeMux()
-	mux.Handle(path, h)
-
-	srv := httptest.NewUnstartedServer(mux)
-	srv.TLS = &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		ClientCAs:    caPool,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS13,
-	}
-	srv.StartTLS()
-	t.Cleanup(srv.Close)
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, caPool)
 
 	t.Run("with cert succeeds", func(t *testing.T) {
 		opt, err := WithMTLSFromPEM(clientCertPEM, clientKeyPEM, caPEM)
 		if err != nil {
 			t.Fatalf("WithMTLSFromPEM: %v", err)
 		}
-		got, err := RegisterAgent(context.Background(), srv.URL,
+		got, err := RegisterAgent(context.Background(), srvURL,
 			"tok", "host", "v0", []byte("csr"), opt)
 		if err != nil {
 			t.Fatalf("RegisterAgent: %v", err)
@@ -619,12 +596,131 @@ func TestWithMTLSFromPEM_ClientPresentsCertificate(t *testing.T) {
 			MinVersion: tls.VersionTLS13,
 		}
 		hc := newHTTPClientWithTLS(tlsConfig)
-		_, err := RegisterAgent(context.Background(), srv.URL,
+		_, err := RegisterAgent(context.Background(), srvURL,
 			"tok", "host", "v0", []byte("csr"), WithHTTPClient(hc))
 		if err == nil {
 			t.Fatal("expected handshake failure without client cert")
 		}
 	})
+}
+
+// startMTLSTestServer starts an httptest TLS server presenting serverCert/Key
+// and requiring a client certificate verified against clientCAPool. It returns
+// the server URL. Shared by the mTLS option tests so the boilerplate lives in
+// one place.
+func startMTLSTestServer(t *testing.T, serverCertPEM, serverKeyPEM []byte, clientCAPool *x509.CertPool) string {
+	t.Helper()
+	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	if err != nil {
+		t.Fatalf("server keypair: %v", err)
+	}
+	handler := &recordingControlHandler{}
+	handler.registerFn = func(*connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+		return connect.NewResponse(&pm.RegisterResponse{DeviceId: &pm.DeviceId{Value: "ok"}}), nil
+	}
+	path, h := pmv1connect.NewControlServiceHandler(handler)
+	mux := http.NewServeMux()
+	mux.Handle(path, h)
+	srv := httptest.NewUnstartedServer(mux)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientCAs:    clientCAPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS13,
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestWithMTLSFromPEM_RejectsServerSignedByForeignCA pins the core gateway-
+// pinning property (WS9 #10): the STRICT variant trusts the internal CA ONLY,
+// so a server whose certificate is signed by a different ("public"/system) CA
+// must be rejected even though it presents a syntactically valid chain. Without
+// this, a publicly-trusted cert with a matching SNI could impersonate the
+// gateway.
+func TestWithMTLSFromPEM_RejectsServerSignedByForeignCA(t *testing.T) {
+	internalCAPEM, _, _ := cryptotest.GenCA(t, "internal-ca")
+	// The client identity is signed by the internal CA so the SERVER accepts the
+	// client; the rejection under test must be the CLIENT refusing the server.
+	internalCAForClientPEM, internalKey, internalCert := cryptotest.GenCA(t, "internal-ca-2")
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, internalCert, internalKey, "device-client", false)
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(internalCAForClientPEM) {
+		t.Fatal("AppendCertsFromPEM(client ca)")
+	}
+
+	// Server cert signed by a FOREIGN CA the strict client does not trust.
+	foreignCAPEM, foreignKey, foreignCert := cryptotest.GenCA(t, "foreign-public-ca")
+	_ = foreignCAPEM
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, foreignCert, foreignKey, "127.0.0.1", true)
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, clientCAPool)
+
+	opt, err := WithMTLSFromPEM(clientCertPEM, clientKeyPEM, internalCAPEM)
+	if err != nil {
+		t.Fatalf("WithMTLSFromPEM: %v", err)
+	}
+	_, err = RegisterAgent(context.Background(), srvURL,
+		"tok", "host", "v0", []byte("csr"), opt)
+	if err == nil {
+		t.Fatal("strict mTLS must reject a server signed by a CA other than the pinned internal CA")
+	}
+}
+
+// TestWithMTLSFromPEMAndSystemRoots_TrustsInternalCA pins that the system-roots
+// variant adds the internal CA to the trust pool (WS9 #10 — the variant had no
+// coverage at all): a server signed by the internal CA is accepted.
+func TestWithMTLSFromPEMAndSystemRoots_TrustsInternalCA(t *testing.T) {
+	caPEM, caKey, caCert := cryptotest.GenCA(t, "internal-ca")
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "127.0.0.1", true)
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "device-client", false)
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("AppendCertsFromPEM(ca)")
+	}
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, clientCAPool)
+
+	opt, err := WithMTLSFromPEMAndSystemRoots(clientCertPEM, clientKeyPEM, caPEM)
+	if err != nil {
+		t.Fatalf("WithMTLSFromPEMAndSystemRoots: %v", err)
+	}
+	got, err := RegisterAgent(context.Background(), srvURL,
+		"tok", "host", "v0", []byte("csr"), opt)
+	if err != nil {
+		t.Fatalf("system-roots variant must trust a server signed by the internal CA: %v", err)
+	}
+	if got.DeviceID != "ok" {
+		t.Errorf("DeviceID = %q", got.DeviceID)
+	}
+}
+
+// TestWithMTLSFromPEMAndSystemRoots_RejectsUntrustedServer pins that broadening
+// the pool to system roots does NOT blanket-trust everything: a server signed by
+// a random CA that is neither the internal CA nor a host system root is still
+// rejected (WS9 #10).
+func TestWithMTLSFromPEMAndSystemRoots_RejectsUntrustedServer(t *testing.T) {
+	internalCAPEM, _, _ := cryptotest.GenCA(t, "internal-ca")
+	clientCAPEM, clientKey, clientCACert := cryptotest.GenCA(t, "internal-ca-2")
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, clientCACert, clientKey, "device-client", false)
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(clientCAPEM) {
+		t.Fatal("AppendCertsFromPEM(client ca)")
+	}
+
+	// Server signed by a CA that is neither the internal CA nor a system root.
+	_, foreignKey, foreignCert := cryptotest.GenCA(t, "untrusted-ca")
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, foreignCert, foreignKey, "127.0.0.1", true)
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, clientCAPool)
+
+	opt, err := WithMTLSFromPEMAndSystemRoots(clientCertPEM, clientKeyPEM, internalCAPEM)
+	if err != nil {
+		t.Fatalf("WithMTLSFromPEMAndSystemRoots: %v", err)
+	}
+	_, err = RegisterAgent(context.Background(), srvURL,
+		"tok", "host", "v0", []byte("csr"), opt)
+	if err == nil {
+		t.Fatal("system-roots variant must still reject a server signed by an untrusted CA")
+	}
 }
 
 func TestWithHTTPClient_AppliedToControlCalls(t *testing.T) {

--- a/go/verify/envelope_test.go
+++ b/go/verify/envelope_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
 
 // newTestEnvelope returns a fully-populated baseline SignedActionEnvelope.
@@ -45,7 +46,7 @@ var fieldMutations = []struct {
 // TestSignVerify_FullEnvelopeRoundTrip pins the correct case: a signature
 // over the deterministic bytes of a full envelope verifies.
 func TestSignVerify_FullEnvelopeRoundTrip(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -72,7 +73,7 @@ func TestSignVerify_FullEnvelopeRoundTrip(t *testing.T) {
 // (sdk#82 / F-C2 / SA-C1) where a compromised relay rewrote the executed
 // action under a still-valid signature.
 func TestVerify_RejectsEveryFieldSwap(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {

--- a/go/verify/verify_streamrpc_test.go
+++ b/go/verify/verify_streamrpc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
 
 // ---------------------------------------------------------------------------
@@ -18,7 +19,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestSignVerifyDomain_RoundTrip_AllDomains(t *testing.T) {
-	certPEM, key := generateTestCA(t)
+	certPEM, key, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(key)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -67,7 +68,7 @@ func TestSignVerifyDomain_RoundTrip_AllDomains(t *testing.T) {
 // payload. This is what stops a compromised relay from lifting, say, an
 // inventory signature onto a LUKS-revoke instruction.
 func TestVerifyDomain_RejectsCrossDomainSignature(t *testing.T) {
-	certPEM, key := generateTestCA(t)
+	certPEM, key, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(key)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -99,7 +100,7 @@ func TestVerifyDomain_RejectsCrossDomainSignature(t *testing.T) {
 // TestSignDomain_RefusesEmptyPayload pins the signer fail-closed: an empty
 // payload is never signed (a blank pre-image would be trivially forgeable).
 func TestSignDomain_RefusesEmptyPayload(t *testing.T) {
-	_, key := generateTestCA(t)
+	_, key, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(key)
 	if _, err := signer.SignDomain(OSQuerySignatureDomain, nil); err == nil {
 		t.Fatal("SignDomain accepted an empty payload")
@@ -111,7 +112,7 @@ func TestSignDomain_RefusesEmptyPayload(t *testing.T) {
 // with Sign still verifies with Verify, and equals signing the same envelope
 // bytes under ActionSignatureDomain via SignDomain.
 func TestActionPath_ByteStable(t *testing.T) {
-	certPEM, key := generateTestCA(t)
+	certPEM, key, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(key)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -271,7 +272,7 @@ func TestLuksAndInventoryCanonical_BindIdentifiers(t *testing.T) {
 // the signature, then verify the received message. Proves both the happy path
 // and that mutating the message after signing (field swap) is rejected.
 func TestEndToEnd_OSQuerySignThenVerify(t *testing.T) {
-	certPEM, key := generateTestCA(t)
+	certPEM, key, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(key)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {

--- a/go/verify/verify_test.go
+++ b/go/verify/verify_test.go
@@ -1,9 +1,7 @@
 package verify
 
 import (
-	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -13,32 +11,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/cryptotest"
 )
 
-// generateTestCA creates a self-signed ECDSA CA certificate and key.
-func generateTestCA(t *testing.T) (certPEM []byte, key *ecdsa.PrivateKey) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("generate CA key: %v", err)
-	}
-	template := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "Test CA"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("create CA certificate: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), key
-}
-
-// generateTestRSACA creates a self-signed RSA CA for testing.
+// generateTestRSACA creates a self-signed RSA CA for testing. The ECDSA CA
+// fixture is the shared cryptotest.GenCA; cryptotest has no RSA variant, so the
+// RSA branch keeps its own helper.
 func generateTestRSACA(t *testing.T) (certPEM []byte, key *rsa.PrivateKey) {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -64,7 +43,7 @@ func generateTestRSACA(t *testing.T) (certPEM []byte, key *rsa.PrivateKey) {
 // TestSignVerify_BytesRoundTrip_ECDSA pins that a signature minted over a
 // byte string verifies with the matching CA public key.
 func TestSignVerify_BytesRoundTrip_ECDSA(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -100,7 +79,7 @@ func TestSignVerify_BytesRoundTrip_RSA(t *testing.T) {
 
 // TestVerify_EmptySignatureRejected covers the ABSENT signature path.
 func TestVerify_EmptySignatureRejected(t *testing.T) {
-	certPEM, _ := generateTestCA(t)
+	certPEM, _, _ := cryptotest.GenCA(t, "Test CA")
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
 		t.Fatalf("NewActionVerifier: %v", err)
@@ -115,7 +94,7 @@ func TestVerify_EmptySignatureRejected(t *testing.T) {
 
 // TestVerify_EmptyEnvelopeRejected covers the ABSENT envelope path.
 func TestVerify_EmptyEnvelopeRejected(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -135,7 +114,7 @@ func TestVerify_EmptyEnvelopeRejected(t *testing.T) {
 
 // TestSign_RefusesEmptyEnvelope is the signer-side fail-closed.
 func TestSign_RefusesEmptyEnvelope(t *testing.T) {
-	_, caKey := generateTestCA(t)
+	_, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	if _, err := signer.Sign(nil); err == nil {
 		t.Fatal("expected Sign to refuse a nil envelope")
@@ -148,7 +127,7 @@ func TestSign_RefusesEmptyEnvelope(t *testing.T) {
 // TestVerify_ByteTamperedSignature flips one byte of the ASN.1 signature
 // (not a wrong key) so a no-op verify cannot pass.
 func TestVerify_ByteTamperedSignature(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -182,7 +161,7 @@ func TestVerify_ByteTamperedSignature(t *testing.T) {
 
 // TestVerify_ByteTamperedEnvelope flips one byte of the signed bytes.
 func TestVerify_ByteTamperedEnvelope(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -202,8 +181,8 @@ func TestVerify_ByteTamperedEnvelope(t *testing.T) {
 
 // TestVerify_WrongKey signs with one CA and verifies with another.
 func TestVerify_WrongKey(t *testing.T) {
-	certPEM, _ := generateTestCA(t)
-	_, differentKey := generateTestCA(t)
+	certPEM, _, _ := cryptotest.GenCA(t, "Test CA")
+	_, differentKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(differentKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {
@@ -280,7 +259,7 @@ func TestSigner_RejectsEd25519Key(t *testing.T) {
 
 // TestSignVerify_LargeEnvelope round-trips a 1 MiB payload.
 func TestSignVerify_LargeEnvelope(t *testing.T) {
-	certPEM, caKey := generateTestCA(t)
+	certPEM, caKey, _ := cryptotest.GenCA(t, "Test CA")
 	signer := NewActionSigner(caKey)
 	verifier, err := NewActionVerifier(certPEM)
 	if err != nil {


### PR DESCRIPTION
Closes #122.

**WS9 #10 — strict mTLS pinning (was unverified).** `WithMTLSFromPEMAndSystemRoots` had no test at all and the strict `WithMTLSFromPEM` was never tested to *reject* a foreign-CA-signed server. Adds three handshake tests: strict rejects a server signed by a CA other than the pinned internal CA; the system-roots variant trusts the internal CA yet still rejects an untrusted one. Shared mTLS httptest-server helper.

**WS16b — DRY.** Migrate the `verify` package tests off the duplicated hand-rolled ECDSA `generateTestCA` onto the shared `cryptotest.GenCA` (RSA branch keeps its own helper; cryptotest has no RSA variant).

Test-only; full sdk build/vet/test green.