### PR TITLE
feat(user): Manager interface over an injected Runner (options, Secret, fitness)

### DIFF
--- a/go/archtest/reveal_sink_test.go
+++ b/go/archtest/reveal_sink_test.go
@@ -1,0 +1,71 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// revealSinkAllowlist lists the ONLY call sites permitted to call
+// exec.Secret.Reveal() — the sanctioned credential sinks that must hand the
+// plaintext to an OS tool. Keyed by "<module-rel path> :: <rendered call>".
+// assertNoStale fails the build if a listed sink stops calling Reveal (e.g. it
+// was refactored away), so the allowlist cannot rot into a silent gap.
+var revealSinkAllowlist = map[string]string{
+	"go/sys/user/password.go :: password.Reveal()": "chpasswd stdin: the sole sink that writes a user password to useradd's helper",
+}
+
+// TestRevealOnlyFromKnownSinks locks the exec.Secret redaction contract: the
+// plaintext may be obtained via Reveal() ONLY at the enumerated credential
+// sinks (chpasswd stdin today; the wifi PSK keyfile, LUKS stdin, etc. as those
+// capability PRs land). Any other .Reveal() call — e.g. one slipped into a
+// slog/fmt path — fails the build. This is the architecture-level complement to
+// the per-package unit pin that a Secret never appears in a recorded
+// Command.Args.
+func TestRevealOnlyFromKnownSinks(t *testing.T) {
+	root := moduleRoot(t)
+	// Scan the device-side capability surface + pkg, where Secrets live. Skip
+	// generated code, the exec package itself (which DEFINES Reveal), and
+	// archtest.
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "gen/") || strings.HasPrefix(rel, "go/archtest/") {
+			return false
+		}
+		if rel == "go/sys/exec/secret.go" {
+			return false // the definition of Reveal, not a use
+		}
+		return strings.HasPrefix(rel, "go/sys/") || strings.HasPrefix(rel, "go/pkg/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero capability Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(revealSinkAllowlist)
+	sawReveal := false
+
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Reveal" || len(call.Args) != 0 {
+				return true
+			}
+			sawReveal = true
+			key := gf.rel + " :: " + render(gf.fset, call)
+			if allow.exempt(key) {
+				return true
+			}
+			t.Errorf("unsanctioned Secret.Reveal() at %s:%d — %s\n  Reveal() exposes credential plaintext and must appear only at an enumerated OS sink. If this is a real new sink, add a justified, guarded entry to revealSinkAllowlist; otherwise pass the Secret itself (it redacts in logs/format).",
+				gf.rel, gf.line(call), render(gf.fset, call))
+			return true
+		})
+	}
+
+	if !sawReveal {
+		t.Fatal("matches-zero guard: found no Reveal() calls anywhere — the detector is dead (or every sink was removed); the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}

--- a/go/sys/user/accountsservice.go
+++ b/go/sys/user/accountsservice.go
@@ -5,36 +5,25 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/manchtools/power-manage/sdk/go/sys/fs"
 )
 
-// accountsServiceDir is the directory where AccountsService stores per-user config.
-const accountsServiceDir = "/var/lib/AccountsService/users"
-
-// SetHiddenOnLoginScreen sets or clears the SystemAccount flag in
-// AccountsService, which controls whether a user appears on the login screen.
+// SetHiddenOnLoginScreen shows or hides a user on the graphical login screen by
+// setting/removing the AccountsService SystemAccount flag.
 //
-// When hidden is true, the user's AccountsService file is created/updated
-// with SystemAccount=true. When false, the setting is removed.
-func SetHiddenOnLoginScreen(ctx context.Context, username string, hidden bool) error {
-	if !IsValidName(username) {
-		return fmt.Errorf("invalid username: %s", username)
+// (File writes still go through the legacy fs helpers; fs gains its own injected
+// Runner in a later capability PR.)
+func (u *shadowUtils) SetHiddenOnLoginScreen(ctx context.Context, name string, hidden bool) error {
+	if err := validateUsername(name); err != nil {
+		return err
 	}
-
-	configPath := filepath.Join(accountsServiceDir, username)
+	configPath := filepath.Join(accountsServiceDir, name)
 
 	if !hidden {
-		// Remove the config file to unhide the user.
-		// RemoveStrict uses rm -f, which already succeeds if the file doesn't exist.
-		return fs.RemoveStrict(ctx, configPath)
+		// rm -f succeeds even if the file is absent.
+		return removeStrict(ctx, configPath)
 	}
-
-	// Check if AccountsService directory exists.
 	if _, err := os.Stat(accountsServiceDir); os.IsNotExist(err) {
 		return fmt.Errorf("AccountsService not installed: %s not found", accountsServiceDir)
 	}
-
-	content := "[User]\nSystemAccount=true\n"
-	return fs.WriteFileAtomic(ctx, configPath, content, "0644", "root", "root")
+	return writeFileAtomic(ctx, configPath, "[User]\nSystemAccount=true\n", "0644", "root", "root")
 }

--- a/go/sys/user/accountsservice_test.go
+++ b/go/sys/user/accountsservice_test.go
@@ -2,22 +2,77 @@ package user
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func TestSetHiddenOnLoginScreen_InvalidUsername(t *testing.T) {
-	err := SetHiddenOnLoginScreen(context.Background(), "", true)
-	if err == nil {
-		t.Error("expected error for empty username")
+// useSeams points the accountsservice file ops at capturing fakes + a temp dir,
+// restoring them on cleanup.
+func useAccountsSeams(t *testing.T, dir string) (writes map[string]string, removes *[]string) {
+	t.Helper()
+	w := map[string]string{}
+	var r []string
+	rw, rr, rdir := writeFileAtomic, removeStrict, accountsServiceDir
+	writeFileAtomic = func(ctx context.Context, path, content, mode, owner, group string) error {
+		w[path] = content
+		return nil
 	}
+	removeStrict = func(ctx context.Context, path string) error {
+		r = append(r, path)
+		return nil
+	}
+	accountsServiceDir = dir
+	t.Cleanup(func() { writeFileAtomic, removeStrict, accountsServiceDir = rw, rr, rdir })
+	return w, &r
+}
 
-	err = SetHiddenOnLoginScreen(context.Background(), "Bad-User!", true)
-	if err == nil {
-		t.Error("expected error for invalid username")
+func TestSetHiddenOnLoginScreen_HideWritesSystemAccount(t *testing.T) {
+	dir := t.TempDir() // exists, so the "not installed" guard passes
+	writes, _ := useAccountsSeams(t, dir)
+
+	if err := mgr(t, exectest.New(0)).SetHiddenOnLoginScreen(context.Background(), "deploy", true); err != nil {
+		t.Fatal(err)
+	}
+	content, ok := writes[filepath.Join(dir, "deploy")]
+	if !ok {
+		t.Fatalf("no AccountsService file written; writes=%v", writes)
+	}
+	if content != "[User]\nSystemAccount=true\n" {
+		t.Errorf("content = %q", content)
 	}
 }
 
-func TestSetHiddenOnLoginScreen_RequiresPrivileges(t *testing.T) {
-	// SetHiddenOnLoginScreen requires sudo and AccountsService. Skip in unit tests.
-	t.Skip("SetHiddenOnLoginScreen requires root privileges and AccountsService")
+func TestSetHiddenOnLoginScreen_UnhideRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	_, removes := useAccountsSeams(t, dir)
+
+	if err := mgr(t, exectest.New(0)).SetHiddenOnLoginScreen(context.Background(), "deploy", false); err != nil {
+		t.Fatal(err)
+	}
+	if len(*removes) != 1 || (*removes)[0] != filepath.Join(dir, "deploy") {
+		t.Errorf("removes = %v, want the single AccountsService file", *removes)
+	}
+}
+
+func TestSetHiddenOnLoginScreen_NotInstalledErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	writes, removes := useAccountsSeams(t, missing)
+	if err := mgr(t, exectest.New(0)).SetHiddenOnLoginScreen(context.Background(), "deploy", true); err == nil {
+		t.Error("hiding with AccountsService absent returned nil error")
+	}
+	if len(writes) != 0 || len(*removes) != 0 {
+		t.Errorf("error path touched the filesystem: writes=%v removes=%v", writes, *removes)
+	}
+}
+
+func TestSetHiddenOnLoginScreen_RejectsInvalidName(t *testing.T) {
+	writes, removes := useAccountsSeams(t, t.TempDir())
+	if err := mgr(t, exectest.New(0)).SetHiddenOnLoginScreen(context.Background(), "-evil", true); err == nil {
+		t.Error("accepted a flag-shaped name")
+	}
+	if len(writes) != 0 || len(*removes) != 0 {
+		t.Errorf("invalid name reached the filesystem: writes=%v removes=%v", writes, *removes)
+	}
 }

--- a/go/sys/user/doc.go
+++ b/go/sys/user/doc.go
@@ -1,0 +1,28 @@
+// Package user manages Linux user accounts and groups through an injected
+// exec.Runner.
+//
+// Build a Manager for an explicit backend (shadow-utils is the only one today)
+// and a Runner, then call its methods. The Manager owns OS mechanism and OS
+// convention — the default-shell policy, the useradd -m/-M "home already exists"
+// dance — while product policy (temporary-password records, SSH authorized_keys,
+// hiding accounts) stays with the caller.
+//
+//	r, _ := exec.NewRunner(exec.Direct) // the agent runs as root; elsewhere: Sudo/Doas
+//	um, _ := user.New(user.ShadowUtils, r)
+//
+//	// Create an interactive account with a home directory:
+//	_ = um.Create(ctx, "deploy", user.CreateOptions{CreateHome: true})
+//
+//	// Set a generated password (carried as a redacted Secret):
+//	pw, _ := user.GeneratePassword(16, user.ComplexityAlphanumeric)
+//	_ = um.SetPassword(ctx, "deploy", pw)
+//	_ = um.ExpirePassword(ctx, "deploy") // force change on first login
+//
+// Every mutating method validates the account/group name (IsValidName), so a
+// name can never become a useradd/usermod flag or inject an extra chpasswd
+// record. Passwords are exec.Secret values that render as "[REDACTED]" and only
+// the chpasswd sink reveals their bytes.
+//
+// In tests, pass exectest.FakeRunner instead of a real Runner to assert the
+// exact commands a Manager builds — no host, no sudo, no container.
+package user

--- a/go/sys/user/edge_test.go
+++ b/go/sys/user/edge_test.go
@@ -1,0 +1,134 @@
+package user
+
+import (
+	"context"
+	"io"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// --- Weird / malformed tool output ---------------------------------------
+
+// A passwd entry with a non-numeric UID is malformed; Get fails closed rather
+// than silently treating it as UID 0 (root).
+func TestGet_NonNumericUIDFailsClosed(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "deploy:x:NOTANUMBER:1000:Deploy:/home/deploy:/bin/bash\n"}, nil)
+	if _, err := mgr(t, f).Get(context.Background(), "deploy"); err == nil {
+		t.Error("Get accepted a non-numeric UID; want a fail-closed error")
+	}
+}
+
+func TestGet_NonNumericGIDFailsClosed(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "deploy:x:1000:NOTANUMBER:Deploy:/home/deploy:/bin/bash\n"}, nil)
+	if _, err := mgr(t, f).Get(context.Background(), "deploy"); err == nil {
+		t.Error("Get accepted a non-numeric GID; want a fail-closed error")
+	}
+}
+
+// A '*'-prefixed shadow password (a common disabled-account marker) is detected
+// as locked, the same as '!'.
+func TestGet_StarLockedIsDetected(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "deploy:x:1000:1000::/home/deploy:/bin/bash\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy:*:19000:0:99999:7:::\n"}, nil)
+	info, err := mgr(t, f).Get(context.Background(), "deploy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Locked {
+		t.Error("'*'-prefixed shadow entry not detected as locked")
+	}
+}
+
+// Get tolerates extra surrounding whitespace / CR in getent output.
+func TestGet_TrimsWhitespaceAndCR(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "  deploy:x:1000:1000:Deploy:/home/deploy:/bin/bash\r\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy\n"}, nil)
+	f.Push(exec.Result{Stdout: "deploy:$6$x:::::::\n"}, nil)
+	info, err := mgr(t, f).Get(context.Background(), "deploy")
+	if err != nil {
+		t.Fatalf("Get with padded output: %v", err)
+	}
+	if info.UID != 1000 || info.Shell != "/bin/bash" {
+		t.Errorf("Info = %+v, want UID 1000 / /bin/bash despite padding", info)
+	}
+}
+
+// A group line with stray empty member entries ("a,,b") must not yield a "".
+func TestGroupMembers_FiltersEmptyEntries(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "docker:x:999:deploy,,ops,\n"}, nil)
+	members, err := mgr(t, f).GroupMembers(context.Background(), "docker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(members, ",") != "deploy,ops" {
+		t.Errorf("members = %v, want [deploy ops] with empties filtered", members)
+	}
+}
+
+// A members field that is ALL separators ("docker:x:999:,,") yields no members.
+func TestGroupMembers_AllEmptyEntriesIsNil(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "docker:x:999:,,\n"}, nil)
+	members, err := mgr(t, f).GroupMembers(context.Background(), "docker")
+	if err != nil || members != nil {
+		t.Errorf("GroupMembers = (%v,%v), want (nil,nil) for an all-separators field", members, err)
+	}
+}
+
+// --- Weird-but-valid inputs ----------------------------------------------
+
+// A password may legitimately contain colons; chpasswd splits on the FIRST
+// colon, so the whole "pass:word" reaches the password field intact.
+func TestSetPassword_ColonInPasswordIsPreserved(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	secret, err := exec.NewSecret("p@ss:w0rd:with:colons")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr(t, f).SetPassword(context.Background(), "deploy", secret); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(f.Calls()[0].Stdin)
+	if string(got) != "deploy:p@ss:w0rd:with:colons" {
+		t.Errorf("chpasswd stdin = %q, want the colon-bearing password intact", got)
+	}
+}
+
+// GeneratePassword succeeds at the exact length bounds.
+func TestGeneratePassword_ExactBounds(t *testing.T) {
+	for _, n := range []int{MinPasswordLength, MaxPasswordLength} {
+		s, err := GeneratePassword(n, ComplexityComplex)
+		if err != nil {
+			t.Fatalf("GeneratePassword(%d): %v", n, err)
+		}
+		if len(s.Reveal()) != n {
+			t.Errorf("length = %d, want %d", len(s.Reveal()), n)
+		}
+	}
+}
+
+// The (practically unreachable) RNG-failure path returns a wrapped error rather
+// than a short/empty password. Exercised via the randInt seam.
+func TestGeneratePassword_RNGFailure(t *testing.T) {
+	restore := randInt
+	randInt = func(io.Reader, *big.Int) (*big.Int, error) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	defer func() { randInt = restore }()
+
+	if _, err := GeneratePassword(16, ComplexityAlphanumeric); err == nil {
+		t.Error("GeneratePassword returned nil error when the RNG failed")
+	}
+}

