### PR TITLE
feat(firewall): Manager interface via New(Backend, namespace, runner); delete iptables/pf + global SetBackend (#136)

### DIFF
--- a/go/sys/firewall/coverage_test.go
+++ b/go/sys/firewall/coverage_test.go
@@ -1,0 +1,160 @@
+package firewall
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// cmd.exec must surface a transport error (err != nil from the Runner), not just
+// a non-zero exit. Driven through firewalld's zone lookup.
+func TestCmdExec_TransportError(t *testing.T) {
+	r := &recordingRunner{}
+	r.push(exec.Result{}, errors.New("connection refused"))
+	m := newMgr(t, Firewalld, "app", r)
+	if _, err := m.List(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "get-default-zone") {
+		t.Errorf("err = %v, want the transport error wrapped", err)
+	}
+}
+
+// --- firewalld RemoveRule failure branches ---
+
+func TestFirewalld_RemoveRule_RemoveServiceFails(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut("public\n")                 // zone
+	r.pushOut("app-https ssh\n")          // list-services (enabled)
+	r.push(exec.Result{ExitCode: 1}, nil) // remove-service fails
+	m := newMgr(t, Firewalld, "app", r)
+	if err := m.RemoveRule(context.Background(), "https"); err == nil ||
+		!strings.Contains(err.Error(), "remove-service") {
+		t.Errorf("err = %v, want a wrapped remove-service failure", err)
+	}
+}
+
+func TestFirewalld_RemoveRule_FinalReloadFails(t *testing.T) {
+	swapFirewalldSeams(t)
+	removeStrict = func(context.Context, string) error { return nil }
+	r := &recordingRunner{}
+	r.pushOut("public\n")                 // zone
+	r.pushOut("app-https ssh\n")          // list-services (enabled)
+	r.pushOut("")                         // remove-service
+	r.push(exec.Result{ExitCode: 1}, nil) // final reload fails
+	m := newMgr(t, Firewalld, "app", r)
+	if err := m.RemoveRule(context.Background(), "https"); err == nil ||
+		!strings.Contains(err.Error(), "--reload") {
+		t.Errorf("err = %v, want a wrapped reload failure", err)
+	}
+}
+
+// firewalldReadServiceRule must reject XML that lacks a port/protocol (e.g. a
+// file an operator hand-edited) rather than returning a half-populated rule.
+func TestFirewalldReadServiceRule_MalformedSkipped(t *testing.T) {
+	swapFirewalldSeams(t)
+	readFile = func(string) ([]byte, error) {
+		return []byte(`<?xml version="1.0"?><service><short>app-x</short></service>`), nil
+	}
+	if _, ok := firewalldReadServiceRule("app", "x"); ok {
+		t.Error("firewalldReadServiceRule accepted XML with no port/protocol")
+	}
+}
+
+// --- nftables helpers ---
+
+func TestNftDeleteManagedTable(t *testing.T) {
+	r := &recordingRunner{}
+	n := &nftables{base: base{ns: "app", cmd: cmd{r: r}}}
+	if err := n.nftDeleteManagedTable(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.calls[0].stdin, "delete table inet app_filter") {
+		t.Errorf("delete-table script = %q", r.calls[0].stdin)
+	}
+}
+
+func TestNftBuildApplyScriptStrict_RejectsInvalidDest(t *testing.T) {
+	_, err := nftBuildApplyScriptStrict("app", Rule{
+		ID: "x", Allow: true, Protocol: ProtocolTCP, Port: 22,
+		Source: "10.0.0.0/8", Dest: "not-an-ip",
+	}, 0)
+	if err == nil || !strings.Contains(err.Error(), "dest") {
+		t.Errorf("err = %v, want a dest address-family failure", err)
+	}
+}
+
+func TestNftParseRules_EdgeInputs(t *testing.T) {
+	if rules, err := nftParseRules(nil); err != nil || rules != nil {
+		t.Errorf("nftParseRules(nil) = (%v,%v), want (nil,nil)", rules, err)
+	}
+	if _, err := nftParseRules([]byte("not json")); err == nil {
+		t.Error("nftParseRules(garbage) returned nil error")
+	}
+}
+
+func TestNftParseRules_DropVerdict(t *testing.T) {
+	input := `{"nftables":[{"rule":{"comment":"blockit","expr":[
+		{"match":{"op":"==","left":{"payload":{"protocol":"udp","field":"dport"}},"right":53}},
+		{"drop":null}
+	]}}]}`
+	rules, err := nftParseRules(json.RawMessage(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 1 || rules[0].Allow || rules[0].Protocol != ProtocolUDP || rules[0].Port != 53 {
+		t.Errorf("rules = %+v, want a single udp/53 drop", rules)
+	}
+}
+
+func TestNftFindRuleHandle_EdgeInputs(t *testing.T) {
+	if _, ok := nftFindRuleHandle(nil, "x"); ok {
+		t.Error("nftFindRuleHandle(nil) reported found")
+	}
+	if _, ok := nftFindRuleHandle([]byte("not json"), "x"); ok {
+		t.Error("nftFindRuleHandle(garbage) reported found")
+	}
+}
+
+// --- ufw helpers ---
+
+func TestUFWBuildAddArgs_ProtoOnly(t *testing.T) {
+	// No port, no scope, concrete protocol → long form `from any to any proto`.
+	args, err := ufwBuildAddArgs("app", Rule{ID: "x", Allow: true, Protocol: ProtocolTCP})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"allow", "from", "any", "to", "any", "proto", "tcp", "comment", "app:x"}
+	assertArgsEqual(t, args, want)
+}
+
+func TestUFWFindRuleNumber_OverflowNumberSkipped(t *testing.T) {
+	// A rule index too large for int overflows strconv.Atoi → the line is skipped
+	// rather than crashing the lookup.
+	status := "[ 99999999999999999999999999999] 22/tcp                  ALLOW IN    Anywhere                   # app:ssh"
+	if _, ok := ufwFindRuleNumber(status, "app", "ssh"); ok {
+		t.Error("ufwFindRuleNumber returned a match for an unparseable index")
+	}
+}
+
+func TestUFWParseToColumn_Variants(t *testing.T) {
+	var anywhere Rule
+	ufwParseToColumn("Anywhere", &anywhere)
+	if anywhere.Port != 0 || anywhere.Protocol != "" || anywhere.Dest != "" {
+		t.Errorf("Anywhere mutated the rule: %+v", anywhere)
+	}
+
+	var barePort Rule
+	ufwParseToColumn("53", &barePort)
+	if barePort.Port != 53 {
+		t.Errorf("bare port = %d, want 53", barePort.Port)
+	}
+
+	var dest Rule
+	ufwParseToColumn("10.0.0.5", &dest)
+	if dest.Dest != "10.0.0.5" {
+		t.Errorf("dest = %q, want 10.0.0.5", dest.Dest)
+	}
+}

--- a/go/sys/firewall/doc.go
+++ b/go/sys/firewall/doc.go
@@ -1,19 +1,19 @@
 // Package firewall is a cross-backend abstraction for host packet-filter
-// management. It is a general-purpose Go library: nothing in the
-// package is specific to any one consumer. Callers construct a
-// [Manager] with a namespace of their choosing, and every subsequent
-// operation is scoped to that namespace.
+// management. It is a general-purpose Go library: nothing in the package is
+// specific to any one consumer. Callers construct a [Manager] for an explicit
+// backend, a namespace of their choosing, and an injected command [exec.Runner];
+// every subsequent operation is scoped to that namespace.
 //
 // # Manager + namespace
 //
-// Identity in this package has two parts: the Manager's namespace and
-// each Rule's ID. The namespace is set at construction
-// ([New]) and isolates one consumer's rules from every other consumer's
-// rules on the host. Two libraries linked into the same Go process,
-// each constructing their own Manager with their own namespace, will
-// not see each other's rules and cannot accidentally mutate them.
+// Identity has two parts: the Manager's namespace and each Rule's ID. The
+// namespace is set at construction ([New]) and isolates one consumer's rules
+// from every other consumer's rules on the host. Two libraries linked into the
+// same Go process, each constructing their own Manager with their own namespace,
+// will not see each other's rules and cannot accidentally mutate them.
 //
-//	mgr, err := firewall.New("myapp")
+//	r, _ := exec.NewRunner(exec.Sudo)
+//	mgr, err := firewall.New(firewall.Nftables, "myapp", r)
 //	if err != nil { ... }
 //	mgr.ApplyRule(ctx, firewall.Rule{
 //	    ID:       "allow-https",
@@ -22,98 +22,84 @@
 //	    Port:     443,
 //	})
 //
-// Rule.ID is opaque to the SDK. Pick whatever scheme fits the
-// application — a per-rule ULID, a hierarchical path, a UUID, a hash.
-// The only constraint is the safe-identifier regex
-// (`^[a-z0-9][a-z0-9_-]{0,62}$`) so the value round-trips through every
-// backend's native annotation field without per-backend escaping.
+// Rule.ID is opaque to the SDK. Pick whatever scheme fits the application — a
+// per-rule ULID, a hierarchical path, a UUID, a hash. The only constraint is the
+// safe-identifier regex (`^[a-z0-9][a-z0-9_-]{0,62}$`) so the value round-trips
+// through every backend's native annotation field without per-backend escaping.
 //
-// Multi-rule actions / batches are first-class: a single caller can
-// install N rules under one namespace just by issuing N ApplyRule
-// calls with distinct IDs. The SDK does not impose a one-action-one-
-// rule constraint.
+// Multi-rule actions / batches are first-class: a single caller can install N
+// rules under one namespace just by issuing N ApplyRule calls with distinct IDs.
 //
 // # Backends
 //
-// v1 ships three concrete backends and reserves enum slots for two more:
+// v1 ships three concrete backends. Pass the chosen one to [New]; [Detect]
+// reports which are usable on the current host (it lists, it never picks).
 //
-//   - [BackendNftables] (default) — talks to the kernel directly via
-//     nft(8). Each Manager owns a dedicated `inet <namespace>_filter`
-//     table. Use on hosts where no higher-level firewall manager is
-//     active (Debian without ufw, Arch, NixOS, minimal base installs).
+//   - [Nftables] — talks to the kernel directly via nft(8). Each Manager owns a
+//     dedicated `inet <namespace>_filter` table. Use on hosts where no
+//     higher-level firewall manager is active (Debian without ufw, Arch, NixOS,
+//     minimal base installs).
 //
-//   - [BackendFirewalld] — talks to the firewalld daemon via
-//     firewall-cmd. firewalld is the authoritative manager on
-//     RHEL/Fedora/CentOS Stream; writing raw nft rules behind its back
-//     gets blown away on the next reload. Each Rule materialises as a
-//     custom service `<namespace>-<id>.xml` in the default zone. v1
-//     scope is narrow: allow-only, concrete tcp/udp, port — no
-//     source/dest scoping.
+//   - [Firewalld] — talks to the firewalld daemon via firewall-cmd. firewalld is
+//     the authoritative manager on RHEL/Fedora/CentOS Stream; writing raw nft
+//     rules behind its back gets blown away on the next reload. Each Rule
+//     materialises as a custom service `<namespace>-<id>.xml` in the default
+//     zone. v1 scope is narrow: allow-only, concrete tcp/udp, port — no
+//     source/dest scoping (an out-of-scope rule returns [ErrInvalidRule]).
 //
-//   - [BackendUFW] — talks to ufw via the ufw(8) CLI. ufw is the
-//     standard manager on Debian/Ubuntu desktops and many container
-//     hosts. Identity is the rule's native `comment` field, formatted
-//     `<namespace>:<id>`. v1 scope is broader than firewalld:
-//     allow + deny, source/dest scoping, and the long-form syntax all
-//     round-trip.
+//   - [UFW] — talks to ufw via the ufw(8) CLI. ufw is the standard manager on
+//     Debian/Ubuntu desktops and many container hosts. Identity is the rule's
+//     native `comment` field, formatted `<namespace>:<id>`. v1 scope is broader
+//     than firewalld: allow + deny, source/dest scoping, and the long-form
+//     syntax all round-trip.
 //
-//   - [BackendIptables], [BackendPF] — reserved enum values, no impl
-//     yet. ApplyRule / RemoveRule / List return
-//     [ErrBackendNotSupported].
-//
-// Backend selection is host-level — a host runs one active packet-
-// filter manager at a time — so the selector is package-level via
-// [SetBackend] / [CurrentBackend]. Namespace selection is per-Manager.
+// Backend selection is explicit per Manager (no process-global selector): the
+// caller decides — usually from [Detect] plus its own configuration — and passes
+// the value to [New]. The zero value and any unimplemented backend are rejected
+// with [ErrUnknownBackend].
 //
 // # Idempotency
 //
-// Rule.ID is the key every backend uses to find a previously installed
-// rule. [Manager.ApplyRule] with an existing ID updates the rule in
-// place (delete-then-add inside a single atomic operation where the
-// backend supports it). [Manager.RemoveRule] on a missing ID is a
-// no-op — the post-condition "this rule is absent" already holds.
+// Rule.ID is the key every backend uses to find a previously installed rule.
+// [Manager.ApplyRule] with an existing ID updates the rule in place
+// (delete-then-add inside a single atomic operation where the backend supports
+// it). [Manager.RemoveRule] on a missing ID is a no-op — the post-condition
+// "this rule is absent" already holds.
 //
-// [Manager.List] returns every rule the Manager owns. Rules outside
-// the Manager's namespace — system-installed defaults, rules owned by
-// a different Manager, operator-added rules — are not returned.
-// Inspecting the surface is safe: callers can iterate List output and
-// remove or update entries without worrying about clobbering something
-// they didn't install.
+// [Manager.List] returns every rule the Manager owns. Rules outside the
+// Manager's namespace — system-installed defaults, rules owned by a different
+// Manager, operator-added rules — are not returned. Inspecting the surface is
+// safe: callers can iterate List output and remove or update entries without
+// clobbering something they didn't install.
 //
 // # Error model
 //
 // Three sentinels callers branch on:
 //
-//   - [ErrBackendNotSupported] — the active backend has no impl for the
-//     requested operation. Distinct from a transient failure; callers
-//     branch on this to decide whether to skip, retry, or surface a
-//     configuration error.
+//   - [ErrUnknownBackend] — [New] was given the zero value or a backend the SDK
+//     does not implement.
 //
-//   - [ErrInvalidRule] — the Rule struct can't be expressed by the
-//     active backend (e.g. a deny rule on firewalld v1, or a port
-//     without a concrete protocol on nftables/ufw) or the ID fails
-//     validation. The wrapped error message names the offending field.
+//   - [ErrInvalidRule] — the Rule can't be expressed by the active backend (a
+//     deny rule on firewalld v1, a port without a concrete protocol on
+//     nftables/ufw) or the ID fails validation. The wrapped message names the
+//     offending field.
 //
-//   - [ErrInvalidNamespace] — the namespace passed to [New] fails
-//     validation. Returned only from [New].
+//   - [ErrInvalidNamespace] — the namespace passed to [New] fails validation.
 //
-//   - The unwrapped error returned by sys/exec.Privileged when the
-//     backend's CLI tool fails. Wrap context as needed; do not collapse
-//     these into a sentinel — the underlying exit code and stderr are
-//     the operator's debugging surface.
+// When a backend's CLI tool fails, the wrapped error carries an
+// exec.CommandError with the exit code and stderr — the operator's debugging
+// surface. Do not collapse these into a sentinel.
 //
 // # Concurrency
 //
-// [CurrentBackend] / [SetBackend] are atomic; the read path is lock-
-// free. A Manager is safe for concurrent use by multiple goroutines,
-// but the CLI tools each backend calls (nft, firewall-cmd, ufw) are
-// not themselves guaranteed reentrant, so simultaneous mutations from
-// many goroutines may serialise inside the OS.
+// A Manager is safe for concurrent use by multiple goroutines, but the CLI tools
+// each backend calls (nft, firewall-cmd, ufw) are not themselves guaranteed
+// reentrant, so simultaneous mutations from many goroutines may serialise inside
+// the OS.
 //
 // # Privilege
 //
-// Every backend's mutating calls go through
-// sdk/go/sys/exec.Privileged so the consumer's configured privilege
-// backend (sudo, doas, or direct-root) is honoured. The package never
-// shells out directly.
+// Every backend's mutating calls go through the injected exec.Runner with
+// escalation requested, so the consumer's configured privilege backend (sudo,
+// doas, or direct-root) is honoured. The package never shells out directly.
 package firewall

--- a/go/sys/firewall/firewall.go
+++ b/go/sys/firewall/firewall.go
@@ -7,53 +7,66 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	osexec "os/exec"
 	"regexp"
-	"sync/atomic"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-// Backend identifies which packet-filter framework the SDK targets.
+// Backend selects the packet-filter framework the SDK targets. Passed explicitly
+// to New; the zero value is invalid (New → ErrUnknownBackend). The
+// never-implemented iptables/pf scaffolds are not ported; a real fourth backend
+// is appended here when actually written.
 type Backend int
 
 const (
-	// BackendNftables is Linux nftables via nft(8). Default — the modern
-	// Linux firewall framework that iptables is migrating toward.
-	BackendNftables Backend = 0
-	// BackendIptables is Linux iptables (iptables-legacy or iptables-nft).
-	BackendIptables Backend = 1
-	// BackendFirewalld is the firewalld wrapper common on Red Hat family.
-	BackendFirewalld Backend = 2
-	// BackendUFW is Debian/Ubuntu's ufw wrapper.
-	BackendUFW Backend = 3
-	// BackendPF is the BSD packet filter.
-	BackendPF Backend = 4
+	// Nftables is Linux nftables via nft(8) — the modern framework iptables is
+	// migrating toward. Each Manager owns a dedicated `inet <namespace>_filter`
+	// table.
+	Nftables Backend = iota + 1
+	// Firewalld wraps firewall-cmd (Red Hat family). Each rule becomes a custom
+	// service in the default zone. v1 scope: allow-only, concrete tcp/udp, port.
+	Firewalld
+	// UFW wraps ufw(8) (Debian/Ubuntu). Identity is the native comment field.
+	UFW
 )
 
-// ErrBackendNotSupported is returned when a caller invokes an operation
-// on a backend that has no concrete implementation yet.
-var ErrBackendNotSupported = errors.New("firewall backend not supported")
+// String renders the backend as its canonical tool name.
+func (b Backend) String() string {
+	switch b {
+	case Nftables:
+		return "nftables"
+	case Firewalld:
+		return "firewalld"
+	case UFW:
+		return "ufw"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(b))
+	}
+}
 
-// ErrInvalidRule is returned by Manager methods when the Rule fails
-// backend-independent validation — most often a Rule.ID that doesn't
-// match the safe-identifier regex.
+// ErrUnknownBackend is returned by New for the zero value or any Backend the SDK
+// does not implement (fail-closed).
+var ErrUnknownBackend = errors.New("firewall: unknown backend")
+
+// ErrInvalidRule is returned by Manager methods when a Rule fails validation —
+// the backend-independent checks (ID/port/protocol/addr) or a backend-specific
+// scope limit (e.g. a deny rule on the firewalld v1 backend).
 var ErrInvalidRule = errors.New("invalid firewall rule")
 
-// ErrInvalidNamespace is returned by New when the caller-supplied
-// namespace doesn't match the safe-identifier regex.
+// ErrInvalidNamespace is returned by New when the namespace fails validation.
 var ErrInvalidNamespace = errors.New("invalid firewall namespace")
 
-// namespaceRE constrains the per-Manager namespace to a backend-safe
-// subset: lowercase letter start, then lowercase/digit/underscore. No
-// hyphens, no colons — those are reserved as separators when the
-// namespace is composed with a Rule.ID into a backend identity string
-// (e.g. nft table names disallow hyphens in some grammars; reserving
-// the separator keeps parsing unambiguous everywhere).
+// namespaceRE constrains the per-Manager namespace to a backend-safe subset:
+// lowercase letter start, then lowercase/digit/underscore. No hyphens or colons
+// — those are reserved as separators when the namespace is composed with a
+// Rule.ID into a backend identity string.
 var namespaceRE = regexp.MustCompile(`^[a-z][a-z0-9_]{0,30}$`)
 
-// ruleIDRE constrains Rule.ID to a backend-safe subset. Lowercase
-// alphanum start, then lowercase/digit/hyphen/underscore. Hyphens are
-// allowed inside an ID (callers commonly compose IDs from an
-// action-style ULID plus a suffix like "-allow-22"), but the leading
-// char excludes hyphen so a stray ID can't look like a CLI flag.
+// ruleIDRE constrains Rule.ID to a backend-safe subset. Hyphens are allowed
+// inside an ID (callers compose IDs from a ULID plus a suffix like "-allow-22"),
+// but the leading char excludes hyphen so a stray ID can't look like a CLI flag.
 var ruleIDRE = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,62}$`)
 
 func validateNamespace(ns string) error {
@@ -76,10 +89,9 @@ func validateRuleID(id string) error {
 	return nil
 }
 
-// validatePort enforces 0 ≤ port ≤ 65535. Port 0 is the "any port"
-// sentinel; any negative or out-of-range value is rejected here so
-// every backend gets the same reply (audit finding #12 called out
-// missing port-range validation as a backend-parity gap).
+// validatePort enforces 0 ≤ port ≤ 65535. Port 0 is the "any port" sentinel; any
+// negative or out-of-range value is rejected here so every backend gets the same
+// reply.
 func validatePort(port int) error {
 	if port < 0 || port > 65535 {
 		return fmt.Errorf("%w: port %d outside valid TCP/UDP range 0..65535", ErrInvalidRule, port)
@@ -87,10 +99,8 @@ func validatePort(port int) error {
 	return nil
 }
 
-// validateProtocol restricts Protocol to the SDK's three canonical
-// values. Anything else (a typo, a future protocol not yet wired)
-// is refused here so the backend dispatch only ever sees one of the
-// expected three.
+// validateProtocol restricts Protocol to the SDK's three canonical values so the
+// backend dispatch only ever sees one of the expected three.
 func validateProtocol(p Protocol) error {
 	switch p {
 	case ProtocolTCP, ProtocolUDP, ProtocolAny:
@@ -101,9 +111,9 @@ func validateProtocol(p Protocol) error {
 	}
 }
 
-// validateAddr accepts an empty string (the "any address" sentinel),
-// a bare IP literal (v4 or v6), or a CIDR. Anything else — including
-// hostnames, garbage, and shell-shape strings — is refused.
+// validateAddr accepts an empty string (the "any address" sentinel), a bare IP
+// literal (v4 or v6), or a CIDR. Anything else — hostnames, garbage,
+// shell-shape strings — is refused.
 func validateAddr(field, addr string) error {
 	if addr == "" {
 		return nil
@@ -117,15 +127,11 @@ func validateAddr(field, addr string) error {
 	return fmt.Errorf("%w: %s %q is not a valid IP address or CIDR", ErrInvalidRule, field, addr)
 }
 
-// validateRule runs every backend-independent invariant a Rule must
-// satisfy before dispatch. Called once at the top of ApplyRule so all
-// three backends inherit the same rejection contract — backend-parity
-// of inputs was the headline of audit finding #12.
-//
-// Backend-specific rejections (firewalld's "no source scopes in the v1
-// rich rule generator", nft's "port without protocol", etc.) layer on
-// top of this; they fire in the backend's own validator after this one
-// passes.
+// validateRule runs every backend-independent invariant a Rule must satisfy
+// before dispatch. Called at the top of every backend's ApplyRule so all three
+// inherit the same rejection contract. Backend-specific rejections (firewalld's
+// allow-only scope, nft's "port without protocol") layer on top in the backend's
+// own validator.
 func validateRule(rule Rule) error {
 	if err := validateRuleID(rule.ID); err != nil {
 		return err
@@ -145,50 +151,6 @@ func validateRule(rule Rule) error {
 	return nil
 }
 
-var backend atomic.Int32
-
-// SetBackend selects the active backend for every Manager in the
-// process. Call once at startup. Backend selection is host-level (a
-// single host runs at most one active packet-filter manager), so the
-// atomic process-wide variable matches the deployment reality even
-// though namespacing is per-Manager.
-//
-// Unknown values are ignored so a zero-valued Backend enum cannot
-// silently regress an explicitly-set backend.
-func SetBackend(b Backend) {
-	switch b {
-	case BackendNftables, BackendIptables, BackendFirewalld, BackendUFW, BackendPF:
-		backend.Store(int32(b))
-	}
-}
-
-// CurrentBackend returns the active backend.
-func CurrentBackend() Backend {
-	return Backend(backend.Load())
-}
-
-// String renders the backend as its canonical tool name.
-func (b Backend) String() string {
-	switch b {
-	case BackendNftables:
-		return "nftables"
-	case BackendIptables:
-		return "iptables"
-	case BackendFirewalld:
-		return "firewalld"
-	case BackendUFW:
-		return "ufw"
-	case BackendPF:
-		return "pf"
-	default:
-		return fmt.Sprintf("unknown(%d)", int(b))
-	}
-}
-
-func unsupported(op string) error {
-	return fmt.Errorf("%w: %s on backend %s", ErrBackendNotSupported, op, CurrentBackend())
-}
-
 // Protocol names a network protocol for rule matching.
 type Protocol string
 
@@ -198,124 +160,132 @@ const (
 	ProtocolAny Protocol = ""
 )
 
-// Rule describes a single allow-or-deny decision. The cross-backend
-// surface stays intentionally minimal — implementations translate it
-// into the backend's native grammar (chains + priorities for nft,
-// zones + services for firewalld, numbered rules for ufw).
+// Rule describes a single allow-or-deny decision. The cross-backend surface
+// stays intentionally minimal — implementations translate it into the backend's
+// native grammar (chains + priorities for nft, zones + services for firewalld,
+// numbered rules for ufw).
 //
-// Idempotency: ID is the key every backend uses to find a previously
-// installed rule. Manager.ApplyRule with an existing ID updates the
-// rule in place; Manager.RemoveRule on a missing ID is a no-op. ID is
-// opaque to the SDK — pick whatever scheme fits the application
-// (a ULID, a UUID, a hierarchical path, a hash). The on-host identity
-// stored by every backend is derived from the Manager's namespace plus
-// this ID, so two Managers with different namespaces will never see
-// each other's rules even if they choose the same ID.
+// Idempotency: ID is the key every backend uses to find a previously installed
+// rule. ApplyRule with an existing ID updates the rule in place; RemoveRule on a
+// missing ID is a no-op. ID is opaque to the SDK — pick whatever scheme fits
+// (a ULID, a UUID, a path, a hash). The on-host identity stored by every backend
+// is derived from the Manager's namespace plus this ID, so two Managers with
+// different namespaces never see each other's rules even with the same ID.
 //
-// ID must match `^[a-z0-9][a-z0-9_-]{0,62}$` so it round-trips through
-// nft comments, firewalld service names, and ufw comments without
-// per-backend escaping.
+// ID must match `^[a-z0-9][a-z0-9_-]{0,62}$` so it round-trips through nft
+// comments, firewalld service names, and ufw comments without per-backend
+// escaping.
 type Rule struct {
-	ID       string   // Stable, namespace-scoped identifier.
-	Allow    bool     // true = allow, false = deny.
-	Protocol Protocol // tcp / udp / "" (any).
-	Port     int      // 0 = any.
-	Source   string   // IPv4/IPv6 CIDR or address; empty = any.
-	Dest     string   // IPv4/IPv6 CIDR or address; empty = any.
+	ID       string   // stable, namespace-scoped identifier
+	Allow    bool     // true = allow, false = deny
+	Protocol Protocol // tcp / udp / "" (any)
+	Port     int      // 0 = any
+	Source   string   // IPv4/IPv6 CIDR or address; empty = any
+	Dest     string   // IPv4/IPv6 CIDR or address; empty = any
 }
 
-// Manager owns a namespaced set of firewall rules. Two Managers with
-// different namespaces are isolated: each one's List, ApplyRule, and
-// RemoveRule only see and touch rules in its own namespace. Other rules
-// on the host (system-installed, operator-added, or owned by a different
-// caller) stay invisible and untouched.
-//
-// Manager is safe for concurrent use by multiple goroutines; the
-// underlying CLI tools (nft, firewall-cmd, ufw) are themselves not
-// guaranteed reentrant, so simultaneous mutations from many goroutines
-// may serialise inside the OS.
-type Manager struct {
-	namespace string
+// Manager owns a namespaced set of firewall rules. Two Managers with different
+// namespaces are isolated: each one's List, ApplyRule, and RemoveRule only see
+// and touch rules in its own namespace. Other rules on the host (system,
+// operator-added, or owned by a different caller) stay invisible and untouched.
+type Manager interface {
+	// ApplyRule installs or updates a rule (idempotent by Rule.ID). Returns
+	// ErrInvalidRule for a rule the active backend can't express.
+	ApplyRule(ctx context.Context, rule Rule) error
+	// RemoveRule removes a rule by ID; a missing rule is a no-op.
+	RemoveRule(ctx context.Context, id string) error
+	// List returns every rule this Manager owns (namespace-scoped).
+	List(ctx context.Context) ([]Rule, error)
+	// Namespace returns the namespace this Manager was constructed with.
+	Namespace() string
 }
 
-// New constructs a Manager for the given namespace. The namespace
-// scopes List, ApplyRule, and RemoveRule, and is also used as the
-// prefix for every rule's on-host identity (e.g. nft owns a dedicated
-// table named `<namespace>_filter`; firewalld services are named
-// `<namespace>-<rule.ID>`; ufw comments are `<namespace>:<rule.ID>`).
+// Option is the functional-option type for backend-specific knobs (none today).
+type Option func(*base)
+
+// New constructs a Manager for the given backend and namespace, driven by runner.
+// Pure: it validates inputs and does not probe the host (use Detect). The zero /
+// unimplemented backend is rejected with ErrUnknownBackend, a bad namespace with
+// ErrInvalidNamespace, and a nil runner with an error.
 //
-// namespace must match `^[a-z][a-z0-9_]{0,30}$`. The 31-char cap and
-// the 63-char Rule.ID cap together leave room for the separators every
-// backend needs (the nft table-name grammar, the firewalld service-name
-// grammar, the 128-byte nft comment field).
-func New(namespace string) (*Manager, error) {
+// namespace must match `^[a-z][a-z0-9_]{0,30}$`. The 31-char cap and the 63-char
+// Rule.ID cap together leave room for the separators every backend needs.
+func New(b Backend, namespace string, runner exec.Runner, _ ...Option) (Manager, error) {
 	if err := validateNamespace(namespace); err != nil {
 		return nil, err
 	}
-	return &Manager{namespace: namespace}, nil
+	if runner == nil {
+		return nil, fmt.Errorf("firewall: runner is required")
+	}
+	base := base{ns: namespace, cmd: cmd{r: runner}}
+	switch b {
+	case Nftables:
+		return &nftables{base: base}, nil
+	case Firewalld:
+		return &firewalld{base: base}, nil
+	case UFW:
+		return &ufw{base: base}, nil
+	default:
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+}
+
+// lookPath is a package-var seam so Detect is deterministically testable.
+var lookPath = osexec.LookPath
+
+// Detect reports the firewall backends usable on THIS host: Nftables when nft is
+// on PATH, Firewalld when firewall-cmd is, UFW when ufw is. It lists; it never
+// picks and never constructs a Manager. An empty slice means no usable manager.
+//
+// The ctx is accepted for signature uniformity with the other capability Detect
+// functions; the present probe is a pure PATH lookup.
+func Detect(ctx context.Context) []Backend {
+	_ = ctx
+	var out []Backend
+	if _, err := lookPath("nft"); err == nil {
+		out = append(out, Nftables)
+	}
+	if _, err := lookPath("firewall-cmd"); err == nil {
+		out = append(out, Firewalld)
+	}
+	if _, err := lookPath("ufw"); err == nil {
+		out = append(out, UFW)
+	}
+	return out
+}
+
+// cmd carries the injected Runner and maps a non-zero exit (or a failure to
+// execute) into an error — the backends rely on "err != nil ⇒ the tool failed",
+// which the old exec.Privileged provided and the new Runner (exit in Result)
+// does not.
+type cmd struct {
+	r exec.Runner
+}
+
+func (c cmd) run(ctx context.Context, name string, args ...string) (exec.Result, error) {
+	return c.exec(ctx, exec.Command{Name: name, Args: args, Escalate: true})
+}
+
+func (c cmd) runStdin(ctx context.Context, stdin, name string, args ...string) (exec.Result, error) {
+	return c.exec(ctx, exec.Command{Name: name, Args: args, Stdin: strings.NewReader(stdin), Escalate: true})
+}
+
+func (c cmd) exec(ctx context.Context, spec exec.Command) (exec.Result, error) {
+	res, err := c.r.Run(ctx, spec)
+	if err != nil {
+		return res, err
+	}
+	if res.ExitCode != 0 {
+		return res, &exec.CommandError{Name: spec.Name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res, nil
+}
+
+// base is embedded by each backend: the namespace plus the command runner.
+type base struct {
+	ns string
+	cmd
 }
 
 // Namespace returns the namespace this Manager was constructed with.
-// Read-only; immutable for the lifetime of the Manager.
-func (m *Manager) Namespace() string { return m.namespace }
-
-// ApplyRule installs or updates a rule. Identified by Rule.ID so
-// reapplying the same rule is idempotent — backends find the previous
-// rule by ID and update it in place. Returns ErrInvalidRule for IDs
-// that fail validation and ErrBackendNotSupported when the active
-// backend has no implementation.
-func (m *Manager) ApplyRule(ctx context.Context, rule Rule) error {
-	if err := validateRule(rule); err != nil {
-		return err
-	}
-	switch CurrentBackend() {
-	case BackendNftables:
-		return applyNftables(ctx, m.namespace, rule)
-	case BackendFirewalld:
-		return applyFirewalld(ctx, m.namespace, rule)
-	case BackendUFW:
-		return applyUFW(ctx, m.namespace, rule)
-	default:
-		return unsupported("ApplyRule")
-	}
-}
-
-// RemoveRule removes a rule by ID. Missing rules are a no-op (the
-// post-condition "this rule is absent" already holds). Validates the
-// ID with the same regex as ApplyRule so a caller can't smuggle
-// backend-grammar-breaking input through the inverse path.
-func (m *Manager) RemoveRule(ctx context.Context, id string) error {
-	if err := validateRuleID(id); err != nil {
-		return err
-	}
-	switch CurrentBackend() {
-	case BackendNftables:
-		return removeNftables(ctx, m.namespace, id)
-	case BackendFirewalld:
-		return removeFirewalld(ctx, m.namespace, id)
-	case BackendUFW:
-		return removeUFW(ctx, m.namespace, id)
-	default:
-		return unsupported("RemoveRule")
-	}
-}
-
-// List returns every rule the Manager currently owns. Rules outside
-// this Manager's namespace (system-installed, owned by a different
-// Manager, operator-added) are not returned — the inspection surface
-// stays scoped to what this caller actually owns, so callers can't
-// accidentally mutate rules they didn't install.
-//
-// Order is not guaranteed across calls; sort if you need stability.
-func (m *Manager) List(ctx context.Context) ([]Rule, error) {
-	switch CurrentBackend() {
-	case BackendNftables:
-		return listNftables(ctx, m.namespace)
-	case BackendFirewalld:
-		return listFirewalld(ctx, m.namespace)
-	case BackendUFW:
-		return listUFW(ctx, m.namespace)
-	default:
-		return nil, unsupported("List")
-	}
-}
+func (b base) Namespace() string { return b.ns }

--- a/go/sys/firewall/firewall_test.go
+++ b/go/sys/firewall/firewall_test.go
@@ -3,211 +3,234 @@ package firewall
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-func TestBackend_DefaultIsNftables(t *testing.T) {
-	SetBackend(BackendNftables)
-	if got := CurrentBackend(); got != BackendNftables {
-		t.Errorf("default = %v, want %v", got, BackendNftables)
+// recordingRunner is the test exec.Runner: it records each Command (so a test can
+// assert the exact tool argv + stdin) and scripts the Run results FIFO. A default
+// result (exit 0, empty) is returned once the script is exhausted.
+type recordingRunner struct {
+	mu      sync.Mutex
+	calls   []capturedCall
+	results []scripted
+}
+
+type capturedCall struct {
+	cmd   exec.Command
+	stdin string
+}
+
+type scripted struct {
+	res exec.Result
+	err error
+}
+
+func (r *recordingRunner) push(res exec.Result, err error) {
+	r.results = append(r.results, scripted{res, err})
+}
+
+// pushOut is a convenience for the common "exit 0 with this stdout" case.
+func (r *recordingRunner) pushOut(stdout string) { r.push(exec.Result{Stdout: stdout}, nil) }
+
+func (r *recordingRunner) record(c exec.Command) (exec.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cc := capturedCall{cmd: c}
+	if c.Stdin != nil {
+		b, _ := io.ReadAll(c.Stdin)
+		cc.stdin = string(b)
+	}
+	r.calls = append(r.calls, cc)
+	if len(r.results) == 0 {
+		return exec.Result{}, nil
+	}
+	s := r.results[0]
+	r.results = r.results[1:]
+	return s.res, s.err
+}
+
+func (r *recordingRunner) Run(ctx context.Context, c exec.Command) (exec.Result, error) {
+	return r.record(c)
+}
+func (r *recordingRunner) Stream(ctx context.Context, c exec.Command, _ exec.OutputCallback) (exec.Result, error) {
+	return r.record(c)
+}
+func (r *recordingRunner) Backend() exec.PrivilegeBackend { return exec.Direct }
+
+var _ exec.Runner = (*recordingRunner)(nil)
+
+// argvOf returns the joined argv of the n-th recorded call.
+func (r *recordingRunner) argvOf(n int) string {
+	if n >= len(r.calls) {
+		return ""
+	}
+	return r.calls[n].cmd.Name + " " + strings.Join(r.calls[n].cmd.Args, " ")
+}
+
+func newMgr(t *testing.T, b Backend, ns string, r exec.Runner) Manager {
+	t.Helper()
+	m, err := New(b, ns, r)
+	if err != nil {
+		t.Fatalf("New(%d, %q): %v", b, ns, err)
+	}
+	return m
+}
+
+// --- New ---
+
+func TestNew_FailClosed(t *testing.T) {
+	r := &recordingRunner{}
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, "app", r); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+	}
+	if _, err := New(Nftables, "app", nil); err == nil {
+		t.Error("New with nil runner returned nil error")
+	}
+	for _, b := range []Backend{Nftables, Firewalld, UFW} {
+		m, err := New(b, "app", r)
+		if err != nil {
+			t.Fatalf("New(%d) err = %v, want nil", b, err)
+		}
+		if m.Namespace() != "app" {
+			t.Errorf("Namespace() = %q, want app", m.Namespace())
+		}
 	}
 }
 
-func TestBackend_IgnoresUnknown(t *testing.T) {
-	t.Cleanup(func() { SetBackend(BackendNftables) })
-	SetBackend(BackendPF)
-	SetBackend(Backend(99))
-	if got := CurrentBackend(); got != BackendPF {
-		t.Errorf("unknown value leaked through: got %v, want %v", got, BackendPF)
-	}
-}
-
-// TestNew_AcceptsValidNamespace — representative namespaces operators
-// might pick. Lowercase ASCII + digits + underscore, starts with a
-// letter, no longer than 31 chars.
 func TestNew_AcceptsValidNamespace(t *testing.T) {
-	good := []string{
-		"app",
-		"pm_firewall",
-		"a",
-		"some_app_42",
-		strings.Repeat("a", 31),
-	}
-	for _, ns := range good {
-		t.Run("ns="+truncate(ns, 16), func(t *testing.T) {
-			mgr, err := New(ns)
-			if err != nil {
-				t.Fatalf("New(%q) = %v; want nil", ns, err)
-			}
-			if mgr.Namespace() != ns {
-				t.Errorf("Namespace() = %q; want %q", mgr.Namespace(), ns)
-			}
-		})
+	r := &recordingRunner{}
+	for _, ns := range []string{"app", "pm_firewall", "a", "some_app_42", strings.Repeat("a", 31)} {
+		if _, err := New(Nftables, ns, r); err != nil {
+			t.Errorf("New(%q) = %v, want nil", ns, err)
+		}
 	}
 }
 
-// TestNew_RejectsInvalidNamespace — the namespace flows into nft table
-// names, firewalld service-name prefixes, and ufw comment prefixes.
-// Anything outside the safe regex must be refused up front so the
-// caller never gets a partially-constructed Manager that breaks later.
 func TestNew_RejectsInvalidNamespace(t *testing.T) {
+	r := &recordingRunner{}
 	bad := []string{
 		"",                      // empty
-		"-leading-hyphen",       // leading char not letter
+		"-leading-hyphen",       // leading char not a letter
 		"1leading-digit",        // leading digit
 		"UPPER",                 // uppercase
 		"has space",             // whitespace
 		"with-hyphen",           // hyphens reserved as separator
 		"with:colon",            // colons reserved as separator
-		strings.Repeat("a", 32), // 32 chars > 31 cap
+		strings.Repeat("a", 32), // 32 > 31 cap
 	}
 	for _, ns := range bad {
-		t.Run("ns="+truncate(ns, 16), func(t *testing.T) {
-			_, err := New(ns)
-			if !errors.Is(err, ErrInvalidNamespace) {
-				t.Fatalf("New(%q) = %v; want ErrInvalidNamespace", ns, err)
+		if _, err := New(Nftables, ns, r); !errors.Is(err, ErrInvalidNamespace) {
+			t.Errorf("New(%q) = %v, want ErrInvalidNamespace", ns, err)
+		}
+	}
+}
+
+// --- Detect ---
+
+func TestDetect(t *testing.T) {
+	orig := lookPath
+	defer func() { lookPath = orig }()
+
+	t.Run("all present", func(t *testing.T) {
+		lookPath = func(string) (string, error) { return "/usr/sbin/tool", nil }
+		got := Detect(context.Background())
+		want := []Backend{Nftables, Firewalld, UFW}
+		if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+			t.Errorf("Detect = %v, want %v", got, want)
+		}
+	})
+	t.Run("only ufw", func(t *testing.T) {
+		lookPath = func(name string) (string, error) {
+			if name == "ufw" {
+				return "/usr/sbin/ufw", nil
 			}
-		})
-	}
+			return "", os.ErrNotExist
+		}
+		got := Detect(context.Background())
+		if len(got) != 1 || got[0] != UFW {
+			t.Errorf("Detect = %v, want [UFW]", got)
+		}
+	})
+	t.Run("none", func(t *testing.T) {
+		lookPath = func(string) (string, error) { return "", os.ErrNotExist }
+		if got := Detect(context.Background()); len(got) != 0 {
+			t.Errorf("Detect = %v, want empty", got)
+		}
+	})
 }
 
-func TestApplyRule_ReturnsSentinel(t *testing.T) {
-	t.Cleanup(func() { SetBackend(BackendNftables) })
-	SetBackend(BackendPF) // BSD pf — no impl in v1, exercises the sentinel path
-	mgr, err := New("test")
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	err = mgr.ApplyRule(context.Background(), Rule{ID: "ssh-in", Allow: true, Protocol: ProtocolTCP, Port: 22})
-	if err == nil || !errors.Is(err, ErrBackendNotSupported) {
-		t.Errorf("want ErrBackendNotSupported, got %v", err)
-	}
-}
+// --- entry-path Rule.ID validation (backend-independent, dispatched through a
+// real backend with a recordingRunner so we prove validation precedes any exec) ---
 
-// TestList_DefaultBackendErrors — List is the inspection counterpart
-// to ApplyRule and dispatches the same way. The unimplemented-backend
-// behaviour must surface the same sentinel so callers can branch
-// uniformly.
-func TestList_DefaultBackendErrors(t *testing.T) {
-	t.Cleanup(func() { SetBackend(BackendNftables) })
-	SetBackend(BackendPF) // BSD pf — no impl yet
-	mgr, err := New("test")
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	_, err = mgr.List(context.Background())
-	if !errors.Is(err, ErrBackendNotSupported) {
-		t.Fatalf("List on unimplemented backend = %v; want ErrBackendNotSupported", err)
-	}
-}
-
-// TestApplyRule_RejectsInvalidID — Rule.ID is the idempotency key;
-// backends round-trip it through their comment fields, so anything
-// that could break the backend's grammar (whitespace, quotes, shell
-// metas, control characters) must be rejected up front. Validation is
-// backend-independent so a rule that's accepted on nftables is also
-// accepted on firewalld.
 func TestApplyRule_RejectsInvalidID(t *testing.T) {
-	mgr, err := New("test")
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
 	bad := []string{
-		"",                // empty
-		" ",               // whitespace only
-		"with space",      // embedded whitespace
-		"UPPER",           // uppercase
-		"-leading-hyphen", // leading hyphen
-		"quote\"in",       // double quote
-		"tick'in",         // single quote
-		"newline\nin",     // control char
-		"semicolon;in",    // shell-meta
-		"pipe|in",         // shell-meta
-		"backtick`in",     // shell-meta
-		"dollar$in",       // shell-meta
-		"way-too-long-" + strings.Repeat("x", 64), // over 63 chars
+		"", " ", "with space", "UPPER", "-leading-hyphen",
+		"quote\"in", "tick'in", "newline\nin", "semicolon;in", "pipe|in",
+		"backtick`in", "dollar$in", "way-too-long-" + strings.Repeat("x", 64),
 	}
