### PR TITLE
feat(exec): injected Runner foundation — Command, Secret, Detect, exectest (#124)

### DIFF
--- a/docs/sdk-rework-contracts.md
+++ b/docs/sdk-rework-contracts.md
@@ -1,0 +1,613 @@
+# SDK Rework — Refined Per-Package Contracts
+
+> Companion to [sdk-rework-design.md](sdk-rework-design.md). That doc holds the
+> ratified architecture (Decisions 1–7); this one is the **line-reviewable API
+> surface** for every in-scope package, derived from a full source audit. Each
+> section lists the interface, options, errors, preserved hardening, and what
+> changes. All forks (U1/O1/F1/P1) are **resolved** — see §14.
+
+Conventions (from the design doc): ctx-first; options structs with valid zero
+values; typed errors (`*exec.CommandError` + sentinels); interface + explicit
+`Backend`; **the `exec.Runner` is passed explicitly as a required constructor
+argument** — `New(backend, runner, opts...)` for backend-pattern packages,
+`New(runner, opts...)` for single-impl — there is **no default escalation** (a
+silent `sudo` default would contradict Decision 5). `Detect(ctx) []Backend` is
+the sole discovery primitive; no global state; no leaked `*exec.Result`. The
+per-package `New(...)` signatures below omit the required `runner` arg for
+brevity.
+
+---
+
+## 0. `exec` — the Runner foundation (implement first)
+
+The ~12 current entrypoints (`Run`, `RunInDir`, `RunWithStdin`, `RunWithCLocale`,
+`RunStreaming`, `RunStreamingChildPath`, `Privileged`, `PrivilegedWithStdin`,
+`PrivilegedStreaming`, `Query*`, `Check*`) collapse into **one `Command` value +
+two methods**:
+
+```go
+type PrivilegeBackend int
+const (
+    Sudo   PrivilegeBackend = iota + 1 // sudo -n
+    Doas                               // doas -n
+    Direct                             // no wrapper — process is already root
+)
+
+// Command describes one execution. Zero value invalid (Name required).
+type Command struct {
+    Name      string    // resolved to an absolute path before escalation
+    Args      []string
+    Dir       string    // "" = inherit cwd
+    Env       []string  // extra KEY=VALUE; screened by the env blocklist
+    Stdin     io.Reader
+    CLocale   bool      // force LC_ALL=C / LANG=C for stable parsing
+    ChildPath string    // explicit child PATH (per-user runuser); "" = sanitized default
+    Escalate  bool      // run through the privilege backend
+}
+
+type Result struct { ExitCode int; Stdout, Stderr string }
+
+// CommandError is returned by the capability layer when a command exits
+// non-zero. Inspect with errors.As. (The Runner itself does NOT treat a
+// non-zero exit as an error — see below.)
+type CommandError struct { Name string; ExitCode int; Stderr string; Err error }
+func (e *CommandError) Error() string ; func (e *CommandError) Unwrap() error
+
+type Stream int
+const ( StdoutStream Stream = iota + 1; StderrStream )
+type OnLine func(s Stream, line string, seq int64)
+
+type Runner interface {
+    Run(ctx context.Context, c Command) (Result, error)
+    Stream(ctx context.Context, c Command, onLine OnLine) (Result, error)
+    Backend() PrivilegeBackend // lets fs pick its fd-safe vs sudo path
+}
+func NewRunner(b PrivilegeBackend) (Runner, error) // pure: validates b is known; does NOT probe the host
+
+// Detect — the SAME discovery primitive every capability backend has (Decision 6):
+// it LISTS the escalation backends available on this host (Sudo if `sudo` on PATH,
+// Doas if `doas` on PATH). It does NOT pick and does NOT construct anything. The
+// consumer reads the list, picks one explicitly, and passes it down. There is no
+// DetectRunner / auto-pick-and-construct (that was the boot-time auto-derive we
+// rejected). Direct — run as the current process, no wrapper — needs no detection.
+func Detect(ctx context.Context) []PrivilegeBackend
+//   avail := exec.Detect(ctx)               // e.g. []PrivilegeBackend{exec.Sudo}
+//   runner, _ := exec.NewRunner(pick(avail)) // consumer picks; pass it to every New(...)
+
+// If the chosen tool turns out unusable, the FIRST escalated command fails closed:
+var ErrEscalationUnavailable error // chosen tool (sudo/doas) not installed
+var ErrEscalationDenied      error // `sudo -n`/`doas -n` needs a password (no NOPASSWD)
+
+// Pure, still package-level:
+const EndOfOptions = "--"
+const MaxOutputBytes = 1 << 20
+func SeparatePositionals(flags []string, positionals ...string) []string
+var ErrInvalidEnvVar, ErrBlockedEnvVar error
+```
+
+- **Runner error semantics:** `Run`/`Stream` return a non-nil `error` only on
+  *failure to execute* (binary not found, ctx cancelled, blocked env var). A
+  **non-zero exit is reported in `Result.ExitCode`, not as an error** — because
+  several callers branch on specific codes (`cryptsetup` 2 = wrong passphrase,
+  `isLuks` 1 = not LUKS, `pkill` 1 = no match). The **capability layer** decides
+  when a non-zero exit becomes a `*CommandError`. Clean split: Runner = mechanism,
+  Manager = policy.
+- **Preserved verbatim:** the env blocklist (`LD_PRELOAD`/`PATH`/`BASH_ENV`/…),
+  `--` positional separation, 1 MiB per-stream output cap + `[output truncated]`,
+  SIGTERM→SIGKILL process-group escalation after `killGrace`, absolute-path
+  resolution before escalation, `CappedBuffer`'s always-consume write contract.
+- **Deleted:** `SetPrivilegeBackend`/`CurrentPrivilegeBackend` globals; the
+  deprecated `Query`/`QueryOutput`/`Check` (caller does `Run` + reads `Result`).
+- **Escalation layering (who decides what):** a capability backend sets
+  `Command.Escalate` per operation ("this needs privilege" — e.g. `pkg.Install`
+  yes, `pkg.Search` no) and builds the argv; it is **escalation-method-agnostic**.
+  The **Runner** is the only component that knows *how* to escalate — `Sudo` →
+  `sudo -n <abs-path> …`, `Doas` → `doas -n …`, `Direct` → bare. The
+  `PrivilegeBackend` is chosen **once**, explicitly, where the Runner is
+  constructed (the agent runs as root → `Direct`, no wrapper; a non-root SDK
+  consumer picks `Sudo`/`Doas` explicitly — from its own config or from
+  `exec.Detect`'s list; the SDK never picks for it). So
+  `apt install vlc` = `runner.Run(Command{Name:"apt-get", Args:[…,"vlc"],
+  Escalate:true})`; the `sudo`/`doas`/nothing prefix is entirely the Runner's job.
+
+---
+
+## 1. `pkg`
+
+```go
+type Backend int
+const ( Apt Backend = iota + 1; Dnf; Pacman; Zypper; Flatpak )
+
+type Manager interface {
+    Info(ctx context.Context) (Info, error)
+    Install(ctx context.Context, names []string, opts InstallOptions) error
+    Remove(ctx context.Context, names []string, opts RemoveOptions) error
+    Update(ctx context.Context) error
+    Upgrade(ctx context.Context, names []string) error // nil = all
+    Search(ctx context.Context, query string) ([]SearchResult, error)
+    List(ctx context.Context) ([]Package, error)
+    ListUpgradable(ctx context.Context) ([]PackageUpdate, error)
+    Show(ctx context.Context, name string) (Package, error)
+    ListVersions(ctx context.Context, name string) (VersionInfo, error)
+    IsInstalled(ctx context.Context, name string) (bool, error)
+    InstalledVersion(ctx context.Context, name string) (string, error)
+    Pin(ctx context.Context, names []string) error
+    Unpin(ctx context.Context, names []string) error
+    ListPinned(ctx context.Context) ([]Package, error)
+    IsPinned(ctx context.Context, name string) (bool, error)
+    Autoremove(ctx context.Context) error // remove orphaned deps; no-op where a backend has no equivalent
+    Repair(ctx context.Context) error     // broken-state repair (subsumes apt FixBroken)
+    InstalledCount(ctx context.Context) (int, error)
+}
+func New(b Backend, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend // probes apt-get/dnf/pacman/zypper/flatpak on PATH
+
+type InstallOptions struct { Version string; AllowDowngrade bool }
+type RemoveOptions  struct { Purge bool } // folds the per-backend Purge methods in
+```
+
+- **ctx moves to every method** (was stored on the constructor via
+  `NewAptWithContext`). `Success bool` dropped from results (`error` is the
+  signal). `GetInstalledVersion`→`InstalledVersion` (no `Get` prefix). `WithSudo`
+  → the required `runner` arg. Per-distro structs (`Apt`/`Dnf`/…) **unexported**.
+- **Validation always-on:** `New` returns the validating manager (the
+  `WithValidation` wrapper becomes the default, not opt-in). All validators
+  preserved: `ValidatePackageName`/`Names`/`Version`, `ValidateRpmPackageName`,
+  `ValidateRemoteName`, `ValidateRepoBaseURL` (https-only), `ValidateGpgKeyRef`
+  (no `..`, no plaintext http, no `ext::`). LANG=C/LC_ALL=C read-side env preserved.
+- `InstallVersion` folds into `Install(names, InstallOptions{Version})`; the
+  per-backend version syntax (`name=version` vs `name-version`) stays internal.
+- **P1 — RESOLVED (generalize or fold; no typed-assertion side-interface).**
+  `Autoremove(ctx) error` is a first-class method — generic across
+  apt/dnf/pacman/flatpak; a backend with no native equivalent **no-ops**
+  (returns nil). `DistUpgrade` **folds into `Upgrade(ctx, nil)`** (apt runs
+  `dist-upgrade` internally for held-back packages; dnf/pacman/flatpak's
+  upgrade-all is already full). `FixBroken` **folds into `Repair(ctx)`**. No
+  apt-only interface.
+
+---
+
+## 2. `user`
+
+```go
+const ShadowUtils Backend = iota + 1 // only value today (Decision 5)
+func New(b Backend, opts ...Option) (Manager, error)
+
+type Manager interface {
+    // Accounts
+    Get(ctx context.Context, name string) (Info, error)
+    Exists(ctx context.Context, name string) (bool, error)
+    Create(ctx context.Context, name string, opts CreateOptions) error
+    Modify(ctx context.Context, name string, opts ModifyOptions) error
+    Delete(ctx context.Context, name string, opts DeleteOptions) error
+    Lock(ctx context.Context, name string) error
+    Unlock(ctx context.Context, name string) error
+    SetPassword(ctx context.Context, name string, password Secret) error
+    ExpirePassword(ctx context.Context, name string) error
+    PrimaryGroup(ctx context.Context, name string) (string, error)
+    SupplementaryGroups(ctx context.Context, name string) ([]string, error)
+    KillSessions(ctx context.Context, name string) error
+    SetHiddenOnLoginScreen(ctx context.Context, name string, hidden bool) error
+    // Groups
+    GroupExists(ctx context.Context, name string) (bool, error)
+    GroupMembers(ctx context.Context, name string) ([]string, error)
+    GroupCreate(ctx context.Context, name string, opts GroupCreateOptions) error
+    GroupDelete(ctx context.Context, name string) error
+    GroupEnsure(ctx context.Context, name string) error
+    AddToGroup(ctx context.Context, name, group string) error
+    RemoveFromGroup(ctx context.Context, name, group string) error
+}
+
+// CreateOptions zero value = normal interactive account, login shell, matching
+// primary group, no home.
+type CreateOptions struct {
+    UID          int      // 0 = auto
+    PrimaryGroup string   // name or numeric GID; "" = useradd matching-group default
+    Groups       []string // supplementary
+    Shell        string   // "" = DefaultShell(System): login shell, nologin if System
+    HomeDir      string   // "" = /home/<name>
+    Comment      string   // GECOS
+    System       bool     // -r; flips DefaultShell to nologin
+    CreateHome   bool     // -m; SDK handles the "home already exists" -M/chown dance
+}
+type ModifyOptions      struct { Shell, HomeDir, Comment, PrimaryGroup string } // "" = unchanged
+type DeleteOptions      struct { RemoveHome bool }
+type GroupCreateOptions struct { GID int; System bool }
+
+// Pure helpers stay package-level (no backend variance):
+func IsValidName(name string) bool
+func DefaultShell(system bool) string          // "/bin/bash" | "/usr/sbin/nologin"
+func GeneratePassword(length int, c Complexity) (Secret, error) // was complex bool
+```
+
+- **The agent's 170-line `createUser` flag-assembly + default-shell policy +
+  `-m`/`-M` home dance move INTO `Create`.** The agent then composes product
+  policy (LPS temp-password rows, SSH `authorized_keys`, AccountsService hiding)
+  on top.
+- `Get`/`Exists`/`PrimaryGroup`/group queries gain `ctx` (the internal 10s
+  `queryTimeout` becomes the default when the ctx has no deadline). **No more
+  `(*exec.Result, error)`** anywhere — non-zero `useradd`/`usermod` exit →
+  `*exec.CommandError` carrying stderr (the "user already exists" context callers
+  need). `ChownRecursive` deprecated alias **deleted** (use `fs`).
+- **Preserved:** `IsValidName`/`validateName` on every mutation (no `-`-leading →
+  flag; no newline/colon injection), `SetPassword` newline/CR rejection.
+- **U1 — `Secret` type — RATIFIED (yes).** Passwords/keys are an `exec.Secret`
+  wrapper (redacted `String()`, `Reveal()` for the one sink, newline-rejecting
+  constructor), not bare `string`. Applies here + encryption + network PSK. §14.
+
+---
+
+## 3. `service`
+
+```go
+const Systemd Backend = iota + 1 // only value (OpenRC/Runit/S6 enum deleted)
+func New(b Backend, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend // probes systemctl + /run/systemd/system
+
+type Manager interface {
+    Status(ctx context.Context, unit string) (UnitStatus, error)
+    IsEnabled(ctx context.Context, unit string) (bool, error)
+    IsActive(ctx context.Context, unit string) (bool, error)
+    IsMasked(ctx context.Context, unit string) (bool, error)
+    Enable(ctx context.Context, unit string) error
+    Disable(ctx context.Context, unit string) error
+    EnableNow(ctx context.Context, unit string) error
+    DisableNow(ctx context.Context, unit string) error
+    Start(ctx context.Context, unit string) error
+    Stop(ctx context.Context, unit string) error
+    Restart(ctx context.Context, unit string) error
+    Mask(ctx context.Context, unit string) error
+    Unmask(ctx context.Context, unit string) error
+    DaemonReload(ctx context.Context) error
+    WriteUnit(ctx context.Context, unit, content string) error
+    RemoveUnit(ctx context.Context, unit string) error
+}
+type UnitStatus struct { Enabled, Active, Masked, Static bool }
+func ValidateUnitName(unit string) error // pure helper
+```
+
+- `Status`/`IsEnabled`/`IsActive`/`IsMasked` gain `ctx` (the 30s
+  `systemctlQueryTimeout` becomes the no-deadline default). Global
+  `SetBackend`/`SetServiceBackend` + aliases deleted.
+- **Preserved:** `validSystemdUnitName` regex, the `validSystemctlOutputs`
+  whitelist (distinguishes "disabled" from "couldn't tell"), `--` on every
+  `systemctl` call, `WriteUnit` via `fs` atomic write.
+
+---
+
+## 4. `encryption`
+
+```go
+const LUKS Backend = iota + 1 // only value (GELI/CGD enum deleted)
+func New(b Backend, opts ...Option) (Manager, error)
+
+type Manager interface {
+    IsEncrypted(ctx context.Context, dev string) (bool, error)      // was IsLuks
+    AddKey(ctx context.Context, dev string, existing, new Secret, opts AddKeyOptions) error
+    RemoveKey(ctx context.Context, dev string, key Secret) error
+    KillSlot(ctx context.Context, dev string, slot int, existing Secret) error
+    VerifyPassphrase(ctx context.Context, dev string, p Secret) (bool, error) // was TestPassphrase
+    DetectVolume(ctx context.Context) (Volume, error)
+    DetectVolumeByKey(ctx context.Context, p Secret) (Volume, error)
+    DetectAllVolumes(ctx context.Context) ([]Volume, error)
+    TPM() (TPMEnroller, bool) // ok=false if backend has no TPM support
+}
+type AddKeyOptions struct { Slot int } // 0 = auto; folds AddKey + AddKeyToSlot
+type Volume struct { DevicePath, MapperName, MountPoint string }
+type TPMEnroller interface {
+    Available(ctx context.Context) (bool, error)        // was HasTPM2
+    Enroll(ctx context.Context, dev string, existing Secret) error
+    Wipe(ctx context.Context, dev string, existing Secret) error
+}
+const ( LuksMinKeySlot = 0; LuksMaxKeySlot = 7 )
+var ErrInvalidKeySlot error
+
+// Pure helpers stay package-level:
+func GeneratePassphrase(minWords int) (Secret, error)
+func ValidatePassphrase(p string, minLength int, c Complexity) string
+func HashPassphrase(p string) string ; func IsRecentlyUsed(p string, hashes []string) bool
+type Complexity int ; const ( ComplexityNone Complexity = iota; ComplexityAlphanumeric; ComplexityComplex )
+```
+
+- **`TestPassphrase`→`VerifyPassphrase`** (the `TestXxx` non-test name is a
+  go-test footgun). `AddKey`+`AddKeyToSlot` collapse to one method + options.
+  `requireBackend`/global `SetBackend` deleted (the handle is LUKS by
+  construction). `HasTPM2`→`TPMEnroller.Available`.
+- **Preserved:** keyslot 0–7 validation, ephemeral key files in `/dev/shm`
+  (mode 0600, never disk), zero-overwrite + `O_NOFOLLOW` cleanup,
+  `cryptsetup` exit-code translation, the `lsblk -J` LUKS/LVM-on-LUKS detection.
+
+---
+
+## 5. `network` (wifi)
+
+```go
+const NetworkManager Backend = iota + 1 // only value (connman/wpa/iwd deleted)
+func New(b Backend, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend // probes nmcli
+
+type Manager interface {
+    ConnectionExists(ctx context.Context, name string) (bool, error)
+    Apply(ctx context.Context, p Profile) (changed bool, err error) // was CreateOrUpdate
+    Delete(ctx context.Context, name string, opts DeleteOptions) error
+    Settings(ctx context.Context, name string) (map[string]string, error)
+}
+type AuthType int ; const ( AuthPSK AuthType = iota + 1; AuthEAPTLS )
+type Profile struct {
+    Name, SSID string
+    AuthType   AuthType
+    PSK        Secret // PSK only — never enters argv (keyfile route preserved)
+    CACert, ClientCert string
+    ClientKey  Secret  // EAP-TLS
+    Identity   string
+    AutoConnect, Hidden bool
+    Priority   int
+    CertDir    string // must be under CertBaseDir
+}
+type DeleteOptions struct { CertDir string }
+const CertBaseDir = "/var/lib/power-manage/wifi"
+```
+
+- `IsAvailable` folds into `Detect`. **`BuildAddArgs`/`BuildModifyArgs`/
+  `BuildPSKKeyfile` become unexported** (they were leaking internals). `Apply`
+  keeps the named `changed bool` return.
+- **Preserved:** PSK-never-in-argv (keyfile mode 0600 + reload), EAP-TLS staged
+  cert swap with rollback, `CertDir`-under-`CertBaseDir` symlink-aware validation.
+
+---
+
+## 6. `firewall`
+
+```go
+const ( Nftables Backend = iota + 1; Firewalld; UFW ) // 3 implemented; iptables/pf deleted
+func New(b Backend, namespace string, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend
+
+type Manager interface {
+    ApplyRule(ctx context.Context, r Rule) error
+    RemoveRule(ctx context.Context, id string) error
+    List(ctx context.Context) ([]Rule, error)
+    Namespace() string
+}
+type Protocol string ; const ( ProtocolTCP Protocol = "tcp"; ProtocolUDP = "udp"; ProtocolAny = "" )
+type Rule struct { ID string; Allow bool; Protocol Protocol; Port int; Source, Dest string }
+var ErrInvalidRule, ErrInvalidNamespace error
+```
+
+- Already a `Manager`; just folds `Backend` into `New` (drops the global
+  `SetBackend`) — **one of the two packages that keeps a real `Backend` arg.**
+- **Preserved:** namespace isolation, `validateRule` (ID/port/protocol/addr) +
+  per-backend scope (firewalld v1 allow-only), idempotent apply / no-op remove.
+- Note the firewalld v1 scope is narrower (no source/dest) — surfaced via
+  `ErrInvalidRule` when a caller exceeds it. Documented, not silently dropped.
+
+---
+
+## 7. `fs`
+
+**F1 — consolidate the write surface — RATIFIED.** The four atomic-ish write
+paths (`WriteFile` priv-tee, `WriteFileAtomic` priv string-mode, `AtomicWriteFile`
+non-priv `os.FileMode`, `SafeReplaceFile` symlink-safe) collapse into **one
+`WriteFile` that is always atomic + symlink-safe**, `os.FileMode` everywhere
+(drop string `"0644"`), options struct.
+
+```go
+func New(runner exec.Runner, opts ...Option) (Manager, error) // single-impl-by-nature; runner required
+
+type Manager interface {
+    ReadFile(ctx context.Context, path string) ([]byte, error)
+    WriteFile(ctx context.Context, path string, data []byte, opts WriteOptions) error
+    Exists(ctx context.Context, path string) (bool, error)
+    Mkdir(ctx context.Context, path string, opts MkdirOptions) error
+    Remove(ctx context.Context, path string) error    // was RemoveStrict; error-swallowing Remove dropped
+    RemoveDir(ctx context.Context, path string) error  // deny-by-default + symlink-safe
+    Copy(ctx context.Context, src, dst string, opts WriteOptions) error
+    SetMode(ctx context.Context, path string, mode os.FileMode) error
+    SetOwnership(ctx context.Context, path, owner, group string) error
+    SetOwnershipRecursive(ctx context.Context, path, owner, group string) error // no longer leaks Result
+    IsReadOnly(ctx context.Context, path string) (bool, error)
+    RemountRW(ctx context.Context, path string) error
+}
+type WriteOptions struct {
+    Mode         os.FileMode // 0 = 0644
+    Owner, Group string
+    Backup       string // "" = none; else copy-then-replace (was SafeBackupAndReplace)
+}
+type MkdirOptions struct { Mode os.FileMode; Owner, Group string; Recursive bool }
+
+// fd-anchored primitives + path predicates stay exported (the agent uses them directly):
+func OpenRealDir(path string) (*os.File, error)
+func FchownNoFollow(path string, uid, gid int) error
+func SetDirPermissionsNoFollow(path string, mode os.FileMode, uid, gid int) error
+func ResolveOwnership(owner, group string) (uid, gid int, err error)
+func IsProtectedPath(path string) bool ; func IsUnderProtectedPrefix(path string) bool
+func ValidatePath(path string) error ; func ResolveAndValidatePath(path string) (string, error)
+var ErrInvalidPath error
+```
+
+- **`WriteFile` picks fd-safe (`O_NOFOLLOW`+`renameat2`) when `Runner.Backend()
+  == Direct` (root), else the sudo tee/mv path** — exactly today's privilege-keyed
+  behaviour, now driven by the injected Runner instead of a global. This is why
+  `Runner` exposes `Backend()`.
+- **Preserved:** every symlink/TOCTOU defense (fd-anchored ops, `RENAME_NOREPLACE`,
+  deny-by-default `IsUnderProtectedPrefix` subtree refusal), atomic-write
+  ordering (mode-before-rename, fsync), `ValidatePath` (NUL / leading-`-`).
+- `Ownership`/`GetOwnership`/`AssertRealDir` retained as helpers; the three
+  separate atomic constructors are gone in favor of `WriteFile`+`WriteOptions`.
+
+---
+
+## 8. `reboot`
+
+```go
+func New(opts ...Option) (Manager, error)
+type Manager interface {
+    IsRequired(ctx context.Context) (bool, error) // was IsRequired() bool — now ctx + honest error
+    Schedule(ctx context.Context, opts ScheduleOptions) error
+    Cancel(ctx context.Context) error
+}
+type ScheduleOptions struct { Delay string; Message string } // Delay "" = "+1"
+```
+
+- `IsRequired` gains `ctx` and **returns the error** instead of swallowing it
+  (caller decides if a probe failure means "assume no"). Multi-distro detection
+  (Debian `/var/run/reboot-required` → Fedora `needs-restarting -r`) stays internal.
+
+---
+
+## 9. `notify`
+
+```go
+func New(opts ...Option) (Manager, error)
+type Manager interface {
+    NotifyAll(ctx context.Context, n Notification) error            // was (…) with NO return
+    NotifyUsers(ctx context.Context, users []string, n Notification) error
+}
+type Notification struct {
+    Title, Body string
+    Urgency     Urgency // was hardcoded "critical"
+    AppName     string  // was hardcoded "Power Manage"
+    Icon        string  // was hardcoded "dialog-warning"
+}
+type Urgency int ; const ( UrgencyLow Urgency = iota; UrgencyNormal; UrgencyCritical )
+```
+
+- **Both methods now return `error`** (today they return nothing and swallow
+  everything — the design's "never silently ignore errors" rule). Best-effort
+  per-recipient failures aggregate into the returned error; the caller chooses to
+  ignore. The hardcoded `notify-send` flags become `Notification` fields.
+- **Preserved:** wall + desktop fan-out, graphical-session filtering
+  (`Remote=no`, `Type ∈ {x11,wayland,mir}`), `runuser`+`DBUS_SESSION_BUS_ADDRESS`.
+
+---
+
+## 10. `inventory`
+
+```go
+func New(opts ...Option) (Collector, error)
+type Collector interface {
+    SystemInfo(ctx context.Context) (SystemInfo, error)
+    OSInfo(ctx context.Context) (OSInfo, error)                 // gains ctx for uniformity
+    Disks(ctx context.Context) ([]DiskInfo, error)
+    NetworkInterfaces(ctx context.Context) ([]NetworkInterface, error)
+}
+type SystemInfo struct { Hostname, CPUModel string; CPUCores int; MemoryTotalMB int64; Arch, KernelVersion string }
+type OSInfo    struct { Name, Version, ID, PrettyName, VersionID, Arch string }
+type DiskInfo  struct { Device, Size, Type, Mount string }
+type NetworkInterface struct { Name, MAC string; Addresses []string; State string }
+```
+
+- Drop the `Get` prefix (`GetSystemInfo`→`SystemInfo`). `OSInfo` gains `ctx` for
+  shape-uniformity even though it's file-only. Structs unchanged (good as-is).
+
+---
+
+## 11. `desktop`
+
+```go
+func New(opts ...Option) (Manager, error)
+type Manager interface {
+    ActiveSessions(ctx context.Context) ([]Session, error)
+    HomeUsers(ctx context.Context) ([]Session, error)
+    UsersWithFlatpakInstall(ctx context.Context, appID string) ([]Session, error)
+    RunAsCommand(ctx context.Context, s Session, opts RunAsOptions, name string, args ...string) (*exec.Cmd, error)
+}
+type Session struct { ID, Username string; UID, GID int; Home, RuntimeDir, Type string }
+type RunAsOptions struct { ExtraEnv []string }
+func EnvFor(s Session) []string ; func UserPath(s Session) string // pure helpers stay
+```
+
+- `HomeUsers`/`UsersWithFlatpakInstall` gain `ctx`. `RunAsCommand`'s positional
+  `extraEnv` becomes `RunAsOptions`.
+- **Preserved:** absolute `loginctl`/`runuser` paths, env-wholesaling (agent env
+  NOT inherited; curated `UserPath` applied last), forced `Home` workdir.
+
+---
+
+## 12. `osquery`
+
+```go
+func New(opts ...Option) (Querier, error) // was NewClient; lazy-init preserved
+type Querier interface {
+    IsInstalled(ctx context.Context) bool
+    ListTables(ctx context.Context) ([]string, error)
+    Query(ctx context.Context, q *pb.OSQuery) (*pb.OSQueryResult, error)
+    QueryTable(ctx context.Context, table string) ([]*pb.OSQueryRow, error)
+    QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, error)
+}
+var ErrNotInstalled, ErrQueryFailed error
+```
+
+- **Preserved verbatim — the security core:** the credential-table **deny-list**
+  (`shadow`, `process_envs`, `crontab`, `shell_history`, `sudoers`),
+  case/whitespace-insensitive, short-circuit before exec; the table-name regex;
+  the `RawSql` escape hatch gated only on `Query` (the CA-signed path), never on
+  `QueryTable`. The deprecated `Registry` (implicit `context.Background()`)
+  **deleted**.
+- **O1 — proto coupling — RATIFIED (keep `pb.*`).** The interface keeps the
+  generated `*pb.OSQuery`/`*pb.OSQueryResult` types (agent-aligned, zero mapping).
+  osquery is an internal agent capability; decoupling buys little for real cost.
+
+---
+
+## 13. `terminal`
+
+```go
+func New(opts ...Option) (Manager, error)
+type Manager interface {
+    Open(ctx context.Context, cfg SessionConfig) (*Session, error) // was Start(cfg) — gains ctx
+}
+type SessionConfig struct {
+    User, Shell string
+    Cols, Rows  uint16
+    Env         []string
+    WorkDir     string
+}
+// *Session methods unchanged in spirit, with one fix:
+func (s *Session) Read(p []byte) (int, error)
+func (s *Session) Write(p []byte) (int, error)
+func (s *Session) Resize(cols, rows uint16) error // NOW validates dims (WS15) before Setsize
+func (s *Session) Close() error
+func (s *Session) Wait() (int, error)
+func (s *Session) Done() <-chan struct{}
+const ( DefaultShell = "/bin/bash"; DefaultCols = 80; DefaultRows = 24 )
+func TTYUsername(name string) string ; func TTYUID(uid, offset int) int ; func OriginalUID(ttyUID, offset int) int
+```
+
+- `Open` gains `ctx` (cancellable PTY allocation). **`Resize` validates dims**
+  (`validateDims`, the WS15 fix) before `Setsize` — today it accepts any uint16.
+- **Preserved:** absolute-shell + exists + executable + not-dir checks, the
+  conditional UID/GID switch (seccomp/no_new_privs parity), curated PATH +
+  env-wholesaling, process-group SIGTERM on `Close`, the reaper goroutine.
+
+---
+
+## 14. Cross-cutting decisions
+
+- **U1 — `Secret` type — RATIFIED (yes).** `type Secret` lives in `exec`,
+  constructed via `exec.NewSecret(string)` (newline/CR-rejecting),
+  `String()`→`"[REDACTED]"`, `Reveal()` for the single sink that needs the
+  bytes. Used for passwords / LUKS keys / wifi PSK + client key — see the
+  `Secret` params in §2, §4, §5. A credential can no longer reach a log by
+  accident, and sensitive params are visually distinct.
+  - **Enforced by a fitness function, not just convention.** A `Reveal()`-only-
+    from-known-sinks archtest (design §6) discovers every `.Reveal()` call site
+    across `sys/*` + `pkg` and fails on any outside the allowlisted credential
+    sinks (chpasswd/cryptsetup stdin, PSK keyfile writer), with no-stale +
+    matches-zero guards. Without it, `Reveal()` is one careless `slog`/`Sprintf`
+    away from defeating the redaction; the unit tier only pins that a `Secret`
+    never lands in a recorded `Command.Args`, which wouldn't catch a direct log.
+- **O1 — proto coupling — RATIFIED (keep `pb.*`).** `osquery` keeps the
+  generated `*pb.OSQuery`/`*pb.OSQueryResult` types (§12). osquery is an internal
+  agent capability; decoupling buys little for real cost.
+- **F1 — fs write consolidation — RATIFIED (consolidate).** One
+  `WriteFile`+`WriteOptions`, always atomic + symlink-safe, `os.FileMode`
+  throughout (§7). Replaces the four write variants.
+- **P1 — apt extras — RATIFIED (generalize or fold).** `Autoremove(ctx)` is a
+  first-class no-op-where-absent interface method; `DistUpgrade`→`Upgrade(nil)`;
+  `FixBroken`→`Repair`. No typed-assertion side-interface (§1).
+- **Boolean→enum sweep:** `GeneratePassword(complex bool)`→`Complexity`,
+  `notify` urgency, `pkg`'s `useSudo`→Runner. Done above.
+- **Deleted everywhere:** every `Set*Backend`/`Current*Backend` global + their
+  deprecated aliases; `Query`/`Check` ctx-less exec helpers; `ChownRecursive`
+  alias; the `osquery.Registry` shim; the three separate `fs` atomic constructors.

--- a/docs/sdk-rework-design.md
+++ b/docs/sdk-rework-design.md
@@ -1,0 +1,780 @@
+# SDK Rework — Design Specification
+
+> Status: **Architecture ratified** (Decisions 1–7, §7); testing strategy in §6.
+> Per-package contracts
+> in §3 are open for line-review. Nothing implemented yet — implementation
+> follows §5, starting at the `exec` Runner foundation.
+> Goal: make `sdk/go` a library a third-party Go developer can pick up and use
+> idiomatically, behaving the way Go developers expect. Supersedes parts of
+> [backend-pattern.md](backend-pattern.md) (see Decision 1).
+
+## 0. Scope
+
+**In scope** (the device-side capability surface):
+`pkg`, `sys/user`, `sys/service`, `sys/encryption`, `sys/network` (wifi),
+`sys/firewall`, `sys/exec`, `sys/fs`, `sys/reboot`, `sys/notify`,
+`sys/inventory`, `sys/desktop`, `sys/osquery`, `sys/terminal`, and the planned
+`sys/dns` / `sys/netconfig`.
+
+**Out of scope** (shared with the server, already idiomatic, leave alone):
+`crypto`, `verify`, `validate`, `logging`, `maintenance`, the streaming
+`client.go`, and all `proto`/generated code. **No `.proto` change is required**
+— this is a Go-API-only rework.
+
+**Sole consumer:** the agent. Every call site is migrated in the same change
+set (per the "security/ergonomics tightening must migrate all callers" rule).
+V1, clean break — **no compatibility shims, no deprecation aliases** (delete the
+old thing outright).
+
+---
+
+## 1. Conventions (the house style every package adopts)
+
+1. **`ctx context.Context` is the first parameter** of every method that does
+   I/O. No package stores a `Context` in a struct (today `pkg` does:
+   `NewAptWithContext(ctx)` then `Install(pkgs...)` with no ctx — fixed).
+2. **Per-call configuration is an options struct with a documented, valid zero
+   value.** Discoverable in godoc, constructed positionally-free. (This is the
+   "explicit `defaultUserShell`" instinct.)
+3. **Cross-call configuration (a backend, a privilege runner) is carried by a
+   handle** built via a constructor. No process-global mutable state.
+4. **Multi-implementation capabilities are Go interfaces (the contract)** with
+   one unexported concrete type per backend. The constructor takes the backend
+   **explicitly** and returns the interface.
+5. **Errors are typed, not result-structs.** A `*CommandError` carries
+   `ExitCode`/`Stderr` and is inspected via `errors.As`. Sentinels
+   (`ErrUnknownBackend`, `ErrBackendUnavailable`, `ErrNotFound`, …) are matched
+   via `errors.Is` (see §2 Decision 1 for the two backend sentinels). The
+   internal `*exec.Result` never crosses a public boundary.
+6. **The SDK owns OS mechanism + OS convention; the agent keeps product
+   policy.** The default-shell policy and the `-m`/`-M` "home already exists"
+   dance move *into* the SDK; LPS temp-password rows, SSH `authorized_keys`
+   splicing, and AccountsService hiding stay *in* the agent.
+7. **All existing hardening is preserved behind the new API, never weakened**
+   (name validation, `--` positional separation, `SafeReplaceFile`, fd-anchored
+   chown/chmod, osquery deny-list, chpasswd newline rejection, PSK-never-in-argv,
+   bounded query timeouts).
+8. **Godoc-first.** Every package gets a `doc.go` with a runnable `Example`, so
+   the SDK's front door is `go doc`, not just the README.
+
+---
+
+## 2. Foundational decisions (these overturn prior choices — please ratify)
+
+### Decision 1 — Retire the global backend singleton (Pattern A → Pattern B everywhere)
+
+`backend-pattern.md` today prescribes a process-wide `atomic.Int32`
+(`SetBackend`/`CurrentBackend`) for "one-per-host" capabilities. We replace it
+with an exported interface + explicit-backend constructor for **every**
+multi-implementation capability:
+
+```go
+// BEFORE (Pattern A — global singleton, hidden state):
+service.SetServiceBackend(service.ServiceBackendSystemd) // once, at boot
+service.EnableNow(ctx, "nginx")                          // reads the hidden global
+
+// AFTER (Pattern B — interface + handle, backend named explicitly):
+svc, err := service.New(service.Systemd) // systemd is the only value today
+svc.EnableNow(ctx, "nginx")
+```
+
+- **Removed:** the global `atomic` selector, `SetBackend`/`CurrentBackend`, and
+  every deprecated `SetServiceBackend`/`SetWifiBackend` alias.
+- **Why:** global mutable state is the single least-idiomatic thing in the SDK —
+  not concurrency-composable, not parallel-testable, spooky-action-at-a-distance.
+  An interface handle is what a Go developer reaches for. `backend-pattern.md` is
+  rewritten to describe only Pattern B.
+
+#### Backend is always passed explicitly — no default, no stubs
+
+Every backend-pattern package takes its `Backend` **by name in the
+constructor**, even when only one backend is implemented today
+(`user.New(user.ShadowUtils)`, `service.New(service.Systemd)`):
+
+- **No default / no magic zero value.** There is no `BackendDefault`. The enum's
+  zero value is **invalid**; `New` rejects an unset/unknown backend with
+  `ErrUnknownBackend` (fail-closed). Valid values start at 1.
+- **The enum contains only backends that actually exist** — no speculative
+  values, no `ErrUnsupportedBackend` placeholders. Today's
+  `ServiceBackendOpenRC`/`Runit`/`S6` (which only ever returned
+  `ErrBackendNotSupported`) are **deleted**, not ported.
+- **Adding a backend later is additive and safe:** append a new enum value and
+  write its implementation. Because every existing call site already *names* its
+  backend, none of them silently change behaviour, and there is no "default to
+  keep alive" when the second backend appears.
+- Backend is never runtime-auto-detected. (`pkg.Detect` stays an explicit,
+  separately-named opt-in for callers who *want* OS detection.)
+- This applies to the **backend-pattern packages**: `pkg`, `user`, `service`,
+  `encryption`, `network`, `firewall`, `dns`, `netconfig`, and `exec` (the
+  privilege `Runner`: `exec.NewRunner(exec.Sudo)`). Packages that are
+  single-implementation *by nature* (§3.8 — `fs`, `reboot`, `notify`,
+  `inventory`, `desktop`, `osquery`, `terminal`) have **no** `Backend` concept
+  and take `New(opts...)` only.
+
+#### Availability & discovery — selected-but-unsupported, and "what can this host run?"
+
+Two failure modes are kept distinct, both `errors.Is`-matchable:
+
+```go
+// You named a Backend value the SDK does not implement (or the invalid zero
+// value). A construction-time, host-independent error.
+var ErrUnknownBackend = errors.New("unknown backend")
+
+// You named an IMPLEMENTED backend, but this host lacks its tooling
+// (e.g. service.Systemd on an OpenRC box, pkg.Apt on Fedora). The wrapped
+// detail names what was missing (binary not on PATH, /run/systemd/system absent).
+var ErrBackendUnavailable = errors.New("backend unavailable")
+```
+
+**Selected-but-unsupported is fail-closed, never silent.** A handle for an
+implemented-but-unavailable backend never executes the wrong tool: the operation
+returns `ErrBackendUnavailable`. It is never a panic and never a fallback to a
+different backend (that would defeat the explicit-choice rule).
+
+**Discovery is one explicit, read-only function — `Detect`.** It hands the
+consumer the backends actually usable on this host; it never picks for them (so
+it does not violate `backend-pattern.md`'s "don't auto-detect and pick" rule).
+`Supported()`/`Available()` are intentionally **not** separate functions —
+"is backend X available?" is `slices.Contains(Detect(ctx), X)`, and "what does
+this build implement?" is the enum/godoc — so `Detect` is the whole surface.
+
+```go
+// Detect returns the implemented backends whose tooling is usable on THIS host.
+// Read-only probe per backend (exec.LookPath / stat of a marker like
+// /run/systemd/system); needs no privilege, so it does not go through the
+// Runner. Empty slice = this capability has no usable backend on this host.
+// Best-effort: a backend that errors on probe is simply omitted.
+func Detect(ctx context.Context) []Backend
+```
+
+Consumer flow (your model — branch on the count):
+
+```go
+switch avail := service.Detect(ctx); len(avail) {
+case 0:
+    return errors.New("no supported service manager on host")
+case 1:
+    svc, _ = service.New(avail[0], r) // exactly one → use it
+default:
+    // caller's own priority among several usable backends:
+    svc, _ = service.New(pick(avail), r)
+}
+
+// To verify a configured choice instead of letting Detect drive:
+if !slices.Contains(service.Detect(ctx), cfg.ServiceBackend) {
+    return fmt.Errorf("configured service backend %v not available here", cfg.ServiceBackend)
+}
+```
+
+**`pkg` is the package where discovery matters most:** the distro's package
+manager *must* be probed (a consumer can't know apt vs dnf from config alone), so
+`pkg.Detect(ctx)` is the real entry point there. This **replaces** today's
+auto-picking `pkg.New()` — `Detect` returns `[]pkg.Backend{pkg.Dnf}` and the
+consumer calls `pkg.New(pkg.Dnf)` explicitly. (`sys/network`'s existing
+`IsAvailable` collapses into `Detect` too.)
+
+**D6 — probe timing — RESOLVED:** `New` stays **pure** (validates only that the
+backend is *known* — no host I/O, no `ctx`; the zero/unknown value →
+`ErrUnknownBackend`). The host probe lives solely in `Detect`, which the caller
+runs to decide. As a backstop, an operation on a named-but-unavailable backend
+fails closed with `ErrBackendUnavailable`. Construction is cheap and total;
+discovery is the single explicit `Detect`.
+
+### Decision 2 — Dependency-inject the privilege runner (retire the `exec` global) — **RATIFIED**
+
+`sys/exec` is the foundation every capability uses to escalate. Today the
+privilege backend (sudo/doas) is another Pattern-A global. We make it an
+injected dependency:
+
+```go
+// A Runner abstracts command execution + privilege escalation.
+type Runner interface {
+    Run(ctx context.Context, c Command) (Result, error)
+    Stream(ctx context.Context, c Command, onLine OnLine) (Result, error)
+    Backend() PrivilegeBackend // lets fs pick its fd-safe vs sudo path
+}
+
+r, _ := exec.NewRunner(exec.Direct)       // agent runs as root; non-root consumer: exec.Sudo / exec.Doas
+svc, _ := service.New(service.Systemd, r) // runner is a REQUIRED arg — no default escalation
+```
+
+- Every capability constructor takes the `exec.Runner` as a **required
+  argument** (`New(backend, runner, opts...)`). **There is no default
+  escalation** — a silent `sudo` default would contradict Decision 5's
+  "explicit, no magic default". The agent passes `Direct` (it runs as root); a
+  non-root consumer passes `Sudo`/`Doas` — from its own config, or by picking
+  from `exec.Detect`'s list.
+- **Who decides what:** the capability sets `Command.Escalate` per operation
+  (Install needs root, Search doesn't); the **Runner** alone knows *how* to
+  escalate (`sudo -n`/`doas -n`/bare). `apt install vlc` →
+  `runner.Run(Command{Name:"apt-get", Args:[…,"vlc"], Escalate:true})`.
+- **Discovery — the same primitive every other interface has.**
+  `exec.Detect(ctx) []PrivilegeBackend` **lists** the escalation backends present
+  on the host (Sudo/Doas if on PATH) — exactly like `pkg.Detect` / `service.Detect`
+  (Decision 6). It lists; it does **not** pick. The consumer reads it, picks one
+  explicitly, and passes it down (`exec.NewRunner(picked)`). The SDK never
+  auto-picks or auto-constructs a runner (that was the boot-time auto-derive we
+  rejected). If the chosen tool is unusable, the first escalated command fails
+  closed — `ErrEscalationUnavailable` (not installed) vs `ErrEscalationDenied`
+  (`sudo -n` needs a password). Never silent, never a fallback.
+- **Sharing is the consumer's job — the SDK ships no global and no facade.** The
+  library exposes the `Runner` interface + `NewRunner`; every capability takes a
+  runner explicitly. *How* a consumer holds and shares that one runner is its
+  composition-root decision (store it on a struct, build a small facade, or — its
+  prerogative — its own package var). A global *in the library* is the rejected
+  `SetPrivilegeBackend`; a global *in the application* is the app's call and fine.
+  This matches idiomatic Go (`*sql.DB`, `*http.Client`, aws-sdk-v2's `aws.Config`)
+  — the library hands you a value; you decide how to hold it. (The agent already
+  does DI: construct the runner once at boot, store the managers on its
+  `Executor` — the runner is never re-threaded.)
+- Makes the whole SDK testable with a fake `Runner` — **no more
+  `exec.SetPrivilegeBackend` global, no integration container required for unit
+  tests of the capability layer.**
+- `Result`/`Command`/`Stream` are small public value types owned by `exec`; the
+  capability packages return `*exec.CommandError` (Decision 3), never `Result`.
+
+### Decision 3 — Typed errors replace the leaked `*exec.Result`
+
+```go
+// CommandError is returned when an underlying OS command fails. It carries the
+// captured stderr and exit code so callers can branch on them without importing
+// internals. Inspect with errors.As.
+type CommandError struct {
+    Op       string // e.g. "useradd", "usermod"
+    ExitCode int
+    Stderr   string
+    Err      error
+}
+func (e *CommandError) Error() string { ... }
+func (e *CommandError) Unwrap() error { return e.Err }
+```
+
+- `pkg.CommandResult{Success bool, ...}` is removed — `error == nil` is the
+  success signal; stdout (when a caller genuinely needs it) is returned
+  separately or surfaced through a typed result only where it carries data
+  (e.g. `Search`, `List`). The redundant `Success` bool goes away.
+- Capability methods return `error` (or `(T, error)` for queries). Callers that
+  want stderr do `var ce *exec.CommandError; errors.As(err, &ce)`.
+
+---
+
+## 3. Per-capability contracts
+
+> **The full, audited, line-reviewable contracts now live in
+> [sdk-rework-contracts.md](sdk-rework-contracts.md)** — complete method sets,
+> options-struct fields, preserved hardening, and the open forks (◇). The
+> sketches below remain as a quick overview; the contracts doc is authoritative.
+
+> Notation: only the exported contract is shown. `Option` is the functional-option
+> type for backend-specific knobs. **The per-package `New(...)` sketches below omit
+> the required `exec.Runner` arg for brevity** — every `New` takes it (see
+> Decision 2 / the contracts doc). Each package keeps its concrete backend types
+> unexported behind the interface.
+
+### 3.1 `pkg` — package management *(already Pattern B; refine)*
+
+```go
+type Manager interface {
+    Info(ctx context.Context) (Info, error)
+    Install(ctx context.Context, names []string, opts InstallOptions) error
+    Remove(ctx context.Context, names []string, opts RemoveOptions) error
+    Update(ctx context.Context) error
+    Upgrade(ctx context.Context, names []string) error // nil names = upgrade all
+    Search(ctx context.Context, query string) ([]SearchResult, error)
+    List(ctx context.Context) ([]Package, error)
+    ListUpgradable(ctx context.Context) ([]PackageUpdate, error)
+    Show(ctx context.Context, name string) (Package, error)
+    ListVersions(ctx context.Context, name string) (VersionInfo, error)
+    IsInstalled(ctx context.Context, name string) (bool, error)
+    InstalledVersion(ctx context.Context, name string) (string, error)
+    Pin(ctx context.Context, names []string) error
+    Unpin(ctx context.Context, names []string) error
+    ListPinned(ctx context.Context) ([]Package, error)
+    IsPinned(ctx context.Context, name string) (bool, error)
+    Autoremove(ctx context.Context) error // remove orphaned deps; no-op where a backend has none (P1)
+    Repair(ctx context.Context) error     // broken-state repair (subsumes apt FixBroken)
+    InstalledCount(ctx context.Context) (int, error)
+}
+
+type Backend int // Apt, Dnf, Pacman, Zypper, Flatpak
+func New(b Backend, opts ...Option) (Manager, error) // explicit backend (runner arg omitted — see note)
+func Detect(ctx context.Context) []Backend           // LISTS usable PMs; consumer picks + calls New
+
+type InstallOptions struct { Version string; AllowDowngrade bool }
+type RemoveOptions  struct { Purge bool }
+```
+
+Changes from today: **ctx-first on every method** (was stored on the
+constructor); `Success bool` removed; `InstalledVersion` renamed from
+`GetInstalledVersion` (Go: no `Get` prefix); `WithSudo(bool)` replaced by
+the required `runner` arg. Per-distro structs (`Apt`, `Dnf`, …) become **unexported**; the
+`validating_manager.go` wrapper (WS8 validators) is preserved as the default
+decorator returned by `New`.
+
+### 3.2 `sys/user` — user & group management *(NEW interface — your point)*
+
+```go
+// Manager is the user/group contract. Linux has several implementations:
+// shadow-utils (useradd/usermod/userdel), Debian adduser/deluser,
+// systemd-homed (homectl), and busybox adduser.
+type Manager interface {
+    // Accounts
+    Get(ctx context.Context, name string) (Info, error)
+    Exists(ctx context.Context, name string) (bool, error)
+    Create(ctx context.Context, name string, opts CreateOptions) error
+    Modify(ctx context.Context, name string, opts ModifyOptions) error
+    Delete(ctx context.Context, name string, opts DeleteOptions) error
+    Lock(ctx context.Context, name string) error
+    Unlock(ctx context.Context, name string) error
+    SetPassword(ctx context.Context, name string, password Secret) error
+    ExpirePassword(ctx context.Context, name string) error
+
+    // Groups
+    GroupExists(ctx context.Context, name string) (bool, error)
+    GroupCreate(ctx context.Context, name string, opts GroupCreateOptions) error
+    GroupDelete(ctx context.Context, name string) error
+    GroupEnsure(ctx context.Context, name string) error
+    AddToGroup(ctx context.Context, name, group string) error
+    RemoveFromGroup(ctx context.Context, name, group string) error
+}
+
+// Backend is passed explicitly even though shadow-utils is the only value today.
+// No default, no zero value: New(ShadowUtils). When adduser/homed/busybox is
+// actually written, it's appended here — existing call sites already say
+// ShadowUtils, so nothing shifts.
+type Backend int
+const ShadowUtils Backend = iota + 1 // 1; zero value is invalid → ErrUnknownBackend
+func New(b Backend, opts ...Option) (Manager, error)
+
+// CreateOptions: the zero value creates a normal interactive account with a
+// login shell and a matching primary group, no home directory.
+type CreateOptions struct {
+    UID          int    // 0 = auto-assign
+    PrimaryGroup string // group name or numeric GID; "" = backend default
+    Shell        string // "" = DefaultShell(System) — login shell, or nologin for system accounts
+    HomeDir      string // "" = backend default (/home/<name> on shadow-utils)
+    Comment      string // GECOS
+    System       bool   // system account; also flips DefaultShell to nologin
+    CreateHome   bool   // create + populate home, idempotent if it already exists
+}
+type ModifyOptions      struct { Shell, HomeDir, Comment, PrimaryGroup string } // "" = leave unchanged
+type DeleteOptions      struct { RemoveHome bool }
+type GroupCreateOptions struct { GID int; System bool }
+```
+
+- **The default-shell policy** (`/bin/bash` for interactive, `/usr/sbin/nologin`
+  for system/disabled) and the `-m`/`-M` "home already exists" handling move
+  here from the agent's [createUser](../../agent/internal/executor/action_user.go).
+  The agent's ~170-line `createUser` collapses to: build `CreateOptions` from the
+  proto, then compose product policy (temp password + LPS metadata, SSH keys,
+  AccountsService hiding) on top of these primitives.
+- **Pure helpers stay package-level** (no backend variance): `IsValidName`,
+  `GeneratePassword(length int, c Complexity) (Secret, error)` (boolean `complex`
+  → a typed `Complexity` enum; returns a `Secret`), `GeneratePassphrase`.
+- **Preserved hardening:** `validateName` on every mutating op (no `-`-leading
+  name → flag; no newline/colon injection), chpasswd newline/CR rejection,
+  bounded query timeouts (now `ctx`-driven with a documented default).
+- **v1 exposes one backend: `ShadowUtils`** (today's `useradd`/`usermod`/
+  `userdel` behaviour, behind the new `Manager` interface — a pure refactor).
+  The `Backend` enum has exactly that one value, **passed explicitly**
+  (`user.New(user.ShadowUtils)`); **no `ErrUnsupportedBackend` stubs**. A real
+  second backend (adduser/homed/busybox) is appended when actually written.
+
+### 3.3 `sys/service` — init/service manager
+
+```go
+type Manager interface {
+    Status(ctx context.Context, unit string) (UnitStatus, error)
+    IsEnabled(ctx context.Context, unit string) (bool, error)
+    IsActive(ctx context.Context, unit string) (bool, error)
+    IsMasked(ctx context.Context, unit string) (bool, error)
+    Enable(ctx context.Context, unit string) error
+    Disable(ctx context.Context, unit string) error
+    EnableNow(ctx context.Context, unit string) error
+    DisableNow(ctx context.Context, unit string) error
+    Start(ctx context.Context, unit string) error
+    Stop(ctx context.Context, unit string) error
+    Restart(ctx context.Context, unit string) error
+    Mask(ctx context.Context, unit string) error
+    Unmask(ctx context.Context, unit string) error
+    DaemonReload(ctx context.Context) error
+    WriteUnit(ctx context.Context, unit, content string) error
+    RemoveUnit(ctx context.Context, unit string) error
+}
+// Backend passed explicitly; Systemd is the only value (OpenRC/Runit/S6 enum
+// values, which only ever returned ErrBackendNotSupported, are deleted).
+type Backend int
+const Systemd Backend = iota + 1
+func New(b Backend, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend // probes systemctl + /run/systemd/system
+```
+
+- `Status`/`IsEnabled` etc. gain `ctx` (were ctx-less). `ValidateUnitName`
+  stays an exported pure helper.
+
+### 3.4 `sys/encryption` — disk encryption
+
+```go
+type Manager interface {
+    IsEncrypted(ctx context.Context, dev string) (bool, error)
+    AddKey(ctx context.Context, dev string, existing, new Secret, opts AddKeyOptions) error
+    RemoveKey(ctx context.Context, dev string, key Secret) error
+    KillSlot(ctx context.Context, dev string, slot int, existing Secret) error
+    VerifyPassphrase(ctx context.Context, dev string, p Secret) (bool, error) // was TestPassphrase (footgun)
+    DetectVolume(ctx context.Context) (Volume, error)
+    DetectAllVolumes(ctx context.Context) ([]Volume, error)
+    TPM() (TPMEnroller, bool) // ok=false when the backend has no TPM support
+}
+type AddKeyOptions struct { Slot int } // Slot 0 = auto; replaces AddKey/AddKeyToSlot pair
+// Backend passed explicitly; LUKS is the only value (GELI/CGD enum values deleted).
+type Backend int
+const LUKS Backend = iota + 1
+func New(b Backend, opts ...Option) (Manager, error)
+```
+
+- `TestPassphrase` → `VerifyPassphrase` (the `TestXxx` name is a go-test
+  footgun). `AddKey` + `AddKeyToSlot` collapse into one method + `AddKeyOptions`.
+  `GeneratePassphrase`/`ValidatePassphrase`/`HashPassphrase` stay pure helpers.
+  `ErrInvalidKeySlot` preserved. Passphrases/keys are the shared `exec.Secret`
+  (U1), not a bare `string`, so they can't be logged at the call site.
+
+### 3.5 `sys/network` — wifi profiles
+
+```go
+type Manager interface {
+    ConnectionExists(ctx context.Context, name string) (bool, error)
+    Apply(ctx context.Context, p Profile) (changed bool, err error) // was CreateOrUpdate
+    Delete(ctx context.Context, name string, opts DeleteOptions) error
+    Settings(ctx context.Context, name string) (map[string]string, error)
+}
+// Backend passed explicitly; NetworkManager (nmcli) is the only value
+// (connman/wpa_supplicant/iwd enum values deleted).
+type Backend int
+const NetworkManager Backend = iota + 1
+func New(b Backend, opts ...Option) (Manager, error)
+func Detect(ctx context.Context) []Backend // probes nmcli (the old IsAvailable, folded in)
+```
+
+- `Profile` (was `WiFiProfile`) is the options struct; its `PSK`/`ClientKey`
+  fields are `Secret` (U1). **`BuildAddArgs` / `BuildModifyArgs` /
+  `BuildPSKKeyfile` become unexported** (internals leaking today). `IsAvailable`
+  folds into `Detect`. The `(bool, error)` from `Apply` keeps the named `changed`
+  return. PSK-never-in-argv hardening preserved.
+
+### 3.6 `sys/firewall` — packet filter *(already Pattern B; align naming)*
+
+```go
+type Manager interface {
+    ApplyRule(ctx context.Context, r Rule) error
+    RemoveRule(ctx context.Context, id string) error
+    List(ctx context.Context) ([]Rule, error)
+    Namespace() string
+}
+type Backend int // Nftables (default), Firewalld, UFW — the 3 implemented today
+func New(b Backend, namespace string, opts ...Option) (Manager, error)
+```
+
+- One of the two packages that **keeps a `Backend` selector** (3 real
+  implementations). Already a `Manager` with `New(namespace)`; folds the backend
+  selection into the constructor (drops the global `SetBackend`) and keeps
+  `Rule`, `Protocol`, `ErrInvalidRule`, `ErrInvalidNamespace`. The unimplemented
+  `IPTables`/`PF` enum values are deleted (added when actually built).
+
+### 3.7 `sys/dns` & `sys/netconfig` *(planned — define the contract now)*
+
+```go
+// dns — systemd-resolved is the only value today; passed explicitly.
+type Manager interface {
+    Get(ctx context.Context) (Config, error)
+    Apply(ctx context.Context, c Config) error
+}
+type Backend int
+const Resolved Backend = iota + 1
+func New(b Backend, opts ...Option) (Manager, error)
+
+// netconfig — NetworkManager is the only value today; passed explicitly.
+type Manager interface {
+    Interfaces(ctx context.Context) ([]Interface, error)
+    Apply(ctx context.Context, i Interface) error
+}
+type Backend int
+const NetworkManager Backend = iota + 1
+func New(b Backend, opts ...Option) (Manager, error)
+```
+
+These move out of `_planned/` into real packages, each exposing only the one
+backend it actually implements (resolved / NetworkManager), passed explicitly.
+A new enum value is appended if and when a real second implementation is written.
+
+### 3.8 Single-implementation packages — interfaces too (uniformity) — **RATIFIED**
+
+**Decision:** for one-shape-to-learn consistency, these get a `Manager`
+interface + `New(...)` constructor like every other package, even though they
+have one Linux implementation. They also get the conventions (ctx-first, options
+structs, typed errors, no leaked `Result`, the required `runner` arg where they shell out).
+
+**Trade-off acknowledged (the one most likely to draw "YAGNI").** Returning an
+interface from `New` for a single concrete impl is mild over-abstraction against
+the "accept interfaces, return structs" guideline — and the fake `Runner`
+already gives these packages their shell-out testability, so the interface is
+buying *uniformity of shape*, not mockability we'd otherwise lack. We take that
+cost deliberately: every capability reads `x, _ := pkgname.New(...); x.Method(ctx, …)`,
+so a consumer learns one shape, and a future second implementation (should one
+ever appear) is additive rather than a breaking constructor change. The cost is
+an extra indirection and a type a caller can't down-cast to reach impl-specific
+methods — accepted, because the interface *is* the full intended surface.
+
+| Package | Interface (sketch) | Idiomatic fixes |
+|---|---|---|
+| `sys/fs` | `Manager`: ReadFile / WriteFile / Mkdir / Remove / RemoveDir / Copy / SetOwnership… | **F1**: one `WriteFile`+`WriteOptions` (always atomic + symlink-safe, `os.FileMode`) replaces the 4 write variants; stop returning `*exec.Result`; keep fd-anchored ops + deny-by-default verbatim |
+| `sys/reboot` | `Manager`: IsRequired / Schedule / Cancel | `Schedule(ctx, ScheduleOptions{Delay, Message})`; multi-distro detection stays internal (not an operator-picked backend) |
+| `sys/notify` | `Manager`: NotifyAll / NotifyUsers | both **must return `error`** (today they swallow) |
+| `sys/inventory` | `Collector`: SystemInfo / OSInfo / Disks / NetworkInterfaces | ctx-first; consistent typed structs |
+| `sys/desktop` | `Manager`: ActiveSessions / HomeUsers / RunAsCommand | ctx-first; `Session` value type stays |
+| `sys/osquery` | `Querier`: Query / QueryTable | keep the lazy-init + the **credential-table deny-list** verbatim; ctx-first (already a handle — add the interface) |
+| `sys/terminal` | `Manager`: Open / Resize / Close | ctx-first (already a handle — add the interface) |
+
+> Note: these are single-implementation **by nature** — there is no second way to
+> read `/proc` or replace a file, so they have no `Backend` concept at all (unlike
+> `service`/`user`, which name their one backend explicitly against a future
+> second). Their constructor is `New(runner, opts...)` — no `Backend` argument,
+> but still the required `exec.Runner` so the construction shape matches.
+
+---
+
+## 4. Onboarding ergonomics (so a consumer "can just start using it")
+
+```go
+// One runner, chosen EXPLICITLY by the consumer from its own config (no SDK
+// detection). The consumer holds it however it likes — the SDK ships no global
+// and no facade.
+r, _ := exec.NewRunner(cfg.Escalation) // e.g. exec.Direct for the root agent; Sudo/Doas elsewhere
+
+svc, _ := service.New(service.Systemd, r)
+_ = svc.EnableNow(ctx, "nginx.service")
+
+um, _ := user.New(user.ShadowUtils, r)
+_ = um.Create(ctx, "deploy", user.CreateOptions{CreateHome: true})
+
+// Tests swap that one arg — no container, no sudo, no global to save/restore:
+um, _ = user.New(user.ShadowUtils, exectest.NewRunner())
+```
+
+- A `doc.go` + runnable `Example` per package.
+- A top-level `sdk/go/README` "Quick start" showing the construct-a-handle flow.
+- Sentinels and `*CommandError` documented as the inspection contract.
+
+---
+
+## 5. Migration plan (design-all-now → implement)
+
+1. **Ratify this doc** (Decisions 1–7, the §6 testing strategy, and §3.8).
+2. **`exec` Runner first** (foundation) — sdk PR: introduce `Runner`,
+   `Command`, `Result`, `CommandError`, `Secret`, `Detect`, and
+   `exectest.FakeRunner`; keep `--` separation + SIGKILL escalation + output cap.
+   Agent: construct one runner at boot — **no default escalation, the consumer
+   picks** (from config or `exec.Detect`).
+3. **Capability packages, one PR each**, in dependency order
+   (`user`, `service`, `encryption`, `network`, `firewall`, `pkg`,
+   then `dns`/`netconfig`), each: **first snapshot the current agent's argv as
+   golden fixtures** (§6 tier 3 — captured from the *unmodified* agent, in the
+   RED commit, before the builder moves) + new interface + backends + options +
+   typed errors + `doc.go`/examples + **full agent call-site migration in the
+   same PR** + tests (correct / absent / present-but-wrong per the TDD rule).
+4. **Single-impl cleanups** (`fs`, `reboot`, `notify`, `inventory`, `desktop`,
+   `osquery`, `terminal`) — batched.
+5. **Rewrite `backend-pattern.md`** to describe only Pattern B; delete Pattern A.
+6. Each sdk PR → bump agent pin → agent PR. Branch-per-issue on both repos.
+
+Cross-repo order per change: **sdk → agent**. No proto, so web is untouched.
+
+### Behavioral signature changes the agent must absorb (migration risk register)
+
+These are not pure renames — the *contract* changes, so the agent call sites
+need real review (not a mechanical find-replace) in the same PR that lands each:
+
+- **`pkg` loses auto-pick.** Today's auto-detecting `pkg.New()` is replaced by
+  `pkg.Detect(ctx)` → explicit `pkg.New(picked, runner)`. The agent's boot/config
+  must now *make and hold* the package-manager choice (it can drive it from
+  `Detect` when config doesn't pin one). Failure mode shifts from "silently
+  picked the wrong PM" to a fail-closed `ErrBackendUnavailable`.
+- **`reboot.IsRequired()` → `(bool, error)`.** It no longer swallows a probe
+  failure; the agent must decide what a failed probe means (assume-no vs surface).
+- **`notify.NotifyAll`/`NotifyUsers` now return `error`.** Were fire-and-forget;
+  the agent now chooses explicitly to log-and-ignore best-effort failures.
+- **No method returns `*exec.Result` anymore.** Call sites that branched on
+  `Result.ExitCode`/`Stderr` (e.g. "user already exists", cryptsetup wrong-
+  passphrase) must switch to `errors.As(err, &ce)` on `*exec.CommandError`, or
+  read the typed query result — verify each such branch, don't assume.
+- **Default escalation is gone.** Every `New` requires a `Runner`; the agent
+  constructs exactly one `exec.Direct` runner at boot (it runs as root) and
+  threads it. A missing/incorrect runner is now a construction-site error, not a
+  silent `sudo`.
+
+---
+
+## 6. Testing strategy & TDD
+
+**Red-before-green, every package.** For each capability the failing tests are
+written *first*, run, and confirmed RED for the right reason, then the
+implementation makes them green — never the reverse. A correct-behaviour test
+that fails is treated as a finding (usually in the code). No `t.Skip`/build-tag
+to make a suite green.
+
+### The keystone: a shipped fake `Runner`
+
+Step 1 ships `sdk/go/sys/exec/exectest` alongside the real `Runner`:
+
+```go
+// FakeRunner records every Command and returns scripted Results, so a capability
+// Manager can be unit-tested with no host, no sudo, no container.
+type FakeRunner struct { Backend exec.PrivilegeBackend }
+func (f *FakeRunner) Calls() []exec.Command            // every Command it received, in order
+func (f *FakeRunner) Push(r exec.Result, err error)    // script the next Run/Stream outcome
+```
+
+Because every capability handle is built with an explicit runner — pass a fake — the
+flag-assembly logic that moves out of the agent (e.g. `user.Create`'s
+`useradd` flags + default-shell policy) is now unit-testable directly.
+
+### Three tiers — unit is ADDITIVE, real-system integration is the source of truth
+
+**Non-regression rule:** the existing real-system coverage is *preserved in full
+and extended*, never replaced. Every `*_Integration` test that runs today against
+a real tool (apt/dnf/pacman/zypper install-remove-upgrade cycles, real
+`cryptsetup` key add/remove/verify, real `useradd`/`usermod`/`userdel`, real
+`systemctl enable/disable`, real `nft`/`ufw`/`firewalld` apply-list-remove cycles)
+is **ported to the new API and kept green**. The fake Runner adds a *new, faster*
+logic tier on top — it does **not** remove a single real-system test. A method
+is not considered covered by unit tests alone.
+
+1. **Real-system integration — the source of truth for "it actually works."**
+   Runs in the real harnesses we already have: `sdk/test/run-tests.sh` (systemd +
+   non-root sudo container) for `sys/*`, and the per-distro package-manager
+   containers for `pkg`. Every capability keeps end-to-end coverage against the
+   **real** tool through the **real** Runner: the command is built, escalated, run,
+   and its side effect verified (the user exists, the slot is added, the unit is
+   enabled, the package is installed, the rule is in the table).
+   - **The Runner gets first-class, thorough real-system tests** — it is the new
+     single chokepoint, so it earns the most: `Sudo`/`Doas` actually escalate
+     (do something only root can), `Direct` runs unwrapped, the env blocklist
+     actually keeps `LD_PRELOAD` out of the child, SIGTERM→SIGKILL actually reaps
+     a **trap-ignoring loop** (a bare `sleep` dies on group SIGTERM → green for the
+     wrong reason — use the WS16 loop), the 1 MiB cap actually truncates, `--`
+     actually blocks flag injection, `Stream` delivers real streaming output.
+   - The privilege-keyed `fs` paths run on real systems **both** ways — the
+     `Direct` (fd-safe `O_NOFOLLOW`/`renameat2`) path *and* the sudo path — since
+     they are different code (the WS6 lesson: unconditional fd broke the non-root
+     sudo integration CI).
+2. **Unit (fake Runner) — additive fast tier, runs under `go test -race ./...`,
+   no container.** Catches logic/validation/error-mapping bugs in milliseconds so
+   the slow real-system tier isn't the only net. For every method, the matrix
+   from the TDD rule — **correct / absent / present-but-wrong** — plus error
+   mapping and hardening pins:
+   - *Correct:* valid options → the exact `Command` is built (name, `--`
+     separation, flags, order); a success `Result` → `nil` error.
+   - *Absent:* missing required field (empty username, zero `Backend`) → rejected
+     **before** the Runner is called (`len(fake.Calls()) == 0`).
+   - *Present-but-wrong:* malformed input — leading-`-` name, newline in a
+     `Secret`, out-of-range keyslot, bad unit name, `http://` repo URL — rejected,
+     Runner never called. ("Wrong" derived from design intent, not from the
+     validator under test.)
+   - *Error mapping:* Runner returns `ExitCode != 0` + `Stderr` → `*exec.CommandError`.
+   - *Hardening pins:* osquery deny-list short-circuits before any call;
+     **`Secret`/PSK never appears in any recorded `Command.Args`**; `Secret.String()`
+     is `"[REDACTED]"`. (The symlink-refusal / TOCTOU pins run in tier 1 — they
+     need a real filesystem to be meaningful.)
+3. **Characterization / parity (golden) — bridges the two, pins the refactor.**
+   A table asserts the new `Manager` builds the **byte-identical argv** today's
+   agent builds (golden values) — so the *preserved* real-system tests still apply
+   to the refactored code, and behaviour can't silently drift. Critical for
+   `user.Create` / `service` / `pkg`, where flag assembly moves between repos.
+   Part of the RED suite — fails until the new code reproduces the old command.
+   - **Capture the goldens from the CURRENT agent FIRST — before touching the
+     code.** The golden corpus is the exact argv today's `createUser` /
+     service / `pkg` paths emit, extracted from the unmodified agent (e.g. by
+     running the existing agent tests with a recording runner, or lifting the
+     literals the current builders produce). Freezing them *before* the refactor
+     is what makes the parity test meaningful: per the TDD rule, the expected
+     value must come from the pre-existing behaviour, **never derived from the
+     new builder under test** — a golden generated from the refactored code
+     proves only that the code equals itself. So step (1) of every capability PR
+     that moves flag assembly is "snapshot the current argv as fixtures," and
+     that snapshot is committed in the RED commit.
+
+### Fitness functions (lock the architecture)
+
+Self-discovering archtest guards, run under `go test`:
+- **No global backend state survives** — discover every `sys/*` + `pkg` package
+  by directory and fail if any exports a `Set*Backend`/`Current*Backend` or a
+  package-level backend selector var. Matches-zero guard so an empty discovery
+  set fails too. Locks Decision 1 against regression.
+- **Every `New(Backend, …)` rejects the zero/unknown value** with
+  `ErrUnknownBackend` — discovered across the backend-pattern packages.
+- **`Secret.Reveal()` is called only from the known credential sinks.** The
+  redacted `String()` + `Reveal()`-single-sink discipline (U1) only holds if
+  `Reveal()` can't leak through a log/format path. An AST guard discovers every
+  `.Reveal()` call site across `sys/*` + `pkg` and fails on any outside an
+  allowlist of the genuine sinks (the chpasswd/cryptsetup stdin writer, the PSK
+  keyfile writer, …). Allowlist entries are by call-site role, and a no-stale
+  guard fails if an allowlisted sink no longer calls `Reveal()`; a matches-zero
+  guard fails if the walk finds no `Reveal()` calls at all (the discovery went
+  dead). This is the fitness-function complement to the unit-tier pin that a
+  `Secret` never appears in a recorded `Command.Args`.
+
+### CI wiring & per-PR flow
+
+- Every PR: `go test -race ./...` (unit + parity + fitness, no container) + the
+  integration-container job. CR review before push; poll CI green.
+- Per capability PR: (1) write the failing tests — unit (fake Runner) + parity
+  golden **+ the ported/extended real-system integration tests** → (2) confirm
+  RED → (3) implement → (4) green (unit locally; the integration job proves it on
+  a real host) → (5) **migrate the agent call sites in the same PR and run the
+  agent suite** (the agent's own unit + integration tests are the safety net that
+  behaviour didn't drift) → (6) CR, merge. The clean-break (sdk+agent together)
+  means main is never left half-migrated.
+- **A capability PR does not merge on green unit tests alone** — its real-system
+  integration job must be green too. Run the SDK integration harness
+  (`sdk/test/run-tests.sh` + per-distro `pkg` containers) locally/CI before merge,
+  same as today.
+
+## 7. Decision log
+
+1. **Decision 1** — interface + explicit-backend constructor everywhere; retire
+   the global singleton. **RATIFIED** (rewrites `backend-pattern.md`).
+2. **Decision 2** — inject a `Runner`, retire `exec.SetPrivilegeBackend`.
+   **RATIFIED.**
+3. **§3.8** — single-implementation packages also become interfaces for
+   uniformity. **RATIFIED.**
+4. **`user` backends for v1** — implement one backend (`ShadowUtils`) behind the
+   `Manager` interface (pure refactor of today's `useradd`/`usermod`/`userdel`).
+   No `ErrUnsupportedBackend` placeholders. **RATIFIED.**
+5. **Backend is always passed explicitly; no default; expose only implemented
+   backends** — every backend-pattern package takes its `Backend` by name in the
+   constructor, even single-backend ones (`user.New(user.ShadowUtils)`). The
+   enum's zero value is invalid (`New` → `ErrUnknownBackend`, fail-closed); valid
+   values start at 1; the enum contains only built backends (speculative values
+   deleted, not stubbed). Adding a backend later is additive — existing call
+   sites already name theirs, so there is no default to keep alive. Packages that
+   are single-implementation *by nature* (§3.8) have no `Backend` at all.
+   **RATIFIED.**
+6. **Availability & discovery** — two sentinels: `ErrUnknownBackend`
+   (unimplemented/zero value, at `New`) and `ErrBackendUnavailable` (implemented
+   but host lacks tooling, fail-closed at use). Discovery is a single
+   `Detect(ctx) []Backend` per backend-pattern package (no separate
+   `Supported`/`Available`). `New` is **pure** (no probe, no `ctx`); the caller
+   runs `Detect` and branches on the count. A named-but-unavailable backend never
+   silently falls back. **RATIFIED.**
+7. **Runner: explicit, discoverable like everything else, no library global, no
+   library facade.** The `exec.Runner` is a **required** arg on every `New` (no
+   default escalation). `exec.Detect(ctx) []PrivilegeBackend` **lists** the
+   available escalation backends (Sudo/Doas on PATH) — the *same* `Detect`
+   primitive as capability backends (Decision 6); it lists, the consumer **picks
+   explicitly** and passes the runner down. The SDK never auto-picks/auto-constructs
+   a runner (no `DetectRunner`; the rejected boot-time auto-derive). **How the
+   runner is shared is the consumer's composition-root decision**; the SDK ships
+   neither a global nor a `System` facade (a library global = the rejected
+   `SetPrivilegeBackend`; an app-level global is the app's prerogative). Layering:
+   capability sets `Command.Escalate` per op; the Runner alone applies
+   sudo/doas/bare. Fail-closed: `ErrEscalationUnavailable` / `ErrEscalationDenied`.
+   **RATIFIED.**

--- a/go/sys/exec/command_error.go
+++ b/go/sys/exec/command_error.go
@@ -1,0 +1,47 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Construction- and escalation-failure sentinels. All are errors.Is-matchable
+// so a caller can fail closed and distinguish the cases.
+var (
+	// ErrUnknownBackend is returned by NewRunner for the zero value or any
+	// PrivilegeBackend the SDK does not implement (fail-closed, no silent
+	// default escalation).
+	ErrUnknownBackend = errors.New("unknown privilege backend")
+
+	// ErrEscalationUnavailable is returned when the chosen escalation tool
+	// (sudo/doas) is not installed on this host.
+	ErrEscalationUnavailable = errors.New("escalation tool not installed")
+
+	// ErrEscalationDenied is returned when `sudo -n` / `doas -n` would need a
+	// password (no NOPASSWD rule) — the agent never has a terminal to type one,
+	// so this fails closed rather than hanging.
+	ErrEscalationDenied = errors.New("escalation requires a password")
+)
+
+// CommandError is the typed error the capability layer wraps a failed command
+// in (Decision 3). The Runner itself does NOT treat a non-zero exit as an error
+// (callers branch on specific codes — cryptsetup 2 = wrong passphrase, etc.);
+// the capability layer decides when a non-zero exit becomes a CommandError. It
+// carries the exit code and captured stderr so callers can branch on them via
+// errors.As without importing internals.
+type CommandError struct {
+	Name     string // the command that failed, e.g. "useradd"
+	ExitCode int
+	Stderr   string
+	Err      error // underlying cause, if any
+}
+
+func (e *CommandError) Error() string {
+	if s := strings.TrimSpace(e.Stderr); s != "" {
+		return fmt.Sprintf("%s: exit %d: %s", e.Name, e.ExitCode, s)
+	}
+	return fmt.Sprintf("%s: exit %d", e.Name, e.ExitCode)
+}
+
+func (e *CommandError) Unwrap() error { return e.Err }

--- a/go/sys/exec/command_error_test.go
+++ b/go/sys/exec/command_error_test.go
@@ -1,0 +1,60 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// CommandError is the typed error the capability layer wraps a non-zero exit
+// in (Decision 3). It must carry ExitCode + Stderr for callers that branch on
+// them via errors.As, and Unwrap to the underlying cause so errors.Is chains.
+
+func TestCommandError_CarriesExitCodeAndStderr(t *testing.T) {
+	ce := &CommandError{Name: "useradd", ExitCode: 9, Stderr: "useradd: user 'deploy' already exists\n"}
+	msg := ce.Error()
+	if !strings.Contains(msg, "useradd") {
+		t.Errorf("Error() = %q, want it to name the command", msg)
+	}
+	if !strings.Contains(msg, "9") {
+		t.Errorf("Error() = %q, want it to include exit code 9", msg)
+	}
+	if !strings.Contains(msg, "already exists") {
+		t.Errorf("Error() = %q, want it to include stderr", msg)
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("Error() = %q, want trailing stderr newline trimmed", msg)
+	}
+}
+
+func TestCommandError_ErrorsAsAndUnwrap(t *testing.T) {
+	cause := errors.New("underlying")
+	ce := &CommandError{Name: "cryptsetup", ExitCode: 2, Stderr: "wrong passphrase", Err: cause}
+	wrapped := fmt.Errorf("add key: %w", ce)
+
+	var got *CommandError
+	if !errors.As(wrapped, &got) {
+		t.Fatal("errors.As did not unwrap to *CommandError")
+	}
+	if got.ExitCode != 2 {
+		t.Errorf("recovered ExitCode = %d, want 2", got.ExitCode)
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Error("errors.Is did not reach the wrapped cause via Unwrap")
+	}
+}
+
+// The Runner's construction/escalation sentinels must be distinct and
+// errors.Is-matchable (fail-closed contract: a caller can tell "tool missing"
+// from "needs a password" from "unknown backend").
+func TestRunnerSentinels_AreDistinct(t *testing.T) {
+	all := []error{ErrUnknownBackend, ErrEscalationUnavailable, ErrEscalationDenied}
+	for i := range all {
+		for j := range all {
+			if i != j && errors.Is(all[i], all[j]) {
+				t.Errorf("sentinels %d and %d are not distinct", i, j)
+			}
+		}
+	}
+}

--- a/go/sys/exec/detect.go
+++ b/go/sys/exec/detect.go
@@ -1,0 +1,28 @@
+package exec
+
+import (
+	"context"
+	"os/exec"
+)
+
+// Detect lists the privilege-escalation backends usable on THIS host (Decision
+// 6/7): Sudo if `sudo` is on PATH, Doas if `doas` is on PATH. It LISTS — it
+// never picks and never constructs a Runner; the consumer reads the list, picks
+// one explicitly, and passes it to NewRunner. Direct (run as the current
+// process, no wrapper) needs no detection and is never returned. A host with
+// neither tool returns an empty slice — a valid result for a root-only consumer
+// that will use Direct.
+//
+// The ctx is accepted for signature uniformity with the capability Detect
+// functions (which stat marker files); the present probe is a pure PATH lookup.
+func Detect(ctx context.Context) []PrivilegeBackend {
+	_ = ctx
+	var out []PrivilegeBackend
+	if _, err := exec.LookPath("sudo"); err == nil {
+		out = append(out, Sudo)
+	}
+	if _, err := exec.LookPath("doas"); err == nil {
+		out = append(out, Doas)
+	}
+	return out
+}

--- a/go/sys/exec/detect_test.go
+++ b/go/sys/exec/detect_test.go
@@ -1,0 +1,41 @@
+package exec
+
+import (
+	osexec "os/exec"
+	"testing"
+)
+
+// Detect LISTS the escalation backends usable on THIS host (Decision 6/7): it
+// lists, it never picks, and it never constructs a Runner. Direct needs no
+// detection (it is "run as the current process"), so it is never returned.
+func TestDetect_ListsOnlyInstalledSudoDoasNeverDirect(t *testing.T) {
+	got := Detect(t.Context())
+
+	for _, b := range got {
+		if b == Direct {
+			t.Errorf("Detect returned Direct; it must list only escalation tools (Sudo/Doas)")
+		}
+		if b != Sudo && b != Doas {
+			t.Errorf("Detect returned unexpected backend %d", b)
+		}
+	}
+	// No duplicates.
+	seen := map[PrivilegeBackend]bool{}
+	for _, b := range got {
+		if seen[b] {
+			t.Errorf("Detect returned duplicate backend %d", b)
+		}
+		seen[b] = true
+	}
+	// Cross-check against the host: presence in the list must agree with
+	// whether the tool is actually on PATH (the expectation is derived from
+	// the host independently of Detect's own probe).
+	_, sudoErr := osexec.LookPath("sudo")
+	if (sudoErr == nil) != seen[Sudo] {
+		t.Errorf("Detect Sudo presence = %v, but sudo on PATH = %v", seen[Sudo], sudoErr == nil)
+	}
+	_, doasErr := osexec.LookPath("doas")
+	if (doasErr == nil) != seen[Doas] {
+		t.Errorf("Detect Doas presence = %v, but doas on PATH = %v", seen[Doas], doasErr == nil)
+	}
+}

--- a/go/sys/exec/exec.go
+++ b/go/sys/exec/exec.go
@@ -174,6 +174,17 @@ func composeEnv(childPath string, envVars []string) []string {
 // A nil env inherits the parent environment fully; a non-nil env (even an
 // empty one) replaces it.
 func runStreamingWithEnv(ctx context.Context, name string, args []string, env []string, dir string, callback OutputCallback) (*Result, error) {
+	return runStreamingWithStdin(ctx, name, args, nil, env, dir, callback)
+}
+
+// runStreamingWithStdin is the shared low-level execution core: line-buffered
+// streaming with a per-stream MaxOutputBytes cap, ctx-cancel SIGTERM→SIGKILL
+// process-group escalation, and non-zero-exit-is-NOT-an-error semantics (the
+// exit code is in Result; the returned error is non-nil only on failure to
+// execute or ctx cancellation). Both the legacy RunStreaming* entry points
+// (stdin nil) and the injected Runner build on it. A nil env inherits the
+// parent environment fully; a non-nil env (even empty) replaces it.
+func runStreamingWithStdin(ctx context.Context, name string, args []string, stdin io.Reader, env []string, dir string, callback OutputCallback) (*Result, error) {
 	c := cmd.NewCmdOptions(cmd.Options{
 		Buffered:       false,
 		Streaming:      true,
@@ -187,7 +198,12 @@ func runStreamingWithEnv(ctx context.Context, name string, args []string, env []
 		c.Env = env
 	}
 
-	statusChan := c.Start()
+	var statusChan <-chan cmd.Status
+	if stdin != nil {
+		statusChan = c.StartWithStdin(stdin)
+	} else {
+		statusChan = c.Start()
+	}
 
 	var stdoutSeq, stderrSeq int64
 	var stdoutBuf, stderrBuf strings.Builder

--- a/go/sys/exec/exectest/fakerunner.go
+++ b/go/sys/exec/exectest/fakerunner.go
@@ -1,0 +1,123 @@
+// Package exectest provides a fake exec.Runner for unit-testing capability
+// packages with no host, no sudo, and no container. It is the keystone of the
+// additive unit tier in the SDK rework (sdk/docs/sdk-rework-design.md §6):
+// because every capability handle is built with an explicit Runner, a test
+// passes a FakeRunner and asserts on the exact Commands the capability built.
+package exectest
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// FakeRunner is a drop-in exec.Runner.
+var _ exec.Runner = (*FakeRunner)(nil)
+
+type scripted struct {
+	res exec.Result
+	err error
+}
+
+// FakeRunner is an exec.Runner that records every Command it receives and
+// returns scripted Results in FIFO order. An unscripted call returns a clean
+// success (zero Result, nil error). Safe for concurrent use.
+type FakeRunner struct {
+	mu      sync.Mutex
+	backend exec.PrivilegeBackend
+	calls   []exec.Command
+	queue   []scripted
+}
+
+// New returns a FakeRunner that reports the given privilege backend. The zero
+// value defaults to exec.Direct (the common unit-test runner).
+func New(backend exec.PrivilegeBackend) *FakeRunner {
+	if backend == 0 {
+		backend = exec.Direct
+	}
+	return &FakeRunner{backend: backend}
+}
+
+// Backend reports the configured privilege backend, so a capability under test
+// can branch on Runner.Backend() (e.g. fs's fd-safe vs sudo path).
+func (f *FakeRunner) Backend() exec.PrivilegeBackend { return f.backend }
+
+// Push scripts the next Run/Stream outcome (FIFO).
+func (f *FakeRunner) Push(r exec.Result, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = append(f.queue, scripted{res: r, err: err})
+}
+
+// Calls returns every Command received, in order.
+func (f *FakeRunner) Calls() []exec.Command {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]exec.Command(nil), f.calls...)
+}
+
+// record appends the attempted Command to the call log.
+func (f *FakeRunner) record(c exec.Command) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, c)
+}
+
+// pop returns the next scripted outcome (FIFO), or a clean success if none.
+func (f *FakeRunner) pop() (exec.Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.queue) == 0 {
+		return exec.Result{}, nil
+	}
+	s := f.queue[0]
+	f.queue = f.queue[1:]
+	return s.res, s.err
+}
+
+// Run records the Command and returns the next scripted Result. An
+// already-cancelled context short-circuits with ctx.Err() WITHOUT consuming a
+// scripted result — mirroring the real Runner, so a capability's ctx handling
+// can be unit-tested faithfully.
+func (f *FakeRunner) Run(ctx context.Context, c exec.Command) (exec.Result, error) {
+	f.record(c)
+	if err := ctx.Err(); err != nil {
+		return exec.Result{}, err
+	}
+	return f.pop()
+}
+
+// Stream records the Command, returns the next scripted Result, and replays the
+// scripted stdout/stderr to onLine line-by-line so streaming capabilities can
+// be exercised without a real process. A cancelled context short-circuits as in
+// Run (no scripted result consumed, no replay).
+func (f *FakeRunner) Stream(ctx context.Context, c exec.Command, onLine exec.OutputCallback) (exec.Result, error) {
+	f.record(c)
+	if err := ctx.Err(); err != nil {
+		return exec.Result{}, err
+	}
+	res, err := f.pop()
+	if onLine != nil {
+		replay(res.Stdout, exec.StreamStdout, onLine)
+		replay(res.Stderr, exec.StreamStderr, onLine)
+	}
+	return res, err
+}
+
+// replay delivers buf to onLine one line at a time. Every delivered line is
+// newline-terminated — INCLUDING an unterminated final line — because that is
+// exactly what the real Runner does (its streaming path appends "\n" to every
+// callback line; verified: `printf 'a\nb'` delivers "a\n" then "b\n").
+// Preserving a missing final newline here would make the fake LESS faithful.
+func replay(buf string, stream exec.StreamType, onLine exec.OutputCallback) {
+	if buf == "" {
+		return
+	}
+	var seq int64
+	for _, line := range strings.Split(strings.TrimSuffix(buf, "\n"), "\n") {
+		onLine(stream, line+"\n", seq)
+		seq++
+	}
+}

--- a/go/sys/exec/exectest/fakerunner_test.go
+++ b/go/sys/exec/exectest/fakerunner_test.go
@@ -1,0 +1,116 @@
+package exectest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// FakeRunner is the keystone of the additive unit tier: a capability Manager
+// built with it can be tested with no host, no sudo, no container. It records
+// every Command in order and returns scripted Results FIFO.
+
+// Compile-time proof it is a drop-in exec.Runner.
+var _ exec.Runner = (*exectest.FakeRunner)(nil)
+
+func TestFakeRunner_RecordsCommandsInOrder(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	ctx := context.Background()
+
+	_, _ = f.Run(ctx, exec.Command{Name: "useradd", Args: []string{"-m", "deploy"}})
+	_, _ = f.Run(ctx, exec.Command{Name: "usermod", Args: []string{"-L", "deploy"}})
+
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("Calls() len = %d, want 2", len(calls))
+	}
+	if calls[0].Name != "useradd" || calls[1].Name != "usermod" {
+		t.Errorf("recorded order = %q,%q, want useradd,usermod", calls[0].Name, calls[1].Name)
+	}
+}
+
+func TestFakeRunner_ScriptsResultsFIFO(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	want1 := exec.Result{ExitCode: 0, Stdout: "first"}
+	errBoom := errors.New("boom")
+	f.Push(want1, nil)
+	f.Push(exec.Result{ExitCode: 7}, errBoom)
+
+	got1, err1 := f.Run(context.Background(), exec.Command{Name: "a"})
+	if err1 != nil || got1.Stdout != "first" {
+		t.Errorf("first Run = (%+v, %v), want (%+v, nil)", got1, err1, want1)
+	}
+	got2, err2 := f.Run(context.Background(), exec.Command{Name: "b"})
+	if !errors.Is(err2, errBoom) || got2.ExitCode != 7 {
+		t.Errorf("second Run = (%+v, %v), want (ExitCode 7, boom)", got2, err2)
+	}
+}
+
+func TestFakeRunner_DefaultsToSuccessWhenUnscripted(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	res, err := f.Run(context.Background(), exec.Command{Name: "true"})
+	if err != nil || res.ExitCode != 0 {
+		t.Errorf("unscripted Run = (%+v, %v), want clean success", res, err)
+	}
+}
+
+func TestFakeRunner_BackendReported(t *testing.T) {
+	if got := exectest.New(exec.Sudo).Backend(); got != exec.Sudo {
+		t.Errorf("Backend() = %d, want Sudo", got)
+	}
+	// Zero value defaults to Direct (the common unit-test runner).
+	if got := exectest.New(0).Backend(); got != exec.Direct {
+		t.Errorf("Backend() for zero value = %d, want Direct default", got)
+	}
+}
+
+// A cancelled context makes FakeRunner behave like the real Runner: it returns
+// ctx.Err(), does NOT consume a scripted result (the command did not run), but
+// still records the attempt so a test can see what the capability tried.
+func TestFakeRunner_RespectsCancelledContext(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "should-not-be-returned"}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := f.Run(ctx, exec.Command{Name: "useradd"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Run with cancelled ctx err = %v, want context.Canceled", err)
+	}
+	if res.Stdout != "" {
+		t.Errorf("cancelled Run returned scripted output %q; the scripted result must not be consumed", res.Stdout)
+	}
+	if len(f.Calls()) != 1 {
+		t.Errorf("Calls() = %d, want the attempted command recorded", len(f.Calls()))
+	}
+	// The scripted result is preserved for the next (non-cancelled) call.
+	if res2, _ := f.Run(context.Background(), exec.Command{Name: "useradd"}); res2.Stdout != "should-not-be-returned" {
+		t.Errorf("scripted result was wrongly consumed by the cancelled call: got %q", res2.Stdout)
+	}
+}
+
+// Stream records the Command too and replays scripted stdout to the callback so
+// streaming capabilities can be unit-tested.
+func TestFakeRunner_StreamRecordsAndReplays(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 0, Stdout: "line1\nline2\n"}, nil)
+
+	var lines []string
+	_, err := f.Stream(context.Background(), exec.Command{Name: "journalctl"},
+		func(s exec.StreamType, line string, seq int64) {
+			lines = append(lines, line)
+		})
+	if err != nil {
+		t.Fatalf("Stream err = %v", err)
+	}
+	if len(f.Calls()) != 1 || f.Calls()[0].Name != "journalctl" {
+		t.Errorf("Stream did not record the Command: %+v", f.Calls())
+	}
+	if len(lines) == 0 {
+		t.Error("Stream replayed no lines to the callback")
+	}
+}

--- a/go/sys/exec/privileged.go
+++ b/go/sys/exec/privileged.go
@@ -8,76 +8,66 @@ import (
 	"sync/atomic"
 )
 
-// PrivilegeBackend selects which privilege-escalation tool Privileged
-// and PrivilegedWithStdin dispatch through. The SDK defaults to the
-// sudo backend; agents running on doas-only hosts call
-// SetPrivilegeBackend(PrivilegeBackendDoas) once at startup, and
-// agents running as root (post sudoers-removal architecture) call
-// SetPrivilegeBackend(PrivilegeBackendRoot) so the dispatch becomes
-// a direct exec instead of a sudo/doas wrap.
-type PrivilegeBackend int
+// This file is the LEGACY process-global privilege path. It is retained, and
+// still load-bearing, only while the capability packages are migrated onto the
+// injected Runner (see runner.go / sdk-rework-design.md Decision 2). It is
+// deleted in the final cleanup PR once no caller reads the global. New code must
+// use NewRunner, never SetPrivilegeBackend.
+//
+// The PrivilegeBackend type and the Sudo/Doas/Direct values are defined in
+// runner.go (the ratified, fail-closed enum). The global below preserves the
+// historical default-to-sudo behaviour for not-yet-migrated callers: an unset
+// global (the invalid zero value) still resolves to sudo via privilegeTool.
 
-const (
-	// PrivilegeBackendSudo wraps commands with `sudo -n`. Default.
-	PrivilegeBackendSudo PrivilegeBackend = 0
-	// PrivilegeBackendDoas wraps commands with `doas -n`.
-	PrivilegeBackendDoas PrivilegeBackend = 1
-	// PrivilegeBackendRoot runs commands directly with no escalation
-	// wrapper. Use when the agent process is already root — sudo's
-	// "root needs to be in sudoers" check varies by distro (opensuse
-	// rejects it by default), and rolling our own no-op pass-through
-	// avoids both that quirk and the cost of forking sudo just to
-	// re-exec the same binary.
-	PrivilegeBackendRoot PrivilegeBackend = 2
-)
-
-// backend stores the active PrivilegeBackend as an int32. Access is
-// via atomic load/store so the setter is safe to call concurrently
-// with any in-flight Privileged call (though in practice the setter
-// runs once at startup).
+// backend stores the active PrivilegeBackend as an int32. Access is via atomic
+// load/store so the setter is safe to call concurrently with any in-flight
+// Privileged call (though in practice the setter runs once at startup).
 var backend atomic.Int32
 
-// SetPrivilegeBackend selects which escalation tool Privileged,
-// PrivilegedWithStdin, and PrivilegedStreaming use. Call this once
-// at startup from the agent's main() based on configuration. Valid
-// values are PrivilegeBackendSudo (default), PrivilegeBackendDoas,
-// and PrivilegeBackendRoot; unknown values are ignored so callers
-// don't accidentally silence the dispatch by passing 0 from a
-// zero-valued proto enum.
+// SetPrivilegeBackend selects which escalation tool the legacy Privileged,
+// PrivilegedWithStdin, and PrivilegedStreaming dispatch through. Call once at
+// startup. Valid values are Sudo, Doas, and Direct; unknown values are ignored
+// so a caller can't silence the dispatch by passing an uninitialised value.
+//
+// Prefer NewRunner and inject the Runner. This global is removed once
+// the capability migration is complete.
 func SetPrivilegeBackend(b PrivilegeBackend) {
 	switch b {
-	case PrivilegeBackendSudo, PrivilegeBackendDoas, PrivilegeBackendRoot:
+	case Sudo, Doas, Direct:
 		backend.Store(int32(b))
 	}
 }
 
-// CurrentPrivilegeBackend returns the active backend. Useful for tests
-// and for agent code that needs to render backend-specific file paths
-// (e.g. /etc/sudoers.d vs /etc/doas.d).
+// CurrentPrivilegeBackend returns the active legacy backend. Used by code that
+// renders backend-specific paths (e.g. /etc/sudoers.d vs /etc/doas.d) and by
+// fs's privilege-keyed write/delete path during the migration window.
+//
+// Prefer Runner.Backend() on an injected Runner.
 func CurrentPrivilegeBackend() PrivilegeBackend {
 	return PrivilegeBackend(backend.Load())
 }
 
-// privilegeTool returns the CLI name for the active backend.
-// Returns the empty string for PrivilegeBackendRoot, which signals
-// the dispatchers to skip the wrapper entirely.
+// privilegeTool returns the CLI name for the active legacy backend. Direct
+// returns "" (skip the wrapper). The unset/zero value resolves to sudo, the
+// historical default for callers that never called SetPrivilegeBackend.
 func privilegeTool() string {
 	switch CurrentPrivilegeBackend() {
-	case PrivilegeBackendDoas:
+	case Doas:
 		return "doas"
-	case PrivilegeBackendRoot:
+	case Direct:
 		return ""
 	default:
 		return "sudo"
 	}
 }
 
-// Privileged runs name with args under the configured privilege backend
-// (sudo by default, doas when SetPrivilegeBackend has been called, or
-// directly with no wrapper when the backend is root). The command is
-// resolved to an absolute path so it matches sudoers/doas.conf rules.
-// The backend is invoked with `-n` to fail immediately rather than
+// Privileged runs name with args under the configured legacy privilege backend
+// (sudo by default, doas when set, or directly with no wrapper when Direct).
+// The command is resolved to an absolute path so it matches sudoers/doas.conf
+// rules. The backend is invoked with `-n` to fail immediately rather than
 // prompting — agents never get a terminal to enter a password.
+//
+// Prefer Runner.Run with Command{Escalate: true}.
 func Privileged(ctx context.Context, name string, args ...string) (*Result, error) {
 	absPath, err := exec.LookPath(name)
 	if err != nil {
@@ -85,7 +75,7 @@ func Privileged(ctx context.Context, name string, args ...string) (*Result, erro
 	}
 	tool := privilegeTool()
 	if tool == "" {
-		// Root backend — direct exec, no wrapper.
+		// Direct backend — direct exec, no wrapper.
 		return Run(ctx, absPath, args...)
 	}
 	if _, err := exec.LookPath(tool); err != nil {
@@ -96,6 +86,8 @@ func Privileged(ctx context.Context, name string, args ...string) (*Result, erro
 }
 
 // PrivilegedWithStdin is the stdin-accepting variant of Privileged.
+//
+// Prefer Runner.Run with Command{Escalate: true, Stdin: r}.
 func PrivilegedWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) (*Result, error) {
 	absPath, err := exec.LookPath(name)
 	if err != nil {
@@ -112,17 +104,12 @@ func PrivilegedWithStdin(ctx context.Context, stdin io.Reader, name string, args
 	return RunWithStdin(ctx, stdin, tool, wrapped...)
 }
 
-// PrivilegedStreaming is the streaming variant of Privileged. Same
-// privilege wrapping as Privileged (absolute-path resolution, `-n`
-// flag, backend-installed check) but dispatches through
-// RunStreaming so callers can observe stdout/stderr lines as they
-// arrive via the OutputCallback.
+// PrivilegedStreaming is the streaming variant of Privileged. Same privilege
+// wrapping as Privileged (absolute-path resolution, `-n` flag, backend-installed
+// check) but dispatches through RunStreaming so callers can observe stdout/stderr
+// lines as they arrive via the OutputCallback.
 //
-// Used by agent action types that produce long-running output
-// (shell scripts under sudo, package-manager streaming) where
-// buffering the entire output before returning would delay the
-// operator's view of progress and could push large results past
-// MaxOutputBytes.
+// Prefer Runner.Stream with Command{Escalate: true}.
 func PrivilegedStreaming(ctx context.Context, name string, args []string, envVars []string, dir string, callback OutputCallback) (*Result, error) {
 	absPath, err := exec.LookPath(name)
 	if err != nil {

--- a/go/sys/exec/privileged_test.go
+++ b/go/sys/exec/privileged_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestPrivilegeBackend_DefaultIsSudo(t *testing.T) {
 	// Reset in case a prior test flipped it.
-	SetPrivilegeBackend(PrivilegeBackendSudo)
-	if got := CurrentPrivilegeBackend(); got != PrivilegeBackendSudo {
-		t.Errorf("default backend = %d, want %d", got, PrivilegeBackendSudo)
+	SetPrivilegeBackend(Sudo)
+	if got := CurrentPrivilegeBackend(); got != Sudo {
+		t.Errorf("default backend = %d, want %d", got, Sudo)
 	}
 	if got := privilegeTool(); got != "sudo" {
 		t.Errorf("privilegeTool() = %q, want %q", got, "sudo")
@@ -16,10 +16,10 @@ func TestPrivilegeBackend_DefaultIsSudo(t *testing.T) {
 }
 
 func TestPrivilegeBackend_SetDoas(t *testing.T) {
-	t.Cleanup(func() { SetPrivilegeBackend(PrivilegeBackendSudo) })
-	SetPrivilegeBackend(PrivilegeBackendDoas)
-	if got := CurrentPrivilegeBackend(); got != PrivilegeBackendDoas {
-		t.Errorf("after SetPrivilegeBackend(Doas), backend = %d, want %d", got, PrivilegeBackendDoas)
+	t.Cleanup(func() { SetPrivilegeBackend(Sudo) })
+	SetPrivilegeBackend(Doas)
+	if got := CurrentPrivilegeBackend(); got != Doas {
+		t.Errorf("after SetPrivilegeBackend(Doas), backend = %d, want %d", got, Doas)
 	}
 	if got := privilegeTool(); got != "doas" {
 		t.Errorf("privilegeTool() = %q, want %q", got, "doas")
@@ -27,13 +27,13 @@ func TestPrivilegeBackend_SetDoas(t *testing.T) {
 }
 
 func TestPrivilegeBackend_IgnoresUnknown(t *testing.T) {
-	t.Cleanup(func() { SetPrivilegeBackend(PrivilegeBackendSudo) })
-	SetPrivilegeBackend(PrivilegeBackendDoas)
+	t.Cleanup(func() { SetPrivilegeBackend(Sudo) })
+	SetPrivilegeBackend(Doas)
 	// An unknown value must NOT silently reset to sudo. Callers that
 	// pass an uninitialised proto enum value shouldn't change behaviour
 	// once the backend has been explicitly set.
 	SetPrivilegeBackend(PrivilegeBackend(99))
-	if got := CurrentPrivilegeBackend(); got != PrivilegeBackendDoas {
-		t.Errorf("unknown backend value leaked through: got %d, want %d", got, PrivilegeBackendDoas)
+	if got := CurrentPrivilegeBackend(); got != Doas {
+		t.Errorf("unknown backend value leaked through: got %d, want %d", got, Doas)
 	}
 }

--- a/go/sys/exec/runner.go
+++ b/go/sys/exec/runner.go
@@ -1,0 +1,226 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// PrivilegeBackend selects how a Runner escalates privilege for a Command whose
+// Escalate flag is set. The zero value is INVALID (fail-closed): NewRunner
+// rejects it with ErrUnknownBackend. Valid values start at 1 (Decision 5/6).
+type PrivilegeBackend int
+
+const (
+	// Sudo escalates via `sudo -n` (non-interactive; never prompts).
+	Sudo PrivilegeBackend = iota + 1
+	// Doas escalates via `doas -n`.
+	Doas
+	// Direct runs with no wrapper — the process is already root. Rolling our
+	// own no-op pass-through avoids sudo's distro-varying "root must be in
+	// sudoers" check (opensuse rejects it by default) and the cost of forking
+	// sudo just to re-exec the same binary.
+	Direct
+)
+
+// Command describes one execution. The zero value is invalid — Name is
+// required. The capability layer fills this in and sets Escalate per operation;
+// it is escalation-method-agnostic. The Runner alone turns Escalate into the
+// concrete sudo/doas/bare invocation.
+type Command struct {
+	Name      string    // resolved to an absolute path before escalation
+	Args      []string  // operands; the caller pre-applies SeparatePositionals
+	Dir       string    // "" = inherit cwd
+	Env       []string  // extra KEY=VALUE; screened by the env hijack blocklist
+	Stdin     io.Reader // "" = no stdin
+	CLocale   bool      // force LC_ALL=C / LANG=C for stable English-only parsing
+	ChildPath string    // explicit, isolating child PATH; "" = inherit/sanitized
+	Escalate  bool      // run through the privilege backend
+}
+
+// Runner abstracts command execution + privilege escalation. It is injected
+// into every capability constructor (Decision 2) so the SDK keeps no global
+// escalation state and the whole capability layer is unit-testable with a fake
+// (see exectest.FakeRunner) — no host, no sudo, no container.
+type Runner interface {
+	// Run executes c and returns its captured output. A non-zero exit is
+	// reported in Result.ExitCode, NOT as an error; a non-nil error means the
+	// command could not be executed (binary not found, blocked env var, ctx
+	// cancelled) or escalation failed (ErrEscalation*).
+	Run(ctx context.Context, c Command) (Result, error)
+	// Stream is Run with real-time line delivery via onLine.
+	Stream(ctx context.Context, c Command, onLine OutputCallback) (Result, error)
+	// Backend reports the privilege backend, so a capability (e.g. fs) can pick
+	// its fd-safe vs sudo code path.
+	Backend() PrivilegeBackend
+}
+
+type runner struct{ backend PrivilegeBackend }
+
+// NewRunner builds a Runner for the named backend. It is PURE: it validates the
+// backend is known and does NOT probe the host (use Detect for that). The zero
+// value and any unimplemented backend are rejected with ErrUnknownBackend.
+func NewRunner(b PrivilegeBackend) (Runner, error) {
+	switch b {
+	case Sudo, Doas, Direct:
+		return &runner{backend: b}, nil
+	default:
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+}
+
+func (r *runner) Backend() PrivilegeBackend { return r.backend }
+
+func (r *runner) Run(ctx context.Context, c Command) (Result, error) {
+	return r.exec(ctx, c, nil)
+}
+
+func (r *runner) Stream(ctx context.Context, c Command, onLine OutputCallback) (Result, error) {
+	return r.exec(ctx, c, onLine)
+}
+
+func (r *runner) exec(ctx context.Context, c Command, onLine OutputCallback) (Result, error) {
+	// Fail closed on an already-cancelled context: never start a command with a
+	// dead ctx (go-cmd's select could otherwise let a fast command win the race
+	// against ctx.Done() and report success). Keeps the real Runner and the
+	// fake behaviourally identical on cancellation.
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+	if c.Name == "" {
+		return Result{}, fmt.Errorf("exec: command name is required")
+	}
+	// Compose + validate the child env FIRST, so a blocked env var (LD_PRELOAD,
+	// PATH, …) is rejected before the child is ever spawned.
+	env, err := buildChildEnv(c)
+	if err != nil {
+		return Result{}, err
+	}
+	// Resolve to an absolute path so it matches sudoers/doas.conf rules and is
+	// deterministic regardless of the child's PATH.
+	absPath, err := resolveAbsolute(c.Name)
+	if err != nil {
+		return Result{}, fmt.Errorf("command not found: %s", c.Name)
+	}
+	// When escalating through a wrapper, the wrapper itself must be installed —
+	// fail closed with ErrEscalationUnavailable rather than running unescalated.
+	if c.Escalate {
+		if tool := escalationTool(r.backend); tool != "" {
+			if _, err := exec.LookPath(tool); err != nil {
+				return Result{}, fmt.Errorf("%w: %s", ErrEscalationUnavailable, tool)
+			}
+		}
+	}
+	name, argv := wrapEscalation(r.backend, c.Escalate, absPath, c.Args)
+
+	res, runErr := runStreamingWithStdin(ctx, name, argv, c.Stdin, env, c.Dir, onLine)
+	result := Result{}
+	if res != nil {
+		result = *res
+	}
+	if runErr != nil {
+		return result, runErr
+	}
+	// A sudo/doas -n auth refusal is an escalation failure, distinct from the
+	// wrapped command's own non-zero exit.
+	if c.Escalate {
+		if denied := detectEscalationDenied(r.backend, result); denied != nil {
+			return result, denied
+		}
+	}
+	return result, nil
+}
+
+// resolveAbsolute resolves name to an ABSOLUTE executable path. exec.LookPath
+// returns a slash-containing relative name unchanged (e.g. "./tool") and with a
+// nil error, so its result is not guaranteed absolute; filepath.Abs enforces it.
+// An absolute path is required by the escalation contract — sudoers/doas match
+// on absolute paths, and escalating a relative path is a security risk.
+func resolveAbsolute(name string) (string, error) {
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(p)
+}
+
+// escalationTool returns the wrapper binary for a backend, or "" when the
+// backend needs no wrapper (Direct).
+func escalationTool(b PrivilegeBackend) string {
+	switch b {
+	case Sudo:
+		return "sudo"
+	case Doas:
+		return "doas"
+	default:
+		return ""
+	}
+}
+
+// wrapEscalation turns (backend, escalate, absolute-path, args) into the final
+// (name, argv). Pure: no I/O. When escalation is requested and the backend uses
+// a wrapper, the wrapper runs with -n (never prompt) and the resolved absolute
+// path. The caller's args slice is never aliased or mutated.
+func wrapEscalation(b PrivilegeBackend, escalate bool, absPath string, args []string) (string, []string) {
+	tool := escalationTool(b)
+	if !escalate || tool == "" { // bare invocation (no escalation, or Direct)
+		return absPath, append([]string(nil), args...)
+	}
+	argv := make([]string, 0, len(args)+2)
+	argv = append(argv, "-n", absPath)
+	argv = append(argv, args...)
+	return tool, argv
+}
+
+// detectEscalationDenied recognises a sudo/doas -n refusal (a password would be
+// required) and turns it into ErrEscalationDenied — distinct from the wrapped
+// command's own non-zero exit. Pure: it inspects only the Result, and matches
+// the wrappers' own diagnostic strings so a genuine command failure is never
+// misclassified.
+func detectEscalationDenied(b PrivilegeBackend, res Result) error {
+	if res.ExitCode == 0 {
+		return nil
+	}
+	s := res.Stderr
+	switch b {
+	case Sudo:
+		if strings.Contains(s, "a password is required") ||
+			strings.Contains(s, "a terminal is required") ||
+			strings.Contains(s, "no askpass program") {
+			return fmt.Errorf("%w: %s", ErrEscalationDenied, strings.TrimSpace(s))
+		}
+	case Doas:
+		if strings.Contains(s, "Authorization required") ||
+			strings.Contains(s, "Authentication failed") {
+			return fmt.Errorf("%w: %s", ErrEscalationDenied, strings.TrimSpace(s))
+		}
+	}
+	return nil
+}
+
+// buildChildEnv composes and validates the Command's child environment. The
+// hijack blocklist (LD_PRELOAD, PATH, BASH_ENV, …) is enforced on Command.Env;
+// a curated PATH goes through ChildPath, which REPLACES (never augments) the
+// parent env — the isolation the per-user runuser fan-out needs. A nil return
+// means "inherit the parent fully" (the contract when no customization is
+// requested).
+func buildChildEnv(c Command) ([]string, error) {
+	extra := append([]string(nil), c.Env...)
+	if c.CLocale {
+		extra = append(extra, "LC_ALL=C", "LANG=C")
+	}
+	if err := validateEnvVars(extra); err != nil {
+		return nil, err
+	}
+	if c.ChildPath != "" {
+		return composeEnv(c.ChildPath, extra), nil // curated PATH; parent NOT inherited
+	}
+	if len(extra) > 0 {
+		return composeEnv(os.Getenv("PATH"), extra), nil // sanitized parent PATH + extras
+	}
+	return nil, nil // inherit parent fully
+}

--- a/go/sys/exec/runner_test.go
+++ b/go/sys/exec/runner_test.go
@@ -1,0 +1,339 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// NewRunner is pure and fail-closed: it validates the backend is KNOWN and does
+// not probe the host. The zero value and any unimplemented value are rejected
+// with ErrUnknownBackend (Decision 5/6) — no silent default escalation.
+
+func TestNewRunner_RejectsZeroAndUnknown(t *testing.T) {
+	for _, b := range []PrivilegeBackend{0, PrivilegeBackend(-1), PrivilegeBackend(99)} {
+		r, err := NewRunner(b)
+		if !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("NewRunner(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+		if r != nil {
+			t.Errorf("NewRunner(%d) returned a non-nil runner on error", b)
+		}
+	}
+}
+
+func TestNewRunner_AcceptsImplementedBackends(t *testing.T) {
+	for _, b := range []PrivilegeBackend{Sudo, Doas, Direct} {
+		r, err := NewRunner(b)
+		if err != nil {
+			t.Fatalf("NewRunner(%d) err = %v, want nil", b, err)
+		}
+		if r.Backend() != b {
+			t.Errorf("Backend() = %d, want %d", r.Backend(), b)
+		}
+	}
+}
+
+// The capability layer sets Command.Escalate and is escalation-method-agnostic;
+// the Runner alone turns that into sudo -n / doas -n / bare. wrapEscalation is
+// the pure seam that decides the final (name, argv) — unit-testable without a
+// real sudo on PATH (the real escalation is covered by the integration harness).
+func TestWrapEscalation(t *testing.T) {
+	const abs = "/usr/sbin/useradd"
+	args := []string{"-m", "deploy"}
+
+	tests := []struct {
+		backend  PrivilegeBackend
+		escalate bool
+		wantName string
+		wantArgv []string
+	}{
+		{Direct, true, abs, []string{"-m", "deploy"}},
+		{Direct, false, abs, []string{"-m", "deploy"}},
+		{Sudo, true, "sudo", []string{"-n", abs, "-m", "deploy"}},
+		{Doas, true, "doas", []string{"-n", abs, "-m", "deploy"}},
+		{Sudo, false, abs, []string{"-m", "deploy"}}, // no escalation requested → bare
+		{Doas, false, abs, []string{"-m", "deploy"}},
+	}
+	for _, tc := range tests {
+		name, argv := wrapEscalation(tc.backend, tc.escalate, abs, args)
+		if name != tc.wantName {
+			t.Errorf("backend=%d escalate=%v: name=%q, want %q", tc.backend, tc.escalate, name, tc.wantName)
+		}
+		if strings.Join(argv, " ") != strings.Join(tc.wantArgv, " ") {
+			t.Errorf("backend=%d escalate=%v: argv=%v, want %v", tc.backend, tc.escalate, argv, tc.wantArgv)
+		}
+	}
+}
+
+// wrapEscalation must not alias/mutate the caller's args slice (a reused arg
+// list must stay pristine across calls).
+func TestWrapEscalation_DoesNotMutateCallerArgs(t *testing.T) {
+	args := []string{"-m", "deploy"}
+	_, _ = wrapEscalation(Sudo, true, "/usr/sbin/useradd", args)
+	if args[0] != "-m" || args[1] != "deploy" || len(args) != 2 {
+		t.Errorf("caller args mutated: %v", args)
+	}
+}
+
+func directRunner(t *testing.T) Runner {
+	t.Helper()
+	r, err := NewRunner(Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	return r
+}
+
+// A non-zero exit is NOT an error — it is reported in Result.ExitCode, because
+// callers branch on specific codes (cryptsetup 2 = wrong passphrase, etc.). The
+// Runner returns a non-nil error only on FAILURE TO EXECUTE.
+func TestRunner_NonZeroExitIsNotAnError(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{Name: "sh", Args: []string{"-c", "exit 3"}})
+	if err != nil {
+		t.Fatalf("Run err = %v, want nil for a clean non-zero exit", err)
+	}
+	if res.ExitCode != 3 {
+		t.Errorf("ExitCode = %d, want 3", res.ExitCode)
+	}
+}
+
+func TestRunner_CapturesStdout(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{Name: "sh", Args: []string{"-c", "printf hello"}})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if !strings.Contains(res.Stdout, "hello") {
+		t.Errorf("Stdout = %q, want it to contain hello", res.Stdout)
+	}
+}
+
+func TestRunner_RejectsEmptyNameAndUnknownBinary(t *testing.T) {
+	if _, err := directRunner(t).Run(context.Background(), Command{Name: ""}); err == nil {
+		t.Error("Run with empty Name returned nil error, want a failure-to-execute error")
+	}
+	if _, err := directRunner(t).Run(context.Background(), Command{Name: "definitely-not-a-real-binary-xyz"}); err == nil {
+		t.Error("Run with a nonexistent binary returned nil error, want command-not-found")
+	}
+}
+
+// The escalation contract requires an ABSOLUTE path (sudoers/doas match on
+// absolute paths; escalating a relative path is a security risk). exec.LookPath
+// returns a slash-containing relative Name UNCHANGED and with a nil error, so
+// the Runner must enforce absoluteness itself.
+func TestResolveAbsolute_BareNameIsAbsolute(t *testing.T) {
+	abs, err := resolveAbsolute("sh")
+	if err != nil {
+		t.Fatalf("resolveAbsolute(sh) err = %v", err)
+	}
+	if !filepath.IsAbs(abs) {
+		t.Errorf("resolveAbsolute(sh) = %q, want an absolute path", abs)
+	}
+}
+
+func TestResolveAbsolute_RelativeSlashNameResolvedToAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	tool := filepath.Join(dir, "tool")
+	if err := os.WriteFile(tool, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	abs, err := resolveAbsolute("./tool")
+	if err != nil {
+		t.Fatalf("resolveAbsolute(./tool) err = %v", err)
+	}
+	if !filepath.IsAbs(abs) {
+		t.Errorf("resolveAbsolute(./tool) = %q, want an absolute path (LookPath leaves it relative)", abs)
+	}
+}
+
+// An already-cancelled context must short-circuit: the command never runs and
+// the Runner returns ctx.Err(). Without an upfront check, go-cmd's select could
+// pick a fast-completing command over ctx.Done() and return nil — so a caller
+// passing a dead ctx could still trigger a side effect. (This also keeps the
+// real Runner and exectest.FakeRunner behaviourally identical on cancellation.)
+func TestRunner_RespectsAlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := directRunner(t).Run(ctx, Command{Name: "sh", Args: []string{"-c", "exit 0"}}); !errors.Is(err, context.Canceled) {
+		t.Errorf("Run with a pre-cancelled ctx err = %v, want context.Canceled", err)
+	}
+}
+
+// Stdin is delivered to the child (the chpasswd/cryptsetup path the capability
+// layer relies on).
+func TestRunner_DeliversStdin(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name:  "cat",
+		Stdin: strings.NewReader("piped-secret"),
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if !strings.Contains(res.Stdout, "piped-secret") {
+		t.Errorf("Stdout = %q, want the piped stdin echoed back", res.Stdout)
+	}
+}
+
+// The env hijack blocklist is enforced through Command.Env — a blocked name is
+// rejected BEFORE the child is spawned (present-but-wrong → Runner does no work).
+func TestRunner_EnvBlocklistRejectedBeforeExec(t *testing.T) {
+	r := directRunner(t)
+	if _, err := r.Run(context.Background(), Command{Name: "sh", Args: []string{"-c", "true"}, Env: []string{"LD_PRELOAD=/evil.so"}}); !errors.Is(err, ErrBlockedEnvVar) {
+		t.Errorf("blocked env err = %v, want ErrBlockedEnvVar", err)
+	}
+	if _, err := r.Run(context.Background(), Command{Name: "sh", Args: []string{"-c", "true"}, Env: []string{"PATH=/evil"}}); !errors.Is(err, ErrBlockedEnvVar) {
+		t.Errorf("PATH-via-Env err = %v, want ErrBlockedEnvVar (use ChildPath for a curated PATH)", err)
+	}
+	if _, err := r.Run(context.Background(), Command{Name: "sh", Args: []string{"-c", "true"}, Env: []string{"not-key-value"}}); !errors.Is(err, ErrInvalidEnvVar) {
+		t.Errorf("malformed env err = %v, want ErrInvalidEnvVar", err)
+	}
+}
+
+func TestRunner_AllowedEnvReachesChild(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name: "sh", Args: []string{"-c", "printf %s \"$PM_TEST_VAR\""},
+		Env: []string{"PM_TEST_VAR=visible"},
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if !strings.Contains(res.Stdout, "visible") {
+		t.Errorf("Stdout = %q, want the allowed env var visible to the child", res.Stdout)
+	}
+}
+
+// CLocale forces LC_ALL=C / LANG=C so the agent's English-only output parsers
+// are stable regardless of the host locale.
+func TestRunner_CLocaleForcesC(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name: "sh", Args: []string{"-c", "printf %s \"$LC_ALL\""},
+		CLocale: true,
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if strings.TrimSpace(res.Stdout) != "C" {
+		t.Errorf("LC_ALL in child = %q, want C", res.Stdout)
+	}
+}
+
+// ChildPath sets an explicit, isolating child PATH (the per-user runuser path):
+// the curated PATH is authoritative and the parent env is NOT inherited.
+func TestRunner_ChildPathIsAuthoritative(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name: "sh", Args: []string{"-c", "printf %s \"$PATH\""},
+		ChildPath: "/curated/bin:/curated/sbin",
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if strings.TrimSpace(res.Stdout) != "/curated/bin:/curated/sbin" {
+		t.Errorf("child PATH = %q, want the curated path", res.Stdout)
+	}
+}
+
+// detectEscalationDenied turns a sudo/doas -n auth refusal into ErrEscalationDenied
+// (distinct from the command's own non-zero exit). Pure seam — unit-tested with
+// synthetic Results so it needs no password-protected sudo.
+func TestDetectEscalationDenied(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend PrivilegeBackend
+		res     Result
+		want    bool
+	}{
+		{"sudo password required", Sudo, Result{ExitCode: 1, Stderr: "sudo: a password is required"}, true},
+		{"sudo terminal required", Sudo, Result{ExitCode: 1, Stderr: "sudo: a terminal is required to read the password"}, true},
+		{"doas auth failure", Doas, Result{ExitCode: 1, Stderr: "doas: Authorization required"}, true},
+		{"direct never denied", Direct, Result{ExitCode: 1, Stderr: "anything"}, false},
+		{"clean exit not denied", Sudo, Result{ExitCode: 0}, false},
+		{"genuine command failure not denied", Sudo, Result{ExitCode: 1, Stderr: "useradd: user already exists"}, false},
+	}
+	for _, tc := range tests {
+		err := detectEscalationDenied(tc.backend, tc.res)
+		if got := errors.Is(err, ErrEscalationDenied); got != tc.want {
+			t.Errorf("%s: denied=%v, want %v (err=%v)", tc.name, got, tc.want, err)
+		}
+	}
+}
+
+// ctx cancellation must SIGKILL a SIGTERM-ignoring child after a bounded grace
+// and return promptly — the WS16 escalation, now via the Runner. Reuses the
+// trap-ignoring harness from exec_kill_test.go (a bare sleep would die on the
+// group SIGTERM and pass for the wrong reason).
+func TestRunner_SIGKILLsChildThatIgnoresSIGTERM(t *testing.T) {
+	// Mutates the package-level killGrace seam, so this test must not be made
+	// parallel (no t.Parallel) — the same constraint as the sibling kill tests.
+	restore := killGrace
+	killGrace = 200 * time.Millisecond
+	defer func() { killGrace = restore }()
+
+	pidFile := t.TempDir() + "/pid"
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	type result struct{ err error }
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		_, err := directRunner(t).Run(ctx, Command{Name: "sh", Args: []string{"-c", sigtermIgnoringScript(pidFile)}})
+		done <- result{err}
+	}()
+
+	select {
+	case r := <-done:
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Errorf("Runner.Run took %v; SIGTERM-ignoring child was not SIGKILLed after grace", elapsed)
+		}
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Errorf("err = %v, want context.DeadlineExceeded on cancel", r.err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Runner.Run pinned on a SIGTERM-ignoring child — SIGKILL escalation not wired into the Runner")
+	}
+
+	assertProcessGroupGone(t, readChildPID(t, pidFile))
+}
+
+// The 1 MiB per-stream output cap is preserved on the Runner path.
+func TestRunner_OutputCapped(t *testing.T) {
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name: "sh", Args: []string{"-c", "yes aaaaaaaaaaaaaaaa | head -c 2000000"},
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if len(res.Stdout) > MaxOutputBytes+len("\n[output truncated]")+64 {
+		t.Errorf("Stdout len = %d, want capped near MaxOutputBytes (%d)", len(res.Stdout), MaxOutputBytes)
+	}
+	if !strings.Contains(res.Stdout, "[output truncated]") {
+		t.Error("Stdout missing the [output truncated] marker after exceeding the cap")
+	}
+}
+
+// Streaming delivers lines through the callback as they arrive.
+func TestRunner_StreamDeliversLines(t *testing.T) {
+	var got []string
+	_, err := directRunner(t).Stream(context.Background(),
+		Command{Name: "sh", Args: []string{"-c", "printf 'a\\nb\\nc\\n'"}},
+		func(s StreamType, line string, seq int64) {
+			if s == StreamStdout {
+				got = append(got, strings.TrimSpace(line))
+			}
+		})
+	if err != nil {
+		t.Fatalf("Stream err = %v", err)
+	}
+	if strings.Join(got, ",") != "a,b,c" {
+		t.Errorf("streamed lines = %v, want [a b c]", got)
+	}
+}

--- a/go/sys/exec/secret.go
+++ b/go/sys/exec/secret.go
@@ -1,0 +1,45 @@
+package exec
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrSecretContainsNewline is returned by NewSecret when the value contains a
+// newline or carriage return. A credential is frequently piped to a tool's
+// stdin (chpasswd, cryptsetup); an embedded newline would split it into a
+// second record, so it is rejected at construction.
+var ErrSecretContainsNewline = errors.New("secret contains a newline or carriage return")
+
+// Secret wraps a sensitive string (password, LUKS key, wifi PSK / client key)
+// so it cannot reach a log or formatted string by accident: String, GoString,
+// and the %v/%s/%#v verbs all render "[REDACTED]". The plaintext is retrievable
+// ONLY via Reveal — the single sanctioned sink. A fitness function (see
+// sdk/docs/sdk-rework-design.md §6) fails the build if Reveal is called outside
+// the known credential sinks, so the redaction can't be quietly defeated.
+type Secret struct {
+	v string
+}
+
+// NewSecret constructs a Secret, rejecting embedded newlines/CR (see
+// ErrSecretContainsNewline). An empty secret is valid — some callers legitimately
+// clear or omit a key.
+func NewSecret(v string) (Secret, error) {
+	if strings.ContainsAny(v, "\n\r") {
+		return Secret{}, ErrSecretContainsNewline
+	}
+	return Secret{v: v}, nil
+}
+
+// String renders the redaction sentinel so a Secret in a log/format never leaks.
+func (s Secret) String() string { return "[REDACTED]" }
+
+// GoString renders the redaction sentinel for the %#v verb as well.
+func (s Secret) GoString() string { return "[REDACTED]" }
+
+// Reveal returns the underlying plaintext. This is the ONLY sanctioned sink;
+// every other access path redacts.
+func (s Secret) Reveal() string { return s.v }
+
+// IsZero reports whether the secret is empty.
+func (s Secret) IsZero() bool { return s.v == "" }

--- a/go/sys/exec/secret_test.go
+++ b/go/sys/exec/secret_test.go
@@ -1,0 +1,85 @@
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Secret must never let plaintext reach a log/format by accident: String(),
+// %v, %s, and %#v all render the redaction sentinel; only Reveal() returns the
+// bytes. The constructor rejects embedded newlines/CR (a credential piped to
+// chpasswd/cryptsetup stdin must be a single line — a newline would split it
+// into a second record).
+
+func TestNewSecret_RejectsNewlineAndCR(t *testing.T) {
+	for _, bad := range []string{"a\nb", "a\rb", "trailing\n", "\r", "x\r\ny"} {
+		if _, err := NewSecret(bad); !errors.Is(err, ErrSecretContainsNewline) {
+			t.Errorf("NewSecret(%q) err = %v, want ErrSecretContainsNewline", bad, err)
+		}
+	}
+}
+
+func TestNewSecret_EmptyIsValidAndZero(t *testing.T) {
+	s, err := NewSecret("")
+	if err != nil {
+		t.Fatalf("NewSecret(\"\") err = %v, want nil", err)
+	}
+	if !s.IsZero() {
+		t.Errorf("empty secret IsZero() = false, want true")
+	}
+}
+
+func TestSecret_RedactsEverywhereButReveal(t *testing.T) {
+	const plaintext = "hunter2-s3cr3t"
+	s, err := NewSecret(plaintext)
+	if err != nil {
+		t.Fatalf("NewSecret err = %v", err)
+	}
+	if s.IsZero() {
+		t.Errorf("non-empty secret IsZero() = true, want false")
+	}
+	if got := s.Reveal(); got != plaintext {
+		t.Errorf("Reveal() = %q, want %q", got, plaintext)
+	}
+	// Format through an interface value — the realistic accidental-leak path
+	// (loggers take ...any). This also keeps the %s case honest: a direct
+	// fmt.Sprintf("%s", stringer) is a staticcheck S1025 smell, and routing via
+	// `any` is exactly how a credential would actually reach a log.
+	var logged any = s
+	renders := map[string]string{
+		"String()": s.String(),
+		"%v":       fmt.Sprintf("%v", logged),
+		"%s":       fmt.Sprintf("%s", logged),
+		"%#v":      fmt.Sprintf("%#v", logged),
+		"%+v":      fmt.Sprintf("%+v", logged),
+	}
+	for verb, out := range renders {
+		if strings.Contains(out, plaintext) {
+			t.Errorf("%s leaked the plaintext: %q", verb, out)
+		}
+		if !strings.Contains(out, "[REDACTED]") {
+			t.Errorf("%s = %q, want it to contain [REDACTED]", verb, out)
+		}
+	}
+}
+
+// A Secret embedded in a larger struct must still redact when the OUTER value
+// is formatted — the most common accidental-leak path (logging a config/options
+// struct that happens to carry a credential).
+func TestSecret_RedactsWhenNestedInStruct(t *testing.T) {
+	const plaintext = "nested-passphrase"
+	s, _ := NewSecret(plaintext)
+	type creds struct {
+		User string
+		Pass Secret
+	}
+	out := fmt.Sprintf("%v", creds{User: "deploy", Pass: s})
+	if strings.Contains(out, plaintext) {
+		t.Fatalf("nested Secret leaked plaintext: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("nested Secret not redacted: %q", out)
+	}
+}

--- a/go/sys/exec/types.go
+++ b/go/sys/exec/types.go
@@ -1,8 +1,14 @@
 // Package exec provides command execution utilities for Linux system management.
 //
 // It wraps the go-cmd library to provide buffered and streaming command execution
-// with privilege-escalation support (sudo or doas, selectable via
-// SetPrivilegeBackend), context cancellation, and output truncation.
+// with privilege escalation, context cancellation, and output truncation.
+//
+// New code uses the injected Runner: build one with NewRunner(Sudo|Doas|Direct)
+// (Detect lists the escalation tools available on the host) and pass it to a
+// capability constructor. The Runner carries no global state and is unit-testable
+// with exectest.FakeRunner. The package-level Run*/Privileged* functions and the
+// SetPrivilegeBackend global are the legacy path, retained only until every
+// capability is migrated onto the Runner.
 package exec
 
 // MaxOutputBytes is the maximum number of bytes captured per output stream.

--- a/go/sys/fs/fd_test_helpers_test.go
+++ b/go/sys/fs/fd_test_helpers_test.go
@@ -30,6 +30,18 @@ func fileUID(t *testing.T, info os.FileInfo) int {
 func useRootBackend(t *testing.T) {
 	t.Helper()
 	prev := exec.CurrentPrivilegeBackend()
-	exec.SetPrivilegeBackend(exec.PrivilegeBackendRoot)
-	t.Cleanup(func() { exec.SetPrivilegeBackend(prev) })
+	exec.SetPrivilegeBackend(exec.Direct)
+	t.Cleanup(func() {
+		switch prev {
+		case exec.Sudo, exec.Doas, exec.Direct:
+			exec.SetPrivilegeBackend(prev)
+		default:
+			// Pre-rework the unset zero value resolved to sudo, so the captured
+			// "prev" round-tripped cleanly. The fail-closed enum now makes the
+			// zero value invalid, which SetPrivilegeBackend ignores — leaving the
+			// global stuck on Direct and breaking later non-root sudo-path tests.
+			// Restore the historical default (sudo) explicitly.
+			exec.SetPrivilegeBackend(exec.Sudo)
+		}
+	})
 }

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -221,7 +221,7 @@ func WriteFileAtomic(ctx context.Context, path, content, mode, owner, group stri
 	if err := ValidatePath(path); err != nil {
 		return err
 	}
-	if exec.CurrentPrivilegeBackend() == exec.PrivilegeBackendRoot {
+	if exec.CurrentPrivilegeBackend() == exec.Direct {
 		return writeFileAtomicRoot(path, content, mode, owner, group)
 	}
 	return writeFileAtomicEscalated(ctx, path, content, mode, owner, group)
@@ -423,7 +423,7 @@ func RemoveDir(ctx context.Context, path string) error {
 	// (WS6 #4). Non-root callers cannot openat as root, so they fall back
 	// to the privilege-backend `rm -rf` (not symlink-safe, but not the
 	// root agent's path).
-	if exec.CurrentPrivilegeBackend() == exec.PrivilegeBackendRoot {
+	if exec.CurrentPrivilegeBackend() == exec.Direct {
 		return removeDirSecure(ctx, clean)
 	}
 	_, err := exec.Privileged(ctx, "rm", "-rf", "--", clean)


### PR DESCRIPTION
First implementation slice of the ratified SDK rework (`sdk/docs/sdk-rework-design.md` §5 step 2, `sdk-rework-contracts.md` §0). The `exec` Runner is the foundation every capability package will depend on. **SDK-only, purely additive** — the legacy `Run*`/`Privileged*`/`Query*` API stays operational for the not-yet-migrated callers.

Closes #124.

## What's new
- **`Runner` interface + `NewRunner(Sudo|Doas|Direct)`** — DI'd privilege escalation (Decision 2). Pure constructor: validates the backend is known, does **not** probe the host. Fail-closed on the zero/unknown value → `ErrUnknownBackend`.
- **`PrivilegeBackend` redefined** to the ratified `Sudo=iota+1, Doas, Direct` (zero invalid, Decision 5/6). `Direct` replaces the old `Root`. The legacy global is rewired onto the new names and kept alive; `sys/fs` updated.
- **`Command`** value type (`Name/Args/Dir/Env/Stdin/CLocale/ChildPath/Escalate`).
- **Escalation layering** — the capability sets `Command.Escalate`; the Runner alone applies `sudo -n`/`doas -n`/bare. Fail-closed `ErrEscalationUnavailable` (tool missing) / `ErrEscalationDenied` (`-n` needs a password).
- **`CommandError`** typed error (Decision 3) — a non-zero exit is reported in `Result.ExitCode`, **not** as an error; the capability layer wraps.
- **`Secret`** (U1) — `NewSecret` (newline/CR-rejecting), `String`/`GoString` → `[REDACTED]`, `Reveal()` single sink.
- **`Detect(ctx) []PrivilegeBackend`** — lists Sudo/Doas on PATH (lists, never picks).
- **`exectest.FakeRunner`** — records every `Command`, scripts `Result`/error, mirrors the real Runner on ctx-cancel. The keystone for unit-testing the capability layer with no host/sudo/container.
- **exec core refactor** — `runStreamingWithStdin` adds stdin to the streaming path; `runStreamingWithEnv` delegates.

## Hardening preserved verbatim
`--` separation, env hijack blocklist (`LD_PRELOAD`/`PATH`/…), 1 MiB per-stream output cap + `[output truncated]`, SIGTERM→SIGKILL process-group escalation, absolute-path resolution before escalation.

## Tests (TDD, red-first)
Secret redaction + newline rejection + nested-struct leak; `CommandError` errors.As/Unwrap; `NewRunner` rejects zero/unknown; `wrapEscalation` argv shaping + no caller-arg mutation; non-zero-exit-is-not-an-error; stdin delivery; env blocklist rejected before exec; CLocale/ChildPath wiring; **already-cancelled ctx short-circuits (real + fake identical)**; ctx-cancel SIGKILL of a trap-ignoring child; output cap; streaming line delivery; `Detect` host cross-check; FakeRunner record/script/replay. `go test -race`, `go vet`, `gofmt` clean.

## Deliberate, documented decisions
- Reuses the existing `StreamType`/`OutputCallback` rather than introducing parallel `Stream`/`OnLine` duplicates during the migration window.
- The **no-global-backend** and **`Reveal()`-only-from-sinks** fitness functions are deferred to the capability PRs that reach those end states — their matches-zero guards would be vacuous now (the global is still load-bearing; nothing calls `Reveal()` yet).
- Local `cr review` run pre-push: 2 Major findings addressed (ctx-cancel fidelity in FakeRunner+Runner; killGrace test parallel-safety note).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `Runner` interface for executing commands with improved privilege escalation control
  * Added `Detect()` function to discover available privilege escalation backends on the system
  * Added `CommandError` type with typed exit codes and captured error output
  * Added `Secret` type for secure handling of sensitive values with automatic redaction
  * Added test utilities for mocking command execution

* **Refactor**
  * Restructured privilege escalation backend selection for explicit control
  * Enhanced error handling with better diagnostics for command failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->