--- a/go/sys/user/errors_test.go
+++ b/go/sys/user/errors_test.go
@@ -1,0 +1,184 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// A Runner execution error (here the real "sudo not installed" sentinel, the
+// fail-closed result of NewRunner(Sudo) on a host without sudo) propagates
+// unchanged from a mutating op — distinct from a non-zero exit.
+func TestRun_PropagatesRunnerError(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable)
+	if err := mgr(t, f).Lock(context.Background(), "deploy"); !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("Lock err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+// ... and from a query op.
+func TestQuery_PropagatesRunnerError(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable)
+	if _, err := mgr(t, f).PrimaryGroup(context.Background(), "deploy"); !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("PrimaryGroup err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+func TestSetPassword_PropagatesRunnerError(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable)
+	pw, _ := exec.NewSecret("TestPass123!")
+	if err := mgr(t, f).SetPassword(context.Background(), "deploy", pw); !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("SetPassword err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+func TestExists_PropagatesRunnerError(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable)
+	if _, err := mgr(t, f).Exists(context.Background(), "deploy"); !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("Exists err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+func TestGroupExists_PropagatesRunnerError(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable)
+	if _, err := mgr(t, f).GroupExists(context.Background(), "staff"); !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("GroupExists err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+// AddToGroup / RemoveFromGroup validate the GROUP name too (a valid user but a
+// flag-shaped group must be rejected before the Runner).
+func TestGroupMembership_RejectsInvalidGroupName(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).AddToGroup(context.Background(), "deploy", "-G"); err == nil {
+		t.Error("AddToGroup accepted a flag-shaped group name")
+	}
+	if err := mgr(t, f).RemoveFromGroup(context.Background(), "deploy", "-G"); err == nil {
+		t.Error("RemoveFromGroup accepted a flag-shaped group name")
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("ran a command for an invalid group name: %+v", f.Calls())
+	}
+}
+
+// A caller-supplied deadline is honored as-is (ensureCtx does not wrap it).
+func TestQuery_HonorsCallerDeadline(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "staff\n"}, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := mgr(t, f).PrimaryGroup(ctx, "deploy"); err != nil {
+		t.Fatalf("PrimaryGroup with a deadline ctx: %v", err)
+	}
+}
+
+// A non-zero exit on a QUERY (e.g. `id` for an unknown user) becomes a typed
+// *exec.CommandError carrying the tool's exit code/stderr.
+func TestQuery_NonZeroExitIsCommandError(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 1, Stderr: "id: 'ghost': no such user"}, nil)
+	_, err := mgr(t, f).PrimaryGroup(context.Background(), "ghost")
+	var ce *exec.CommandError
+	if !errors.As(err, &ce) || ce.ExitCode != 1 {
+		t.Errorf("PrimaryGroup err = %v, want *exec.CommandError exit 1", err)
+	}
+}
+
+// Get surfaces a passwd-lookup failure (unknown user → getent exits 2).
+func TestGet_PasswdLookupFailure(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 2}, nil) // getent passwd: not found
+	if _, err := mgr(t, f).Get(context.Background(), "ghost"); err == nil {
+		t.Error("Get returned nil error for an unknown user")
+	}
+}
+
+// GroupMembers treats an unreadable/absent group as "no members", not an error.
+func TestGroupMembers_AbsentGroupIsEmpty(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 2}, nil) // getent group: not found
+	members, err := mgr(t, f).GroupMembers(context.Background(), "ghosts")
+	if err != nil || members != nil {
+		t.Errorf("GroupMembers = (%v,%v), want (nil,nil) for an absent group", members, err)
+	}
+}
+
+// SupplementaryGroups: an `id -Gn` failure is surfaced...
+func TestSupplementaryGroups_PrimaryListFailure(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 1, Stderr: "id: 'ghost': no such user"}, nil)
+	if _, err := mgr(t, f).SupplementaryGroups(context.Background(), "ghost"); err == nil {
+		t.Error("SupplementaryGroups returned nil error when id -Gn failed")
+	}
+}
+
+// ...and if only the PRIMARY-group lookup fails, it FAILS CLOSED rather than
+// returning a list that might include the primary (the method's contract is
+// "excluding the primary", which it can no longer guarantee).
+func TestSupplementaryGroups_PrimaryLookupFailsClosed(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "staff docker sudo\n"}, nil) // id -Gn ok
+	f.Push(exec.Result{ExitCode: 1}, nil)                   // id -gn (primary) fails
+	groups, err := mgr(t, f).SupplementaryGroups(context.Background(), "deploy")
+	if err == nil {
+		t.Errorf("SupplementaryGroups returned (%v,nil); want a fail-closed error when the primary lookup fails", groups)
+	}
+	if groups != nil {
+		t.Errorf("groups = %v, want nil on the fail-closed path", groups)
+	}
+}
+
+// Create surfaces a failure to fix ownership of a pre-existing home.
+func TestCreate_ChownFailureSurfaces(t *testing.T) {
+	existing := t.TempDir()
+	f := exectest.New(exec.Direct)
+	restore := setOwnershipRecursive
+	setOwnershipRecursive = func(ctx context.Context, path, owner, group string) (*exec.Result, error) {
+		return nil, exec.ErrEscalationDenied
+	}
+	defer func() { setOwnershipRecursive = restore }()
+
+	err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{HomeDir: existing, CreateHome: true})
+	if err == nil || !strings.Contains(err.Error(), "ownership") {
+		t.Errorf("Create err = %v, want an ownership-fix failure", err)
+	}
+}
+
+// KillSessions surfaces a pkill execution failure (not a non-zero exit).
+func TestKillSessions_PkillExecError(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 1}, nil)                // loginctl non-zero → fall through
+	f.Push(exec.Result{}, exec.ErrEscalationUnavailable) // pkill cannot execute
+	err := mgr(t, f).KillSessions(context.Background(), "deploy")
+	if !errors.Is(err, exec.ErrEscalationUnavailable) {
+		t.Errorf("KillSessions err = %v, want the wrapped pkill exec error", err)
+	}
+}
+
+// Get tolerates an unreadable shadow file — the real case being a non-root agent
+// whose `getent shadow` escalation is denied. Locked stays false rather than
+// erroring.
+func TestGet_ShadowUnreadableLeavesUnlocked(t *testing.T) {
+	f := exectest.New(exec.Sudo)
+	f.Push(exec.Result{Stdout: "deploy:x:1000:1000:Deploy User:/home/deploy:/bin/bash\n"}, nil) // passwd
+	f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)                                        // group
+	f.Push(exec.Result{Stdout: "deploy sudo\n"}, nil)                                           // id -Gn
+	f.Push(exec.Result{}, exec.ErrEscalationDenied)                                             // shadow: needs a password
+	info, err := mgr(t, f).Get(context.Background(), "deploy")
+	if err != nil {
+		t.Fatalf("Get should tolerate an unreadable shadow: %v", err)
+	}
+	if info.Locked {
+		t.Error("Locked = true, want false when shadow is unreadable")
+	}
+}

--- a/go/sys/user/group.go
+++ b/go/sys/user/group.go
@@ -2,147 +2,134 @@ package user
 
 import (
 	"context"
-	"slices"
-	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-// =============================================================================
-// Group Query Functions
-// =============================================================================
-
-// GroupExists checks if a group exists on the system.
-func GroupExists(name string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
-	defer cancel()
-	return exec.CheckCtx(ctx, "getent", "group", name)
-}
-
-// GroupMembers returns the members of a group.
-// Returns nil if the group doesn't exist or has no members.
-func GroupMembers(name string) []string {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
-	defer cancel()
-	out, err := exec.QueryCtx(ctx, "getent", "group", name)
-	if err != nil {
-		return nil
-	}
-	fields := strings.Split(strings.TrimSpace(out), ":")
-	if len(fields) < 4 || fields[3] == "" {
-		return nil
-	}
-	return strings.Split(fields[3], ",")
-}
-
-// GroupHasUser checks if a user is a member of the specified group.
-func GroupHasUser(username, groupName string) bool {
-	members := GroupMembers(groupName)
-	for _, m := range members {
-		if m == username {
-			return true
+// MembersMatch reports whether two member lists contain the same set of names,
+// ignoring order and duplicates. A pure helper for group-membership
+// reconciliation (compare desired vs. GroupMembers); the caller decides what to
+// do about a mismatch.
+func MembersMatch(a, b []string) bool {
+	set := func(xs []string) map[string]struct{} {
+		m := make(map[string]struct{}, len(xs))
+		for _, x := range xs {
+			m[x] = struct{}{}
 		}
+		return m
 	}
-	return false
-}
-
-// GroupMembersMatch checks if the current group members match the desired list.
-// Comparison is order-independent.
-func GroupMembersMatch(groupName string, desiredUsers []string) bool {
-	if !GroupExists(groupName) {
-		return len(desiredUsers) == 0
-	}
-	current := GroupMembers(groupName)
-	if len(current) != len(desiredUsers) {
+	sa, sb := set(a), set(b)
+	if len(sa) != len(sb) {
 		return false
 	}
-
-	sortedCurrent := make([]string, len(current))
-	copy(sortedCurrent, current)
-	sort.Strings(sortedCurrent)
-
-	sortedDesired := make([]string, len(desiredUsers))
-	copy(sortedDesired, desiredUsers)
-	sort.Strings(sortedDesired)
-
-	for i := range sortedCurrent {
-		if sortedCurrent[i] != sortedDesired[i] {
+	for k := range sa {
+		if _, ok := sb[k]; !ok {
 			return false
 		}
 	}
 	return true
 }
 
-// =============================================================================
-// Group Management Operations
-// =============================================================================
-
-// GroupCreate creates a new group.
-// Extra args are passed before the group name (e.g., "-g", "1001", "-r").
-// Rejects names that would become flags or contain control characters —
-// the same IsValidName rules apply because groupadd/usermod parse argv
-// identically to useradd.
-//
-// Returns the command result so callers can surface groupadd's stderr
-// — symmetric with the user.Create / user.Modify / user.Delete shape
-// (F038 in the SDK tech-debt audit).
-func GroupCreate(ctx context.Context, name string, args ...string) (*exec.Result, error) {
+// GroupExists reports whether a group exists.
+func (u *shadowUtils) GroupExists(ctx context.Context, name string) (bool, error) {
 	if err := validateName("group name", name); err != nil {
-		return nil, err
+		return false, err
 	}
-	// slices.Clone avoids aliasing the caller's backing array — a
-	// bare `append(args, name)` would write into the caller's slice
-	// whenever it has spare capacity.
-	fullArgs := append(slices.Clone(args), name)
-	return exec.Privileged(ctx, "groupadd", fullArgs...)
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"group", name}})
+	if err != nil {
+		return false, err
+	}
+	return res.ExitCode == 0, nil
 }
 
-// GroupDelete deletes a group. See GroupCreate for the result-return
-// rationale.
-func GroupDelete(ctx context.Context, name string) (*exec.Result, error) {
+// GroupMembers returns a group's members, or nil if the group has none / does
+// not exist.
+func (u *shadowUtils) GroupMembers(ctx context.Context, name string) ([]string, error) {
 	if err := validateName("group name", name); err != nil {
 		return nil, err
 	}
-	return exec.Privileged(ctx, "groupdel", name)
-}
-
-// GroupEnsureExists creates a group if it doesn't already exist.
-// Returns (nil, nil) when the group already exists (no command run).
-func GroupEnsureExists(ctx context.Context, name string) (*exec.Result, error) {
-	if err := validateName("group name", name); err != nil {
-		return nil, err
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	out, err := u.query(ctx, "getent", "group", name)
+	if err != nil {
+		return nil, nil // not found / unreadable → no members
 	}
-	if GroupExists(name) {
+	fields := strings.Split(out, ":")
+	if len(fields) < 4 || fields[3] == "" {
 		return nil, nil
 	}
-	return GroupCreate(ctx, name)
+	// Filter empty entries defensively (a stray "a,,b" must not yield a "").
+	raw := strings.Split(fields[3], ",")
+	members := make([]string, 0, len(raw))
+	for _, m := range raw {
+		if m != "" {
+			members = append(members, m)
+		}
+	}
+	if len(members) == 0 {
+		return nil, nil
+	}
+	return members, nil
 }
 
-// =============================================================================
-// Group Membership Operations
-// =============================================================================
-
-// GroupAddUser adds a user to a supplementary group. See GroupCreate
-// for the result-return rationale.
-func GroupAddUser(ctx context.Context, username, groupName string) (*exec.Result, error) {
-	if err := validateName("username", username); err != nil {
-		return nil, err
+// GroupCreate creates a new group.
+func (u *shadowUtils) GroupCreate(ctx context.Context, name string, opts GroupCreateOptions) error {
+	if err := validateName("group name", name); err != nil {
+		return err
 	}
-	if err := validateName("group name", groupName); err != nil {
-		return nil, err
+	args := make([]string, 0, 4)
+	if opts.GID > 0 {
+		args = append(args, "-g", strconv.Itoa(opts.GID))
 	}
-	return exec.Privileged(ctx, "usermod", "-aG", groupName, username)
+	if opts.System {
+		args = append(args, "-r")
+	}
+	args = append(args, name)
+	return u.run(ctx, "groupadd", args...)
 }
 
-// GroupRemoveUser removes a user from a supplementary group. See
-// GroupCreate for the result-return rationale.
-func GroupRemoveUser(ctx context.Context, username, groupName string) (*exec.Result, error) {
-	if err := validateName("username", username); err != nil {
-		return nil, err
+// GroupDelete deletes a group.
+func (u *shadowUtils) GroupDelete(ctx context.Context, name string) error {
+	if err := validateName("group name", name); err != nil {
+		return err
 	}
-	if err := validateName("group name", groupName); err != nil {
-		return nil, err
+	return u.run(ctx, "groupdel", name)
+}
+
+// GroupEnsure creates a group if it does not already exist (no-op when present).
+func (u *shadowUtils) GroupEnsure(ctx context.Context, name string) error {
+	exists, err := u.GroupExists(ctx, name)
+	if err != nil {
+		return err
 	}
-	return exec.Privileged(ctx, "gpasswd", "-d", username, groupName)
+	if exists {
+		return nil
+	}
+	return u.GroupCreate(ctx, name, GroupCreateOptions{})
+}
+
+// AddToGroup adds a user to a supplementary group (usermod -aG).
+func (u *shadowUtils) AddToGroup(ctx context.Context, name, group string) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	if err := validateName("group name", group); err != nil {
+		return err
+	}
+	return u.run(ctx, "usermod", "-aG", group, name)
+}
+
+// RemoveFromGroup removes a user from a supplementary group (gpasswd -d).
+func (u *shadowUtils) RemoveFromGroup(ctx context.Context, name, group string) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	if err := validateName("group name", group); err != nil {
+		return err
+	}
+	return u.run(ctx, "gpasswd", "-d", name, group)
 }

--- a/go/sys/user/group_integration_test.go
+++ b/go/sys/user/group_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package user_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/user"
+)
+
+func testGroupName(suffix string) string {
+	return testUsername("g" + suffix)
+}
+
+func cleanupGroup(t *testing.T, m user.Manager, name string) {
+	t.Helper()
+	_ = m.GroupDelete(context.Background(), name)
+}
+
+func TestGroupCreateDelete_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testGroupName("cr")
+	defer cleanupGroup(t, m, name)
+
+	if err := m.GroupCreate(ctx, name, user.GroupCreateOptions{}); err != nil {
+		t.Fatalf("GroupCreate: %v", err)
+	}
+	if ok, err := m.GroupExists(ctx, name); err != nil || !ok {
+		t.Fatalf("GroupExists after create = (%v,%v), want (true,nil)", ok, err)
+	}
+	if err := m.GroupDelete(ctx, name); err != nil {
+		t.Fatalf("GroupDelete: %v", err)
+	}
+	if ok, err := m.GroupExists(ctx, name); err != nil || ok {
+		t.Error("group still exists after delete")
+	}
+}
+
+func TestGroupDeleteNonexistent_Integration(t *testing.T) {
+	if err := newManager(t).GroupDelete(context.Background(), "pmnonexistentgrp12345"); err == nil {
+		t.Fatal("expected error deleting a non-existent group")
+	}
+}
+
+func TestGroupExists_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	if ok, err := m.GroupExists(ctx, "root"); err != nil || !ok {
+		t.Errorf("GroupExists(root) = (%v,%v), want (true,nil)", ok, err)
+	}
+	if ok, err := m.GroupExists(ctx, "pmnonexistentgrp12345"); err != nil || ok {
+		t.Error("non-existent group reported as existing")
+	}
+}
+
+func TestGroupMembershipCycle_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	groupName := testGroupName("mb")
+	userName := testUsername("gm")
+	defer cleanupGroup(t, m, groupName)
+	defer cleanupUser(t, m, userName)
+
+	if err := m.GroupCreate(ctx, groupName, user.GroupCreateOptions{}); err != nil {
+		t.Fatalf("GroupCreate: %v", err)
+	}
+	createTestUser(t, m, userName)
+
+	if err := m.AddToGroup(ctx, userName, groupName); err != nil {
+		t.Fatalf("AddToGroup: %v", err)
+	}
+	members, err := m.GroupMembers(ctx, groupName)
+	if err != nil {
+		t.Fatalf("GroupMembers: %v", err)
+	}
+	if !slices.Contains(members, userName) {
+		t.Errorf("members %v missing %q after AddToGroup", members, userName)
+	}
+
+	if err := m.RemoveFromGroup(ctx, userName, groupName); err != nil {
+		t.Fatalf("RemoveFromGroup: %v", err)
+	}
+	members, err = m.GroupMembers(ctx, groupName)
+	if err != nil {
+		t.Fatalf("GroupMembers: %v", err)
+	}
+	if slices.Contains(members, userName) {
+		t.Errorf("members %v still contains %q after RemoveFromGroup", members, userName)
+	}
+}
+
+func TestGroupEnsure_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testGroupName("ee")
+	defer cleanupGroup(t, m, name)
+
+	if err := m.GroupEnsure(ctx, name); err != nil {
+		t.Fatalf("GroupEnsure (create): %v", err)
+	}
+	if ok, err := m.GroupExists(ctx, name); err != nil || !ok {
+		t.Error("group should exist after ensure")
+	}
+	if err := m.GroupEnsure(ctx, name); err != nil {
+		t.Fatalf("GroupEnsure (no-op): %v", err)
+	}
+}

--- a/go/sys/user/group_test.go
+++ b/go/sys/user/group_test.go
@@ -1,241 +1,145 @@
-//go:build integration
-
-package user_test
+package user
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
-	"github.com/manchtools/power-manage/sdk/go/sys/user"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func testGroupName(suffix string) string {
-	return testUsername("g" + suffix)
+func TestGroupCreate_Golden(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).GroupCreate(context.Background(), "staff", GroupCreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "groupadd", []string{"staff"}, true)
+	})
+	t.Run("system + gid", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).GroupCreate(context.Background(), "svc", GroupCreateOptions{GID: 900, System: true}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "groupadd", []string{"-g", "900", "-r", "svc"}, true)
+	})
 }
 
-func cleanupGroup(t *testing.T, name string) {
-	t.Helper()
-	ctx := context.Background()
-	exec.Privileged(ctx, "groupdel", name)
+func TestGroupDelete_Golden(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).GroupDelete(context.Background(), "staff"); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f, "groupdel", []string{"staff"}, true)
 }
 
-func TestGroupCreate(t *testing.T) {
-	ctx := context.Background()
-	name := testGroupName("cr")
-	defer cleanupGroup(t, name)
+func TestGroupEnsure(t *testing.T) {
+	t.Run("exists → no groupadd", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 0}, nil) // getent group → exists
+		if err := mgr(t, f).GroupEnsure(context.Background(), "staff"); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 1 || f.Calls()[0].Name != "getent" {
+			t.Errorf("expected only the existence probe, got %+v", f.Calls())
+		}
+	})
+	t.Run("absent → groupadd", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 2}, nil) // getent group → absent
+		f.Push(exec.Result{ExitCode: 0}, nil) // groupadd
+		if err := mgr(t, f).GroupEnsure(context.Background(), "staff"); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 2 || calls[1].Name != "groupadd" {
+			t.Errorf("expected probe + groupadd, got %+v", calls)
+		}
+	})
+}
 