-	for _, id := range bad {
-		t.Run("id="+truncate(id, 16), func(t *testing.T) {
-			err := mgr.ApplyRule(context.Background(), Rule{ID: id, Allow: true, Protocol: ProtocolTCP, Port: 22})
+	for _, b := range []Backend{Nftables, Firewalld, UFW} {
+		for _, id := range bad {
+			r := &recordingRunner{}
+			m := newMgr(t, b, "app", r)
+			err := m.ApplyRule(context.Background(), Rule{ID: id, Allow: true, Protocol: ProtocolTCP, Port: 22})
 			if !errors.Is(err, ErrInvalidRule) {
-				t.Fatalf("ApplyRule(id=%q) = %v; want ErrInvalidRule", id, err)
+				t.Errorf("backend %d ApplyRule(id=%q) = %v, want ErrInvalidRule", b, id, err)
 			}
-		})
+			if len(r.calls) != 0 {
+				t.Errorf("backend %d ran %d command(s) for an invalid ID; validation must precede exec", b, len(r.calls))
+			}
+		}
 	}
 }
 
-// TestApplyRule_AcceptsValidID — the allowed character class is
-// documented on Rule.ID; lock in a representative sample so the regex
-// doesn't get tightened by accident. Uses BackendPF so the dispatch
-// falls through to the sentinel path without trying to shell out to a
-// real firewall tool (the test verifies "id passed validation," not
-// "nft is available on this host").
 func TestApplyRule_AcceptsValidID(t *testing.T) {
-	t.Cleanup(func() { SetBackend(BackendNftables) })
-	SetBackend(BackendPF)
-	mgr, err := New("test")
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
 	good := []string{
-		"ssh-in",
-		"allow-22",
-		"web_https",
-		"a",                                   // single char ok
-		"01jxr5qxa3pn5g9b7tvyf2h4nm-allow-22", // ULID + suffix (multi-rule action)
-		"01jxr5qxa3pn5g9b7tvyf2h4nm",          // bare ULID-style ID
+		"ssh-in", "allow-22", "web_https", "a",
+		"01jxr5qxa3pn5g9b7tvyf2h4nm-allow-22", "01jxr5qxa3pn5g9b7tvyf2h4nm",
 	}
 	for _, id := range good {
-		t.Run("id="+id, func(t *testing.T) {
-			err := mgr.ApplyRule(context.Background(), Rule{ID: id, Allow: true, Protocol: ProtocolTCP, Port: 22})
-			// We're locking in "the id passed validation and reached
-			// the dispatch layer." On BackendPF the dispatch hits the
-			// default arm and returns ErrBackendNotSupported, which is
-			// fine — anything except ErrInvalidRule means the regex
-			// accepted the id.
-			if errors.Is(err, ErrInvalidRule) {
-				t.Fatalf("ApplyRule(id=%q) rejected valid id: %v", id, err)
-			}
-		})
+		r := &recordingRunner{}
+		// nft list returns exit 1 (no table) then the add succeeds.
+		r.push(exec.Result{ExitCode: 1}, nil)
+		r.pushOut("")
+		m := newMgr(t, Nftables, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: id, Allow: true, Protocol: ProtocolTCP, Port: 22}); errors.Is(err, ErrInvalidRule) {
+			t.Errorf("ApplyRule(id=%q) rejected a valid ID: %v", id, err)
+		}
 	}
 }
 
