### PR TITLE
test(exec): close Runner-foundation coverage gaps to 100%

### DIFF
--- a/go/sys/exec/escalation_test.go
+++ b/go/sys/exec/escalation_test.go
@@ -1,0 +1,119 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeExecScript writes an executable shell script and returns its path.
+func writeExecScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+// When escalation is requested but the wrapper tool is not on PATH, the Runner
+// fails closed with ErrEscalationUnavailable rather than running unescalated.
+// A temp-dir PATH containing the payload but NOT sudo makes this deterministic.
+func TestRunner_EscalationUnavailableWhenToolMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeExecScript(t, dir, "payload", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir) // sudo is intentionally absent here
+
+	r, err := NewRunner(Sudo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), Command{Name: "payload", Escalate: true}); !errors.Is(err, ErrEscalationUnavailable) {
+		t.Errorf("err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+// When the wrapper runs but refuses (a `sudo -n` that would need a password),
+// the Runner surfaces ErrEscalationDenied — distinct from the command's own
+// non-zero exit. Exercised end-to-end with a fake `sudo` on PATH that emits the
+// real diagnostic and exits 1.
+func TestRunner_EscalationDeniedFromWrapper(t *testing.T) {
+	dir := t.TempDir()
+	writeExecScript(t, dir, "sudo", "#!/bin/sh\necho 'sudo: a password is required' >&2\nexit 1\n")
+	writeExecScript(t, dir, "payload", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir)
+
+	r, err := NewRunner(Sudo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run(context.Background(), Command{Name: "payload", Escalate: true}); !errors.Is(err, ErrEscalationDenied) {
+		t.Errorf("err = %v, want ErrEscalationDenied", err)
+	}
+}
+
+// A successful escalated run through a fake `sudo` (exit 0) returns no error and
+// reports the wrapped command's exit code — the happy escalation path.
+func TestRunner_EscalatedRunSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	// Fake sudo execs its remaining args ("-n <abs payload> …" → drops -n).
+	writeExecScript(t, dir, "sudo", "#!/bin/sh\nshift\nexec \"$@\"\n")
+	writeExecScript(t, dir, "payload", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir)
+
+	r, err := NewRunner(Sudo)
+	if err != nil {
+		t.Fatalf("NewRunner err = %v, want nil", err)
+	}
+	res, err := r.Run(context.Background(), Command{Name: "payload", Escalate: true})
+	if err != nil {
+		t.Fatalf("escalated run err = %v, want nil", err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", res.ExitCode)
+	}
+}
+
+// Detect lists exactly the escalation tools present on PATH — covered with fake
+// sudo + doas so both branches run deterministically (a real host may lack doas).
+func TestDetect_ListsFakeToolsOnPath(t *testing.T) {
+	dir := t.TempDir()
+	writeExecScript(t, dir, "sudo", "#!/bin/sh\n")
+	writeExecScript(t, dir, "doas", "#!/bin/sh\n")
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background())
+	var hasSudo, hasDoas bool
+	for _, b := range got {
+		switch b {
+		case Sudo:
+			hasSudo = true
+		case Doas:
+			hasDoas = true
+		default:
+			t.Errorf("Detect returned unexpected backend %d", b)
+		}
+	}
+	if !hasSudo || !hasDoas {
+		t.Errorf("Detect = %v, want both Sudo and Doas", got)
+	}
+}
+
+// Detect returns an empty slice when neither tool is on PATH (a root-only host
+// that will use Direct).
+func TestDetect_EmptyWhenNoToolsOnPath(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir
+	if got := Detect(context.Background()); len(got) != 0 {
+		t.Errorf("Detect = %v, want empty on a host with no sudo/doas", got)
+	}
+}
+
+// CommandError.Error formats without a stderr suffix when stderr is empty.
+func TestCommandError_ErrorWithoutStderr(t *testing.T) {
+	ce := &CommandError{Name: "userdel", ExitCode: 1}
+	if got, want := ce.Error(), "userdel: exit 1"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/go/sys/exec/exectest/stream_test.go
+++ b/go/sys/exec/exectest/stream_test.go
@@ -1,0 +1,55 @@
+package exectest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// Stream with a nil callback still records the Command and returns the scripted
+// Result (no replay attempted).
+func TestFakeRunner_StreamNilCallback(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 0, Stdout: "line\n"}, nil)
+
+	res, err := f.Stream(context.Background(), exec.Command{Name: "journalctl"}, nil)
+	if err != nil {
+		t.Fatalf("Stream(nil callback) err = %v", err)
+	}
+	if res.Stdout != "line\n" {
+		t.Errorf("Stdout = %q, want the scripted result", res.Stdout)
+	}
+	if len(f.Calls()) != 1 || f.Calls()[0].Name != "journalctl" {
+		t.Errorf("Stream did not record the Command: %+v", f.Calls())
+	}
+}
+
+// Stream mirrors Run on an already-cancelled context: it returns ctx.Err(),
+// does NOT consume the scripted result, and replays nothing.
+func TestFakeRunner_StreamRespectsCancelledContext(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "must-not-replay\n"}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	replayed := 0
+	res, err := f.Stream(ctx, exec.Command{Name: "journalctl"},
+		func(exec.StreamType, string, int64) { replayed++ })
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if replayed != 0 {
+		t.Errorf("replayed %d lines on a cancelled Stream, want 0", replayed)
+	}
+	if res.Stdout != "" {
+		t.Errorf("res = %+v, want zero value (scripted result not consumed)", res)
+	}
+	// The scripted result is preserved for the next (non-cancelled) call.
+	if next, _ := f.Run(context.Background(), exec.Command{Name: "journalctl"}); next.Stdout != "must-not-replay\n" {
+		t.Errorf("scripted result was wrongly consumed by the cancelled Stream: %q", next.Stdout)
+	}
+}


### PR DESCRIPTION
Test-only backfill (no production change) bringing the exec Runner foundation (#124/#125) to 100% of its new symbols, matching the user Manager bar (#126/#127). Legacy exec.go/privileged.go/query.go/capped_buffer.go are intentionally left as-is. Closes #128.

- `runner.exec`: `ErrEscalationUnavailable` (wrapper tool missing) and the escalation-**denied** call-site (`detectEscalationDenied` on a real run), exercised end-to-end via a temp-dir PATH with fake `sudo` scripts — no seam; plus a happy escalated-run path.
- `Detect`: the doas branch + empty-on-no-tools (fake sudo/doas on PATH).
- `CommandError.Error`: the no-stderr formatting branch.
- `exectest.FakeRunner.Stream`: the nil-callback path and the cancelled-ctx short-circuit.

`runner.exec`, `Detect`, `CommandError.Error`, `FakeRunner.Run`/`Stream` now at 100%. Race + staticcheck + gofmt clean.