-	_, err := user.GroupCreate(ctx, name)
-	if err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
+func TestAddRemoveGroup_Golden(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).AddToGroup(context.Background(), "deploy", "docker"); err != nil {
+		t.Fatal(err)
 	}
+	wantOneCmd(t, f, "usermod", []string{"-aG", "docker", "deploy"}, true)
 
-	if !user.GroupExists(name) {
-		t.Error("group should exist after creation")
+	f2 := exectest.New(exec.Direct)
+	if err := mgr(t, f2).RemoveFromGroup(context.Background(), "deploy", "docker"); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f2, "gpasswd", []string{"-d", "deploy", "docker"}, true)
+}
+
+func TestGroupExistsAndMembers(t *testing.T) {
+	t.Run("exists", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 0}, nil)
+		ok, err := mgr(t, f).GroupExists(context.Background(), "staff")
+		if err != nil || !ok {
+			t.Errorf("GroupExists = (%v,%v), want (true,nil)", ok, err)
+		}
+	})
+	t.Run("members parsed", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "docker:x:999:deploy,ops\n"}, nil)
+		members, err := mgr(t, f).GroupMembers(context.Background(), "docker")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Join(members, ",") != "deploy,ops" {
+			t.Errorf("members = %v, want [deploy ops]", members)
+		}
+	})
+	t.Run("no members → nil", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "docker:x:999:\n"}, nil)
+		members, err := mgr(t, f).GroupMembers(context.Background(), "docker")
+		if err != nil || members != nil {
+			t.Errorf("members = (%v,%v), want (nil,nil)", members, err)
+		}
+	})
+}
+
+func TestGroupCreate_RejectsInvalidName(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).GroupCreate(context.Background(), "-evil", GroupCreateOptions{}); err == nil {
+		t.Error("GroupCreate accepted a flag-shaped name")
+	}
+	if len(f.Calls()) != 0 {
+		t.Error("ran groupadd for an invalid name")
 	}
 }
 