-// TestRemoveRule_RejectsInvalidID — symmetric guard on the remove path
-// so a caller can't smuggle backend-grammar-breaking input through the
-// inverse op.
 func TestRemoveRule_RejectsInvalidID(t *testing.T) {
-	mgr, err := New("test")
-	if err != nil {
-		t.Fatalf("New: %v", err)
+	for _, b := range []Backend{Nftables, Firewalld, UFW} {
+		r := &recordingRunner{}
+		m := newMgr(t, b, "app", r)
+		if err := m.RemoveRule(context.Background(), "id with space"); !errors.Is(err, ErrInvalidRule) {
+			t.Errorf("backend %d RemoveRule(invalid) = %v, want ErrInvalidRule", b, err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("backend %d ran a command for an invalid remove ID", b)
+		}
 	}
-	err = mgr.RemoveRule(context.Background(), "id with space")
-	if !errors.Is(err, ErrInvalidRule) {
-		t.Fatalf("RemoveRule(invalid) = %v; want ErrInvalidRule", err)
-	}
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "..."
 }
 
 func TestBackendString(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		b    Backend
 		want string
 	}{
-		{BackendNftables, "nftables"},
-		{BackendIptables, "iptables"},
-		{BackendFirewalld, "firewalld"},
-		{BackendUFW, "ufw"},
-		{BackendPF, "pf"},
+		{Nftables, "nftables"},
+		{Firewalld, "firewalld"},
+		{UFW, "ufw"},
 		{Backend(42), "unknown(42)"},
-	}
-	for _, tt := range tests {
+	} {
 		if got := tt.b.String(); got != tt.want {
 			t.Errorf("%d.String() = %q, want %q", tt.b, got, tt.want)
 		}

--- a/go/sys/firewall/firewalld.go
+++ b/go/sys/firewall/firewalld.go
@@ -7,10 +7,15 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
-	sysfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
 )
+
+// firewalld is the firewall-cmd-backed Manager. Every mutating call is escalated
+// through the injected Runner; service XML is written via the fs seams.
+type firewalld struct {
+	base
+}
+
+var _ Manager = (*firewalld)(nil)
 
 // firewalld backend. Each Rule is materialised as a single custom
 // firewalld service definition (XML at /etc/firewalld/services/<ns>-<id>.xml)
@@ -40,51 +45,56 @@ func firewalldServiceName(namespace, id string) string {
 	return namespace + "-" + id
 }
 
-// applyFirewalld installs or updates rule. Writes the service XML,
-// reloads firewalld so the new definition is recognised, and adds it
-// to the default zone (no-op if already present).
-func applyFirewalld(ctx context.Context, namespace string, rule Rule) error {
+// ApplyRule installs or updates rule. Writes the service XML, reloads firewalld
+// so the new definition is recognised, and adds it to the default zone (no-op if
+// already present).
+func (f *firewalld) ApplyRule(ctx context.Context, rule Rule) error {
+	if err := validateRule(rule); err != nil {
+		return err
+	}
 	if err := firewalldValidateRule(rule); err != nil {
 		return err
 	}
-	zone, err := firewalldDefaultZone(ctx)
+	zone, err := f.firewalldDefaultZone(ctx)
 	if err != nil {
 		return err
 	}
-	svc := firewalldServiceName(namespace, rule.ID)
-	xml := firewalldServiceXML(namespace, rule)
+	svc := firewalldServiceName(f.ns, rule.ID)
+	xml := firewalldServiceXML(f.ns, rule)
 	path := filepath.Join(firewalldServicesDir, svc+".xml")
-	if err := sysfs.WriteFileAtomic(ctx, path, xml, "0644", "root", "root"); err != nil {
+	if err := writeFileAtomic(ctx, path, xml, "0644", "root", "root"); err != nil {
 		return fmt.Errorf("write service xml %s: %w", path, err)
 	}
 	// Reload so the new service definition is parsed. Without this,
 	// --add-service rejects the name.
-	if _, err := sysexec.Privileged(ctx, "firewall-cmd", "--reload"); err != nil {
+	if _, err := f.run(ctx, "firewall-cmd", "--reload"); err != nil {
 		return fmt.Errorf("firewall-cmd --reload: %w", err)
 	}
 	// --permanent so the change survives reboot; --add-service is
 	// idempotent at the API level (no-op when already enabled).
-	if _, err := sysexec.Privileged(ctx, "firewall-cmd",
+	if _, err := f.run(ctx, "firewall-cmd",
 		"--permanent", "--zone="+zone, "--add-service="+svc,
 	); err != nil {
 		return fmt.Errorf("firewall-cmd add-service: %w", err)
 	}
 	// Final reload so the runtime config matches permanent.
-	if _, err := sysexec.Privileged(ctx, "firewall-cmd", "--reload"); err != nil {
+	if _, err := f.run(ctx, "firewall-cmd", "--reload"); err != nil {
 		return fmt.Errorf("firewall-cmd --reload (post-enable): %w", err)
 	}
 	return nil
 }
 
-// removeFirewalld disables the service in the default zone and deletes
-// its XML file. Missing services / files are no-ops, matching the
-// idempotency contract.
-func removeFirewalld(ctx context.Context, namespace, id string) error {
-	zone, err := firewalldDefaultZone(ctx)
+// RemoveRule disables the service in the default zone and deletes its XML file.
+// Missing services / files are no-ops, matching the idempotency contract.
+func (f *firewalld) RemoveRule(ctx context.Context, id string) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+	zone, err := f.firewalldDefaultZone(ctx)
 	if err != nil {
 		return err
 	}
-	svc := firewalldServiceName(namespace, id)
+	svc := firewalldServiceName(f.ns, id)
 
 	// List services first so we can tell "service isn't enabled
 	// (legitimate idempotency no-op)" apart from "firewall-cmd failed
@@ -93,67 +103,67 @@ func removeFirewalld(ctx context.Context, namespace, id string) error {
 	// would swallow real failures and return success while the rule
 	// is still enabled. String-matching the error message would work
 	// but is fragile across firewalld versions and locales.
-	enabled, err := firewalldServiceIsEnabled(ctx, zone, svc)
+	enabled, err := f.firewalldServiceIsEnabled(ctx, zone, svc)
 	if err != nil {
 		return fmt.Errorf("firewall-cmd list-services: %w", err)
 	}
 	if enabled {
-		if _, err := sysexec.Privileged(ctx, "firewall-cmd",
+		if _, err := f.run(ctx, "firewall-cmd",
 			"--permanent", "--zone="+zone, "--remove-service="+svc,
 		); err != nil {
 			return fmt.Errorf("firewall-cmd --remove-service: %w", err)
 		}
 	}
 	path := filepath.Join(firewalldServicesDir, svc+".xml")
-	if err := sysfs.RemoveStrict(ctx, path); err != nil && !os.IsNotExist(err) {
+	if err := removeStrict(ctx, path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove %s: %w", path, err)
 	}
-	if _, err := sysexec.Privileged(ctx, "firewall-cmd", "--reload"); err != nil {
+	if _, err := f.run(ctx, "firewall-cmd", "--reload"); err != nil {
 		return fmt.Errorf("firewall-cmd --reload: %w", err)
 	}
 	return nil
 }
 
-// firewalldServiceIsEnabled reports whether svc is currently in the
-// permanent service list for zone. Pre-check before --remove-service
-// so removeFirewalld can distinguish idempotency no-ops from real
-// failures without parsing error messages.
-func firewalldServiceIsEnabled(ctx context.Context, zone, svc string) (bool, error) {
-	res, err := sysexec.Privileged(ctx, "firewall-cmd",
+// firewalldServiceIsEnabled reports whether svc is currently in the permanent
+// service list for zone. Pre-check before --remove-service so RemoveRule can
+// distinguish idempotency no-ops from real failures without parsing error
+// messages.
+func (f *firewalld) firewalldServiceIsEnabled(ctx context.Context, zone, svc string) (bool, error) {
+	res, err := f.run(ctx, "firewall-cmd",
 		"--permanent", "--zone="+zone, "--list-services",
 	)
 	if err != nil {
 		return false, err
 	}
-	for _, f := range strings.Fields(res.Stdout) {
-		if f == svc {
+	for _, field := range strings.Fields(res.Stdout) {
+		if field == svc {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-// listFirewalld returns every managed service enabled in the default
-// zone whose name starts with `<namespace>-`, reconstructed into Rule
-// structs by reading each service's XML body.
-func listFirewalld(ctx context.Context, namespace string) ([]Rule, error) {
-	zone, err := firewalldDefaultZone(ctx)
+// List returns every managed service enabled in the default zone whose name
+// starts with `<namespace>-`, reconstructed into Rule structs by reading each
+// service's XML body.
+func (f *firewalld) List(ctx context.Context) ([]Rule, error) {
+	zone, err := f.firewalldDefaultZone(ctx)
 	if err != nil {
 		return nil, err
 	}
-	res, err := sysexec.Privileged(ctx, "firewall-cmd",
+	res, err := f.run(ctx, "firewall-cmd",
 		"--permanent", "--zone="+zone, "--list-services",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("firewall-cmd list-services: %w", err)
 	}
-	ids := firewalldFilterNamespaceServices(res.Stdout, namespace)
+	ids := firewalldFilterNamespaceServices(res.Stdout, f.ns)
 	rules := make([]Rule, 0, len(ids))
 	for _, id := range ids {
-		rule, ok := firewalldReadServiceRule(namespace, id)
+		rule, ok := firewalldReadServiceRule(f.ns, id)
 		if !ok {
-			// Service is enabled but its XML disappeared (operator
-			// deleted by hand) — skip rather than fail the whole List.
+			// Service is enabled but its XML disappeared (operator deleted by
+			// hand) — skip rather than fail the whole List.
 			continue
 		}
 		rules = append(rules, rule)
@@ -223,7 +233,7 @@ func firewalldFilterNamespaceServices(out, namespace string) []string {
 // the XML doesn't look like one we wrote.
 func firewalldReadServiceRule(namespace, id string) (Rule, bool) {
 	path := filepath.Join(firewalldServicesDir, firewalldServiceName(namespace, id)+".xml")
-	body, err := os.ReadFile(path) //nolint:gosec // path constructed from a validated namespace + id.
+	body, err := readFile(path) //nolint:gosec // path constructed from a validated namespace + id.
 	if err != nil {
 		return Rule{}, false
 	}
@@ -257,8 +267,8 @@ func firewalldReadServiceRule(namespace, id string) (Rule, bool) {
 // zone. Caches nothing — `--get-default-zone` is a cheap call and
 // operators changing the default zone at runtime should see the new
 // answer on the next Apply.
-func firewalldDefaultZone(ctx context.Context) (string, error) {
-	res, err := sysexec.Privileged(ctx, "firewall-cmd", "--get-default-zone")
+func (f *firewalld) firewalldDefaultZone(ctx context.Context) (string, error) {
+	res, err := f.run(ctx, "firewall-cmd", "--get-default-zone")
 	if err != nil {
 		return "", fmt.Errorf("firewall-cmd --get-default-zone: %w", err)
 	}

--- a/go/sys/firewall/firewalld_test.go
+++ b/go/sys/firewall/firewalld_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 const firewalldTestNamespace = "fwtest"
@@ -135,18 +137,28 @@ func TestFirewalldFilterNamespaceServices(t *testing.T) {
 // cleans up the services it created so subsequent runs start fresh.
 // =============================================================================
 
+func firewalldIntegrationManager(t *testing.T) Manager {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct) // skip guard guarantees we are root
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	return newMgr(t, Firewalld, firewalldTestNamespace, r)
+}
+
 func TestFirewalldIntegration_ApplyListRemoveCycle(t *testing.T) {
 	skipIfNotFirewalldUsable(t)
 	ctx := context.Background()
+	m := firewalldIntegrationManager(t)
 	rule := Rule{ID: "test-svc", Allow: true, Protocol: ProtocolTCP, Port: 12345}
-	t.Cleanup(func() { _ = removeFirewalld(ctx, firewalldTestNamespace, rule.ID) })
+	t.Cleanup(func() { _ = m.RemoveRule(ctx, rule.ID) })
 
-	if err := applyFirewalld(ctx, firewalldTestNamespace, rule); err != nil {
-		t.Fatalf("applyFirewalld: %v", err)
+	if err := m.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
 	}
-	rules, err := listFirewalld(ctx, firewalldTestNamespace)
+	rules, err := m.List(ctx)
 	if err != nil {
-		t.Fatalf("listFirewalld: %v", err)
+		t.Fatalf("List: %v", err)
 	}
 	found := false
 	for _, r := range rules {
@@ -158,23 +170,24 @@ func TestFirewalldIntegration_ApplyListRemoveCycle(t *testing.T) {
 		t.Fatalf("applied rule not visible in List: %+v", rules)
 	}
 
-	if err := removeFirewalld(ctx, firewalldTestNamespace, rule.ID); err != nil {
-		t.Fatalf("removeFirewalld: %v", err)
+	if err := m.RemoveRule(ctx, rule.ID); err != nil {
+		t.Fatalf("RemoveRule: %v", err)
 	}
 }
 
 func TestFirewalldIntegration_ApplyIsIdempotent(t *testing.T) {
 	skipIfNotFirewalldUsable(t)
 	ctx := context.Background()
+	m := firewalldIntegrationManager(t)
 	rule := Rule{ID: "idemp", Allow: true, Protocol: ProtocolTCP, Port: 12346}
-	t.Cleanup(func() { _ = removeFirewalld(ctx, firewalldTestNamespace, rule.ID) })
+	t.Cleanup(func() { _ = m.RemoveRule(ctx, rule.ID) })
 
 	for i := 0; i < 3; i++ {
-		if err := applyFirewalld(ctx, firewalldTestNamespace, rule); err != nil {
-			t.Fatalf("applyFirewalld #%d: %v", i, err)
+		if err := m.ApplyRule(ctx, rule); err != nil {
+			t.Fatalf("ApplyRule #%d: %v", i, err)
 		}
 	}
-	rules, _ := listFirewalld(ctx, firewalldTestNamespace)
+	rules, _ := m.List(ctx)
 	count := 0
 	for _, r := range rules {
 		if r.ID == rule.ID {

--- a/go/sys/firewall/nftables.go
+++ b/go/sys/firewall/nftables.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // nftables backend. Each Manager owns a dedicated `inet <namespace>_filter`
@@ -19,8 +17,13 @@ import (
 //
 // All mutations go through `nft -f -` (batch / stdin) so the kernel
 // applies them in a single atomic transaction — partial state is never
-// visible. The wrapper `exec.Privileged` handles sudo / doas
-// elevation per the active PrivilegeBackend.
+// visible. The injected Runner handles sudo / doas elevation per the
+// configured PrivilegeBackend.
+type nftables struct {
+	base
+}
+
+var _ Manager = (*nftables)(nil)
 
 const (
 	nftFamily = "inet"
@@ -51,26 +54,37 @@ func nftAddressFamily(addr string) (string, error) {
 	return "", fmt.Errorf("%w: %q is not a valid IP address or CIDR", ErrInvalidRule, addr)
 }
 
-func applyNftables(ctx context.Context, namespace string, rule Rule) error {
-	script, err := nftBuildApplyScriptStrict(namespace, rule, 0)
+// ApplyRule installs or updates rule. The whole change (table + chain ensure,
+// optional delete-of-previous, add) goes into one atomic `nft -f -` batch.
+func (n *nftables) ApplyRule(ctx context.Context, rule Rule) error {
+	if err := validateRule(rule); err != nil {
+		return err
+	}
+	// If a rule with this ID already exists, replace it in the same batch so the
+	// kernel never sees "old gone but new not yet applied". A missing table
+	// (list error) just means handle 0 = no delete.
+	var handle int64
+	if raw, lerr := n.nftListJSON(ctx); lerr == nil {
+		if h, ok := nftFindRuleHandle(raw, rule.ID); ok {
+			handle = h
+		}
+	}
+	// Built once, after the handle is known, so there's a single source of the
+	// nft-untranslatable rejection (port without protocol / mixed IP families).
+	script, err := nftBuildApplyScriptStrict(n.ns, rule, handle)
 	if err != nil {
 		return err
 	}
-	// Translate "" into 0 (no delete) without surfacing the empty
-	// listing as an error.
-	if raw, lerr := nftListJSON(ctx, namespace); lerr == nil {
-		if handle, ok := nftFindRuleHandle(raw, rule.ID); ok {
-			script, err = nftBuildApplyScriptStrict(namespace, rule, handle)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nftRunScript(ctx, script)
+	return n.nftRunScript(ctx, script)
 }
 
-func removeNftables(ctx context.Context, namespace, id string) error {
-	raw, err := nftListJSON(ctx, namespace)
+// RemoveRule deletes the rule with the given ID; a missing table or rule is a
+// no-op (the post-condition "absent" already holds).
+func (n *nftables) RemoveRule(ctx context.Context, id string) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+	raw, err := n.nftListJSON(ctx)
 	if err != nil {
 		// No table → nothing to remove.
 		return nil
@@ -79,12 +93,13 @@ func removeNftables(ctx context.Context, namespace, id string) error {
 	if !ok {
 		return nil
 	}
-	script := fmt.Sprintf("delete rule %s %s %s handle %d\n", nftFamily, nftTableName(namespace), nftChain, handle)
-	return nftRunScript(ctx, script)
+	script := fmt.Sprintf("delete rule %s %s %s handle %d\n", nftFamily, nftTableName(n.ns), nftChain, handle)
+	return n.nftRunScript(ctx, script)
 }
 
-func listNftables(ctx context.Context, namespace string) ([]Rule, error) {
-	raw, err := nftListJSON(ctx, namespace)
+// List returns every managed rule in this namespace's table.
+func (n *nftables) List(ctx context.Context) ([]Rule, error) {
+	raw, err := n.nftListJSON(ctx)
 	if err != nil {
 		// No table yet → no managed rules.
 		return nil, nil
@@ -92,34 +107,32 @@ func listNftables(ctx context.Context, namespace string) ([]Rule, error) {
 	return nftParseRules(raw)
 }
 
-// nftListJSON runs `nft -j list table inet <namespace>_filter` and
-// returns the raw JSON. The query is unprivileged in principle but in
-// practice most distros restrict nft to root, so the call goes through
-// exec.Privileged like every other op in this file.
-func nftListJSON(ctx context.Context, namespace string) ([]byte, error) {
-	res, err := sysexec.Privileged(ctx, "nft", "-j", "list", "table", nftFamily, nftTableName(namespace))
+// nftListJSON runs `nft -j list table inet <namespace>_filter` and returns the
+// raw JSON. Most distros restrict nft to root, so the call is escalated like
+// every other op here. A non-zero exit (table missing) surfaces as an error the
+// callers translate into "no managed rules".
+func (n *nftables) nftListJSON(ctx context.Context) ([]byte, error) {
+	res, err := n.run(ctx, "nft", "-j", "list", "table", nftFamily, nftTableName(n.ns))
 	if err != nil {
 		return nil, fmt.Errorf("nft list table: %w", err)
 	}
 	return []byte(res.Stdout), nil
 }
 
-// nftRunScript pipes a batch script into `nft -f -`. The script is
-// applied atomically; nft's transaction guarantees roll back the
-// whole batch if any line fails to parse or apply.
-func nftRunScript(ctx context.Context, script string) error {
-	_, err := sysexec.PrivilegedWithStdin(ctx, strings.NewReader(script), "nft", "-f", "-")
-	if err != nil {
+// nftRunScript pipes a batch script into `nft -f -`. nft's transaction
+// guarantees roll back the whole batch if any line fails.
+func (n *nftables) nftRunScript(ctx context.Context, script string) error {
+	if _, err := n.runStdin(ctx, script, "nft", "-f", "-"); err != nil {
 		return fmt.Errorf("nft -f -: %w", err)
 	}
 	return nil
 }
 
-// nftDeleteManagedTable removes this namespace's table; used by test
+// nftDeleteManagedTable removes this namespace's table; used by integration-test
 // cleanup so each test starts on a fresh kernel.
-func nftDeleteManagedTable(ctx context.Context, namespace string) error {
-	script := fmt.Sprintf("delete table %s %s\n", nftFamily, nftTableName(namespace))
-	_, err := sysexec.PrivilegedWithStdin(ctx, strings.NewReader(script), "nft", "-f", "-")
+func (n *nftables) nftDeleteManagedTable(ctx context.Context) error {
+	script := fmt.Sprintf("delete table %s %s\n", nftFamily, nftTableName(n.ns))
+	_, err := n.runStdin(ctx, script, "nft", "-f", "-")
 	return err // missing table on the second teardown surfaces as a (harmless) error
 }
 

--- a/go/sys/firewall/nftables_test.go
+++ b/go/sys/firewall/nftables_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // nftTestNamespace is the namespace every nftables test uses. Tests
@@ -291,44 +293,58 @@ func TestNftFindRuleHandle(t *testing.T) {
 // cleans up its namespace's table on exit so the next run starts fresh.
 // =============================================================================
 
+// nftIntegrationBackend builds a concrete *nftables driven by a real root Runner
+// for the integration cycle tests (also exposes nftDeleteManagedTable for
+// cleanup).
+func nftIntegrationBackend(t *testing.T) *nftables {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct) // skip guard guarantees we are root
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	return &nftables{base: base{ns: nftTestNamespace, cmd: cmd{r: r}}}
+}
+
 func TestNftablesIntegration_ApplyListRemoveCycle(t *testing.T) {
 	skipIfNotNftablesUsable(t)
-	t.Cleanup(func() { _ = nftDeleteManagedTable(context.Background(), nftTestNamespace) })
+	n := nftIntegrationBackend(t)
+	t.Cleanup(func() { _ = n.nftDeleteManagedTable(context.Background()) })
 
 	ctx := context.Background()
 	rule := Rule{ID: "test-ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}
 
-	if err := applyNftables(ctx, nftTestNamespace, rule); err != nil {
-		t.Fatalf("applyNftables: %v", err)
+	if err := n.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
 	}
-	rules, err := listNftables(ctx, nftTestNamespace)
+	rules, err := n.List(ctx)
 	if err != nil {
-		t.Fatalf("listNftables: %v", err)
+		t.Fatalf("List: %v", err)
 	}
 	if len(rules) != 1 || rules[0].ID != "test-ssh" {
-		t.Fatalf("listNftables = %+v; want [{ID:test-ssh ...}]", rules)
+		t.Fatalf("List = %+v; want [{ID:test-ssh ...}]", rules)
 	}
-	if err := removeNftables(ctx, nftTestNamespace, "test-ssh"); err != nil {
-		t.Fatalf("removeNftables: %v", err)
+	if err := n.RemoveRule(ctx, "test-ssh"); err != nil {
+		t.Fatalf("RemoveRule: %v", err)
 	}
-	rules, _ = listNftables(ctx, nftTestNamespace)
+	rules, _ = n.List(ctx)
 	if len(rules) != 0 {
-		t.Fatalf("after remove: listNftables = %+v; want empty", rules)
+		t.Fatalf("after remove: List = %+v; want empty", rules)
 	}
 }
 
 func TestNftablesIntegration_ApplyIsIdempotent(t *testing.T) {
 	skipIfNotNftablesUsable(t)
-	t.Cleanup(func() { _ = nftDeleteManagedTable(context.Background(), nftTestNamespace) })
+	n := nftIntegrationBackend(t)
+	t.Cleanup(func() { _ = n.nftDeleteManagedTable(context.Background()) })
 
 	ctx := context.Background()
 	rule := Rule{ID: "idemp", Allow: true, Protocol: ProtocolTCP, Port: 8080}
 	for i := 0; i < 3; i++ {
-		if err := applyNftables(ctx, nftTestNamespace, rule); err != nil {
-			t.Fatalf("applyNftables #%d: %v", i, err)
+		if err := n.ApplyRule(ctx, rule); err != nil {
+			t.Fatalf("ApplyRule #%d: %v", i, err)
 		}
 	}
-	rules, _ := listNftables(ctx, nftTestNamespace)
+	rules, _ := n.List(ctx)
 	if len(rules) != 1 {
 		t.Fatalf("after 3 applies: rules = %+v; want exactly 1", rules)
 	}
@@ -336,9 +352,10 @@ func TestNftablesIntegration_ApplyIsIdempotent(t *testing.T) {
 
 func TestNftablesIntegration_RemoveOnMissingIsNoOp(t *testing.T) {
 	skipIfNotNftablesUsable(t)
-	t.Cleanup(func() { _ = nftDeleteManagedTable(context.Background(), nftTestNamespace) })
+	n := nftIntegrationBackend(t)
+	t.Cleanup(func() { _ = n.nftDeleteManagedTable(context.Background()) })
 
-	if err := removeNftables(context.Background(), nftTestNamespace, "never-applied"); err != nil {
-		t.Fatalf("removeNftables(missing) = %v; want nil", err)
+	if err := n.RemoveRule(context.Background(), "never-applied"); err != nil {
+		t.Fatalf("RemoveRule(missing) = %v; want nil", err)
 	}
 }

--- a/go/sys/firewall/runner_test.go
+++ b/go/sys/firewall/runner_test.go
@@ -1,0 +1,569 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// =============================================================================
+// nftables — apply/remove/list driven by a recordingRunner (no kernel).
+// =============================================================================
+
+// nftListJSONWith builds an `nft -j list` envelope carrying one rule with the
+// given comment/handle so the idempotency + List paths can be exercised.
+func nftListJSONWith(comment string, handle int) string {
+	return `{"nftables":[
+		{"table":{"family":"inet","name":"app_filter","handle":1}},
+		{"chain":{"family":"inet","table":"app_filter","name":"input","handle":2}},
+		{"rule":{"family":"inet","table":"app_filter","chain":"input","handle":` +
+		itoa(handle) + `,"comment":"` + comment + `","expr":[
+			{"match":{"op":"==","left":{"payload":{"protocol":"tcp","field":"dport"}},"right":22}},
+			{"accept":null}
+		]}}
+	]}`
+}
+
+func TestNftables_ApplyRule_NewRule(t *testing.T) {
+	r := &recordingRunner{}
+	r.push(exec.Result{ExitCode: 1}, nil) // nft list: table missing
+	r.pushOut("")                         // nft -f -: ok
+	m := newMgr(t, Nftables, "app", r)
+
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.calls) != 2 {
+		t.Fatalf("ran %d commands, want 2 (list + apply)", len(r.calls))
+	}
+	if got := r.argvOf(0); got != "nft -j list table inet app_filter" {
+		t.Errorf("list argv = %q", got)
+	}
+	script := r.calls[1].stdin
+	for _, want := range []string{
+		"add table inet app_filter",
+		"add chain inet app_filter input",
+		`add rule inet app_filter input tcp dport 22 accept comment "ssh"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("apply script missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "delete rule") {
+		t.Errorf("new rule must not emit a delete:\n%s", script)
+	}
+}
+
+func TestNftables_ApplyRule_ReplacesExisting(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut(nftListJSONWith("ssh", 7)) // existing rule with handle 7
+	r.pushOut("")                        // apply ok
+	m := newMgr(t, Nftables, "app", r)
+
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: false, Protocol: ProtocolUDP, Port: 53}); err != nil {
+		t.Fatal(err)
+	}
+	script := r.calls[1].stdin
+	if !strings.Contains(script, "delete rule inet app_filter input handle 7") {
+		t.Errorf("replace must delete the old handle 7 in the same batch:\n%s", script)
+	}
+	if !strings.Contains(script, `udp dport 53 drop comment "ssh"`) {
+		t.Errorf("replacement rule body wrong:\n%s", script)
+	}
+}
+
+func TestNftables_ApplyRule_PortWithoutProtocolRejected(t *testing.T) {
+	r := &recordingRunner{}
+	r.push(exec.Result{ExitCode: 1}, nil) // list: no table
+	m := newMgr(t, Nftables, "app", r)
+	err := m.ApplyRule(context.Background(), Rule{ID: "bad", Allow: true, Protocol: ProtocolAny, Port: 22})
+	if !errors.Is(err, ErrInvalidRule) {
+		t.Errorf("err = %v, want ErrInvalidRule (port without protocol)", err)
+	}
+	// The build (and rejection) happens after a read-only list probe; the
+	// mutating `nft -f -` must never run.
+	for _, c := range r.calls {
+		if strings.Contains(strings.Join(c.cmd.Args, " "), "-f") {
+			t.Error("an untranslatable rule reached the mutating nft -f - call")
+		}
+	}
+}
+
+func TestNftables_ApplyRule_RunFailure(t *testing.T) {
+	r := &recordingRunner{}
+	r.push(exec.Result{ExitCode: 1}, nil)                         // list: no table
+	r.push(exec.Result{ExitCode: 1, Stderr: "syntax error"}, nil) // nft -f - fails
+	m := newMgr(t, Nftables, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err == nil ||
+		!strings.Contains(err.Error(), "nft -f -") {
+		t.Errorf("err = %v, want a wrapped nft -f - failure", err)
+	}
+}
+
+func TestNftables_RemoveRule(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(nftListJSONWith("ssh", 9)) // list
+		r.pushOut("")                        // delete run
+		m := newMgr(t, Nftables, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(r.calls[1].stdin, "delete rule inet app_filter input handle 9") {
+			t.Errorf("remove script = %q", r.calls[1].stdin)
+		}
+	})
+	t.Run("no table is a no-op", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil) // list: missing table
+		m := newMgr(t, Nftables, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("ran %d commands, want 1 (list only)", len(r.calls))
+		}
+	})
+	t.Run("rule absent is a no-op", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(nftListJSONWith("other", 3)) // list has a different rule
+		m := newMgr(t, Nftables, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("ran %d commands, want 1 (list only, no delete)", len(r.calls))
+		}
+	})
+}
+
+func TestNftables_List(t *testing.T) {
+	t.Run("returns managed rules", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(nftListJSONWith("web-https", 9))
+		m := newMgr(t, Nftables, "app", r)
+		rules, err := m.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rules) != 1 || rules[0].ID != "web-https" || rules[0].Port != 22 {
+			t.Errorf("rules = %+v", rules)
+		}
+	})
+	t.Run("no table → empty", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, Nftables, "app", r)
+		rules, err := m.List(context.Background())
+		if err != nil || len(rules) != 0 {
+			t.Errorf("List = (%v,%v), want (nil,nil)", rules, err)
+		}
+	})
+}
+
+// =============================================================================
+// firewalld — apply/remove/list with the fs seams stubbed.
+// =============================================================================
+
+func swapFirewalldSeams(t *testing.T) {
+	t.Helper()
+	ow, or_, ord := writeFileAtomic, removeStrict, readFile
+	t.Cleanup(func() { writeFileAtomic, removeStrict, readFile = ow, or_, ord })
+}
+
+func TestFirewalld_ApplyRule_Happy(t *testing.T) {
+	swapFirewalldSeams(t)
+	var wrotePath, wroteBody string
+	writeFileAtomic = func(_ context.Context, path, content, _, _, _ string) error {
+		wrotePath, wroteBody = path, content
+		return nil
+	}
+	r := &recordingRunner{}
+	r.pushOut("public\n") // --get-default-zone
+	r.pushOut("")         // --reload
+	r.pushOut("")         // --add-service
+	r.pushOut("")         // --reload (post-enable)
+	m := newMgr(t, Firewalld, "app", r)
+
+	if err := m.ApplyRule(context.Background(), Rule{ID: "https", Allow: true, Protocol: ProtocolTCP, Port: 443}); err != nil {
+		t.Fatal(err)
+	}
+	if wrotePath != "/etc/firewalld/services/app-https.xml" {
+		t.Errorf("service path = %q", wrotePath)
+	}
+	if !strings.Contains(wroteBody, `<port port="443" protocol="tcp"/>`) {
+		t.Errorf("service xml missing port element:\n%s", wroteBody)
+	}
+	if got := r.argvOf(2); got != "firewall-cmd --permanent --zone=public --add-service=app-https" {
+		t.Errorf("add-service argv = %q", got)
+	}
+	if len(r.calls) != 4 {
+		t.Errorf("ran %d commands, want 4 (zone, reload, add, reload)", len(r.calls))
+	}
+}
+
+func TestFirewalld_ApplyRule_ScopeRejections(t *testing.T) {
+	cases := map[string]Rule{
+		"deny":      {ID: "r", Allow: false, Protocol: ProtocolTCP, Port: 1},
+		"source":    {ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1, Source: "10.0.0.0/8"},
+		"dest":      {ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1, Dest: "10.0.0.1"},
+		"any proto": {ID: "r", Allow: true, Protocol: ProtocolAny, Port: 1},
+		"port zero": {ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 0},
+	}
+	for name, rule := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &recordingRunner{}
+			m := newMgr(t, Firewalld, "app", r)
+			if err := m.ApplyRule(context.Background(), rule); !errors.Is(err, ErrInvalidRule) {
+				t.Errorf("err = %v, want ErrInvalidRule", err)
+			}
+			if len(r.calls) != 0 {
+				t.Errorf("ran %d commands for an out-of-scope rule; scope check must precede exec", len(r.calls))
+			}
+		})
+	}
+}
+
+func TestFirewalld_ApplyRule_Failures(t *testing.T) {
+	t.Run("get-default-zone fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1, Stderr: "no daemon"}, nil)
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "get-default-zone") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("empty zone", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut("   \n")
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "empty") {
+			t.Errorf("err = %v, want the empty-zone error", err)
+		}
+	})
+	t.Run("writeFileAtomic fails", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		writeFileAtomic = func(context.Context, string, string, string, string, string) error {
+			return errors.New("disk full")
+		}
+		r := &recordingRunner{}
+		r.pushOut("public\n")
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "write service xml") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("reload fails", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		writeFileAtomic = func(context.Context, string, string, string, string, string) error { return nil }
+		r := &recordingRunner{}
+		r.pushOut("public\n")                 // zone
+		r.push(exec.Result{ExitCode: 1}, nil) // reload fails
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "--reload") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("add-service fails", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		writeFileAtomic = func(context.Context, string, string, string, string, string) error { return nil }
+		r := &recordingRunner{}
+		r.pushOut("public\n")                 // zone
+		r.pushOut("")                         // reload
+		r.push(exec.Result{ExitCode: 1}, nil) // add-service fails
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "add-service") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("post-enable reload fails", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		writeFileAtomic = func(context.Context, string, string, string, string, string) error { return nil }
+		r := &recordingRunner{}
+		r.pushOut("public\n")                 // zone
+		r.pushOut("")                         // reload
+		r.pushOut("")                         // add-service
+		r.push(exec.Result{ExitCode: 1}, nil) // post-enable reload fails
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.ApplyRule(context.Background(), Rule{ID: "r", Allow: true, Protocol: ProtocolTCP, Port: 1}); err == nil ||
+			!strings.Contains(err.Error(), "post-enable") {
+			t.Errorf("err = %v", err)
+		}
+	})
+}
+
+func TestFirewalld_RemoveRule(t *testing.T) {
+	t.Run("enabled → removed", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		var removed string
+		removeStrict = func(_ context.Context, path string) error { removed = path; return nil }
+		r := &recordingRunner{}
+		r.pushOut("public\n")        // zone
+		r.pushOut("app-https ssh\n") // list-services (svc enabled)
+		r.pushOut("")                // remove-service
+		r.pushOut("")                // reload
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.RemoveRule(context.Background(), "https"); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.argvOf(2); got != "firewall-cmd --permanent --zone=public --remove-service=app-https" {
+			t.Errorf("remove argv = %q", got)
+		}
+		if removed != "/etc/firewalld/services/app-https.xml" {
+			t.Errorf("removed path = %q", removed)
+		}
+	})
+	t.Run("not enabled → skip remove, still cleans + reloads", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		removeStrict = func(context.Context, string) error { return nil }
+		r := &recordingRunner{}
+		r.pushOut("public\n") // zone
+		r.pushOut("ssh\n")    // list-services (svc absent)
+		r.pushOut("")         // reload
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.RemoveRule(context.Background(), "https"); err != nil {
+			t.Fatal(err)
+		}
+		if len(r.calls) != 3 {
+			t.Errorf("ran %d commands, want 3 (zone, list, reload — no remove)", len(r.calls))
+		}
+	})
+	t.Run("list-services fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut("public\n")
+		r.push(exec.Result{ExitCode: 1}, nil) // list-services
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.RemoveRule(context.Background(), "https"); err == nil ||
+			!strings.Contains(err.Error(), "list-services") {
+			t.Errorf("err = %v", err)
+		}
+	})
+	t.Run("RemoveStrict hard failure", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		removeStrict = func(context.Context, string) error { return errors.New("permission denied") }
+		r := &recordingRunner{}
+		r.pushOut("public\n")
+		r.pushOut("ssh\n") // not enabled
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.RemoveRule(context.Background(), "https"); err == nil ||
+			!strings.Contains(err.Error(), "remove") {
+			t.Errorf("err = %v, want a wrapped RemoveStrict failure", err)
+		}
+	})
+	t.Run("zone lookup fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, Firewalld, "app", r)
+		if err := m.RemoveRule(context.Background(), "https"); err == nil {
+			t.Error("RemoveRule continued past a zone-lookup failure")
+		}
+	})
+}
+
+func TestFirewalld_List(t *testing.T) {
+	t.Run("reconstructs from xml", func(t *testing.T) {
+		swapFirewalldSeams(t)
+		readFile = func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, "app-https.xml") {
+				return []byte(firewalldServiceXML("app", Rule{ID: "https", Allow: true, Protocol: ProtocolTCP, Port: 443})), nil
+			}
+			return nil, errors.New("missing")
+		}
+		r := &recordingRunner{}
+		r.pushOut("public\n")                 // zone
+		r.pushOut("app-https app-gone ssh\n") // list-services
+		m := newMgr(t, Firewalld, "app", r)
+		rules, err := m.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		// app-https reconstructs; app-gone's xml is missing → skipped; ssh isn't ours.
+		if len(rules) != 1 || rules[0].ID != "https" || rules[0].Port != 443 {
+			t.Errorf("rules = %+v, want just https/443", rules)
+		}
+	})
+	t.Run("zone fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, Firewalld, "app", r)
+		if _, err := m.List(context.Background()); err == nil {
+			t.Error("List continued past a zone failure")
+		}
+	})
+	t.Run("list-services fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut("public\n")
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, Firewalld, "app", r)
+		if _, err := m.List(context.Background()); err == nil ||
+			!strings.Contains(err.Error(), "list-services") {
+			t.Errorf("err = %v", err)
+		}
+	})
+}
+
+// =============================================================================
+// ufw — apply/remove/list driven by a recordingRunner.
+// =============================================================================
+
+// ufwStatusWith renders a minimal `ufw status numbered` body with one numbered
+// rule carrying the given comment.
+func ufwStatusWith(num int, to, comment string) string {
+	return "Status: active\n\n" +
+		"     To                         Action      From\n" +
+		"     --                         ------      ----\n" +
+		"[ " + itoa(num) + "] " + to + "                     ALLOW IN    Anywhere                   # " + comment + "\n"
+}
+
+func TestUFW_ApplyRule_NewRule(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut("Status: active\n") // status numbered: no existing rule
+	r.pushOut("")                 // ufw allow ...
+	m := newMgr(t, UFW, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.argvOf(1); got != "ufw allow 22/tcp comment app:ssh" {
+		t.Errorf("add argv = %q", got)
+	}
+}
+
+func TestUFW_ApplyRule_ReplacesExisting(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut(ufwStatusWith(3, "22/tcp", "app:ssh")) // status shows existing rule #3
+	r.pushOut("")                                    // ufw --force delete 3
+	r.pushOut("")                                    // ufw allow ...
+	m := newMgr(t, UFW, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.argvOf(1); got != "ufw --force delete 3" {
+		t.Errorf("delete argv = %q", got)
+	}
+}
+
+func TestUFW_ApplyRule_DeleteExistingFails(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut(ufwStatusWith(3, "22/tcp", "app:ssh"))
+	r.push(exec.Result{ExitCode: 1}, nil) // delete fails
+	m := newMgr(t, UFW, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err == nil ||
+		!strings.Contains(err.Error(), "delete existing rule") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestUFW_ApplyRule_StatusErrorStillAdds(t *testing.T) {
+	r := &recordingRunner{}
+	r.push(exec.Result{ExitCode: 1}, nil) // status fails (inactive) → skip delete
+	r.pushOut("")                         // add still runs
+	m := newMgr(t, UFW, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.argvOf(1); got != "ufw allow 22/tcp comment app:ssh" {
+		t.Errorf("add argv = %q", got)
+	}
+}
+
+func TestUFW_ApplyRule_AddFails(t *testing.T) {
+	r := &recordingRunner{}
+	r.pushOut("Status: active\n")
+	r.push(exec.Result{ExitCode: 1, Stderr: "bad rule"}, nil)
+	m := newMgr(t, UFW, "app", r)
+	if err := m.ApplyRule(context.Background(), Rule{ID: "ssh", Allow: true, Protocol: ProtocolTCP, Port: 22}); err == nil ||
+		!strings.Contains(err.Error(), "ufw allow") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestUFW_ApplyRule_ScopeRejection(t *testing.T) {
+	r := &recordingRunner{}
+	m := newMgr(t, UFW, "app", r)
+	// Port without a concrete protocol is rejected before any exec.
+	if err := m.ApplyRule(context.Background(), Rule{ID: "bad", Allow: true, Protocol: ProtocolAny, Port: 22}); !errors.Is(err, ErrInvalidRule) {
+		t.Errorf("err = %v, want ErrInvalidRule", err)
+	}
+	if len(r.calls) != 0 {
+		t.Error("ran a command for a port-without-protocol rule")
+	}
+}
+
+func TestUFW_RemoveRule(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(ufwStatusWith(2, "22/tcp", "app:ssh"))
+		r.pushOut("") // delete
+		m := newMgr(t, UFW, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if got := r.argvOf(1); got != "ufw --force delete 2" {
+			t.Errorf("delete argv = %q", got)
+		}
+	})
+	t.Run("inactive ufw is a no-op", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil) // status fails
+		m := newMgr(t, UFW, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("ran %d commands, want 1 (status only)", len(r.calls))
+		}
+	})
+	t.Run("not found is a no-op", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(ufwStatusWith(2, "22/tcp", "other:ssh")) // different namespace
+		m := newMgr(t, UFW, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
+			t.Fatal(err)
+		}
+		if len(r.calls) != 1 {
+			t.Errorf("ran %d commands, want 1 (status only, no delete)", len(r.calls))
+		}
+	})
+	t.Run("delete fails", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(ufwStatusWith(2, "22/tcp", "app:ssh"))
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, UFW, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err == nil ||
+			!strings.Contains(err.Error(), "--force delete") {
+			t.Errorf("err = %v", err)
+		}
+	})
+}
+
+func TestUFW_List(t *testing.T) {
+	t.Run("parses namespaced rules", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.pushOut(ufwStatusWith(1, "22/tcp", "app:ssh"))
+		m := newMgr(t, UFW, "app", r)
+		rules, err := m.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rules) != 1 || rules[0].ID != "ssh" || rules[0].Port != 22 || rules[0].Protocol != ProtocolTCP {
+			t.Errorf("rules = %+v", rules)
+		}
+	})
+	t.Run("inactive → empty", func(t *testing.T) {
+		r := &recordingRunner{}
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, UFW, "app", r)
+		rules, err := m.List(context.Background())
+		if err != nil || len(rules) != 0 {
+			t.Errorf("List = (%v,%v), want empty", rules, err)
+		}
+	})
+}

--- a/go/sys/firewall/seams.go
+++ b/go/sys/firewall/seams.go
@@ -1,0 +1,17 @@
+package firewall
+
+import (
+	"os"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/fs"
+)
+
+// Filesystem seams. The firewalld backend materialises each rule as a service
+// XML file. These package vars default to the real fs helpers (fs gains its own
+// injected Runner in a later capability PR) and to os.ReadFile, so unit tests can
+// drive ApplyRule/RemoveRule/List without writing under /etc/firewalld.
+var (
+	writeFileAtomic = fs.WriteFileAtomic
+	removeStrict    = fs.RemoveStrict
+	readFile        = os.ReadFile
+)

--- a/go/sys/firewall/ufw.go
+++ b/go/sys/firewall/ufw.go
@@ -6,9 +6,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
+
+// ufw is the ufw(8)-backed Manager. Every Apply/Remove/List goes through the ufw
+// CLI (escalated via the injected Runner) because ufw expects to be the
+// authoritative manager — raw nft rules behind its back get blown away on reload.
+type ufw struct {
+	base
+}
+
+var _ Manager = (*ufw)(nil)
 
 // ufw backend. ufw is Debian/Ubuntu's userspace wrapper over
 // nftables/iptables. Like firewalld it expects to be the authoritative
@@ -41,71 +48,78 @@ func ufwCommentIdentity(namespace, id string) string {
 	return namespace + ":" + id
 }
 
-func applyUFW(ctx context.Context, namespace string, rule Rule) error {
-	if err := ufwValidateRule(rule); err != nil {
+// ApplyRule installs or updates rule. Any previous variant with the same ID is
+// deleted first so the final ruleset has exactly one rule per ID.
+func (u *ufw) ApplyRule(ctx context.Context, rule Rule) error {
+	if err := validateRule(rule); err != nil {
 		return err
 	}
-	// Best-effort find-and-delete the previous rule by id. We do this
-	// before the add so the final ruleset has exactly one rule per
-	// id — re-adding without delete would let stale variants
-	// accumulate.
-	if status, err := ufwStatusNumbered(ctx); err == nil {
-		if num, ok := ufwFindRuleNumber(status, namespace, rule.ID); ok {
-			if err := ufwDeleteByNumber(ctx, num); err != nil {
+	// Build (and ufw-scope-validate) the add args first, so an out-of-scope rule
+	// is rejected before any exec — ufwBuildAddArgs is the single source of the
+	// ufw scope check.
+	args, err := ufwBuildAddArgs(u.ns, rule)
+	if err != nil {
+		return err
+	}
+	// Best-effort find-and-delete the previous rule by id before the add —
+	// re-adding without delete would let stale variants accumulate.
+	if status, err := u.ufwStatusNumbered(ctx); err == nil {
+		if num, ok := ufwFindRuleNumber(status, u.ns, rule.ID); ok {
+			if err := u.ufwDeleteByNumber(ctx, num); err != nil {
 				return fmt.Errorf("ufw delete existing rule %d: %w", num, err)
 			}
 		}
 	}
-	args, err := ufwBuildAddArgs(namespace, rule)
-	if err != nil {
-		return err
-	}
-	if _, err := sysexec.Privileged(ctx, "ufw", args...); err != nil {
+	if _, err := u.run(ctx, "ufw", args...); err != nil {
 		return fmt.Errorf("ufw %s: %w", strings.Join(args, " "), err)
 	}
 	return nil
 }
 
-func removeUFW(ctx context.Context, namespace, id string) error {
-	status, err := ufwStatusNumbered(ctx)
+// RemoveRule deletes the rule with the given ID; an inactive ufw or a missing
+// rule is a no-op.
+func (u *ufw) RemoveRule(ctx context.Context, id string) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+	status, err := u.ufwStatusNumbered(ctx)
 	if err != nil {
-		// No status (likely ufw inactive) → no rule to remove. Matches
-		// the idempotency contract: "this rule is absent" already holds.
+		// No status (likely ufw inactive) → no rule to remove. Matches the
+		// idempotency contract: "this rule is absent" already holds.
 		return nil
 	}
-	num, ok := ufwFindRuleNumber(status, namespace, id)
+	num, ok := ufwFindRuleNumber(status, u.ns, id)
 	if !ok {
 		return nil
 	}
-	return ufwDeleteByNumber(ctx, num)
+	return u.ufwDeleteByNumber(ctx, num)
 }
 
-func listUFW(ctx context.Context, namespace string) ([]Rule, error) {
-	status, err := ufwStatusNumbered(ctx)
+// List returns every managed rule (comment prefix `<namespace>:`).
+func (u *ufw) List(ctx context.Context) ([]Rule, error) {
+	status, err := u.ufwStatusNumbered(ctx)
 	if err != nil {
 		// ufw not active → no managed rules.
 		return nil, nil
 	}
-	return ufwParseStatus(status, namespace)
+	return ufwParseStatus(status, u.ns)
 }
 
-// ufwStatusNumbered runs `ufw status numbered` and returns its stdout.
-// Goes through Privileged because ufw insists on root for status, even
-// though the underlying kernel state is world-readable.
-func ufwStatusNumbered(ctx context.Context) (string, error) {
-	res, err := sysexec.Privileged(ctx, "ufw", "status", "numbered")
+// ufwStatusNumbered runs `ufw status numbered` and returns its stdout. Escalated
+// because ufw insists on root for status even though the kernel state is
+// world-readable.
+func (u *ufw) ufwStatusNumbered(ctx context.Context) (string, error) {
+	res, err := u.run(ctx, "ufw", "status", "numbered")
 	if err != nil {
 		return "", fmt.Errorf("ufw status numbered: %w", err)
 	}
 	return res.Stdout, nil
 }
 
-// ufwDeleteByNumber issues `ufw --force delete N`. The --force flag
-// suppresses the "are you sure? (y/n)" prompt that would otherwise hang
-// the call.
-func ufwDeleteByNumber(ctx context.Context, num int) error {
-	_, err := sysexec.Privileged(ctx, "ufw", "--force", "delete", strconv.Itoa(num))
-	if err != nil {
+// ufwDeleteByNumber issues `ufw --force delete N`. --force suppresses the
+// "are you sure? (y/n)" prompt that would otherwise hang the call.
+func (u *ufw) ufwDeleteByNumber(ctx context.Context, num int) error {
+	if _, err := u.run(ctx, "ufw", "--force", "delete", strconv.Itoa(num)); err != nil {
 		return fmt.Errorf("ufw --force delete %d: %w", num, err)
 	}
 	return nil

--- a/go/sys/firewall/ufw_test.go
+++ b/go/sys/firewall/ufw_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 const ufwTestNamespace = "fwtest"
@@ -247,18 +249,28 @@ func assertArgsEqual(t *testing.T, got, want []string) {
 // its own rules so subsequent runs start fresh.
 // =============================================================================
 
+func ufwIntegrationManager(t *testing.T) Manager {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct) // skip guard guarantees we are root
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	return newMgr(t, UFW, ufwTestNamespace, r)
+}
+
 func TestUFWIntegration_ApplyListRemoveCycle(t *testing.T) {
 	skipIfNotUFWUsable(t)
 	ctx := context.Background()
+	m := ufwIntegrationManager(t)
 	rule := Rule{ID: "test-rule", Allow: true, Protocol: ProtocolTCP, Port: 12345}
-	t.Cleanup(func() { _ = removeUFW(ctx, ufwTestNamespace, rule.ID) })
+	t.Cleanup(func() { _ = m.RemoveRule(ctx, rule.ID) })
 
-	if err := applyUFW(ctx, ufwTestNamespace, rule); err != nil {
-		t.Fatalf("applyUFW: %v", err)
+	if err := m.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
 	}
-	rules, err := listUFW(ctx, ufwTestNamespace)
+	rules, err := m.List(ctx)
 	if err != nil {
-		t.Fatalf("listUFW: %v", err)
+		t.Fatalf("List: %v", err)
 	}
 	found := false
 	for _, r := range rules {
@@ -269,23 +281,24 @@ func TestUFWIntegration_ApplyListRemoveCycle(t *testing.T) {
 	if !found {
 		t.Fatalf("applied rule not visible in List: %+v", rules)
 	}
-	if err := removeUFW(ctx, ufwTestNamespace, rule.ID); err != nil {
-		t.Fatalf("removeUFW: %v", err)
+	if err := m.RemoveRule(ctx, rule.ID); err != nil {
+		t.Fatalf("RemoveRule: %v", err)
 	}
 }
 
 func TestUFWIntegration_ApplyIsIdempotent(t *testing.T) {
 	skipIfNotUFWUsable(t)
 	ctx := context.Background()
+	m := ufwIntegrationManager(t)
 	rule := Rule{ID: "idemp", Allow: true, Protocol: ProtocolTCP, Port: 12346}
-	t.Cleanup(func() { _ = removeUFW(ctx, ufwTestNamespace, rule.ID) })
+	t.Cleanup(func() { _ = m.RemoveRule(ctx, rule.ID) })
 
 	for i := 0; i < 3; i++ {
-		if err := applyUFW(ctx, ufwTestNamespace, rule); err != nil {
-			t.Fatalf("applyUFW #%d: %v", i, err)
+		if err := m.ApplyRule(ctx, rule); err != nil {
+			t.Fatalf("ApplyRule #%d: %v", i, err)
 		}
 	}
-	rules, _ := listUFW(ctx, ufwTestNamespace)
+	rules, _ := m.List(ctx)
 	count := 0
 	for _, r := range rules {
 		if r.ID == rule.ID {


### PR DESCRIPTION
SDK rework capability (contracts §6). Folds firewall into the `New(Backend, runner)` shape on the exec Runner foundation (#125), following network (#135). One of the two capabilities that keeps a real `Backend` arg. Held to the bar: 100% coverage + success/fail/weird + real values.

## SDK changes
- `Manager` is now an interface returned by `New(b Backend, namespace string, runner exec.Runner, opts ...Option)`; fail-closed on unknown backend (`ErrUnknownBackend`), invalid namespace (`ErrInvalidNamespace`), nil runner. The three backends (nftables/firewalld/ufw) are unexported structs embedding a shared `base{ns, cmd}` — `cmd` injects the Runner and maps a non-zero exit (or transport error) to `*exec.CommandError`, restoring the "err ≠ nil ⇒ tool failed" contract the backends rely on (the old `exec.Privileged` folded exit into err; the new Runner puts it in `Result`).
- `Backend` redefined `Nftables=iota+1, Firewalld, UFW` (zero invalid). **Deleted** the iptables + pf scaffolds, `SetBackend`/`CurrentBackend`, the process-global `atomic` dispatch, `ErrBackendNotSupported`, `unsupported()`.
- nft/firewall-cmd/ufw routed through the injected Runner (escalated); firewalld keeps `fs.WriteFileAtomic`/`RemoveStrict` via seams (fs is a later cleanup PR). `Detect(ctx)` probes nft / firewall-cmd / ufw on PATH.
- **Preserved hardening:** per-Manager namespace isolation; backend-independent `validateRule` (ID/port/protocol/addr) + per-backend scope (firewalld v1 allow-only/no-scope via `ErrInvalidRule`; nft+ufw reject port-without-protocol; nft rejects mixed IPv4/IPv6 families); idempotent apply (find-by-ID, atomic nft replace) / no-op remove. nft + ufw `ApplyRule` build their wire form **once** (single source of the untranslatable-rule rejection), dropping an unreachable double-build/double-validate branch — a minor, harmless tweak (an untranslatable rule does one read-only probe before rejecting; all `validateRule` failures still exec nothing).

## Tests — 100% statement coverage
`recordingRunner` unit tests for apply/remove/list across all three backends (golden argv, scripted tool output, exit-code→error mapping, idempotent replace, no-op remove, every failure branch); the pure builders/parsers kept; root-only integration cycle tests ported to the Manager API; `New` fail-closed; namespace/ID/scope validation parity; `Detect`.

No agent/server consumers of `sys/firewall` today, so this is a clean SDK-internal improvement (zero downstream breakage). Agent migration deferred where it eventually lands.

Closes manchtools/power-manage-sdk#136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added backend detection capability to identify available firewall tools on the system.
  * Introduced explicit backend selection model with dependency injection for cleaner API.

* **Improvements**
  * Reduced supported backends from five to three, focusing on most-used implementations.
  * Enhanced input validation with stricter namespace and rule checks.
  * Improved error handling with clearer error types.

* **Tests**
  * Added comprehensive test coverage for all backend implementations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->