-func TestGroupDelete(t *testing.T) {
-	ctx := context.Background()
-	name := testGroupName("dl")
-
-	if _, err := user.GroupCreate(ctx, name); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
+func TestMembersMatch(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want bool
+	}{
+		{nil, nil, true},
+		{[]string{}, nil, true},
+		{[]string{"a", "b"}, []string{"b", "a"}, true},      // order-independent
+		{[]string{"a", "a", "b"}, []string{"a", "b"}, true}, // dup-independent
+		{[]string{"a"}, []string{"a", "b"}, false},
+		{[]string{"a", "b"}, []string{"a", "c"}, false},
+		{[]string{"x"}, nil, false},
 	}
-
-	_, err := user.GroupDelete(ctx, name)
-	if err != nil {
-		t.Fatalf("GroupDelete failed: %v", err)
-	}
-
-	if user.GroupExists(name) {
-		t.Error("group should not exist after deletion")
-	}
-}
-
-func TestGroupDeleteNonexistent(t *testing.T) {
-	ctx := context.Background()
-	_, err := user.GroupDelete(ctx, "pm-nonexistent-group-12345")
-	if err == nil {
-		t.Fatal("expected error deleting non-existent group")
-	}
-}
-
-func TestGroupExists(t *testing.T) {
-	if !user.GroupExists("root") {
-		t.Error("root group should exist")
-	}
-	if user.GroupExists("pm-nonexistent-group-12345") {
-		t.Error("non-existent group should not exist")
-	}
-}
-
-func TestGroupMembers(t *testing.T) {
-	ctx := context.Background()
-	groupName := testGroupName("mb")
-	userName := testUsername("gm")
-	defer cleanupGroup(t, groupName)
-	defer cleanupUser(t, userName)
-
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	createTestUser(t, userName)
-
-	if _, err := user.GroupAddUser(ctx, userName, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	members := user.GroupMembers(groupName)
-	found := false
-	for _, m := range members {
-		if m == userName {
-			found = true
-			break
+	for _, c := range cases {
+		if got := MembersMatch(c.a, c.b); got != c.want {
+			t.Errorf("MembersMatch(%v,%v) = %v, want %v", c.a, c.b, got, c.want)
 		}
 	}
-	if !found {
-		t.Errorf("expected %q in group members, got %v", userName, members)
-	}
 }
 
-func TestGroupAddUser(t *testing.T) {
-	ctx := context.Background()
-	groupName := testGroupName("au")
-	userName := testUsername("ga")
-	defer cleanupGroup(t, groupName)
-	defer cleanupUser(t, userName)
-
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	createTestUser(t, userName)
-
-	if _, err := user.GroupAddUser(ctx, userName, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	if !user.GroupHasUser(userName, groupName) {
-		t.Error("user should be in group after GroupAddUser")
-	}
-}
-
-func TestGroupRemoveUser(t *testing.T) {
-	ctx := context.Background()
-	groupName := testGroupName("ru")
-	userName := testUsername("gr")
-	defer cleanupGroup(t, groupName)
-	defer cleanupUser(t, userName)
-
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	createTestUser(t, userName)
-
-	if _, err := user.GroupAddUser(ctx, userName, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	if _, err := user.GroupRemoveUser(ctx, userName, groupName); err != nil {
-		t.Fatalf("GroupRemoveUser failed: %v", err)
-	}
-
-	if user.GroupHasUser(userName, groupName) {
-		t.Error("user should not be in group after GroupRemoveUser")
-	}
-}
-
-func TestGroupEnsureExists(t *testing.T) {
-	ctx := context.Background()
-	name := testGroupName("ee")
-	defer cleanupGroup(t, name)
-
-	// Should create
-	_, err := user.GroupEnsureExists(ctx, name)
-	if err != nil {
-		t.Fatalf("GroupEnsureExists (create) failed: %v", err)
-	}
-	if !user.GroupExists(name) {
-		t.Error("group should exist after ensure")
-	}
-
-	// Should be no-op
-	_, err = user.GroupEnsureExists(ctx, name)
-	if err != nil {
-		t.Fatalf("GroupEnsureExists (no-op) failed: %v", err)
-	}
-}
-
-func TestGroupHasUser(t *testing.T) {
-	ctx := context.Background()
-	groupName := testGroupName("hu")
-	userName := testUsername("gh")
-	defer cleanupGroup(t, groupName)
-	defer cleanupUser(t, userName)
-
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	createTestUser(t, userName)
-
-	if user.GroupHasUser(userName, groupName) {
-		t.Error("user should not be in group initially")
-	}
-
-	if _, err := user.GroupAddUser(ctx, userName, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	if !user.GroupHasUser(userName, groupName) {
-		t.Error("user should be in group after add")
-	}
-}
-
-func TestGroupMembersMatch(t *testing.T) {
-	ctx := context.Background()
-	groupName := testGroupName("mm")
-	user1 := testUsername("m1")
-	user2 := testUsername("m2")
-	defer cleanupGroup(t, groupName)
-	defer cleanupUser(t, user1)
-	defer cleanupUser(t, user2)
-
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	createTestUser(t, user1)
-	createTestUser(t, user2)
-
-	// Empty group vs empty desired
-	if !user.GroupMembersMatch(groupName, []string{}) {
-		t.Error("empty group should match empty desired list")
-	}
-
-	// Add users
-	if _, err := user.GroupAddUser(ctx, user1, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-	if _, err := user.GroupAddUser(ctx, user2, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	// Should match (order independent)
-	if !user.GroupMembersMatch(groupName, []string{user2, user1}) {
-		t.Error("group members should match desired list (order independent)")
-	}
-
-	// Should not match with extra user
-	if user.GroupMembersMatch(groupName, []string{user1}) {
-		t.Error("should not match when desired list is shorter")
-	}
-
-	// Non-existent group with empty desired
-	if !user.GroupMembersMatch("pm-nonexistent-group-12345", []string{}) {
-		t.Error("non-existent group should match empty desired list")
-	}
-
-	// Non-existent group with non-empty desired
-	if user.GroupMembersMatch("pm-nonexistent-group-12345", []string{"someone"}) {
-		t.Error("non-existent group should not match non-empty desired list")
+func TestAddToGroup_MapsNonZeroExit(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 6, Stderr: "usermod: group 'deployers' does not exist"}, nil)
+	err := mgr(t, f).AddToGroup(context.Background(), "deploy", "deployers")
+	var ce *exec.CommandError
+	if !errors.As(err, &ce) || ce.ExitCode != 6 {
+		t.Errorf("err = %v, want *exec.CommandError exit 6", err)
 	}
 }

--- a/go/sys/user/password.go
+++ b/go/sys/user/password.go
@@ -1,48 +1,91 @@
 package user
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 const (
-	// MinPasswordLength is the minimum allowed password length.
+	// MinPasswordLength is the minimum allowed generated-password length.
 	MinPasswordLength = 8
-	// MaxPasswordLength is the maximum allowed password length.
+	// MaxPasswordLength is the maximum allowed generated-password length.
 	MaxPasswordLength = 128
 
 	charsetAlphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	charsetSpecial      = "!@#$%^&*()_+-=[]{}|;:,.<>?"
 )
 
-// GeneratePassword creates a cryptographically secure random password.
-// If complex is true, the password includes special characters.
-// Length must be between MinPasswordLength and MaxPasswordLength.
-// Uses crypto/rand.Int for uniform distribution (no modulo bias).
-func GeneratePassword(length int, complex bool) (string, error) {
+// randInt is a seam over crypto/rand.Int so the (practically unreachable)
+// RNG-failure error path is exercisable in tests.
+var randInt = rand.Int
+
+// Complexity selects the character set GeneratePassword draws from.
+type Complexity int
+
+const (
+	// ComplexityAlphanumeric uses letters and digits only (the zero value).
+	ComplexityAlphanumeric Complexity = iota
+	// ComplexityComplex adds special characters.
+	ComplexityComplex
+)
+
+// GeneratePassword returns a cryptographically secure random password as a
+// Secret. length must be in [MinPasswordLength, MaxPasswordLength]. crypto/rand
+// gives a uniform distribution (no modulo bias).
+func GeneratePassword(length int, c Complexity) (exec.Secret, error) {
 	if length < MinPasswordLength {
-		return "", fmt.Errorf("password length must be at least %d", MinPasswordLength)
+		return exec.Secret{}, fmt.Errorf("password length must be at least %d", MinPasswordLength)
 	}
 	if length > MaxPasswordLength {
-		return "", fmt.Errorf("password length must be at most %d", MaxPasswordLength)
+		return exec.Secret{}, fmt.Errorf("password length must be at most %d", MaxPasswordLength)
 	}
 
 	charset := charsetAlphanumeric
-	if complex {
+	if c == ComplexityComplex {
 		charset += charsetSpecial
 	}
-
 	charsetLen := big.NewInt(int64(len(charset)))
-	password := make([]byte, length)
-
-	for i := 0; i < length; i++ {
-		idx, err := rand.Int(rand.Reader, charsetLen)
+	buf := make([]byte, length)
+	for i := range buf {
+		idx, err := randInt(rand.Reader, charsetLen)
 		if err != nil {
-			return "", fmt.Errorf("failed to generate random index: %w", err)
+			return exec.Secret{}, fmt.Errorf("generate random index: %w", err)
 		}
-		password[i] = charset[idx.Int64()]
+		buf[i] = charset[idx.Int64()]
 	}
+	// The charset contains no newline/CR, so NewSecret cannot reject this.
+	return exec.NewSecret(string(buf))
+}
 
-	return string(password), nil
+// SetPassword sets a user's password via chpasswd. The Secret guarantees the
+// password carries no newline/CR (NewSecret rejects them), so it cannot inject a
+// second chpasswd "user:password" record, and the username is IsValidName-checked.
+func (u *shadowUtils) SetPassword(ctx context.Context, name string, password exec.Secret) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	// Reveal() here is the single sanctioned chpasswd sink (see the Secret
+	// redaction contract / the Reveal fitness function).
+	stdin := strings.NewReader(name + ":" + password.Reveal())
+	res, err := u.r.Run(ctx, exec.Command{Name: "chpasswd", Stdin: stdin, Escalate: true})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return &exec.CommandError{Name: "chpasswd", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return nil
+}
+
+// ExpirePassword forces a password change on next login (chage -d 0).
+func (u *shadowUtils) ExpirePassword(ctx context.Context, name string) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	return u.run(ctx, "chage", "-d", "0", name)
 }

--- a/go/sys/user/password_test.go
+++ b/go/sys/user/password_test.go
@@ -1,97 +1,120 @@
-package user_test
+package user
 
 import (
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
-	"github.com/manchtools/power-manage/sdk/go/sys/user"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func TestGeneratePassword(t *testing.T) {
-	pwd, err := user.GeneratePassword(16, false)
-	if err != nil {
-		t.Fatalf("GeneratePassword failed: %v", err)
+func TestGeneratePassword_Bounds(t *testing.T) {
+	if _, err := GeneratePassword(MinPasswordLength-1, ComplexityAlphanumeric); err == nil {
+		t.Error("too-short length accepted")
 	}
-	if len(pwd) != 16 {
-		t.Errorf("expected length 16, got %d", len(pwd))
-	}
-
-	// Should only contain alphanumeric
-	for _, c := range pwd {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
-			t.Errorf("unexpected character %q in non-complex password", c)
-		}
+	if _, err := GeneratePassword(MaxPasswordLength+1, ComplexityAlphanumeric); err == nil {
+		t.Error("too-long length accepted")
 	}
 }
 
-func TestGeneratePasswordComplex(t *testing.T) {
-	// Generate several complex passwords and check that at least one contains a special char
-	hasSpecial := false
-	specialChars := "!@#$%^&*()_+-=[]{}|;:,.<>?"
-
-	for i := 0; i < 20; i++ {
-		pwd, err := user.GeneratePassword(32, true)
-		if err != nil {
-			t.Fatalf("GeneratePassword failed: %v", err)
+func TestGeneratePassword_LengthCharsetAndSecret(t *testing.T) {
+	s, err := GeneratePassword(24, ComplexityAlphanumeric)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pw := s.Reveal()
+	if len(pw) != 24 {
+		t.Errorf("length = %d, want 24", len(pw))
+	}
+	for _, c := range pw {
+		if !strings.ContainsRune(charsetAlphanumeric, c) {
+			t.Errorf("alphanumeric password contains out-of-charset rune %q", c)
 		}
-		for _, c := range pwd {
-			if strings.ContainsRune(specialChars, c) {
-				hasSpecial = true
-				break
+	}
+	// It is a Secret: never reveals plaintext through formatting.
+	if got := s.String(); got != "[REDACTED]" || strings.Contains(got, pw) {
+		t.Errorf("generated password not redacted: %q", got)
+	}
+	// The generator never produces a newline/CR (would break chpasswd).
+	if strings.ContainsAny(pw, "\n\r") {
+		t.Error("generated password contains a newline/CR")
+	}
+}
+
+func TestGeneratePassword_ComplexUsesSpecialAndStaysInCharset(t *testing.T) {
+	// Every char stays within alphanumeric+special, AND across many draws at
+	// least one special char actually appears — so this fails if ComplexityComplex
+	// ever regresses to alphanumeric-only. With 50×32 chars drawn from an ~87-char
+	// set containing ~25 specials, P(never a special) is astronomically small.
+	sawSpecial := false
+	for i := 0; i < 50; i++ {
+		s, err := GeneratePassword(32, ComplexityComplex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range s.Reveal() {
+			if !strings.ContainsRune(charsetAlphanumeric+charsetSpecial, c) {
+				t.Fatalf("complex password contains out-of-charset rune %q", c)
+			}
+			if strings.ContainsRune(charsetSpecial, c) {
+				sawSpecial = true
 			}
 		}
-		if hasSpecial {
-			break
-		}
 	}
-
-	if !hasSpecial {
-		t.Error("expected at least one complex password to contain special characters")
+	if !sawSpecial {
+		t.Error("ComplexityComplex produced no special character across 50×32 chars — it may have regressed to alphanumeric-only")
 	}
 }
 
-func TestGeneratePasswordLength(t *testing.T) {
-	// Test minimum
-	_, err := user.GeneratePassword(7, false)
-	if err == nil {
-		t.Error("expected error for length < 8")
-	}
-
-	// Test at minimum
-	pwd, err := user.GeneratePassword(8, false)
+func TestSetPassword_ChpasswdStdinAndSecretNeverInArgv(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	secret, err := exec.NewSecret("sup3r-s3cret-value")
 	if err != nil {
-		t.Fatalf("GeneratePassword(8) failed: %v", err)
+		t.Fatal(err)
 	}
-	if len(pwd) != 8 {
-		t.Errorf("expected length 8, got %d", len(pwd))
+	if err := mgr(t, f).SetPassword(context.Background(), "deploy", secret); err != nil {
+		t.Fatal(err)
 	}
-
-	// Test maximum
-	pwd, err = user.GeneratePassword(128, false)
-	if err != nil {
-		t.Fatalf("GeneratePassword(128) failed: %v", err)
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d calls, want 1", len(calls))
 	}
-	if len(pwd) != 128 {
-		t.Errorf("expected length 128, got %d", len(pwd))
+	c := calls[0]
+	if c.Name != "chpasswd" || !c.Escalate {
+		t.Errorf("command = %q escalate=%v, want escalated chpasswd", c.Name, c.Escalate)
 	}
-
-	// Test over maximum
-	_, err = user.GeneratePassword(129, false)
-	if err == nil {
-		t.Error("expected error for length > 128")
+	// The plaintext must go through STDIN, never argv.
+	for _, a := range c.Args {
+		if strings.Contains(a, "sup3r-s3cret-value") {
+			t.Errorf("secret leaked into argv: %q", a)
+		}
+	}
+	if c.Stdin == nil {
+		t.Fatal("chpasswd received no stdin")
+	}
+	got, _ := io.ReadAll(c.Stdin)
+	if string(got) != "deploy:sup3r-s3cret-value" {
+		t.Errorf("chpasswd stdin = %q, want %q", got, "deploy:sup3r-s3cret-value")
 	}
 }
 
-func TestGeneratePasswordUniqueness(t *testing.T) {
-	passwords := make(map[string]bool)
-	for i := 0; i < 100; i++ {
-		pwd, err := user.GeneratePassword(16, false)
-		if err != nil {
-			t.Fatalf("GeneratePassword failed: %v", err)
-		}
-		if passwords[pwd] {
-			t.Fatal("generated duplicate password")
-		}
-		passwords[pwd] = true
+func TestSetPassword_MapsNonZeroExit(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 1, Stderr: "chpasswd: (user deploy) pam_chauthtok() failed, error:\nAuthentication token manipulation error"}, nil)
+	err := mgr(t, f).SetPassword(context.Background(), "deploy", exec.Secret{})
+	var ce *exec.CommandError
+	if !errors.As(err, &ce) || ce.ExitCode != 1 {
+		t.Errorf("err = %v, want *exec.CommandError exit 1", err)
 	}
+}
+
+func TestExpirePassword_Golden(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).ExpirePassword(context.Background(), "deploy"); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f, "chage", []string{"-d", "0", "deploy"}, true)
 }

--- a/go/sys/user/seams.go
+++ b/go/sys/user/seams.go
@@ -1,0 +1,17 @@
+package user
+
+import "github.com/manchtools/power-manage/sdk/go/sys/fs"
+
+// Package-var seams over the legacy fs helpers this package still calls (fs gains
+// its own injected Runner in a later capability PR). Tests save/restore and
+// override them to exercise the fs-touching branches — the Create -M+chown path
+// and SetHiddenOnLoginScreen — without a real filesystem or privilege.
+var (
+	setOwnershipRecursive = fs.SetOwnershipRecursive
+	writeFileAtomic       = fs.WriteFileAtomic
+	removeStrict          = fs.RemoveStrict
+)
+
+// accountsServiceDir is the AccountsService per-user config directory. A var (not
+// const) so tests can point it at a temp dir.
+var accountsServiceDir = "/var/lib/AccountsService/users"

--- a/go/sys/user/sessions.go
+++ b/go/sys/user/sessions.go
@@ -2,43 +2,30 @@ package user
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os/exec"
 
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-// KillSessions terminates all sessions for a user.
-// Uses loginctl terminate-user if available, falls back to pkill -KILL -u.
-func KillSessions(ctx context.Context, username string) error {
-	if !IsValidName(username) {
-		return fmt.Errorf("invalid username: %s", username)
+// KillSessions terminates all of a user's sessions. It prefers systemd's
+// loginctl terminate-user and falls back to pkill -KILL -u. A pkill exit of 1
+// (no matching processes) is treated as success.
+func (u *shadowUtils) KillSessions(ctx context.Context, name string) error {
+	if err := validateUsername(name); err != nil {
+		return err
 	}
-
-	// Try loginctl first (systemd).
-	var loginctlErr error
-	if _, err := exec.LookPath("loginctl"); err == nil {
-		_, loginctlErr = sysexec.Privileged(ctx, "loginctl", "terminate-user", username)
-		if loginctlErr == nil {
-			return nil
-		}
-		// Fall through to pkill on failure.
+	// loginctl first; the Runner resolves and runs it, reporting "not found" if
+	// systemd-logind is absent, in which case we fall through to pkill.
+	if res, err := u.r.Run(ctx, exec.Command{Name: "loginctl", Args: []string{"terminate-user", name}, Escalate: true}); err == nil && res.ExitCode == 0 {
+		return nil
 	}
-
-	// Fallback: pkill -KILL -u.
-	// pkill exits 1 if no processes matched, which is fine.
-	result, err := sysexec.Privileged(ctx, "pkill", "-KILL", "-u", username)
+	res, err := u.r.Run(ctx, exec.Command{Name: "pkill", Args: []string{"-KILL", "-u", name}, Escalate: true})
 	if err != nil {
-		// Exit code 1 means no processes found — not an error.
-		if result != nil && result.ExitCode == 1 {
-			return nil
-		}
-		// Combine both errors if loginctl also failed.
-		if loginctlErr != nil {
-			return fmt.Errorf("kill sessions for %s: %w", username, errors.Join(loginctlErr, err))
-		}
-		return fmt.Errorf("kill sessions for %s: %w", username, err)
+		return fmt.Errorf("kill sessions for %s: %w", name, err)
+	}
+	// pkill exits 1 when no processes matched — not an error here.
+	if res.ExitCode != 0 && res.ExitCode != 1 {
+		return &exec.CommandError{Name: "pkill", ExitCode: res.ExitCode, Stderr: res.Stderr}
 	}
 	return nil
 }

--- a/go/sys/user/sessions_test.go
+++ b/go/sys/user/sessions_test.go
@@ -2,22 +2,56 @@ package user
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func TestKillSessions_InvalidUsername(t *testing.T) {
-	err := KillSessions(context.Background(), "")
-	if err == nil {
-		t.Error("expected error for empty username")
-	}
+func TestKillSessions(t *testing.T) {
+	t.Run("loginctl succeeds → no pkill", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 0}, nil) // loginctl terminate-user
+		if err := mgr(t, f).KillSessions(context.Background(), "deploy"); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 1 || calls[0].Name != "loginctl" || !calls[0].Escalate {
+			t.Errorf("expected one escalated loginctl call, got %+v", calls)
+		}
+	})
 
-	err = KillSessions(context.Background(), "../root")
-	if err == nil {
-		t.Error("expected error for invalid username")
-	}
-}
+	t.Run("loginctl missing → falls back to pkill", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{}, errors.New("command not found: loginctl")) // loginctl run error
+		f.Push(exec.Result{ExitCode: 0}, nil)                            // pkill
+		if err := mgr(t, f).KillSessions(context.Background(), "deploy"); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 2 || calls[1].Name != "pkill" {
+			t.Errorf("expected loginctl then pkill, got %+v", calls)
+		}
+	})
 
-func TestKillSessions_RequiresPrivileges(t *testing.T) {
-	// KillSessions requires sudo. Skip in unprivileged tests.
-	t.Skip("KillSessions requires root privileges")
+	t.Run("pkill exit 1 (no processes) is success", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 1}, nil) // loginctl non-zero → fall through
+		f.Push(exec.Result{ExitCode: 1}, nil) // pkill: no matching processes
+		if err := mgr(t, f).KillSessions(context.Background(), "deploy"); err != nil {
+			t.Errorf("pkill exit 1 should be success, got %v", err)
+		}
+	})
+
+	t.Run("pkill hard failure surfaces", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 1}, nil)                                         // loginctl
+		f.Push(exec.Result{ExitCode: 2, Stderr: "pkill: invalid option -- 'u'"}, nil) // pkill real error
+		err := mgr(t, f).KillSessions(context.Background(), "deploy")
+		var ce *exec.CommandError
+		if !errors.As(err, &ce) || ce.ExitCode != 2 {
+			t.Errorf("err = %v, want *exec.CommandError exit 2", err)
+		}
+	})
 }

--- a/go/sys/user/user.go
+++ b/go/sys/user/user.go
@@ -1,30 +1,33 @@
-// Package user provides user and group management utilities for Linux systems.
-//
-// User operations (Create, Delete, Modify, Lock, etc.) escalate through the
-// configured privilege backend (sudo or doas — see exec.SetPrivilegeBackend).
-// Query operations (Get, Exists, PrimaryGroup) run as the current user where
-// possible, falling back to the privilege backend for restricted data like
-// the shadow file.
 package user
 
 import (
 	"context"
 	"fmt"
-	"slices"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
-	"github.com/manchtools/power-manage/sdk/go/sys/fs"
 )
 
-// queryTimeout caps the context-less query helpers (Get / Exists /
-// PrimaryGroup / SupplementaryGroups) so a hung getent / id call —
-// e.g. a stalled NSS module — cannot pin the calling goroutine
-// indefinitely. Local NSS lookups normally return in milliseconds;
-// 10s leaves headroom for slow LDAP / SSSD backends. F023.
+// queryTimeout caps a query op when the caller's context carries no deadline so
+// a hung getent/id (e.g. a stalled NSS/LDAP/SSSD backend) cannot pin the call
+// indefinitely. Local lookups return in milliseconds; 10s leaves headroom.
 const queryTimeout = 10 * time.Second
+
+// Backend selects the user/group implementation. It is passed explicitly even
+// though shadow-utils is the only value today; the zero value is invalid
+// (New → ErrUnknownBackend) and a real second backend (adduser/homed/busybox)
+// is appended when actually written.
+type Backend int
+
+// ShadowUtils is the useradd/usermod/userdel/chpasswd/chage implementation.
+const ShadowUtils Backend = iota + 1
+
+// ErrUnknownBackend is returned by New for the zero value or any Backend the
+// SDK does not implement (fail-closed).
+var ErrUnknownBackend = fmt.Errorf("user: unknown backend")
 
 // Info holds the current state of a user account.
 type Info struct {
@@ -33,213 +36,350 @@ type Info struct {
 	Comment string
 	HomeDir string
 	Shell   string
-	Groups  []string // supplementary groups (excluding primary)
+	Groups  []string // supplementary groups (excluding the primary)
 	Locked  bool
 }
 
-// =============================================================================
-// User Query Functions
-// =============================================================================
+// CreateOptions configures Create. The zero value creates a normal interactive
+// account with a login shell and the backend's matching primary group, and NO
+// home directory.
+type CreateOptions struct {
+	UID          int      // 0 = auto-assign
+	PrimaryGroup string   // group name or numeric GID; "" = useradd matching-group default
+	Groups       []string // supplementary groups
+	Shell        string   // "" = DefaultShell(System)
+	HomeDir      string   // "" = /home/<name>
+	Comment      string   // GECOS
+	System       bool     // -r system account; also flips DefaultShell to nologin
+	CreateHome   bool     // -m; Create handles the "home already exists" -M/chown dance
+}
 
-// Get retrieves the current state of a user from the system.
-func Get(username string) (*Info, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
-	defer cancel()
+// ModifyOptions configures Modify. An empty string leaves that attribute
+// unchanged; if every field is empty Modify is a no-op (no usermod run).
+type ModifyOptions struct {
+	Shell        string
+	HomeDir      string
+	Comment      string
+	PrimaryGroup string
+}
 
-	// Get passwd entry: username:x:uid:gid:comment:home:shell
-	out, err := exec.QueryCtx(ctx, "getent", "passwd", username)
+// DeleteOptions configures Delete.
+type DeleteOptions struct {
+	RemoveHome bool // userdel -r
+}
+
+// GroupCreateOptions configures GroupCreate.
+type GroupCreateOptions struct {
+	GID    int  // 0 = auto-assign
+	System bool // -r system group
+}
+
+// Manager is the user/group contract. Today shadow-utils is the only
+// implementation; the interface leaves room for adduser/systemd-homed/busybox.
+type Manager interface {
+	// Accounts
+	Get(ctx context.Context, name string) (Info, error)
+	Exists(ctx context.Context, name string) (bool, error)
+	Create(ctx context.Context, name string, opts CreateOptions) error
+	Modify(ctx context.Context, name string, opts ModifyOptions) error
+	Delete(ctx context.Context, name string, opts DeleteOptions) error
+	Lock(ctx context.Context, name string) error
+	Unlock(ctx context.Context, name string) error
+	SetPassword(ctx context.Context, name string, password exec.Secret) error
+	ExpirePassword(ctx context.Context, name string) error
+	PrimaryGroup(ctx context.Context, name string) (string, error)
+	SupplementaryGroups(ctx context.Context, name string) ([]string, error)
+	KillSessions(ctx context.Context, name string) error
+	SetHiddenOnLoginScreen(ctx context.Context, name string, hidden bool) error
+	// Groups
+	GroupExists(ctx context.Context, name string) (bool, error)
+	GroupMembers(ctx context.Context, name string) ([]string, error)
+	GroupCreate(ctx context.Context, name string, opts GroupCreateOptions) error
+	GroupDelete(ctx context.Context, name string) error
+	GroupEnsure(ctx context.Context, name string) error
+	AddToGroup(ctx context.Context, name, group string) error
+	RemoveFromGroup(ctx context.Context, name, group string) error
+}
+
+// shadowUtils is the shadow-utils Manager. Every operation runs through the
+// injected exec.Runner (reads unescalated; writes and the shadow read with
+// Escalate), so the whole package is unit-testable with exectest.FakeRunner.
+type shadowUtils struct {
+	r exec.Runner
+}
+
+// New returns a Manager for the named backend, driven by runner. It is pure:
+// it validates the backend is known and does not probe the host. The zero value
+// and any unimplemented backend are rejected with ErrUnknownBackend.
+func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
+	if b != ShadowUtils {
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+	if runner == nil {
+		return nil, fmt.Errorf("user: runner is required")
+	}
+	return &shadowUtils{r: runner}, nil
+}
+
+// Option is the functional-option type for backend-specific knobs. None are
+// defined today; it reserves the constructor shape.
+type Option func(*shadowUtils)
+
+// ensureCtx applies the package query timeout when the caller's context has no
+// deadline of its own.
+func ensureCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, queryTimeout)
+}
+
+// run executes an escalated mutating command and maps a non-zero exit to a
+// *exec.CommandError carrying stderr (the "user already exists" context callers
+// need).
+func (u *shadowUtils) run(ctx context.Context, name string, args ...string) error {
+	res, err := u.r.Run(ctx, exec.Command{Name: name, Args: args, Escalate: true})
 	if err != nil {
-		return nil, fmt.Errorf("lookup passwd entry for %q: %w", username, err)
+		return err
+	}
+	if res.ExitCode != 0 {
+		return &exec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return nil
+}
+
+// query executes an unescalated read command and returns trimmed stdout, mapping
+// a non-zero exit to a *exec.CommandError.
+func (u *shadowUtils) query(ctx context.Context, name string, args ...string) (string, error) {
+	res, err := u.r.Run(ctx, exec.Command{Name: name, Args: args})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", &exec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return strings.TrimSpace(res.Stdout), nil
+}
+
+// =============================================================================
+// Accounts
+// =============================================================================
+
+// Create creates a new user account. The default-shell policy and the
+// "home already exists" -M/chown dance live here (moved out of the agent).
+func (u *shadowUtils) Create(ctx context.Context, name string, opts CreateOptions) error {
+	if err := validateUsername(name); err != nil {
+		return err
 	}
 
-	fields := strings.Split(strings.TrimSpace(out), ":")
-	if len(fields) < 7 {
-		return nil, fmt.Errorf("invalid passwd entry")
+	args := make([]string, 0, 16)
+	if opts.UID > 0 {
+		args = append(args, "-u", strconv.Itoa(opts.UID))
+	}
+	if opts.PrimaryGroup != "" {
+		args = append(args, "-g", opts.PrimaryGroup)
+	}
+	if len(opts.Groups) > 0 {
+		args = append(args, "-G", strings.Join(opts.Groups, ","))
+	}
+	if opts.HomeDir != "" {
+		args = append(args, "-d", opts.HomeDir)
+	}
+	shell := opts.Shell
+	if shell == "" {
+		shell = DefaultShell(opts.System)
+	}
+	args = append(args, "-s", shell)
+	if opts.System {
+		args = append(args, "-r")
 	}
 
-	uid, _ := strconv.Atoi(fields[2])
-	gid, _ := strconv.Atoi(fields[3])
+	homeDir := opts.HomeDir
+	if homeDir == "" {
+		homeDir = "/home/" + name
+	}
+	_, statErr := os.Stat(homeDir)
+	homeExists := statErr == nil
+	// useradd -m fails if the home already exists; use -M and fix ownership
+	// afterwards so an explicit CreateHome over a pre-seeded directory is
+	// idempotent.
+	if opts.CreateHome && !homeExists {
+		args = append(args, "-m")
+	} else {
+		args = append(args, "-M")
+	}
+	if opts.Comment != "" {
+		args = append(args, "-c", opts.Comment)
+	}
+	args = append(args, name)
 
-	info := &Info{
-		UID:     uid,
-		GID:     gid,
-		Comment: fields[4],
-		HomeDir: fields[5],
-		Shell:   fields[6],
+	if err := u.run(ctx, "useradd", args...); err != nil {
+		return err
 	}
 
-	// Resolve the primary group name from the GID we already have, so we
-	// don't have to shell out to `id -gn` in addition to `id -Gn`.
-	var primary string
-	if out, err := exec.QueryCtx(ctx, "getent", "group", strconv.Itoa(gid)); err == nil {
-		// getent group format: name:passwd:gid:members
-		if idx := strings.IndexByte(out, ':'); idx > 0 {
-			primary = out[:idx]
+	if opts.CreateHome && homeExists {
+		group := opts.PrimaryGroup
+		if group == "" {
+			group = name // useradd's matching-group default
+		}
+		if _, err := setOwnershipRecursive(ctx, homeDir, name, group); err != nil {
+			return fmt.Errorf("fix ownership of existing home %q: %w", homeDir, err)
 		}
 	}
+	return nil
+}
 
-	// Get supplementary groups (filter out the primary group).
-	if allGroups, err := exec.QueryCtx(ctx, "id", "-Gn", username); err == nil {
-		for _, g := range strings.Fields(strings.TrimSpace(allGroups)) {
+// Modify changes account attributes. Empty option fields are left unchanged; if
+// nothing is set it is a no-op (no usermod run).
+func (u *shadowUtils) Modify(ctx context.Context, name string, opts ModifyOptions) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	args := make([]string, 0, 8)
+	if opts.Shell != "" {
+		args = append(args, "-s", opts.Shell)
+	}
+	if opts.HomeDir != "" {
+		args = append(args, "-d", opts.HomeDir)
+	}
+	if opts.Comment != "" {
+		args = append(args, "-c", opts.Comment)
+	}
+	if opts.PrimaryGroup != "" {
+		args = append(args, "-g", opts.PrimaryGroup)
+	}
+	if len(args) == 0 {
+		return nil // nothing to change
+	}
+	args = append(args, name)
+	return u.run(ctx, "usermod", args...)
+}
+
+// Delete removes a user account (and its home when opts.RemoveHome).
+func (u *shadowUtils) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	if opts.RemoveHome {
+		return u.run(ctx, "userdel", "-r", name)
+	}
+	return u.run(ctx, "userdel", name)
+}
+
+// Lock locks an account (usermod -L).
+func (u *shadowUtils) Lock(ctx context.Context, name string) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	return u.run(ctx, "usermod", "-L", name)
+}
+
+// Unlock unlocks an account (usermod -U).
+func (u *shadowUtils) Unlock(ctx context.Context, name string) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	return u.run(ctx, "usermod", "-U", name)
+}
+
+// Get retrieves the current state of a user.
+func (u *shadowUtils) Get(ctx context.Context, name string) (Info, error) {
+	if err := validateUsername(name); err != nil {
+		return Info{}, err
+	}
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+
+	out, err := u.query(ctx, "getent", "passwd", name)
+	if err != nil {
+		return Info{}, fmt.Errorf("lookup passwd entry for %q: %w", name, err)
+	}
+	fields := strings.Split(out, ":")
+	if len(fields) < 7 {
+		return Info{}, fmt.Errorf("invalid passwd entry for %q", name)
+	}
+	uid, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return Info{}, fmt.Errorf("invalid UID in passwd entry for %q: %w", name, err)
+	}
+	gid, err := strconv.Atoi(fields[3])
+	if err != nil {
+		return Info{}, fmt.Errorf("invalid GID in passwd entry for %q: %w", name, err)
+	}
+	info := Info{UID: uid, GID: gid, Comment: fields[4], HomeDir: fields[5], Shell: fields[6]}
+
+	// Resolve the primary group name from the GID so we filter it out below.
+	var primary string
+	if gout, err := u.query(ctx, "getent", "group", strconv.Itoa(gid)); err == nil {
+		if idx := strings.IndexByte(gout, ':'); idx > 0 {
+			primary = gout[:idx]
+		}
+	}
+	if allGroups, err := u.query(ctx, "id", "-Gn", name); err == nil {
+		for _, g := range strings.Fields(allGroups) {
 			if g != primary {
 				info.Groups = append(info.Groups, g)
 			}
 		}
 	}
 
-	// Check if account is locked (password field starts with ! or *).
-	// The shadow file is root-only — escalate via the configured
-	// privilege backend (sudo or doas, see exec.SetPrivilegeBackend).
-	// If escalation is not authorized for this caller, the Privileged
-	// call returns an error and we leave Locked=false rather than guessing.
-	if shadowRes, err := exec.Privileged(ctx, "getent", "shadow", username); err == nil && shadowRes != nil && shadowRes.ExitCode == 0 && shadowRes.Stdout != "" {
-		shadowFields := strings.Split(strings.TrimSpace(shadowRes.Stdout), ":")
-		if len(shadowFields) >= 2 {
-			passField := shadowFields[1]
-			info.Locked = strings.HasPrefix(passField, "!") || strings.HasPrefix(passField, "*")
+	// The shadow file is root-only: read it escalated. If escalation is not
+	// authorized, leave Locked=false rather than guessing.
+	if res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"shadow", name}, Escalate: true}); err == nil && res.ExitCode == 0 && res.Stdout != "" {
+		sf := strings.Split(strings.TrimSpace(res.Stdout), ":")
+		if len(sf) >= 2 {
+			info.Locked = strings.HasPrefix(sf[1], "!") || strings.HasPrefix(sf[1], "*")
 		}
 	}
-
 	return info, nil
 }
 
-// Exists checks if a user exists on the system.
-func Exists(username string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
-	defer cancel()
-	return exec.CheckCtx(ctx, "id", username)
-}
-
-// IsValidName checks if a username is valid and safe.
-// Valid usernames: start with lowercase letter, contain only [a-z0-9_-], max 32 chars.
-func IsValidName(username string) bool {
-	if len(username) == 0 || len(username) > 32 {
-		return false
-	}
-	// Must start with a lowercase letter
-	if username[0] < 'a' || username[0] > 'z' {
-		return false
-	}
-	// Rest can be lowercase letters, digits, underscores, or hyphens
-	for _, c := range username[1:] {
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
-			return false
-		}
-	}
-	return true
-}
-
-// validateName checks a POSIX-style account name (user or group)
-// against IsValidName and returns a descriptive error naming the
-// argument kind. Every privileged helper in this package goes
-// through it so that (a) a name starting with "-" cannot become a
-// useradd/usermod/groupadd flag, and (b) a name containing control
-// characters (newline, colon) cannot inject extra chpasswd records.
-func validateName(kind, name string) error {
+// Exists reports whether a user exists.
+func (u *shadowUtils) Exists(ctx context.Context, name string) (bool, error) {
 	if !IsValidName(name) {
-		return fmt.Errorf("invalid %s %q: must start with a lowercase letter and contain only [a-z0-9_-], max 32 chars", kind, name)
+		return false, nil
 	}
-	return nil
-}
-
-// validateUsername is a thin wrapper around validateName for
-// readability at call sites that specifically handle usernames.
-func validateUsername(username string) error { return validateName("username", username) }
-
-// =============================================================================
-// User Management Operations
-// =============================================================================
-
-// Create creates a new user account with the given options.
-// Extra args are passed before the username (e.g., "-m", "-s", "/bin/bash").
-// Returns the command result (stdout/stderr/exit code) so callers can
-// surface useradd's stderr — important context like "user 'foo' already
-// exists" lives there. The Result is non-nil on most failure paths too.
-func Create(ctx context.Context, username string, args ...string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
-	}
-	// slices.Clone avoids aliasing the caller's backing array — a
-	// bare `append(args, username)` would write into the caller's
-	// slice whenever it has spare capacity.
-	fullArgs := append(slices.Clone(args), username)
-	return exec.Privileged(ctx, "useradd", fullArgs...)
-}
-
-// Modify modifies an existing user account.
-// Extra args are passed before the username (e.g., "-s", "/bin/zsh").
-// Returns the command result so callers can surface usermod's stderr.
-func Modify(ctx context.Context, username string, args ...string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
-	}
-	fullArgs := append(slices.Clone(args), username)
-	return exec.Privileged(ctx, "usermod", fullArgs...)
-}
-
-// Delete removes a user account. If removeHome is true, also removes the home directory.
-// Returns the command result so callers can surface userdel's stderr.
-func Delete(ctx context.Context, username string, removeHome bool) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
-	}
-	if removeHome {
-		return exec.Privileged(ctx, "userdel", "-r", username)
-	}
-	return exec.Privileged(ctx, "userdel", username)
-}
-
-// Lock locks a user account (usermod -L).
-func Lock(ctx context.Context, username string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
-	}
-	return exec.Privileged(ctx, "usermod", "-L", username)
-}
-
-// Unlock unlocks a user account (usermod -U).
-func Unlock(ctx context.Context, username string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
-	}
-	return exec.Privileged(ctx, "usermod", "-U", username)
-}
-
-// =============================================================================
-// User Group Queries
-// =============================================================================
-
-// PrimaryGroup returns the primary group name for a user.
-func PrimaryGroup(username string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := ensureCtx(ctx)
 	defer cancel()
-	out, err := exec.QueryCtx(ctx, "id", "-gn", username)
+	res, err := u.r.Run(ctx, exec.Command{Name: "id", Args: []string{name}})
 	if err != nil {
+		return false, err
+	}
+	return res.ExitCode == 0, nil
+}
+
+// PrimaryGroup returns the user's primary group name.
+func (u *shadowUtils) PrimaryGroup(ctx context.Context, name string) (string, error) {
+	if err := validateUsername(name); err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(out), nil
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	return u.query(ctx, "id", "-gn", name)
 }
 
-// SupplementaryGroups returns the supplementary groups for a user
-// (excluding the primary group).
-func SupplementaryGroups(username string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+// SupplementaryGroups returns the user's supplementary groups (excluding the
+// primary).
+func (u *shadowUtils) SupplementaryGroups(ctx context.Context, name string) ([]string, error) {
+	if err := validateUsername(name); err != nil {
+		return nil, err
+	}
+	ctx, cancel := ensureCtx(ctx)
 	defer cancel()
-	out, err := exec.QueryCtx(ctx, "id", "-Gn", username)
+	out, err := u.query(ctx, "id", "-Gn", name)
 	if err != nil {
 		return nil, err
 	}
-	groups := strings.Fields(strings.TrimSpace(out))
-
-	// Filter out primary group
-	primaryGroup, err := PrimaryGroup(username)
+	groups := strings.Fields(out)
+	primary, err := u.query(ctx, "id", "-gn", name)
 	if err != nil {
-		return groups, nil
+		// Cannot guarantee the primary is excluded (the method's contract), so
+		// fail closed rather than return a list that may include it.
+		return nil, fmt.Errorf("lookup primary group for %q: %w", name, err)
 	}
-
-	var supplementary []string
+	supplementary := make([]string, 0, len(groups))
 	for _, g := range groups {
-		if g != primaryGroup {
+		if g != primary {
 			supplementary = append(supplementary, g)
 		}
 	}
@@ -247,45 +387,43 @@ func SupplementaryGroups(username string) ([]string, error) {
 }
 
 // =============================================================================
-// Password Management
+// Validation (pure helpers)
 // =============================================================================
 
-// SetPassword sets a user's password using chpasswd.
-// Rejects passwords containing newlines — chpasswd reads newline-
-// separated "user:password" records from stdin, so a newline in the
-// password (or a crafted username) would inject a second record and
-// let a caller change an unrelated account. IsValidName already
-// eliminates newline-carrying usernames.
-func SetPassword(ctx context.Context, username, password string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
+// IsValidName reports whether name is a valid, safe POSIX account name: starts
+// with a lowercase letter, contains only [a-z0-9_-], max 32 chars. The leading-
+// letter rule means a name can never become a useradd/usermod flag, and the
+// charset rejects the newline/colon that would inject an extra chpasswd record.
+func IsValidName(name string) bool {
+	if len(name) == 0 || len(name) > 32 {
+		return false
 	}
-	if strings.ContainsAny(password, "\n\r") {
-		return nil, fmt.Errorf("invalid password: must not contain newline or carriage-return characters")
+	if name[0] < 'a' || name[0] > 'z' {
+		return false
 	}
-	return exec.PrivilegedWithStdin(ctx, strings.NewReader(fmt.Sprintf("%s:%s", username, password)), "chpasswd")
+	for _, c := range name[1:] {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-') {
+			return false
+		}
+	}
+	return true
 }
 
-// ExpirePassword forces a user to change their password on next login.
-func ExpirePassword(ctx context.Context, username string) (*exec.Result, error) {
-	if err := validateUsername(username); err != nil {
-		return nil, err
+// DefaultShell returns the SDK's default login shell: an interactive shell for
+// normal accounts, nologin for system accounts. (Product concepts like
+// "disabled" are the consumer's policy — pass Shell explicitly for those.)
+func DefaultShell(system bool) string {
+	if system {
+		return "/usr/sbin/nologin"
 	}
-	return exec.Privileged(ctx, "chage", "-d", "0", username)
+	return "/bin/bash"
 }
 
-// =============================================================================
-// User Permission Operations
-// =============================================================================
-
-// ChownRecursive is a thin compatibility alias that forwards to
-// fs.SetOwnershipRecursive. The implementation moved out of sys/user
-// because it operates on any path, not on a user account; sys/fs is
-// the natural home for ownership ops alongside SetOwnership. Kept
-// here so existing agent call sites keep compiling. F018 in the SDK
-// tech-debt audit.
-//
-// Deprecated: use fs.SetOwnershipRecursive.
-func ChownRecursive(ctx context.Context, path, owner, group string) (*exec.Result, error) {
-	return fs.SetOwnershipRecursive(ctx, path, owner, group)
+func validateName(kind, name string) error {
+	if !IsValidName(name) {
+		return fmt.Errorf("invalid %s %q: must start with a lowercase letter and contain only [a-z0-9_-], max 32 chars", kind, name)
+	}
+	return nil
 }
+
+func validateUsername(name string) error { return validateName("username", name) }

--- a/go/sys/user/user_integration_test.go
+++ b/go/sys/user/user_integration_test.go
@@ -1,0 +1,324 @@
+//go:build integration
+
+package user_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/fs"
+	"github.com/manchtools/power-manage/sdk/go/sys/user"
+)
+
+// newManager builds a real-Runner user.Manager. The integration container runs
+// the suite as the non-root power-manage user with passwordless sudo, so the
+// escalation backend is Sudo.
+func newManager(t *testing.T) user.Manager {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Sudo)
+	if err != nil {
+		t.Fatalf("NewRunner(Sudo): %v", err)
+	}
+	m, err := user.New(user.ShadowUtils, r)
+	if err != nil {
+		t.Fatalf("user.New: %v", err)
+	}
+	return m
+}
+
+func testUsername(suffix string) string {
+	return fmt.Sprintf("pmtest%s%d", suffix, os.Getpid()%10000)
+}
+
+func cleanupUser(t *testing.T, m user.Manager, username string) {
+	t.Helper()
+	_ = m.Delete(context.Background(), username, user.DeleteOptions{RemoveHome: true})
+}
+
+func createTestUser(t *testing.T, m user.Manager, username string) {
+	t.Helper()
+	if err := m.Create(context.Background(), username, user.CreateOptions{CreateHome: true}); err != nil {
+		t.Fatalf("create test user %s: %v", username, err)
+	}
+}
+
+func TestCreate_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("cr")
+	defer cleanupUser(t, m, name)
+
+	if err := m.Create(ctx, name, user.CreateOptions{CreateHome: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if ok, err := m.Exists(ctx, name); err != nil || !ok {
+		t.Fatalf("Exists after create = (%v,%v), want (true,nil)", ok, err)
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.Shell != "/bin/bash" {
+		t.Errorf("default shell = %s, want /bin/bash", info.Shell)
+	}
+}
+
+func TestCreateSystemUser_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("sys")
+	defer cleanupUser(t, m, name)
+
+	if err := m.Create(ctx, name, user.CreateOptions{System: true}); err != nil {
+		t.Fatalf("Create system user: %v", err)
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.Shell != "/usr/sbin/nologin" {
+		t.Errorf("system shell = %s, want /usr/sbin/nologin", info.Shell)
+	}
+	if info.UID >= 1000 {
+		t.Errorf("system UID = %d, want < 1000", info.UID)
+	}
+}
+
+func TestGet_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("gt")
+	defer cleanupUser(t, m, name)
+
+	if err := m.Create(ctx, name, user.CreateOptions{CreateHome: true, Comment: "Test User"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.UID == 0 {
+		t.Error("expected non-zero UID")
+	}
+	if info.Comment != "Test User" {
+		t.Errorf("comment = %q, want 'Test User'", info.Comment)
+	}
+	if info.HomeDir == "" {
+		t.Error("expected non-empty home directory")
+	}
+	if info.Shell != "/bin/bash" {
+		t.Errorf("shell = %s, want /bin/bash", info.Shell)
+	}
+}
+
+func TestGetNonexistent_Integration(t *testing.T) {
+	if _, err := newManager(t).Get(context.Background(), "pmnonexistent12345"); err == nil {
+		t.Fatal("expected error for non-existent user")
+	}
+}
+
+func TestExists_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	if ok, err := m.Exists(ctx, "root"); err != nil || !ok {
+		t.Errorf("Exists(root) = (%v,%v), want (true,nil)", ok, err)
+	}
+	if ok, err := m.Exists(ctx, "pmnonexistent12345"); err != nil || ok {
+		t.Error("non-existent user reported as existing")
+	}
+}
+
+func TestModify_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("mod")
+	defer cleanupUser(t, m, name)
+	createTestUser(t, m, name)
+
+	if err := m.Modify(ctx, name, user.ModifyOptions{Shell: "/bin/sh"}); err != nil {
+		t.Fatalf("Modify: %v", err)
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.Shell != "/bin/sh" {
+		t.Errorf("shell after modify = %s, want /bin/sh", info.Shell)
+	}
+}
+
+func TestDelete_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("del")
+	createTestUser(t, m, name)
+
+	if err := m.Delete(ctx, name, user.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if ok, err := m.Exists(ctx, name); err != nil || ok {
+		t.Error("user still exists after delete")
+	}
+}
+
+func TestDeleteWithHome_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("dlh")
+	createTestUser(t, m, name)
+
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	homeDir := info.HomeDir
+	if err := m.Delete(ctx, name, user.DeleteOptions{RemoveHome: true}); err != nil {
+		t.Fatalf("Delete with home: %v", err)
+	}
+	if ok, err := m.Exists(ctx, name); err != nil || ok {
+		t.Error("user still exists after delete")
+	}
+	if fs.FileExists(ctx, homeDir) {
+		t.Error("home directory was not removed")
+	}
+}
+
+func TestDeleteNonexistent_Integration(t *testing.T) {
+	err := newManager(t).Delete(context.Background(), "pmnonexistent12345", user.DeleteOptions{})
+	if err == nil {
+		t.Fatal("expected error deleting a non-existent user")
+	}
+	// The typed error must carry userdel's exit code and stderr.
+	var ce *exec.CommandError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err = %v, want *exec.CommandError", err)
+	}
+	if ce.ExitCode == 0 {
+		t.Errorf("CommandError.ExitCode = 0, want non-zero")
+	}
+	if ce.Stderr == "" {
+		t.Errorf("CommandError.Stderr empty, want userdel's diagnostic")
+	}
+}
+
+func TestLockUnlock_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("lck")
+	defer cleanupUser(t, m, name)
+	createTestUser(t, m, name)
+
+	pw, _ := exec.NewSecret("TestPass123!")
+	if err := m.SetPassword(ctx, name, pw); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+
+	if err := m.Lock(ctx, name); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if info, err := m.Get(ctx, name); err != nil || !info.Locked {
+		t.Errorf("after Lock: Locked=%v err=%v, want locked", info.Locked, err)
+	}
+	if err := m.Unlock(ctx, name); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if info, err := m.Get(ctx, name); err != nil || info.Locked {
+		t.Errorf("after Unlock: Locked=%v err=%v, want unlocked", info.Locked, err)
+	}
+}
+
+func TestSetPassword_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("pwd")
+	defer cleanupUser(t, m, name)
+	createTestUser(t, m, name)
+
+	pw, _ := exec.NewSecret("TestPass123!")
+	if err := m.SetPassword(ctx, name, pw); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.Locked {
+		t.Error("account locked after setting a password")
+	}
+}
+
+func TestExpirePassword_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("exp")
+	defer cleanupUser(t, m, name)
+	createTestUser(t, m, name)
+
+	pw, _ := exec.NewSecret("TestPass123!")
+	if err := m.SetPassword(ctx, name, pw); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+	if err := m.ExpirePassword(ctx, name); err != nil {
+		t.Fatalf("ExpirePassword: %v", err)
+	}
+}
+
+func TestPrimaryGroup_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("pg")
+	defer cleanupUser(t, m, name)
+	createTestUser(t, m, name)
+
+	group, err := m.PrimaryGroup(ctx, name)
+	if err != nil {
+		t.Fatalf("PrimaryGroup: %v", err)
+	}
+	if group == "" {
+		t.Error("expected non-empty primary group")
+	}
+}
+
+func TestSupplementaryGroups_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("sg")
+	groupName := testUsername("sgg")
+	defer cleanupUser(t, m, name)
+	defer func() { _ = m.GroupDelete(ctx, groupName) }()
+	createTestUser(t, m, name)
+
+	if err := m.GroupCreate(ctx, groupName, user.GroupCreateOptions{}); err != nil {
+		t.Fatalf("GroupCreate: %v", err)
+	}
+	if err := m.AddToGroup(ctx, name, groupName); err != nil {
+		t.Fatalf("AddToGroup: %v", err)
+	}
+
+	groups, err := m.SupplementaryGroups(ctx, name)
+	if err != nil {
+		t.Fatalf("SupplementaryGroups: %v", err)
+	}
+	found := false
+	for _, g := range groups {
+		if g == groupName {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("group %q not in supplementary groups %v", groupName, groups)
+	}
+	primary, err := m.PrimaryGroup(ctx, name)
+	if err != nil {
+		t.Fatalf("PrimaryGroup: %v", err)
+	}
+	for _, g := range groups {
+		if g == primary {
+			t.Errorf("primary group %q must not appear in supplementary list", primary)
+		}
+	}
+}

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -1,422 +1,392 @@
-//go:build integration
-
-package user_test
+package user
 
 import (
 	"context"
-	"fmt"
-	"os"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
-	"github.com/manchtools/power-manage/sdk/go/sys/fs"
-	"github.com/manchtools/power-manage/sdk/go/sys/user"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func testUsername(suffix string) string {
-	return fmt.Sprintf("pmtest%s%d", suffix, os.Getpid()%10000)
-}
-
-func cleanupUser(t *testing.T, username string) {
+func mgr(t *testing.T, f *exectest.FakeRunner) Manager {
 	t.Helper()
-	ctx := context.Background()
-	exec.Privileged(ctx, "userdel", "-r", username)
+	m, err := New(ShadowUtils, f)
+	if err != nil {
+		t.Fatalf("New(ShadowUtils): %v", err)
+	}
+	return m
 }
 
-func createTestUser(t *testing.T, username string) {
+// wantOneCmd asserts exactly one command was run, with the given name, argv, and
+// escalation flag.
+func wantOneCmd(t *testing.T, f *exectest.FakeRunner, name string, args []string, escalate bool) {
 	t.Helper()
-	ctx := context.Background()
-	if _, err := user.Create(ctx, username, "-m", "-s", "/bin/bash"); err != nil {
-		t.Fatalf("failed to create test user %s: %v", username, err)
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d commands, want 1: %+v", len(calls), calls)
+	}
+	c := calls[0]
+	if c.Name != name {
+		t.Errorf("command name = %q, want %q", c.Name, name)
+	}
+	if strings.Join(c.Args, "\x00") != strings.Join(args, "\x00") {
+		t.Errorf("argv = %v\n want %v", c.Args, args)
+	}
+	if c.Escalate != escalate {
+		t.Errorf("Escalate = %v, want %v", c.Escalate, escalate)
 	}
 }
 
-func TestCreate(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("cr")
-	defer cleanupUser(t, name)
-
-	result, err := user.Create(ctx, name, "-m", "-s", "/bin/bash")
-	if err != nil {
-		t.Fatalf("Create failed: %v", err)
+func TestNew_FailClosed(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, f); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
 	}
-	// Verify the *exec.Result contract on the success path.
-	if result == nil {
-		t.Fatal("expected non-nil *exec.Result on success")
+	if _, err := New(ShadowUtils, nil); err == nil {
+		t.Error("New with nil runner returned nil error, want a required-runner error")
 	}
-	if result.ExitCode != 0 {
-		t.Errorf("expected exit code 0 on success, got %d", result.ExitCode)
-	}
-
-	if !user.Exists(name) {
-		t.Error("user should exist after creation")
-	}
-
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	if info.Shell != "/bin/bash" {
-		t.Errorf("expected shell /bin/bash, got %s", info.Shell)
+	if _, err := New(ShadowUtils, f); err != nil {
+		t.Errorf("New(ShadowUtils, runner) err = %v, want nil", err)
 	}
 }
 
-func TestCreateSystemUser(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("sys")
-	defer cleanupUser(t, name)
+// Create — golden argv across option combinations. HomeDir is set explicitly so
+// the -m/-M home-exists stat is deterministic.
+func TestCreate_GoldenArgv(t *testing.T) {
+	nonexistent := filepath.Join(t.TempDir(), "nohome")
 
-	_, err := user.Create(ctx, name, "--system", "--no-create-home", "-s", "/usr/sbin/nologin")
-	if err != nil {
-		t.Fatalf("Create system user failed: %v", err)
-	}
+	t.Run("minimal interactive with home", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{HomeDir: nonexistent, CreateHome: true}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "useradd", []string{"-d", nonexistent, "-s", "/bin/bash", "-m", "deploy"}, true)
+	})
 
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
+	t.Run("system account gets nologin + -r + -M", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Create(context.Background(), "svc", CreateOptions{System: true}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "useradd", []string{"-s", "/usr/sbin/nologin", "-r", "-M", "svc"}, true)
+	})
+
+	t.Run("full options in canonical order", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		opts := CreateOptions{
+			UID: 1500, PrimaryGroup: "staff", Groups: []string{"docker", "sudo"},
+			HomeDir: nonexistent, Comment: "Service Acct", System: true, CreateHome: false,
+		}
+		if err := mgr(t, f).Create(context.Background(), "svc", opts); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "useradd", []string{
+			"-u", "1500", "-g", "staff", "-G", "docker,sudo", "-d", nonexistent,
+			"-s", "/usr/sbin/nologin", "-r", "-M", "-c", "Service Acct", "svc",
+		}, true)
+	})
+
+	t.Run("explicit shell overrides the default", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Create(context.Background(), "ops", CreateOptions{Shell: "/bin/zsh"}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "useradd", []string{"-s", "/bin/zsh", "-M", "ops"}, true)
+	})
+}
+
+// Create over a PRE-EXISTING home uses -M (useradd -m would fail) and fixes
+// ownership afterwards — exercised via the fs seam so the test stays hermetic.
+func TestCreate_ExistingHomeUsesMinusMAndChowns(t *testing.T) {
+	existing := t.TempDir() // exists
+	f := exectest.New(exec.Direct)
+
+	var chown struct {
+		path, owner, group string
+		called             bool
 	}
-	if info.Shell != "/usr/sbin/nologin" {
-		t.Errorf("expected nologin shell, got %s", info.Shell)
+	restore := setOwnershipRecursive
+	setOwnershipRecursive = func(ctx context.Context, path, owner, group string) (*exec.Result, error) {
+		chown.path, chown.owner, chown.group, chown.called = path, owner, group, true
+		return &exec.Result{}, nil
 	}
-	// System users typically have UID < 1000
-	if info.UID >= 1000 {
-		t.Errorf("expected system UID < 1000, got %d", info.UID)
+	defer func() { setOwnershipRecursive = restore }()
+
+	if err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{HomeDir: existing, CreateHome: true, PrimaryGroup: "staff"}); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f, "useradd", []string{"-g", "staff", "-d", existing, "-s", "/bin/bash", "-M", "deploy"}, true)
+	if !chown.called {
+		t.Fatal("ownership of the pre-existing home was not fixed")
+	}
+	if chown.path != existing || chown.owner != "deploy" || chown.group != "staff" {
+		t.Errorf("chown(%q,%q,%q), want (%q,deploy,staff)", chown.path, chown.owner, chown.group, existing)
 	}
 }
 
-func TestGet(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("gt")
-	defer cleanupUser(t, name)
+func TestCreate_ChownDefaultsGroupToUsername(t *testing.T) {
+	existing := t.TempDir()
+	f := exectest.New(exec.Direct)
+	var gotGroup string
+	restore := setOwnershipRecursive
+	setOwnershipRecursive = func(ctx context.Context, path, owner, group string) (*exec.Result, error) {
+		gotGroup = group
+		return &exec.Result{}, nil
+	}
+	defer func() { setOwnershipRecursive = restore }()
 
-	if _, err := user.Create(ctx, name, "-m", "-s", "/bin/bash", "-c", "Test User"); err != nil {
-		t.Fatalf("Create failed: %v", err)
+	if err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{HomeDir: existing, CreateHome: true}); err != nil {
+		t.Fatal(err)
 	}
-
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	if info.UID == 0 {
-		t.Error("expected non-zero UID")
-	}
-	if info.Comment != "Test User" {
-		t.Errorf("expected comment 'Test User', got %q", info.Comment)
-	}
-	if info.HomeDir == "" {
-		t.Error("expected non-empty home directory")
-	}
-	if info.Shell != "/bin/bash" {
-		t.Errorf("expected /bin/bash, got %s", info.Shell)
+	if gotGroup != "deploy" {
+		t.Errorf("chown group = %q, want the username (useradd matching-group default)", gotGroup)
 	}
 }
 
-func TestGetNonexistent(t *testing.T) {
-	_, err := user.Get("pm-nonexistent-user-12345")
-	if err == nil {
-		t.Fatal("expected error for non-existent user")
+func TestCreate_RejectsInvalidNameBeforeRunner(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).Create(context.Background(), "-rf", CreateOptions{}); err == nil {
+		t.Error("Create with a flag-shaped name returned nil error")
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("runner was called for an invalid name: %+v", f.Calls())
 	}
 }
 
-func TestExists(t *testing.T) {
-	if !user.Exists("root") {
-		t.Error("root user should exist")
+func TestCreate_MapsNonZeroExitToCommandError(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 9, Stderr: "useradd: user 'deploy' already exists"}, nil)
+	err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{})
+	var ce *exec.CommandError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err = %v, want *exec.CommandError", err)
 	}
-	if user.Exists("pm-nonexistent-user-12345") {
-		t.Error("non-existent user should not exist")
+	if ce.ExitCode != 9 || !strings.Contains(ce.Stderr, "already exists") {
+		t.Errorf("CommandError = %+v, want exit 9 + stderr", ce)
 	}
 }
 
 func TestModify(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("mod")
-	defer cleanupUser(t, name)
-
-	createTestUser(t, name)
-
-	_, err := user.Modify(ctx, name, "-s", "/bin/sh")
-	if err != nil {
-		t.Fatalf("Modify failed: %v", err)
-	}
-
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	if info.Shell != "/bin/sh" {
-		t.Errorf("expected /bin/sh after modify, got %s", info.Shell)
-	}
+	t.Run("golden each field", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		opts := ModifyOptions{Shell: "/bin/zsh", HomeDir: "/srv/deploy", Comment: "Deploy Service", PrimaryGroup: "staff"}
+		if err := mgr(t, f).Modify(context.Background(), "deploy", opts); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "usermod", []string{"-s", "/bin/zsh", "-d", "/srv/deploy", "-c", "Deploy Service", "-g", "staff", "deploy"}, true)
+	})
+	t.Run("empty options is a no-op (no usermod)", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Modify(context.Background(), "deploy", ModifyOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Modify ran a command: %+v", f.Calls())
+		}
+	})
 }
 
 func TestDelete(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("del")
-
-	createTestUser(t, name)
-
-	_, err := user.Delete(ctx, name, false)
-	if err != nil {
-		t.Fatalf("Delete failed: %v", err)
-	}
-
-	if user.Exists(name) {
-		t.Error("user should not exist after deletion")
-	}
-}
-
-func TestDeleteWithHome(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("dlh")
-
-	createTestUser(t, name)
-
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	homeDir := info.HomeDir
-
-	_, err = user.Delete(ctx, name, true)
-	if err != nil {
-		t.Fatalf("Delete with home failed: %v", err)
-	}
-
-	if user.Exists(name) {
-		t.Error("user should not exist after deletion")
-	}
-	if fs.FileExists(ctx, homeDir) {
-		t.Error("home directory should be removed")
-	}
-}
-
-func TestDeleteNonexistent(t *testing.T) {
-	ctx := context.Background()
-	result, err := user.Delete(ctx, "pm-nonexistent-user-12345", false)
-	if err == nil {
-		t.Fatal("expected error deleting non-existent user")
-	}
-	// The whole point of returning *exec.Result is that callers can
-	// surface the underlying tool's stderr. Verify the contract holds
-	// on a deterministic failure path.
-	if result == nil {
-		t.Fatal("expected non-nil *exec.Result on failure")
-	}
-	if result.ExitCode == 0 {
-		t.Errorf("expected non-zero exit code on failure, got %d", result.ExitCode)
-	}
-	if result.Stderr == "" {
-		t.Errorf("expected stderr to be populated on failure, got empty (exit=%d)", result.ExitCode)
-	}
+	t.Run("with home", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Delete(context.Background(), "deploy", DeleteOptions{RemoveHome: true}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "userdel", []string{"-r", "deploy"}, true)
+	})
+	t.Run("without home", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Delete(context.Background(), "deploy", DeleteOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		wantOneCmd(t, f, "userdel", []string{"deploy"}, true)
+	})
 }
 
 func TestLockUnlock(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("lck")
-	defer cleanupUser(t, name)
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).Lock(context.Background(), "deploy"); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f, "usermod", []string{"-L", "deploy"}, true)
 
-	createTestUser(t, name)
+	f2 := exectest.New(exec.Direct)
+	if err := mgr(t, f2).Unlock(context.Background(), "deploy"); err != nil {
+		t.Fatal(err)
+	}
+	wantOneCmd(t, f2, "usermod", []string{"-U", "deploy"}, true)
+}
 
-	// Set a password first so lock is meaningful
-	if _, err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
-		t.Fatalf("SetPassword failed: %v", err)
+func TestGet(t *testing.T) {
+	t.Run("parses passwd + groups + unlocked shadow", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "deploy:x:1000:1000:Deploy User:/home/deploy:/bin/bash\n"}, nil) // getent passwd
+		f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)                                        // getent group 1000
+		f.Push(exec.Result{Stdout: "deploy docker sudo\n"}, nil)                                    // id -Gn
+		f.Push(exec.Result{Stdout: "deploy:$6$abc:19000:0:99999:7:::\n"}, nil)                      // getent shadow
+
+		info, err := mgr(t, f).Get(context.Background(), "deploy")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.UID != 1000 || info.GID != 1000 || info.Comment != "Deploy User" || info.HomeDir != "/home/deploy" || info.Shell != "/bin/bash" {
+			t.Errorf("Info = %+v", info)
+		}
+		if strings.Join(info.Groups, ",") != "docker,sudo" {
+			t.Errorf("Groups = %v, want [docker sudo] (primary filtered)", info.Groups)
+		}
+		if info.Locked {
+			t.Error("Locked = true, want false for a hashed shadow entry")
+		}
+		// The shadow read must be escalated.
+		if c := f.Calls()[3]; c.Name != "getent" || !c.Escalate {
+			t.Errorf("shadow read = %+v, want escalated getent", c)
+		}
+	})
+
+	t.Run("detects locked account", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "deploy:x:1000:1000::/home/deploy:/bin/bash\n"}, nil)
+		f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)
+		f.Push(exec.Result{Stdout: "deploy\n"}, nil)
+		f.Push(exec.Result{Stdout: "deploy:!$6$abc:19000:0:99999:7:::\n"}, nil)
+		info, err := mgr(t, f).Get(context.Background(), "deploy")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !info.Locked {
+			t.Error("Locked = false, want true for a '!'-prefixed shadow entry")
+		}
+	})
+
+	t.Run("malformed passwd entry errors", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "deploy:x:1000\n"}, nil)
+		if _, err := mgr(t, f).Get(context.Background(), "deploy"); err == nil {
+			t.Error("Get with a malformed passwd entry returned nil error")
+		}
+	})
+}
+
+func TestExists(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 0}, nil)
+		ok, err := mgr(t, f).Exists(context.Background(), "deploy")
+		if err != nil || !ok {
+			t.Errorf("Exists = (%v,%v), want (true,nil)", ok, err)
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 1}, nil)
+		ok, _ := mgr(t, f).Exists(context.Background(), "ghost")
+		if ok {
+			t.Error("Exists = true for an absent user")
+		}
+	})
+	t.Run("invalid name short-circuits without running id", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		ok, err := mgr(t, f).Exists(context.Background(), "-rf")
+		if ok || err != nil {
+			t.Errorf("Exists(-rf) = (%v,%v), want (false,nil)", ok, err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Error("ran id for an invalid name")
+		}
+	})
+}
+
+func TestPrimaryAndSupplementaryGroups(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "staff\n"}, nil)
+	pg, err := mgr(t, f).PrimaryGroup(context.Background(), "deploy")
+	if err != nil || pg != "staff" {
+		t.Errorf("PrimaryGroup = (%q,%v), want (staff,nil)", pg, err)
 	}
 
-	// Lock
-	if _, err := user.Lock(ctx, name); err != nil {
-		t.Fatalf("Lock failed: %v", err)
-	}
-	info, err := user.Get(name)
+	f2 := exectest.New(exec.Direct)
+	f2.Push(exec.Result{Stdout: "staff docker sudo\n"}, nil) // id -Gn
+	f2.Push(exec.Result{Stdout: "staff\n"}, nil)             // id -gn (primary)
+	sg, err := mgr(t, f2).SupplementaryGroups(context.Background(), "deploy")
 	if err != nil {
-		t.Fatalf("Get failed: %v", err)
+		t.Fatal(err)
 	}
-	if !info.Locked {
-		t.Error("user should be locked")
-	}
-
-	// Unlock
-	if _, err := user.Unlock(ctx, name); err != nil {
-		t.Fatalf("Unlock failed: %v", err)
-	}
-	info, err = user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	if info.Locked {
-		t.Error("user should be unlocked")
+	if strings.Join(sg, ",") != "docker,sudo" {
+		t.Errorf("SupplementaryGroups = %v, want [docker sudo] (primary filtered)", sg)
 	}
 }
 
-func TestSetPassword(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("pwd")
-	defer cleanupUser(t, name)
-
-	createTestUser(t, name)
-
-	_, err := user.SetPassword(ctx, name, "TestPass123!")
-	if err != nil {
-		t.Fatalf("SetPassword failed: %v", err)
+// TestEveryMethodRejectsUnsafeNameBeforeRunner is the self-discovering security
+// guard: for EVERY Manager method, a flag-shaped name ("-rf") must never reach
+// the Runner as a command argument. Discovered by reflection over the interface,
+// so a newly-added method is covered automatically.
+func TestEveryMethodRejectsUnsafeNameBeforeRunner(t *testing.T) {
+	const unsafe = "-rf"
+	mt := reflect.TypeOf((*Manager)(nil)).Elem()
+	if mt.NumMethod() == 0 {
+		t.Fatal("matches-zero guard: Manager has no methods — reflection is mis-scoped")
 	}
+	secretType := reflect.TypeOf(exec.Secret{})
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	checked := 0
 
-	// Verify the user is no longer locked (has a valid password)
-	info, err := user.Get(name)
-	if err != nil {
-		t.Fatalf("Get failed: %v", err)
-	}
-	if info.Locked {
-		t.Error("user should not be locked after setting password")
-	}
-}
+	// safe is a valid name/group placed in every OTHER string position, so each
+	// string parameter is tested for validation INDIVIDUALLY — a method that
+	// validates only one of several string params is still caught.
+	const safe = "deploy"
 
-func TestExpirePassword(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("exp")
-	defer cleanupUser(t, name)
+	for i := 0; i < mt.NumMethod(); i++ {
+		name := mt.Method(i).Name
+		ft := reflect.ValueOf(mgr(t, exectest.New(exec.Direct))).MethodByName(name).Type()
 
-	createTestUser(t, name)
-	if _, err := user.SetPassword(ctx, name, "TestPass123!"); err != nil {
-		t.Fatalf("SetPassword failed: %v", err)
-	}
+		var stringParams []int
+		for p := 0; p < ft.NumIn(); p++ {
+			if ft.In(p).Kind() == reflect.String {
+				stringParams = append(stringParams, p)
+			}
+		}
+		if len(stringParams) == 0 {
+			continue
+		}
 
-	_, err := user.ExpirePassword(ctx, name)
-	if err != nil {
-		t.Fatalf("ExpirePassword failed: %v", err)
-	}
-
-	// Verify the password is expired by checking chage output
-	out, err := exec.Query("sudo", "-n", "chage", "-l", name)
-	if err != nil {
-		t.Logf("chage -l failed (may need sudo): %v", err)
-		return
-	}
-	// "Last password change" should show "password must be changed"
-	_ = out // Just verifying no error
-}
-
-func TestPrimaryGroup(t *testing.T) {
-	name := testUsername("pg")
-	defer cleanupUser(t, name)
-
-	createTestUser(t, name)
-
-	group, err := user.PrimaryGroup(name)
-	if err != nil {
-		t.Fatalf("PrimaryGroup failed: %v", err)
-	}
-	if group == "" {
-		t.Error("expected non-empty primary group")
-	}
-	// Primary group typically matches username
-	if group != name {
-		t.Logf("primary group %q differs from username %q (may be expected)", group, name)
-	}
-}
-
-func TestSupplementaryGroups(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("sg")
-	groupName := testUsername("sgg")
-	defer cleanupUser(t, name)
-	defer func() { exec.Privileged(ctx, "groupdel", groupName) }()
-
-	createTestUser(t, name)
-
-	// Create a test group and add user to it
-	if _, err := user.GroupCreate(ctx, groupName); err != nil {
-		t.Fatalf("GroupCreate failed: %v", err)
-	}
-	if _, err := user.GroupAddUser(ctx, name, groupName); err != nil {
-		t.Fatalf("GroupAddUser failed: %v", err)
-	}
-
-	groups, err := user.SupplementaryGroups(name)
-	if err != nil {
-		t.Fatalf("SupplementaryGroups failed: %v", err)
-	}
-
-	found := false
-	for _, g := range groups {
-		if g == groupName {
-			found = true
-			break
+		// One sub-case per string parameter: only that param is unsafe, the
+		// rest are valid. Catches a method that validates one string but not another.
+		for _, target := range stringParams {
+			f := exectest.New(exec.Direct)
+			fn := reflect.ValueOf(mgr(t, f)).MethodByName(name)
+			args := make([]reflect.Value, ft.NumIn())
+			for p := 0; p < ft.NumIn(); p++ {
+				pt := ft.In(p)
+				switch {
+				case pt == ctxType:
+					args[p] = reflect.ValueOf(context.Background())
+				case pt.Kind() == reflect.String:
+					if p == target {
+						args[p] = reflect.ValueOf(unsafe)
+					} else {
+						args[p] = reflect.ValueOf(safe)
+					}
+				case pt == secretType:
+					args[p] = reflect.ValueOf(exec.Secret{})
+				default:
+					args[p] = reflect.Zero(pt)
+				}
+			}
+			fn.Call(args)
+			if n := len(f.Calls()); n != 0 {
+				t.Errorf("%s ran %d command(s) when only string param #%d was unsafe (%q) — every string param must be validated before the Runner", name, n, target, unsafe)
+			}
+			checked++
 		}
 	}
-	if !found {
-		t.Errorf("expected %q in supplementary groups, got %v", groupName, groups)
-	}
-
-	// Primary group should NOT be in supplementary list
-	primary, _ := user.PrimaryGroup(name)
-	for _, g := range groups {
-		if g == primary {
-			t.Errorf("primary group %q should not be in supplementary list", primary)
-		}
-	}
-}
-
-func TestChownRecursive(t *testing.T) {
-	ctx := context.Background()
-	name := testUsername("co")
-	defer cleanupUser(t, name)
-
-	createTestUser(t, name)
-
-	dir := fmt.Sprintf("/tmp/pm-chown-test-%d", os.Getpid())
-	defer func() { exec.Privileged(ctx, "rm", "-rf", dir) }()
-
-	if err := fs.Mkdir(ctx, dir+"/sub", true); err != nil {
-		t.Fatalf("Mkdir failed: %v", err)
-	}
-	if err := fs.WriteFile(ctx, dir+"/sub/file.txt", "test"); err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-
-	if _, err := user.ChownRecursive(ctx, dir, name, name); err != nil {
-		t.Fatalf("ChownRecursive failed: %v", err)
-	}
-
-	// Verify ownership of the file
-	owner, group := fs.GetOwnership(dir + "/sub/file.txt")
-	if owner != name {
-		t.Errorf("expected owner %q, got %q", name, owner)
-	}
-	if group != name {
-		t.Errorf("expected group %q, got %q", name, group)
-	}
-
-	// No-op path: empty owner and group should return (nil, nil) so
-	// callers can distinguish skipped from succeeded.
-	res, err := user.ChownRecursive(ctx, dir, "", "")
-	if err != nil {
-		t.Fatalf("ChownRecursive no-op returned error: %v", err)
-	}
-	if res != nil {
-		t.Errorf("expected nil *exec.Result on no-op, got %+v", res)
-	}
-}
-
-func TestIsValidName(t *testing.T) {
-	valid := []string{"root", "test-user", "user_name", "a", "abc123", "a-b-c"}
-	for _, name := range valid {
-		if !user.IsValidName(name) {
-			t.Errorf("expected %q to be valid", name)
-		}
-	}
-
-	invalid := []string{
-		"",
-		"1starts-with-digit",
-		"-starts-with-dash",
-		"_starts-with-underscore",
-		"UPPERCASE",
-		"has spaces",
-		"has.dots",
-		"has@symbol",
-		"abcdefghijklmnopqrstuvwxyz1234567", // 33 chars, too long
-	}
-	for _, name := range invalid {
-		if user.IsValidName(name) {
-			t.Errorf("expected %q to be invalid", name)
-		}
+	if checked == 0 {
+		t.Fatal("matches-zero guard: no name-taking methods were exercised")
 	}
 }

--- a/go/sys/user/validate_test.go
+++ b/go/sys/user/validate_test.go
@@ -1,101 +1,49 @@
 package user
 
 import (
-	"context"
 	"strings"
 	"testing"
 )
 
-// TestPrivilegedFunctions_RejectMaliciousUsername covers the
-// flag-injection + chpasswd-newline-injection vectors for every
-// privileged helper that takes a username. Each call should fail
-// validation and therefore never reach exec.Privileged; we can
-// assert that by using a cancelled context — if validation doesn't
-// short-circuit first, the call would observe ctx.Err() instead
-// of our "invalid username" error.
-func TestPrivilegedFunctions_RejectMaliciousUsername(t *testing.T) {
-	badNames := []string{
-		"-o",          // would become a useradd flag
-		"--help",      // systemctl/groupadd flag
-		"",            // empty
-		"RootUser",    // uppercase — violates convention
-		"alice\nroot", // newline — chpasswd stdin injection
-		"alice:root",  // colon — chpasswd field separator
-		"user with spaces",
-		"alice/..", // path traversal characters
+func TestIsValidName(t *testing.T) {
+	// The length fencepost both ways: exactly 32 is valid, 33 is not.
+	max32 := "a" + strings.Repeat("b", 31) // 32 chars
+	if !IsValidName(max32) {
+		t.Errorf("IsValidName(32-char) = false, want true (exact max boundary)")
+	}
+	if IsValidName(max32 + "c") {
+		t.Errorf("IsValidName(33-char) = true, want false (one over max)")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	for _, name := range badNames {
-		t.Run(name, func(t *testing.T) {
-			if _, err := Create(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("Create(%q): want validation error, got %v", name, err)
-			}
-			if _, err := Modify(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("Modify(%q): want validation error, got %v", name, err)
-			}
-			if _, err := Delete(ctx, name, false); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("Delete(%q): want validation error, got %v", name, err)
-			}
-			if _, err := Lock(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("Lock(%q): want validation error, got %v", name, err)
-			}
-			if _, err := Unlock(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("Unlock(%q): want validation error, got %v", name, err)
-			}
-			if _, err := SetPassword(ctx, name, "TestPass123!"); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("SetPassword(%q): want validation error, got %v", name, err)
-			}
-			if _, err := ExpirePassword(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid username") {
-				t.Errorf("ExpirePassword(%q): want validation error, got %v", name, err)
-			}
-
-			if _, err := GroupCreate(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid group name") {
-				t.Errorf("GroupCreate(%q): want group-name validation error, got %v", name, err)
-			}
-			if _, err := GroupDelete(ctx, name); err == nil || !strings.Contains(err.Error(), "invalid group name") {
-				t.Errorf("GroupDelete(%q): want group-name validation error, got %v", name, err)
-			}
-		})
+	valid := []string{"deploy", "a", "user_1", "svc-acct", max32}
+	for _, n := range valid {
+		if !IsValidName(n) {
+			t.Errorf("IsValidName(%q) = false, want true", n)
+		}
 	}
-}
-
-func TestSetPassword_RejectsNewlineInPassword(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Valid username, crafted password — must be rejected by the
-	// password check, not slip through to chpasswd stdin.
-	badPasswords := []string{
-		"pass\nroot:attackerpass",
-		"pass\r\nroot:attackerpass",
-		"\npayload",
+	invalid := []string{
+		"",                                  // empty
+		"Deploy",                            // uppercase start
+		"1user",                             // digit start
+		"-rf",                               // flag-shaped (leading dash)
+		"_priv",                             // underscore start
+		"user name",                         // space
+		"user:x",                            // colon (chpasswd record separator)
+		"user\nroot",                        // newline (record injection)
+		"a2345678901234567890123456789012x", // > 32 chars
 	}
-	for _, pw := range badPasswords {
-		if _, err := SetPassword(ctx, "alice", pw); err == nil || !strings.Contains(err.Error(), "invalid password") {
-			t.Errorf("SetPassword(valid, %q): want invalid-password error, got %v", pw, err)
+	for _, n := range invalid {
+		if IsValidName(n) {
+			t.Errorf("IsValidName(%q) = true, want false", n)
 		}
 	}
 }
 
-func TestGroupMembership_RejectsMaliciousNames(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Either argument being malicious must cause rejection before
-	// exec.Privileged is called.
-	if _, err := GroupAddUser(ctx, "-o", "wheel"); err == nil || !strings.Contains(err.Error(), "invalid username") {
-		t.Errorf("GroupAddUser(bad user): got %v", err)
+func TestDefaultShell(t *testing.T) {
+	if got := DefaultShell(false); got != "/bin/bash" {
+		t.Errorf("DefaultShell(false) = %q, want /bin/bash", got)
 	}
-	if _, err := GroupAddUser(ctx, "alice", "-o"); err == nil || !strings.Contains(err.Error(), "invalid group name") {
-		t.Errorf("GroupAddUser(bad group): got %v", err)
-	}
-	if _, err := GroupRemoveUser(ctx, "-o", "wheel"); err == nil || !strings.Contains(err.Error(), "invalid username") {
-		t.Errorf("GroupRemoveUser(bad user): got %v", err)
-	}
-	if _, err := GroupRemoveUser(ctx, "alice", "-o"); err == nil || !strings.Contains(err.Error(), "invalid group name") {
-		t.Errorf("GroupRemoveUser(bad group): got %v", err)
+	if got := DefaultShell(true); got != "/usr/sbin/nologin" {
+		t.Errorf("DefaultShell(true) = %q, want /usr/sbin/nologin", got)
 	}
 }


### PR DESCRIPTION
SDK rework PR 2 (contracts §2; design §5 step 3 — `user` is first in dependency order). Builds on the merged exec Runner foundation (#124/#125). Closes #126.

Rewrites `sys/user` from the thin `args ...string` passthrough into an idiomatic `Manager`:

- **`New(ShadowUtils, runner)`** — explicit backend + injected `exec.Runner`; fail-closed on an unknown backend / nil runner. Every op runs through the Runner (reads unescalated; writes + the shadow read escalated) → unit-testable with `exectest.FakeRunner`, no host/sudo/container.
- **Options structs** (`CreateOptions`/`ModifyOptions`/`DeleteOptions`/`GroupCreateOptions`); passwords are `exec.Secret` (chpasswd via **stdin**, never argv).
- The **default-shell policy** and the `useradd -m/-M` "home already exists" + chown dance move INTO `Create`. `Create` no longer auto-creates the primary group (a surprising library side effect) — callers use `GroupEnsure` explicitly.
- Group/password/session/accountsservice ops fold onto the `Manager`. Pure helpers: `IsValidName`, `DefaultShell`, `GeneratePassword(Complexity)`, `MembersMatch`.
- Preserved hardening: `validateName` on every mutation, chpasswd newline rejection via `Secret`, bounded query timeouts. Thin passthrough + `ChownRecursive` alias deleted (clean break).

## Testing — 100% statement coverage
- Golden argv for every command (useradd/usermod/userdel/chpasswd/chage/usermod -L|-U/groupadd/...).
- FakeRunner unit tests in the correct / absent / present-but-wrong matrix + typed-error mapping.
- A **self-discovering reflection guard**: every `Manager` method rejects a flag-shaped name before the Runner.
- The **`Reveal()`-only-from-known-sinks** architecture fitness function (chpasswd stdin is its first real sink — the guard deferred from PR 1).
- A **weird-input** suite: non-numeric UID/GID (fail closed), `*`-locked shadow, CRLF/whitespace trimming, empty/all-separator group members, colon-bearing passwords, exact length bounds, RNG-failure path (seam).
- Real-system integration tests (user + group) ported to the Manager API.

Two latent bugs were fixed in passing (both caught while writing weird-case tests / by CodeRabbit): `Get` silently parsing a non-numeric UID as 0 (=root), and `SupplementaryGroups` returning the primary group when the primary lookup failed (now fails closed, honoring its "excluding the primary" contract).

**Agent migration is deferred to its own PR** — the agent validates the surface; if an abstraction is awkward there, the SDK gets reworked then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Manager` interface for user and group operations with structured options.
  * Password generation now supports complexity levels and returns encrypted secrets to prevent accidental exposure.
  * Password management operations include set and expire functionality.

* **Refactor**
  * Migrated user/group management from package-level functions to a backend-driven `Manager` pattern.
  * Improved password handling security by using secrets instead of plain strings.

* **Tests**
  * Added comprehensive unit tests for user/group lifecycle, password operations, and error scenarios.
  * Added integration tests validating end-to-end user management against system commands.
  * Added architecture-level test enforcing secret reveal patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->