### PR TITLE
feat(sys): inject exec.Runner into single-impl packages (reboot, osquery, notify, inventory) (#138)

### DIFF
--- a/go/sys/inventory/inventory.go
+++ b/go/sys/inventory/inventory.go
@@ -2,20 +2,23 @@
 
 // Package inventory provides lightweight system inventory collection using
 // standard Linux interfaces (/proc, /etc, standard tools) without requiring
-// osquery.
+// osquery. Command-backed collectors run through an injected exec.Runner.
+//
+//	r, _ := exec.NewRunner(exec.Direct)
+//	inv, _ := inventory.New(r)
+//	sys, _ := inv.System(ctx)
 //
 // Status: SDK-resident, single-consumer today (the agent's connect-time
 // inventory snapshot). The package lives in the SDK rather than under
-// agent/internal/sys because the planned server-side compliance preview
-// (control server emitting "what would my next inventory look like?"
-// for a registered device) needs the same parsers. Until that consumer
-// materialises, the second-consumer rule (CLAUDE.md) is provisionally
-// waived. F027 in TECH_DEBT_AUDIT.md.
+// agent/internal/sys because the planned server-side compliance preview needs
+// the same parsers. F027 in TECH_DEBT_AUDIT.md.
 package inventory
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -23,8 +26,15 @@ import (
 	"strings"
 
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
 
-	"context"
+// Seams for the file-backed sources, overridable from tests so the
+// command-driven collectors can be exercised deterministically.
+var (
+	cpuinfoPath   = "/proc/cpuinfo"
+	meminfoPath   = "/proc/meminfo"
+	osReleasePath = "/etc/os-release"
+	hostnameFn    = os.Hostname
 )
 
 // SystemInfo holds basic hardware and kernel information.
@@ -37,43 +47,185 @@ type SystemInfo struct {
 	KernelVersion string
 }
 
-// GetSystemInfo returns basic system information.
-// Sources: hostname(), /proc/cpuinfo, /proc/meminfo, runtime.GOARCH, uname -r.
-func GetSystemInfo(ctx context.Context) (*SystemInfo, error) {
-	info := &SystemInfo{
-		Arch: runtime.GOARCH,
-	}
+// OSInfo holds operating system identification details.
+type OSInfo struct {
+	Name       string // e.g. "Fedora Linux"
+	Version    string // e.g. "43"
+	ID         string // e.g. "fedora"
+	PrettyName string // e.g. "Fedora Linux 43 (Workstation Edition)"
+	VersionID  string // e.g. "43"
+	Arch       string // e.g. "x86_64" (runtime.GOARCH)
+}
 
-	hostname, err := os.Hostname()
+// DiskInfo holds block device information.
+type DiskInfo struct {
+	Device string // e.g. "/dev/sda"
+	Size   string // e.g. "500G" (human-readable from lsblk)
+	Type   string // e.g. "disk", "part"
+	Mount  string // e.g. "/"
+}
+
+// NetworkInterface holds network interface details.
+type NetworkInterface struct {
+	Name      string
+	MAC       string
+	Addresses []string // e.g. ["192.168.1.100/24", "fe80::1/64"]
+	State     string   // "UP" or "DOWN"
+}
+
+// Collector gathers system inventory. Command-backed methods run through the
+// injected Runner; OS() is a pure /etc/os-release read.
+type Collector interface {
+	System(ctx context.Context) (*SystemInfo, error)
+	OS() (*OSInfo, error)
+	Disks(ctx context.Context) ([]DiskInfo, error)
+	NetworkInterfaces(ctx context.Context) ([]NetworkInterface, error)
+}
+
+// New returns a Collector driven by runner. A nil runner is rejected.
+func New(runner exec.Runner) (Collector, error) {
+	if runner == nil {
+		return nil, errors.New("inventory: runner is required")
+	}
+	return &collector{r: runner}, nil
+}
+
+type collector struct {
+	r exec.Runner
+}
+
+// read runs an unprivileged query and returns its stdout, mapping a non-zero
+// exit (or a failure to execute) to an error.
+func (c *collector) read(ctx context.Context, name string, args ...string) (string, error) {
+	res, err := c.r.Run(ctx, exec.Command{Name: name, Args: args})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", &exec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res.Stdout, nil
+}
+
+// System returns basic system information. Sources: hostname, /proc/cpuinfo,
+// /proc/meminfo, runtime.GOARCH, uname -r.
+func (c *collector) System(ctx context.Context) (*SystemInfo, error) {
+	info := &SystemInfo{Arch: runtime.GOARCH}
+
+	hostname, err := hostnameFn()
 	if err != nil {
 		return nil, fmt.Errorf("get hostname: %w", err)
 	}
 	info.Hostname = hostname
 
-	cpuModel, cpuCores, err := parseCPUInfo("/proc/cpuinfo")
+	cpuModel, cpuCores, err := parseCPUInfo(cpuinfoPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse cpuinfo: %w", err)
 	}
 	info.CPUModel = cpuModel
 	info.CPUCores = cpuCores
 
-	memTotal, err := parseMemTotal("/proc/meminfo")
+	memTotal, err := parseMemTotal(meminfoPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse meminfo: %w", err)
 	}
 	info.MemoryTotalMB = memTotal
 
-	result, err := exec.Run(ctx, "uname", "-r")
+	out, err := c.read(ctx, "uname", "-r")
 	if err != nil {
 		return nil, fmt.Errorf("get kernel version: %w", err)
 	}
-	info.KernelVersion = strings.TrimSpace(result.Stdout)
+	info.KernelVersion = strings.TrimSpace(out)
 
 	return info, nil
 }
 
-// parseCPUInfo reads /proc/cpuinfo and extracts the CPU model name and core
-// count.
+// OS returns operating system details from /etc/os-release.
+func (c *collector) OS() (*OSInfo, error) {
+	info, err := parseOSRelease(osReleasePath)
+	if err != nil {
+		return nil, err
+	}
+	info.Arch = runtime.GOARCH
+	return info, nil
+}
+
+// Disks returns block device information via lsblk --json.
+func (c *collector) Disks(ctx context.Context) ([]DiskInfo, error) {
+	out, err := c.read(ctx, "lsblk", "--json", "-o", "NAME,SIZE,TYPE,MOUNTPOINT")
+	if err != nil {
+		return nil, fmt.Errorf("run lsblk: %w", err)
+	}
+
+	type blockDevice struct {
+		Name       string        `json:"name"`
+		Size       string        `json:"size"`
+		Type       string        `json:"type"`
+		Mountpoint string        `json:"mountpoint"`
+		Children   []blockDevice `json:"children"`
+	}
+	var output struct {
+		Blockdevices []blockDevice `json:"blockdevices"`
+	}
+	if err := json.Unmarshal([]byte(out), &output); err != nil {
+		return nil, fmt.Errorf("parse lsblk output: %w", err)
+	}
+
+	var disks []DiskInfo
+	var walk func(devices []blockDevice)
+	walk = func(devices []blockDevice) {
+		for _, bd := range devices {
+			disks = append(disks, DiskInfo{
+				Device: "/dev/" + bd.Name,
+				Size:   bd.Size,
+				Type:   bd.Type,
+				Mount:  bd.Mountpoint,
+			})
+			if len(bd.Children) > 0 {
+				walk(bd.Children)
+			}
+		}
+	}
+	walk(output.Blockdevices)
+	return disks, nil
+}
+
+// NetworkInterfaces returns network interface details via ip -j addr.
+func (c *collector) NetworkInterfaces(ctx context.Context) ([]NetworkInterface, error) {
+	out, err := c.read(ctx, "ip", "-j", "addr")
+	if err != nil {
+		return nil, fmt.Errorf("run ip addr: %w", err)
+	}
+
+	var output []struct {
+		IfName    string `json:"ifname"`
+		Address   string `json:"address"`
+		OperState string `json:"operstate"`
+		AddrInfo  []struct {
+			Local     string `json:"local"`
+			PrefixLen int    `json:"prefixlen"`
+		} `json:"addr_info"`
+	}
+	if err := json.Unmarshal([]byte(out), &output); err != nil {
+		return nil, fmt.Errorf("parse ip addr output: %w", err)
+	}
+
+	interfaces := make([]NetworkInterface, 0, len(output))
+	for _, iface := range output {
+		ni := NetworkInterface{
+			Name:  iface.IfName,
+			MAC:   iface.Address,
+			State: strings.ToUpper(iface.OperState),
+		}
+		for _, addr := range iface.AddrInfo {
+			ni.Addresses = append(ni.Addresses, fmt.Sprintf("%s/%d", addr.Local, addr.PrefixLen))
+		}
+		interfaces = append(interfaces, ni)
+	}
+	return interfaces, nil
+}
+
+// parseCPUInfo reads /proc/cpuinfo and extracts the CPU model name and core count.
 func parseCPUInfo(path string) (model string, cores int, err error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -131,26 +283,6 @@ func parseMemTotal(path string) (int64, error) {
 	return 0, fmt.Errorf("MemTotal not found in %s", path)
 }
 
-// OSInfo holds operating system identification details.
-type OSInfo struct {
-	Name       string // e.g. "Fedora Linux"
-	Version    string // e.g. "43"
-	ID         string // e.g. "fedora"
-	PrettyName string // e.g. "Fedora Linux 43 (Workstation Edition)"
-	VersionID  string // e.g. "43"
-	Arch       string // e.g. "x86_64" (from runtime.GOARCH mapped to uname convention)
-}
-
-// GetOSInfo returns operating system details from /etc/os-release.
-func GetOSInfo() (*OSInfo, error) {
-	info, err := parseOSRelease("/etc/os-release")
-	if err != nil {
-		return nil, err
-	}
-	info.Arch = runtime.GOARCH
-	return info, nil
-}
-
 // parseOSRelease parses an os-release file and returns OSInfo.
 func parseOSRelease(path string) (*OSInfo, error) {
 	f, err := os.Open(path)
@@ -162,8 +294,7 @@ func parseOSRelease(path string) (*OSInfo, error) {
 	info := &OSInfo{}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		line := scanner.Text()
-		key, value, ok := parseOSReleaseLine(line)
+		key, value, ok := parseOSReleaseLine(scanner.Text())
 		if !ok {
 			continue
 		}
@@ -186,8 +317,8 @@ func parseOSRelease(path string) (*OSInfo, error) {
 	return info, nil
 }
 
-// parseOSReleaseLine parses a single KEY=VALUE line from os-release.
-// Values may be optionally quoted with double quotes.
+// parseOSReleaseLine parses a single KEY=VALUE line from os-release. Values may be
+// optionally quoted with double quotes.
 func parseOSReleaseLine(line string) (key, value string, ok bool) {
 	line = strings.TrimSpace(line)
 	if line == "" || strings.HasPrefix(line, "#") {
@@ -199,102 +330,8 @@ func parseOSReleaseLine(line string) (key, value string, ok bool) {
 	}
 	key = parts[0]
 	value = parts[1]
-	// Remove surrounding quotes if present.
 	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
 		value = value[1 : len(value)-1]
 	}
 	return key, value, true
-}
-
-// DiskInfo holds block device information.
-type DiskInfo struct {
-	Device string // e.g. "/dev/sda"
-	Size   string // e.g. "500G" (human-readable from lsblk)
-	Type   string // e.g. "disk", "part"
-	Mount  string // e.g. "/"
-}
-
-// GetDisks returns block device information via lsblk --json.
-func GetDisks(ctx context.Context) ([]DiskInfo, error) {
-	result, err := exec.Run(ctx, "lsblk", "--json", "-o", "NAME,SIZE,TYPE,MOUNTPOINT")
-	if err != nil {
-		return nil, fmt.Errorf("run lsblk: %w", err)
-	}
-
-	type blockDevice struct {
-		Name       string        `json:"name"`
-		Size       string        `json:"size"`
-		Type       string        `json:"type"`
-		Mountpoint string        `json:"mountpoint"`
-		Children   []blockDevice `json:"children"`
-	}
-
-	var output struct {
-		Blockdevices []blockDevice `json:"blockdevices"`
-	}
-	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
-		return nil, fmt.Errorf("parse lsblk output: %w", err)
-	}
-
-	var disks []DiskInfo
-	var walk func(devices []blockDevice)
-	walk = func(devices []blockDevice) {
-		for _, bd := range devices {
-			disks = append(disks, DiskInfo{
-				Device: "/dev/" + bd.Name,
-				Size:   bd.Size,
-				Type:   bd.Type,
-				Mount:  bd.Mountpoint,
-			})
-			if len(bd.Children) > 0 {
-				walk(bd.Children)
-			}
-		}
-	}
-	walk(output.Blockdevices)
-	return disks, nil
-}
-
-// NetworkInterface holds network interface details.
-type NetworkInterface struct {
-	Name      string
-	MAC       string
-	Addresses []string // e.g. ["192.168.1.100/24", "fe80::1/64"]
-	State     string   // "UP" or "DOWN"
-}
-
-// GetNetworkInterfaces returns network interface details via ip -j addr.
-func GetNetworkInterfaces(ctx context.Context) ([]NetworkInterface, error) {
-	result, err := exec.Run(ctx, "ip", "-j", "addr")
-	if err != nil {
-		return nil, fmt.Errorf("run ip addr: %w", err)
-	}
-
-	var output []struct {
-		IfName    string   `json:"ifname"`
-		Address   string   `json:"address"`
-		OperState string   `json:"operstate"`
-		Flags     []string `json:"flags"`
-		AddrInfo  []struct {
-			Local     string `json:"local"`
-			PrefixLen int    `json:"prefixlen"`
-		} `json:"addr_info"`
-	}
-	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
-		return nil, fmt.Errorf("parse ip addr output: %w", err)
-	}
-
-	interfaces := make([]NetworkInterface, 0, len(output))
-	for _, iface := range output {
-		ni := NetworkInterface{
-			Name:  iface.IfName,
-			MAC:   iface.Address,
-			State: strings.ToUpper(iface.OperState),
-		}
-		for _, addr := range iface.AddrInfo {
-			ni.Addresses = append(ni.Addresses, fmt.Sprintf("%s/%d", addr.Local, addr.PrefixLen))
-		}
-		interfaces = append(interfaces, ni)
-	}
-	return interfaces, nil
 }

--- a/go/sys/inventory/inventory_parsers_test.go
+++ b/go/sys/inventory/inventory_parsers_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package inventory
+
+import (
+	"testing"
+)
+
+// Reading a *directory* with bufio.Scanner: os.Open succeeds but the first Read
+// returns EISDIR, so scanner.Err() is non-nil — the cheap way to exercise the
+// defensive scan-error branches of the parsers.
+func TestParsers_ScanError(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := parseCPUInfo(dir); err == nil {
+		t.Error("parseCPUInfo(dir) = nil error, want a scan error")
+	}
+	if _, err := parseMemTotal(dir); err == nil {
+		t.Error("parseMemTotal(dir) = nil error, want a scan error")
+	}
+	if _, err := parseOSRelease(dir); err == nil {
+		t.Error("parseOSRelease(dir) = nil error, want a scan error")
+	}
+}
+
+func TestParseMemTotal_EdgeCases(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"MemTotal with no value", "MemTotal:\n"},
+		{"MemTotal value not a number", "MemTotal:       notanumber kB\n"},
+		{"no MemTotal line at all", "MemFree:         8192000 kB\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parseMemTotal(writeTemp(t, c.content)); err == nil {
+				t.Errorf("parseMemTotal(%q) = nil error, want failure", c.content)
+			}
+		})
+	}
+}
+
+func TestParseOSReleaseLine_NoEquals(t *testing.T) {
+	// A non-comment, non-empty line without '=' is not a property.
+	if _, _, ok := parseOSReleaseLine("this is not a property"); ok {
+		t.Error("parseOSReleaseLine accepted a line with no '='")
+	}
+}

--- a/go/sys/inventory/inventory_test.go
+++ b/go/sys/inventory/inventory_test.go
@@ -4,105 +4,193 @@ package inventory
 
 import (
 	"context"
+	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-func testCtx(t *testing.T) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-	return ctx
+func newCollector(t *testing.T, r exec.Runner) Collector {
+	t.Helper()
+	c, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
 }
 
-func TestGetSystemInfo(t *testing.T) {
-	ctx := testCtx(t)
-	info, err := GetSystemInfo(ctx)
-	if err != nil {
-		t.Fatalf("GetSystemInfo() error: %v", err)
+// writeTemp writes content to a temp file and returns its path.
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
 	}
+	return p
+}
 
-	if info.Hostname == "" {
-		t.Error("Hostname is empty")
-	}
-	if info.CPUModel == "" {
-		t.Error("CPUModel is empty")
-	}
-	if info.CPUCores <= 0 {
-		t.Errorf("CPUCores = %d, want > 0", info.CPUCores)
-	}
-	if info.MemoryTotalMB <= 0 {
-		t.Errorf("MemoryTotalMB = %d, want > 0", info.MemoryTotalMB)
-	}
-	if info.Arch == "" {
-		t.Error("Arch is empty")
-	}
-	if info.KernelVersion == "" {
-		t.Error("KernelVersion is empty")
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error")
 	}
 }
 
-func TestGetOSInfo(t *testing.T) {
-	info, err := GetOSInfo()
-	if err != nil {
-		t.Fatalf("GetOSInfo() error: %v", err)
-	}
+func TestSystem(t *testing.T) {
+	cpu := strings.Join([]string{
+		"processor\t: 0", "model name\t: Test CPU",
+		"processor\t: 1", "model name\t: Test CPU",
+	}, "\n")
+	restore := func() func() {
+		oc, om, oh := cpuinfoPath, meminfoPath, hostnameFn
+		cpuinfoPath = writeTemp(t, cpu)
+		meminfoPath = writeTemp(t, "MemTotal:       16384000 kB\n")
+		hostnameFn = func() (string, error) { return "host01", nil }
+		return func() { cpuinfoPath, meminfoPath, hostnameFn = oc, om, oh }
+	}()
+	t.Cleanup(restore)
 
-	if info.ID == "" {
-		t.Error("ID is empty")
-	}
-	if info.PrettyName == "" {
-		t.Error("PrettyName is empty")
-	}
-	if info.Arch == "" {
-		t.Error("Arch is empty")
-	}
-}
-
-func TestGetDisks(t *testing.T) {
-	ctx := testCtx(t)
-	disks, err := GetDisks(ctx)
-	if err != nil {
-		t.Fatalf("GetDisks() error: %v", err)
-	}
-
-	if len(disks) == 0 {
-		t.Fatal("expected at least one disk")
-	}
-
-	for _, d := range disks {
-		if d.Device == "" {
-			t.Error("disk Device is empty")
+	t.Run("success", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "6.1.0-test\n"}, nil) // uname -r
+		info, err := newCollector(t, r).System(context.Background())
+		if err != nil {
+			t.Fatal(err)
 		}
-		if d.Type == "" {
-			t.Error("disk Type is empty")
+		if info.Hostname != "host01" || info.CPUModel != "Test CPU" || info.CPUCores != 2 ||
+			info.MemoryTotalMB != 16000 || info.KernelVersion != "6.1.0-test" || info.Arch == "" {
+			t.Errorf("info = %+v", info)
 		}
-	}
+		if cmd := r.Calls()[0]; cmd.Name != "uname" || cmd.Escalate {
+			t.Errorf("command = %+v, want unprivileged uname", cmd)
+		}
+	})
+
+	t.Run("hostname error", func(t *testing.T) {
+		oh := hostnameFn
+		hostnameFn = func() (string, error) { return "", errors.New("no hostname") }
+		t.Cleanup(func() { hostnameFn = oh })
+		if _, err := newCollector(t, exectest.New(exec.Direct)).System(context.Background()); err == nil {
+			t.Error("System ignored a hostname failure")
+		}
+	})
+
+	t.Run("cpuinfo missing", func(t *testing.T) {
+		oc := cpuinfoPath
+		cpuinfoPath = filepath.Join(t.TempDir(), "nope")
+		t.Cleanup(func() { cpuinfoPath = oc })
+		if _, err := newCollector(t, exectest.New(exec.Direct)).System(context.Background()); err == nil {
+			t.Error("System ignored a missing cpuinfo")
+		}
+	})
+
+	t.Run("meminfo missing", func(t *testing.T) {
+		om := meminfoPath
+		meminfoPath = filepath.Join(t.TempDir(), "nope")
+		t.Cleanup(func() { meminfoPath = om })
+		if _, err := newCollector(t, exectest.New(exec.Direct)).System(context.Background()); err == nil {
+			t.Error("System ignored a missing meminfo")
+		}
+	})
+
+	t.Run("uname failure", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+		if _, err := newCollector(t, r).System(context.Background()); err == nil {
+			t.Error("System ignored a uname failure")
+		}
+	})
 }
 
-func TestGetNetworkInterfaces(t *testing.T) {
-	ctx := testCtx(t)
-	ifaces, err := GetNetworkInterfaces(ctx)
-	if err != nil {
-		t.Fatalf("GetNetworkInterfaces() error: %v", err)
-	}
-
-	if len(ifaces) == 0 {
-		t.Fatal("expected at least one interface")
-	}
-
-	// Loopback should always exist.
-	found := false
-	for _, iface := range ifaces {
-		if iface.Name == "lo" {
-			found = true
-			break
+func TestOS(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		op := osReleasePath
+		osReleasePath = writeTemp(t, "ID=fedora\nPRETTY_NAME=\"Fedora Linux 43\"\n")
+		t.Cleanup(func() { osReleasePath = op })
+		info, err := newCollector(t, exectest.New(exec.Direct)).OS()
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
-	if !found {
-		t.Error("loopback interface (lo) not found")
-	}
+		if info.ID != "fedora" || info.PrettyName != "Fedora Linux 43" || info.Arch == "" {
+			t.Errorf("info = %+v", info)
+		}
+	})
+	t.Run("missing os-release", func(t *testing.T) {
+		op := osReleasePath
+		osReleasePath = filepath.Join(t.TempDir(), "nope")
+		t.Cleanup(func() { osReleasePath = op })
+		if _, err := newCollector(t, exectest.New(exec.Direct)).OS(); err == nil {
+			t.Error("OS ignored a missing os-release")
+		}
+	})
+}
+
+func TestDisks(t *testing.T) {
+	t.Run("success with nested children", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: `{"blockdevices":[
+			{"name":"sda","size":"500G","type":"disk","mountpoint":null,
+			 "children":[{"name":"sda1","size":"500G","type":"part","mountpoint":"/"}]}
+		]}`}, nil)
+		disks, err := newCollector(t, r).Disks(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(disks) != 2 || disks[0].Device != "/dev/sda" || disks[1].Device != "/dev/sda1" || disks[1].Mount != "/" {
+			t.Errorf("disks = %+v", disks)
+		}
+	})
+	t.Run("run failure", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 1}, nil)
+		if _, err := newCollector(t, r).Disks(context.Background()); err == nil {
+			t.Error("Disks ignored an lsblk failure")
+		}
+	})
+	t.Run("parse failure", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "not json"}, nil)
+		if _, err := newCollector(t, r).Disks(context.Background()); err == nil {
+			t.Error("Disks ignored unparseable lsblk output")
+		}
+	})
+}
+
+func TestNetworkInterfaces(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: `[
+			{"ifname":"lo","address":"00:00:00:00:00:00","operstate":"unknown",
+			 "addr_info":[{"local":"127.0.0.1","prefixlen":8}]},
+			{"ifname":"eth0","address":"aa:bb:cc:dd:ee:ff","operstate":"up",
+			 "addr_info":[{"local":"192.168.1.5","prefixlen":24}]}
+		]`}, nil)
+		ifaces, err := newCollector(t, r).NetworkInterfaces(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ifaces) != 2 || ifaces[0].Name != "lo" || ifaces[1].State != "UP" ||
+			len(ifaces[1].Addresses) != 1 || ifaces[1].Addresses[0] != "192.168.1.5/24" {
+			t.Errorf("ifaces = %+v", ifaces)
+		}
+	})
+	t.Run("run failure", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{}, errors.New("ip not found"))
+		if _, err := newCollector(t, r).NetworkInterfaces(context.Background()); err == nil {
+			t.Error("NetworkInterfaces ignored an ip failure")
+		}
+	})
+	t.Run("parse failure", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "not json"}, nil)
+		if _, err := newCollector(t, r).NetworkInterfaces(context.Background()); err == nil {
+			t.Error("NetworkInterfaces ignored unparseable ip output")
+		}
+	})
 }
 
 func TestParseOSRelease(t *testing.T) {

--- a/go/sys/notify/notify.go
+++ b/go/sys/notify/notify.go
@@ -1,11 +1,16 @@
-// Package notify sends system-wide notifications to logged-in users.
-// It uses wall for terminal sessions and notify-send for graphical sessions.
-// All operations are best-effort — errors are logged but never returned,
-// ensuring notifications never block the calling action.
+// Package notify sends system-wide notifications to logged-in users through an
+// injected exec.Runner. It uses wall for terminal sessions and notify-send for
+// graphical sessions. All operations are best-effort — errors are logged but
+// never returned, so notifications never block the calling action.
+//
+//	r, _ := exec.NewRunner(exec.Sudo)
+//	n, _ := notify.New(r)
+//	n.NotifyAll(ctx, "Maintenance", "Reboot in 5 minutes")
 package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +21,13 @@ import (
 	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
+// Seams: notify-send presence + the per-user D-Bus socket check. Overridable from
+// tests so desktop-notification dispatch can be exercised without a real session.
+var (
+	lookPath   = osexec.LookPath
+	statSocket = os.Stat
+)
+
 // session represents a logged-in user session discovered via loginctl.
 type session struct {
 	id   string
@@ -24,77 +36,90 @@ type session struct {
 	typ  string // "tty", "x11", "wayland", "mir"
 }
 
-// NotifyAll sends a notification to all logged-in users.
-// Terminal users receive a wall broadcast, graphical users receive a desktop notification.
-func NotifyAll(ctx context.Context, title, message string) {
-	sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
-	sendDesktopNotifications(ctx, title, message, nil)
+// Manager sends notifications to logged-in users. All methods are best-effort
+// (failures are logged, never returned).
+type Manager interface {
+	// NotifyAll notifies every logged-in user: a wall broadcast to terminal
+	// sessions and a desktop notification to graphical ones.
+	NotifyAll(ctx context.Context, title, message string)
+	// NotifyUsers notifies the named users only (wall still broadcasts, since it
+	// has no per-user target).
+	NotifyUsers(ctx context.Context, usernames []string, title, message string)
 }
 
-// NotifyUsers sends a notification to specific users.
-// Only sessions belonging to the named users receive notifications.
-func NotifyUsers(ctx context.Context, usernames []string, title, message string) {
-	sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
+// New returns a Manager driven by runner. A nil runner is rejected.
+func New(runner exec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("notify: runner is required")
+	}
+	return &notifier{r: runner}, nil
+}
 
+type notifier struct {
+	r exec.Runner
+}
+
+func (n *notifier) NotifyAll(ctx context.Context, title, message string) {
+	n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
+	n.sendDesktopNotifications(ctx, title, message, nil)
+}
+
+func (n *notifier) NotifyUsers(ctx context.Context, usernames []string, title, message string) {
+	n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
 	filter := make(map[string]bool, len(usernames))
 	for _, u := range usernames {
 		filter[u] = true
 	}
-	sendDesktopNotifications(ctx, title, message, filter)
+	n.sendDesktopNotifications(ctx, title, message, filter)
 }
 
-// sendWall broadcasts a message to all terminal sessions.
-func sendWall(ctx context.Context, message string) {
-	result, err := exec.PrivilegedWithStdin(ctx, strings.NewReader(message), "wall")
-	if err != nil {
-		stderr := ""
-		if result != nil {
-			stderr = result.Stderr
-		}
-		slog.Warn("wall notification failed", "error", err, "stderr", stderr)
+// sendWall broadcasts a message to all terminal sessions via wall (stdin).
+func (n *notifier) sendWall(ctx context.Context, message string) {
+	res, err := n.r.Run(ctx, exec.Command{
+		Name:     "wall",
+		Stdin:    strings.NewReader(message),
+		Escalate: true,
+	})
+	if err != nil || res.ExitCode != 0 {
+		slog.Warn("wall notification failed", "error", err, "stderr", res.Stderr)
 	}
 }
 
-// sendDesktopNotifications discovers graphical sessions and sends notify-send
-// to each. If userFilter is non-nil, only sessions matching those usernames
-// are notified.
-func sendDesktopNotifications(ctx context.Context, title, message string, userFilter map[string]bool) {
-	if _, err := osexec.LookPath("notify-send"); err != nil {
+// sendDesktopNotifications discovers graphical sessions and sends notify-send to
+// each. With a non-nil userFilter only matching usernames are notified.
+func (n *notifier) sendDesktopNotifications(ctx context.Context, title, message string, userFilter map[string]bool) {
+	if _, err := lookPath("notify-send"); err != nil {
 		slog.Warn("notify-send not available, skipping desktop notifications")
 		return
 	}
-
-	sessions := listGraphicalSessions(ctx)
+	sessions := n.listGraphicalSessions(ctx)
 	slog.Info("discovered graphical sessions for desktop notification", "count", len(sessions))
 	for _, s := range sessions {
 		if userFilter != nil && !userFilter[s.user] {
 			continue
 		}
-		sendDesktopNotification(ctx, s, title, message)
+		n.sendDesktopNotification(ctx, s, title, message)
 	}
 }
 
 // listGraphicalSessions returns all active graphical login sessions.
-func listGraphicalSessions(ctx context.Context) []session {
-	result, err := exec.Privileged(ctx, "loginctl", "list-sessions", "--no-legend")
-	if err != nil || result.ExitCode != 0 {
-		stderr := ""
-		if result != nil {
-			stderr = result.Stderr
-		}
-		slog.Warn("failed to list sessions", "error", err, "stderr", stderr)
+func (n *notifier) listGraphicalSessions(ctx context.Context) []session {
+	res, err := n.r.Run(ctx, exec.Command{Name: "loginctl", Args: []string{"list-sessions", "--no-legend"}, Escalate: true})
+	if err != nil || res.ExitCode != 0 {
+		slog.Warn("failed to list sessions", "error", err, "stderr", res.Stderr)
 		return nil
 	}
 
 	var sessions []session
-	for _, sessionID := range parseLoginctlListSessions(result.Stdout) {
-		// Query session type and user details. Without --value loginctl
-		// prints Key=Value lines so we can parse by name — D-Bus
-		// emission order isn't documented as stable, so positional
-		// parsing would silently misassign fields when the order
-		// shifts across systemd versions.
-		info, err := exec.Privileged(ctx, "loginctl", "show-session", sessionID,
-			"-p", "Type", "-p", "Name", "-p", "User")
+	for _, sessionID := range parseLoginctlListSessions(res.Stdout) {
+		// Without --value loginctl prints Key=Value lines so we parse by name —
+		// D-Bus emission order isn't documented as stable, so positional parsing
+		// would silently misassign fields across systemd versions.
+		info, err := n.r.Run(ctx, exec.Command{
+			Name:     "loginctl",
+			Args:     []string{"show-session", sessionID, "-p", "Type", "-p", "Name", "-p", "User"},
+			Escalate: true,
+		})
 		if err != nil || info.ExitCode != 0 {
 			continue
 		}
@@ -104,15 +129,13 @@ func listGraphicalSessions(ctx context.Context) []session {
 		}
 		sessions = append(sessions, s)
 	}
-
 	return sessions
 }
 
-// parseLoginctlListSessions extracts session IDs from `loginctl
-// list-sessions --no-legend` output. The first whitespace-separated
-// field is the session ID; lines with fewer than three fields are
-// skipped (matches the prior in-line behaviour). Pure-function shape
-// so it can be tested without shelling out (F026 in TECH_DEBT_AUDIT.md).
+// parseLoginctlListSessions extracts session IDs from `loginctl list-sessions
+// --no-legend` output. The first whitespace-separated field is the session ID;
+// lines with fewer than three fields are skipped. Pure-function shape so it can be
+// tested without shelling out (F026 in TECH_DEBT_AUDIT.md).
 func parseLoginctlListSessions(stdout string) []string {
 	var ids []string
 	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
@@ -125,13 +148,11 @@ func parseLoginctlListSessions(stdout string) []string {
 	return ids
 }
 
-// parseLoginctlShowSession parses `loginctl show-session <id> -p Type
-// -p Name -p User` output into a session struct. loginctl emits
-// Key=Value lines in D-Bus dictionary order, NOT the order of the -p
-// flags, so we parse by name instead of relying on positional output.
-// Returns (session, false) when any of Type / Name / User is missing,
-// when User isn't a numeric uid, when Name is empty, or when Type
-// isn't a graphical session (x11 / wayland / mir).
+// parseLoginctlShowSession parses `loginctl show-session <id> -p Type -p Name -p
+// User` output into a session struct, by property name (loginctl emits Key=Value
+// in D-Bus dictionary order, not -p order). Returns (session, false) when any of
+// Type / Name / User is missing, User isn't a numeric uid, Name is empty, or Type
+// isn't graphical (x11 / wayland / mir).
 func parseLoginctlShowSession(sessionID, stdout string) (session, bool) {
 	props := map[string]string{}
 	for _, line := range strings.Split(stdout, "\n") {
@@ -154,41 +175,33 @@ func parseLoginctlShowSession(sessionID, stdout string) (session, bool) {
 	if typ != "x11" && typ != "wayland" && typ != "mir" {
 		return session{}, false
 	}
-	return session{
-		id:   sessionID,
-		user: user,
-		uid:  uid,
-		typ:  typ,
-	}, true
+	return session{id: sessionID, user: user, uid: uid, typ: typ}, true
 }
 
-// sendDesktopNotification sends a freedesktop notification to a single graphical session.
-// It runs notify-send as the target user via runuser with the user's DBUS session.
-func sendDesktopNotification(ctx context.Context, s session, title, message string) {
-	dbusAddr := fmt.Sprintf("unix:path=/run/user/%d/bus", s.uid)
-
-	// Check if the DBUS socket exists
+// sendDesktopNotification sends a freedesktop notification to a single graphical
+// session, running notify-send as the target user (via runuser) with the user's
+// D-Bus session address. Each argument is passed separately to avoid shell
+// injection.
+func (n *notifier) sendDesktopNotification(ctx context.Context, s session, title, message string) {
 	socketPath := fmt.Sprintf("/run/user/%d/bus", s.uid)
-	if _, err := os.Stat(socketPath); err != nil {
-		slog.Warn("DBUS socket not found, skipping desktop notification",
-			"user", s.user, "path", socketPath)
+	if _, err := statSocket(socketPath); err != nil {
+		slog.Warn("DBUS socket not found, skipping desktop notification", "user", s.user, "path", socketPath)
 		return
 	}
+	dbusAddr := "unix:path=" + socketPath
 
-	// Use runuser to execute notify-send as the target user.
-	// Each argument is passed separately to avoid shell injection.
-	result, err := exec.Privileged(ctx, "env",
-		"DBUS_SESSION_BUS_ADDRESS="+dbusAddr,
-		"runuser", "-u", s.user, "--",
-		"notify-send", "-u", "critical", "-a", "Power Manage", "-i", "dialog-warning",
-		title, message,
-	)
-	if err != nil || (result != nil && result.ExitCode != 0) {
-		stderr := ""
-		if result != nil {
-			stderr = result.Stderr
-		}
+	res, err := n.r.Run(ctx, exec.Command{
+		Name: "env",
+		Args: []string{
+			"DBUS_SESSION_BUS_ADDRESS=" + dbusAddr,
+			"runuser", "-u", s.user, "--",
+			"notify-send", "-u", "critical", "-a", "Power Manage", "-i", "dialog-warning",
+			title, message,
+		},
+		Escalate: true,
+	})
+	if err != nil || res.ExitCode != 0 {
 		slog.Warn("desktop notification failed",
-			"user", s.user, "session", s.id, "type", s.typ, "error", err, "stderr", stderr)
+			"user", s.user, "session", s.id, "type", s.typ, "error", err, "stderr", res.Stderr)
 	}
 }

--- a/go/sys/notify/notify_runner_test.go
+++ b/go/sys/notify/notify_runner_test.go
@@ -1,0 +1,177 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func mgr(t *testing.T, r exec.Runner) Manager {
+	t.Helper()
+	m, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// seamPresent makes notify-send "installed" and the D-Bus socket "present".
+func seamPresent(t *testing.T) {
+	t.Helper()
+	ol, os_ := lookPath, statSocket
+	t.Cleanup(func() { lookPath, statSocket = ol, os_ })
+	lookPath = func(string) (string, error) { return "/usr/bin/notify-send", nil }
+	statSocket = func(string) (os.FileInfo, error) { return nil, nil }
+}
+
+func argv(c exec.Command) string { return c.Name + " " + strings.Join(c.Args, " ") }
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error")
+	}
+}
+
+func TestNotifyAll_FullGraphicalPath(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                                     // wall
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -\nc2 1001 bob seat0 -"}, nil) // list-sessions
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil)        // show c1
+	r.Push(exec.Result{Stdout: "Type=x11\nName=bob\nUser=1001"}, nil)              // show c2
+	r.Push(exec.Result{}, nil)                                                     // env notify-send alice
+	r.Push(exec.Result{}, nil)                                                     // env notify-send bob
+
+	mgr(t, r).NotifyAll(context.Background(), "Maintenance", "Reboot soon")
+
+	calls := r.Calls()
+	if len(calls) != 6 {
+		t.Fatalf("ran %d commands, want 6 (wall, list, 2× show, 2× env)", len(calls))
+	}
+	// wall carries the combined message on stdin, escalated.
+	if calls[0].Name != "wall" || !calls[0].Escalate {
+		t.Errorf("call0 = %+v, want escalated wall", calls[0])
+	}
+	if calls[0].Stdin == nil {
+		t.Fatal("wall has no stdin")
+	}
+	if b, _ := io.ReadAll(calls[0].Stdin); string(b) != "Maintenance: Reboot soon" {
+		t.Errorf("wall stdin = %q", b)
+	}
+	// the desktop notifications run as the target user with the title+message last.
+	last := argv(calls[5])
+	if !strings.Contains(last, "runuser -u bob") || !strings.Contains(last, "Maintenance Reboot soon") {
+		t.Errorf("env argv = %q, want runuser bob + title/message", last)
+	}
+	if !strings.Contains(argv(calls[4]), "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus") {
+		t.Errorf("alice env missing her dbus socket: %q", argv(calls[4]))
+	}
+}
+
+func TestNotifyUsers_FiltersToNamedUsers(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                                     // wall
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -\nc2 1001 bob seat0 -"}, nil) // list
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil)        // show c1
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=bob\nUser=1001"}, nil)          // show c2
+	r.Push(exec.Result{}, nil)                                                     // env (alice only)
+
+	mgr(t, r).NotifyUsers(context.Background(), []string{"alice"}, "T", "M")
+
+	calls := r.Calls()
+	// wall + list + 2× show + 1× env(alice). bob is filtered out.
+	if len(calls) != 5 {
+		t.Fatalf("ran %d commands, want 5 (bob filtered out)", len(calls))
+	}
+	if !strings.Contains(argv(calls[4]), "runuser -u alice") {
+		t.Errorf("only alice should be notified, got %q", argv(calls[4]))
+	}
+}
+
+func TestNotifyAll_NoNotifySendBinary(t *testing.T) {
+	ol, os_ := lookPath, statSocket
+	t.Cleanup(func() { lookPath, statSocket = ol, os_ })
+	lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	statSocket = func(string) (os.FileInfo, error) { return nil, nil }
+
+	r := exectest.New(exec.Sudo)
+	mgr(t, r).NotifyAll(context.Background(), "T", "M")
+	// Only wall runs; desktop dispatch short-circuits with no notify-send.
+	if calls := r.Calls(); len(calls) != 1 || calls[0].Name != "wall" {
+		t.Errorf("calls = %v, want just wall", calls)
+	}
+}
+
+func TestSendWall_FailureIsBestEffort(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "wall: cannot"}, nil) // wall fails
+	r.Push(exec.Result{Stdout: ""}, nil)                          // list-sessions empty
+	// Must not panic; best-effort.
+	mgr(t, r).NotifyAll(context.Background(), "T", "M")
+	if r.Calls()[0].Name != "wall" {
+		t.Error("wall not attempted")
+	}
+}
+
+func TestListGraphicalSessions_Failures(t *testing.T) {
+	t.Run("list-sessions fails → no desktop notifies", func(t *testing.T) {
+		seamPresent(t)
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{}, nil)                            // wall
+		r.Push(exec.Result{ExitCode: 1, Stderr: "nope"}, nil) // list-sessions fails
+		mgr(t, r).NotifyAll(context.Background(), "T", "M")
+		if n := len(r.Calls()); n != 2 {
+			t.Errorf("ran %d, want 2 (wall + failed list)", n)
+		}
+	})
+	t.Run("show-session failure and parse-reject are skipped", func(t *testing.T) {
+		seamPresent(t)
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{}, nil)                                   // wall
+		r.Push(exec.Result{Stdout: "c1 1 a s -\nc2 2 b s -"}, nil)   // list (2)
+		r.Push(exec.Result{ExitCode: 1}, nil)                        // show c1 fails
+		r.Push(exec.Result{Stdout: "Type=tty\nName=b\nUser=2"}, nil) // show c2 = tty (reject)
+		mgr(t, r).NotifyAll(context.Background(), "T", "M")
+		// wall + list + 2× show, no env (both sessions dropped).
+		if n := len(r.Calls()); n != 4 {
+			t.Errorf("ran %d, want 4 (no env for dropped sessions)", n)
+		}
+	})
+}
+
+func TestSendDesktopNotification_SocketAbsentAndFailure(t *testing.T) {
+	t.Run("socket absent → skip env", func(t *testing.T) {
+		ol, os_ := lookPath, statSocket
+		t.Cleanup(func() { lookPath, statSocket = ol, os_ })
+		lookPath = func(string) (string, error) { return "/usr/bin/notify-send", nil }
+		statSocket = func(string) (os.FileInfo, error) { return nil, errors.New("no socket") }
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{}, nil)                                              // wall
+		r.Push(exec.Result{Stdout: "c1 1000 alice s -"}, nil)                   // list
+		r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show
+		mgr(t, r).NotifyAll(context.Background(), "T", "M")
+		if n := len(r.Calls()); n != 3 {
+			t.Errorf("ran %d, want 3 (no env when the dbus socket is missing)", n)
+		}
+	})
+	t.Run("env failure is best-effort", func(t *testing.T) {
+		seamPresent(t)
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{}, nil)                                              // wall
+		r.Push(exec.Result{Stdout: "c1 1000 alice s -"}, nil)                   // list
+		r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show
+		r.Push(exec.Result{ExitCode: 1, Stderr: "notify-send failed"}, nil)     // env fails
+		mgr(t, r).NotifyAll(context.Background(), "T", "M")
+		if n := len(r.Calls()); n != 4 {
+			t.Errorf("ran %d, want 4 (env attempted despite failure)", n)
+		}
+	})
+}

--- a/go/sys/notify/notify_test.go
+++ b/go/sys/notify/notify_test.go
@@ -103,6 +103,14 @@ func TestParseLoginctlShowSession(t *testing.T) {
 			wantOK:    false,
 		},
 		{
+			// Inverse of the above: User present but Name empty. Builds an
+			// anonymous session we can't target, so it's rejected.
+			name:      "missing Name property is rejected",
+			sessionID: "c6b",
+			stdout:    "Type=wayland\nUser=1009",
+			wantOK:    false,
+		},
+		{
 			// Malformed UID is now treated as an invalid session
 			// because uid=0 (the silent Atoi fallback) would build
 			// /run/user/0/bus and either misroute the notification
@@ -119,6 +127,14 @@ func TestParseLoginctlShowSession(t *testing.T) {
 			stdout:    "  Type=wayland \n  Name=henry  \n  User=1005  ",
 			wantOK:    true,
 			want:      session{id: "c8", user: "henry", uid: 1005, typ: "wayland"},
+		},
+		{
+			// A line with no '=' (blank line, banner) is ignored, not fatal.
+			name:      "ignores lines without an equals sign",
+			sessionID: "c9",
+			stdout:    "Type=x11\n\nName=ivy\nUser=1006\nnot a property",
+			wantOK:    true,
+			want:      session{id: "c9", user: "ivy", uid: 1006, typ: "x11"},
 		},
 	}
 	for _, tc := range cases {

--- a/go/sys/osquery/osquery.go
+++ b/go/sys/osquery/osquery.go
@@ -1,4 +1,13 @@
-// Package osquery provides integration with the osquery binary for system queries.
+// Package osquery integrates the osquery binary for system queries through an
+// injected exec.Runner.
+//
+// Build a Client with a Runner and call its methods; every query is escalated
+// through the Runner. The convenience table path refuses a curated deny-list of
+// credential-bearing tables before running anything; the signed RawSql escape
+// hatch is the operator's explicit path and is intentionally not gated.
+//
+//	r, _ := exec.NewRunner(exec.Sudo)
+//	c, err := osquery.NewClient(r) // ErrNotInstalled if osqueryi is absent
 package osquery
 
 import (
@@ -6,26 +15,26 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
+	osexec "os/exec"
 	"regexp"
 	"strings"
 	"time"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // validTableName matches only safe osquery table names (alphanumeric + underscore).
 var validTableName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
-// sensitiveTables are osquery tables that can expose credential material or
-// other high-value secrets — password-hash metadata (shadow), secrets in
-// process environments (process_envs), scheduled commands (crontab), shell
-// history (shell_history), and sudoers policy (sudoers). They all pass
-// validTableName, so the shape-only check is not enough: the convenience table
-// path refuses them so a compromised control server cannot exfiltrate them
-// through the agent's privileged osquery. The signed RawSql escape hatch is
-// intentionally NOT gated here — it is the operator's explicit, CA-signed path.
+// sensitiveTables are osquery tables that can expose credential material or other
+// high-value secrets — password-hash metadata (shadow), secrets in process
+// environments (process_envs), scheduled commands (crontab), shell history
+// (shell_history), and sudoers policy (sudoers). They all pass validTableName, so
+// the shape-only check is not enough: the convenience table path refuses them so a
+// compromised control server cannot exfiltrate them through the agent's
+// privileged osquery. The signed RawSql escape hatch is intentionally NOT gated
+// here — it is the operator's explicit, CA-signed path.
 var sensitiveTables = map[string]bool{
 	"shadow":        true,
 	"process_envs":  true,
@@ -34,8 +43,8 @@ var sensitiveTables = map[string]bool{
 	"sudoers":       true,
 }
 
-// isSensitiveTable reports whether name is on the curated deny-list. Comparison
-// is case- and whitespace-insensitive so trivial variants cannot slip past.
+// isSensitiveTable reports whether name is on the curated deny-list. Comparison is
+// case- and whitespace-insensitive so trivial variants cannot slip past.
 func isSensitiveTable(name string) bool {
 	return sensitiveTables[strings.ToLower(strings.TrimSpace(name))]
 }
@@ -58,19 +67,23 @@ var (
 	defaultTimeout = 30 * time.Second
 )
 
-// Client wraps osquery binary execution.
+// Client wraps osquery binary execution over an injected Runner.
 type Client struct {
 	binaryPath string
+	r          exec.Runner
 }
 
-// NewClient creates a new osquery client.
-// Returns ErrNotInstalled if osquery binary is not found.
-func NewClient() (*Client, error) {
+// NewClient creates an osquery client driven by runner. Returns ErrNotInstalled
+// when the osqueryi binary is not found, and an error when runner is nil.
+func NewClient(runner exec.Runner) (*Client, error) {
+	if runner == nil {
+		return nil, errors.New("osquery: runner is required")
+	}
 	path := findOsqueryBinary()
 	if path == "" {
 		return nil, ErrNotInstalled
 	}
-	return &Client{binaryPath: path}, nil
+	return &Client{binaryPath: path, r: runner}, nil
 }
 
 // IsInstalled checks if osquery is installed on the system.
@@ -78,26 +91,24 @@ func IsInstalled() bool {
 	return findOsqueryBinary() != ""
 }
 
-// lookPath is the resolution function used by findOsqueryBinary.
-// It defaults to exec.LookPath and is overridable from tests so the
-// binary-discovery logic can be exercised without depending on what
-// is installed on the test host (F026 in TECH_DEBT_AUDIT.md).
-var lookPath = exec.LookPath
+// lookPath is the resolution function used by findOsqueryBinary. It defaults to
+// os/exec.LookPath and is overridable from tests so binary discovery can be
+// exercised without depending on what is installed on the test host (F026 in
+// TECH_DEBT_AUDIT.md).
+var lookPath = osexec.LookPath
 
 // findOsqueryBinary searches for the osqueryi binary.
 //
-// Resolution order: explicit absolute paths in osqueryPaths first
-// (matches the "use the system package's location if available"
-// expectation on Fedora/RHEL/Debian), then PATH lookup for the bare
-// "osqueryi" name (covers Homebrew/Linuxbrew, Nix, Snap, manual
-// installs).
+// Resolution order: explicit absolute paths in osqueryPaths first (matches the
+// "use the system package's location if available" expectation on
+// Fedora/RHEL/Debian), then PATH lookup for the bare "osqueryi" name (covers
+// Homebrew/Linuxbrew, Nix, Snap, manual installs).
 func findOsqueryBinary() string {
 	for _, path := range osqueryPaths {
 		if _, err := lookPath(path); err == nil {
 			return path
 		}
 	}
-	// Also check PATH
 	if path, err := lookPath("osqueryi"); err == nil {
 		return path
 	}
@@ -208,12 +219,8 @@ func (c *Client) QueryTable(ctx context.Context, tableName string) ([]*pb.OSQuer
 	return c.QuerySQL(ctx, sql)
 }
 
-// execPrivileged runs the osquery binary under the privilege backend. It is a
-// package var so tests can record (and refuse) execution, proving the
-// sensitive-table deny-list short-circuits BEFORE any query is run.
-var execPrivileged = sysexec.Privileged
-
-// execQuery executes an osquery command via sudo and returns the output.
+// execQuery executes an osquery command (escalated through the Runner) and
+// returns its stdout.
 func (c *Client) execQuery(ctx context.Context, query string) (string, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -228,47 +235,16 @@ func (c *Client) execQuery(ctx context.Context, query string) (string, error) {
 		args = append(args, "--json", query)
 	}
 
-	result, err := execPrivileged(ctx, c.binaryPath, args...)
+	res, err := c.r.Run(ctx, exec.Command{Name: c.binaryPath, Args: args, Escalate: true})
 	if err != nil {
-		stderr := ""
-		if result != nil {
-			stderr = result.Stderr
-		}
-		if stderr != "" {
-			return "", fmt.Errorf("%w: %s", ErrQueryFailed, stderr)
-		}
 		return "", fmt.Errorf("%w: %v", ErrQueryFailed, err)
 	}
-
-	return strings.TrimSpace(result.Stdout), nil
-}
-
-// Registry provides backwards compatibility with the old interface.
-type Registry struct {
-	client *Client
-}
-
-// NewRegistry creates a new Registry.
-// Returns an error if osquery is not installed.
-func NewRegistry() (*Registry, error) {
-	client, err := NewClient()
-	if err != nil {
-		return nil, err
+	if res.ExitCode != 0 {
+		if stderr := strings.TrimSpace(res.Stderr); stderr != "" {
+			return "", fmt.Errorf("%w: %s", ErrQueryFailed, stderr)
+		}
+		return "", fmt.Errorf("%w: exit code %d", ErrQueryFailed, res.ExitCode)
 	}
-	return &Registry{client: client}, nil
-}
 
-// Query executes a query against an osquery table.
-func (r *Registry) Query(query *pb.OSQuery) (*pb.OSQueryResult, error) {
-	return r.client.Query(context.Background(), query)
-}
-
-// ListTables returns available osquery tables.
-func (r *Registry) ListTables() ([]string, error) {
-	return r.client.ListTables(context.Background())
-}
-
-// QueryTable queries a specific table by name.
-func (r *Registry) QueryTable(tableName string) ([]*pb.OSQueryRow, error) {
-	return r.client.QueryTable(context.Background(), tableName)
+	return strings.TrimSpace(res.Stdout), nil
 }

--- a/go/sys/osquery/osquery_coverage_test.go
+++ b/go/sys/osquery/osquery_coverage_test.go
@@ -1,0 +1,114 @@
+package osquery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func TestListTables(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	// Bare table names are kept; "=>"-prefixed lines, "+" header noise, and
+	// blanks are skipped.
+	r.Push(exec.Result{Stdout: "os_version\nuptime\n+ ignore me\n\n=> skip me\nsystem_info\n"}, nil)
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	tables, err := c.ListTables(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"os_version": true, "uptime": true, "system_info": true}
+	if len(tables) != 3 {
+		t.Fatalf("tables = %v, want 3 entries", tables)
+	}
+	for _, tb := range tables {
+		if !want[tb] {
+			t.Errorf("unexpected table %q", tb)
+		}
+	}
+	// `.tables` is a dot-command — passed bare, not via --json.
+	if argv := strings.Join(r.Calls()[0].Args, " "); argv != ".tables" {
+		t.Errorf("argv = %q, want bare `.tables`", argv)
+	}
+}
+
+func TestListTables_ExecError(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	if _, err := c.ListTables(context.Background()); err == nil {
+		t.Error("ListTables swallowed a query failure")
+	}
+}
+
+func TestQuery_CustomTableSQL(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "[]"}, nil)
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", Table: "authorized_keys"})
+	if err != nil || !res.Success {
+		t.Fatalf("Query(authorized_keys) = (%+v,%v)", res, err)
+	}
+	if argv := strings.Join(r.Calls()[0].Args, " "); !strings.Contains(argv, "JOIN authorized_keys USING (uid)") {
+		t.Errorf("custom JOIN SQL not used: %q", argv)
+	}
+}
+
+func TestQuery_QuerySQLErrorSurfacesInResult(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "not json"}, nil) // parse failure inside QuerySQL
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", Table: "os_version"})
+	if err != nil {
+		t.Fatalf("Query should fold the SQL error into the result, not return it: %v", err)
+	}
+	if res.Success || res.Error == "" {
+		t.Errorf("res = %+v, want Success=false with a populated Error", res)
+	}
+}
+
+func TestQueryTable(t *testing.T) {
+	t.Run("benign", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: `[{"name":"x"}]`}, nil)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		rows, err := c.QueryTable(context.Background(), "os_version")
+		if err != nil || len(rows) != 1 {
+			t.Fatalf("QueryTable = (%v,%v), want one row", rows, err)
+		}
+	})
+	t.Run("custom tableSQL", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "[]"}, nil)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QueryTable(context.Background(), "authorized_keys"); err != nil {
+			t.Fatal(err)
+		}
+		if argv := strings.Join(r.Calls()[0].Args, " "); !strings.Contains(argv, "JOIN authorized_keys") {
+			t.Errorf("custom SQL not used: %q", argv)
+		}
+	})
+	t.Run("invalid name rejected before exec", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QueryTable(context.Background(), "bad name!"); err == nil {
+			t.Error("QueryTable accepted an invalid name")
+		}
+		if len(r.Calls()) != 0 {
+			t.Error("ran a query for an invalid table name")
+		}
+	})
+	t.Run("sensitive table refused before exec", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QueryTable(context.Background(), "shadow"); err == nil {
+			t.Error("QueryTable returned a sensitive table")
+		}
+		if len(r.Calls()) != 0 {
+			t.Error("ran a query for a sensitive table")
+		}
+	})
+}

--- a/go/sys/osquery/osquery_sensitive_test.go
+++ b/go/sys/osquery/osquery_sensitive_test.go
@@ -2,29 +2,24 @@ package osquery
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	pb "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
 // The non-raw Query() table path must refuse known-sensitive tables even though
 // they match validTableName, and must do so BEFORE building or running any SQL.
 // The sensitive cases are sourced from intent (credential-bearing osquery
-// tables), not from the validTableName regex. The execPrivileged seam records
-// every execution so the test can prove the deny path runs zero queries.
+// tables), not from the validTableName regex. The FakeRunner records every
+// execution so the test can prove the deny path runs zero queries.
 func TestQuery_DeniesSensitiveTables(t *testing.T) {
-	orig := execPrivileged
-	t.Cleanup(func() { execPrivileged = orig })
-
-	var executed []string // args actually sent to the osquery binary
-	execPrivileged = func(ctx context.Context, name string, args ...string) (*sysexec.Result, error) {
-		executed = append(executed, strings.Join(args, " "))
-		return &sysexec.Result{Stdout: "[]"}, nil // valid empty JSON result set
-	}
-
-	c := &Client{binaryPath: "/usr/bin/osqueryi"}
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "[]"}, nil) // consumed only by the benign os_version run
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
 	ctx := context.Background()
 
 	// present-but-wrong: each sensitive table is regex-valid but policy-forbidden.
@@ -40,9 +35,6 @@ func TestQuery_DeniesSensitiveTables(t *testing.T) {
 			t.Errorf("Query(%q) error = %q, want it to name the table as not permitted", table, res.Error)
 		}
 	}
-	if len(executed) != 0 {
-		t.Errorf("a denied table must execute no query, but %d ran: %v", len(executed), executed)
-	}
 
 	// ABSENT: empty table and empty RawSql → the existing invalid-name rejection.
 	res, err := c.Query(ctx, &pb.OSQuery{QueryId: "q", Table: ""})
@@ -53,8 +45,12 @@ func TestQuery_DeniesSensitiveTables(t *testing.T) {
 		t.Errorf("empty table = %+v, want the invalid-name rejection", res)
 	}
 
+	// No query has run yet — every denied/invalid table short-circuits.
+	if n := len(r.Calls()); n != 0 {
+		t.Fatalf("a denied table must execute no query, but %d ran: %v", n, r.Calls())
+	}
+
 	// correct: a benign table builds and runs SELECT * FROM <table> exactly once.
-	executed = nil
 	res, err = c.Query(ctx, &pb.OSQuery{QueryId: "q", Table: "os_version"})
 	if err != nil {
 		t.Fatalf("Query(os_version) error: %v", err)
@@ -62,15 +58,73 @@ func TestQuery_DeniesSensitiveTables(t *testing.T) {
 	if !res.Success {
 		t.Errorf("a non-sensitive table must be queryable, got %+v", res)
 	}
-	if len(executed) != 1 || !strings.Contains(executed[0], "SELECT * FROM os_version") {
-		t.Errorf("expected exactly one os_version query, got %v", executed)
+	calls := r.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one query, got %d: %v", len(calls), calls)
 	}
+	if argv := strings.Join(calls[0].Args, " "); !strings.Contains(argv, "SELECT * FROM os_version") || !calls[0].Escalate {
+		t.Errorf("os_version query argv = %q (escalate=%v), want an escalated --json SELECT", argv, calls[0].Escalate)
+	}
+}
+
+// The RawSql escape hatch is intentionally NOT gated by the deny-list — it is the
+// operator's explicit, CA-signed path. A raw query naming a sensitive table runs.
+func TestQuery_RawSqlBypassesDenyList(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: `[{"hash":"x"}]`}, nil)
+	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", RawSql: "SELECT * FROM shadow"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success {
+		t.Errorf("RawSql must bypass the deny-list, got %+v", res)
+	}
+	if argv := strings.Join(r.Calls()[0].Args, " "); !strings.Contains(argv, "SELECT * FROM shadow") {
+		t.Errorf("raw SQL not passed through: %q", argv)
+	}
+}
+
+func TestExecQuery_Failures(t *testing.T) {
+	t.Run("exec error", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{}, errors.New("sudo: a password is required"))
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); !errors.Is(err, ErrQueryFailed) {
+			t.Errorf("err = %v, want ErrQueryFailed", err)
+		}
+	})
+	t.Run("non-zero exit with stderr", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "no such table: bogus"}, nil)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		_, err := c.QuerySQL(context.Background(), "SELECT * FROM bogus")
+		if !errors.Is(err, ErrQueryFailed) || !strings.Contains(err.Error(), "no such table") {
+			t.Errorf("err = %v, want ErrQueryFailed naming the stderr", err)
+		}
+	})
+	t.Run("non-zero exit no stderr", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 2}, nil)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); !errors.Is(err, ErrQueryFailed) {
+			t.Errorf("err = %v, want ErrQueryFailed", err)
+		}
+	})
+	t.Run("unparseable JSON", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "not json"}, nil)
+		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); err == nil ||
+			!strings.Contains(err.Error(), "parse osquery output") {
+			t.Errorf("err = %v, want a parse failure", err)
+		}
+	})
 }
 
 // Self-discovering guard: the deny-list must be non-empty, every member must be
 // enforced by isSensitiveTable (including case/whitespace variants), and sample
-// benign tables must stay queryable. Adding a table to sensitiveTables is
-// automatically covered; emptying the set or dropping enforcement fails here.
+// benign tables must stay queryable.
 func TestSensitiveTables_PolicyNonEmptyAndEnforced(t *testing.T) {
 	if len(sensitiveTables) == 0 {
 		t.Fatal("the sensitive-table deny-list must not be empty")

--- a/go/sys/osquery/osquery_test.go
+++ b/go/sys/osquery/osquery_test.go
@@ -3,6 +3,9 @@ package osquery
 import (
 	"errors"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
 // TestFindOsqueryBinary_DiscoveryOrder pins the resolution order of
@@ -90,12 +93,36 @@ func TestNewClient_NotInstalled(t *testing.T) {
 		return "", errors.New("not found")
 	}
 
-	c, err := NewClient()
+	c, err := NewClient(exectest.New(exec.Direct))
 	if !errors.Is(err, ErrNotInstalled) {
 		t.Errorf("NewClient: want ErrNotInstalled, got %v", err)
 	}
 	if c != nil {
 		t.Errorf("NewClient: want nil client on failure, got %+v", c)
+	}
+}
+
+func TestNewClient_NilRunner(t *testing.T) {
+	if _, err := NewClient(nil); err == nil {
+		t.Error("NewClient(nil) returned nil error")
+	}
+}
+
+func TestNewClient_Success(t *testing.T) {
+	restore := lookPath
+	defer func() { lookPath = restore }()
+	lookPath = func(name string) (string, error) {
+		if name == "/usr/bin/osqueryi" {
+			return name, nil
+		}
+		return "", errors.New("not found")
+	}
+	c, err := NewClient(exectest.New(exec.Direct))
+	if err != nil || c == nil {
+		t.Fatalf("NewClient = (%v,%v), want a client", c, err)
+	}
+	if c.binaryPath != "/usr/bin/osqueryi" {
+		t.Errorf("binaryPath = %q", c.binaryPath)
 	}
 }
 

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -1,10 +1,17 @@
-// Package reboot provides system reboot detection and scheduling utilities.
+// Package reboot provides system reboot detection and scheduling through an
+// injected exec.Runner.
 //
-// Status: SDK-resident, single-consumer today (the agent's reboot-required
-// + scheduled-reboot pipeline). Sits in the SDK because the planned
-// server-side maintenance-window simulator needs the same "next reboot
-// window" math; until that surfaces the second-consumer rule
-// (CLAUDE.md) is provisionally waived. F027 in TECH_DEBT_AUDIT.md.
+// Build a Manager with a Runner and call its methods. Scheduling escalates
+// through the Runner; the reboot-required probe runs unprivileged.
+//
+//	r, _ := exec.NewRunner(exec.Sudo)
+//	rb, _ := reboot.New(r)
+//	if need, _ := rb.IsRequired(ctx); need { _ = rb.Schedule(ctx, "+5", "patching") }
+//
+// Status: SDK-resident, single-consumer today (the agent's reboot-required +
+// scheduled-reboot pipeline). Sits in the SDK because the planned server-side
+// maintenance-window simulator needs the same "next reboot window" math. F027 in
+// TECH_DEBT_AUDIT.md.
 package reboot
 
 import (
@@ -13,72 +20,68 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 
-	sysexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-// Injectable seams for testing. Production code uses the defaults.
-var (
-	statFunc     = os.Stat
-	lookPathFunc = exec.LookPath
-	runCmdFunc   = func(name string, args ...string) error {
-		return exec.Command(name, args...).Run()
-	}
-)
+// rebootRequiredPath is the Debian/Ubuntu reboot-required marker (created by
+// update-notifier). A var so tests can redirect it.
+var rebootRequiredPath = "/var/run/reboot-required"
 
-// IsRequired checks if the system requires a reboot after updates.
-//
-// Detection methods:
-//   - Debian/Ubuntu: checks /var/run/reboot-required (created by update-notifier)
-//   - Fedora/RHEL: runs needs-restarting -r (exit 1 = reboot needed)
-//
-// Returns false on unsupported systems or if detection fails. Unexpected
-// errors (permission denied on stat, exec failure on needs-restarting) are
-// logged via slog.Debug rather than returned, since callers treat this as a
-// best-effort hint.
-func IsRequired() bool {
-	// Debian/Ubuntu: file-based detection. A successful stat means the
-	// file exists and reboot is required. ErrNotExist is the expected
-	// "no reboot needed" path; any other error is unexpected and logged.
-	if _, err := statFunc("/var/run/reboot-required"); err == nil {
-		return true
-	} else if !errors.Is(err, os.ErrNotExist) {
-		slog.Debug("stat /var/run/reboot-required failed", "error", err)
-	}
+// statFunc seams the marker-file check for tests.
+var statFunc = os.Stat
 
-	// Fedora/RHEL: needs-restarting (from dnf-utils/yum-utils).
-	// Look up the binary; if absent, we silently fall through (no detection
-	// available on this system).
-	path, err := lookPathFunc("needs-restarting")
-	if err != nil {
-		return false
-	}
-
-	runErr := runCmdFunc(path, "-r")
-	if runErr == nil {
-		return false // exit 0 = no reboot needed
-	}
-	// needs-restarting exits 1 when a reboot IS needed.
-	var exitErr *exec.ExitError
-	if errors.As(runErr, &exitErr) {
-		return exitErr.ExitCode() == 1
-	}
-	// Couldn't even run needs-restarting (e.g. *exec.Error wrapping ENOENT
-	// or a permission error). Log and report no reboot rather than guess.
-	slog.Debug("needs-restarting -r failed to run", "error", runErr)
-	return false
+// Manager detects and schedules system reboots.
+type Manager interface {
+	// IsRequired reports whether the system needs a reboot after updates. It is
+	// best-effort: an unsupported host or a detection failure yields (false, nil);
+	// the returned error is reserved for a genuinely unexpected condition the
+	// caller may want to surface (e.g. a non-ENOENT stat error on the marker).
+	IsRequired(ctx context.Context) (bool, error)
+	// Schedule schedules a reboot via shutdown -r. An empty delay defaults to
+	// "+1"; a non-empty message is broadcast to logged-in users.
+	Schedule(ctx context.Context, delay, message string) error
+	// Cancel cancels a pending scheduled reboot (shutdown -c).
+	Cancel(ctx context.Context) error
 }
 
-// Schedule schedules a system reboot via shutdown -r.
-//
-// Parameters:
-//   - ctx: context for the sudo command
-//   - delay: shutdown delay (e.g. "+1" for 1 minute, "+5" for 5 minutes, "now" for immediate)
-//   - message: broadcast message shown to logged-in users (omitted when empty)
-//
-// An empty delay defaults to "+1" since shutdown(8) requires a time argument.
-func Schedule(ctx context.Context, delay, message string) error {
+// New returns a Manager driven by runner. A nil runner is rejected.
+func New(runner exec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("reboot: runner is required")
+	}
+	return &rebooter{r: runner}, nil
+}
+
+type rebooter struct {
+	r exec.Runner
+}
+
+// IsRequired checks the Debian/Ubuntu marker file, then falls back to
+// `needs-restarting -r` (Fedora/RHEL; exit 1 = reboot needed) run unprivileged
+// through the Runner. A binary that isn't installed, or any execution failure, is
+// treated as "not required" — this is a hint, not an authority.
+func (rb *rebooter) IsRequired(ctx context.Context) (bool, error) {
+	if _, err := statFunc(rebootRequiredPath); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// A stat error other than "not found" (e.g. permission) is the one
+		// genuinely unexpected condition worth surfacing.
+		return false, fmt.Errorf("stat %s: %w", rebootRequiredPath, err)
+	}
+
+	res, err := rb.r.Run(ctx, exec.Command{Name: "needs-restarting", Args: []string{"-r"}})
+	if err != nil {
+		// needs-restarting absent or unrunnable → no detection available here.
+		slog.Debug("needs-restarting -r could not run", "error", err)
+		return false, nil
+	}
+	// Exit 1 = a reboot is needed; 0 = not; anything else = indeterminate.
+	return res.ExitCode == 1, nil
+}
+
+// Schedule schedules a system reboot via shutdown -r (escalated).
+func (rb *rebooter) Schedule(ctx context.Context, delay, message string) error {
 	if delay == "" {
 		delay = "+1"
 	}
@@ -86,16 +89,21 @@ func Schedule(ctx context.Context, delay, message string) error {
 	if message != "" {
 		args = append(args, message)
 	}
-	if _, err := sysexec.Privileged(ctx, "shutdown", args...); err != nil {
-		return fmt.Errorf("schedule reboot: %w", err)
-	}
-	return nil
+	return rb.shutdown(ctx, "schedule reboot", args...)
 }
 
-// Cancel cancels a pending scheduled reboot.
-func Cancel(ctx context.Context) error {
-	if _, err := sysexec.Privileged(ctx, "shutdown", "-c"); err != nil {
-		return fmt.Errorf("cancel reboot: %w", err)
+// Cancel cancels a pending scheduled reboot (escalated).
+func (rb *rebooter) Cancel(ctx context.Context) error {
+	return rb.shutdown(ctx, "cancel reboot", "-c")
+}
+
+func (rb *rebooter) shutdown(ctx context.Context, op string, args ...string) error {
+	res, err := rb.r.Run(ctx, exec.Command{Name: "shutdown", Args: args, Escalate: true})
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("%s: %w", op, &exec.CommandError{Name: "shutdown", ExitCode: res.ExitCode, Stderr: res.Stderr})
 	}
 	return nil
 }

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -1,209 +1,142 @@
 package reboot
 
 import (
+	"context"
 	"errors"
+	"io/fs"
 	"os"
-	"os/exec"
-	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
 )
 
-// withSeams snapshots and restores the package-level injection points so
-// tests can override them safely.
-func withSeams(t *testing.T) {
+func mgr(t *testing.T, r exec.Runner) Manager {
 	t.Helper()
-	origStat, origLookPath, origRunCmd := statFunc, lookPathFunc, runCmdFunc
-	t.Cleanup(func() {
-		statFunc = origStat
-		lookPathFunc = origLookPath
-		runCmdFunc = origRunCmd
+	m, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// withStat redirects the marker-file stat seam for one test.
+func withStat(t *testing.T, fn func(string) (os.FileInfo, error)) {
+	t.Helper()
+	orig := statFunc
+	statFunc = fn
+	t.Cleanup(func() { statFunc = orig })
+}
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error")
+	}
+}
+
+func TestIsRequired_MarkerPresent(t *testing.T) {
+	withStat(t, func(string) (os.FileInfo, error) { return nil, nil }) // exists
+	r := exectest.New(exec.Direct)
+	need, err := mgr(t, r).IsRequired(context.Background())
+	if err != nil || !need {
+		t.Fatalf("IsRequired = (%v,%v), want (true,nil)", need, err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("marker present should short-circuit before running needs-restarting")
+	}
+}
+
+func TestIsRequired_MarkerStatError(t *testing.T) {
+	withStat(t, func(string) (os.FileInfo, error) {
+		return nil, &fs.PathError{Op: "stat", Err: errors.New("permission denied")}
+	})
+	if _, err := mgr(t, exectest.New(exec.Direct)).IsRequired(context.Background()); err == nil {
+		t.Error("a non-ENOENT stat error should surface, not be swallowed")
+	}
+}
+
+func TestIsRequired_NeedsRestarting(t *testing.T) {
+	withStat(t, func(string) (os.FileInfo, error) { return nil, os.ErrNotExist })
+	cases := []struct {
+		name   string
+		res    exec.Result
+		runErr error
+		want   bool
+	}{
+		{"reboot needed (exit 1)", exec.Result{ExitCode: 1}, nil, true},
+		{"no reboot (exit 0)", exec.Result{ExitCode: 0}, nil, false},
+		{"indeterminate (exit 2)", exec.Result{ExitCode: 2}, nil, false},
+		{"not installed (run error)", exec.Result{}, errors.New("exec: needs-restarting not found"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := exectest.New(exec.Direct)
+			r.Push(c.res, c.runErr)
+			need, err := mgr(t, r).IsRequired(context.Background())
+			if err != nil || need != c.want {
+				t.Fatalf("IsRequired = (%v,%v), want (%v,nil)", need, err, c.want)
+			}
+			cmd := r.Calls()[0]
+			if cmd.Name != "needs-restarting" || cmd.Escalate || strings.Join(cmd.Args, " ") != "-r" {
+				t.Errorf("command = %+v, want unprivileged `needs-restarting -r`", cmd)
+			}
+		})
+	}
+}
+
+func TestSchedule(t *testing.T) {
+	t.Run("default delay + message, escalated", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		if err := mgr(t, r).Schedule(context.Background(), "", "patching now"); err != nil {
+			t.Fatal(err)
+		}
+		cmd := r.Calls()[0]
+		if cmd.Name != "shutdown" || !cmd.Escalate {
+			t.Fatalf("command = %+v, want escalated shutdown", cmd)
+		}
+		if strings.Join(cmd.Args, " ") != "-r +1 patching now" {
+			t.Errorf("argv = %q, want `-r +1 patching now`", strings.Join(cmd.Args, " "))
+		}
+	})
+	t.Run("explicit delay, no message", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		if err := mgr(t, r).Schedule(context.Background(), "+5", ""); err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Join(r.Calls()[0].Args, " "); got != "-r +5" {
+			t.Errorf("argv = %q, want `-r +5`", got)
+		}
+	})
+	t.Run("non-zero exit is an error", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "Failed to schedule"}, nil)
+		if err := mgr(t, r).Schedule(context.Background(), "+1", ""); err == nil {
+			t.Error("Schedule swallowed a non-zero exit")
+		}
+	})
+	t.Run("exec failure is an error", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		r.Push(exec.Result{}, errors.New("sudo: a password is required"))
+		if err := mgr(t, r).Schedule(context.Background(), "+1", ""); err == nil {
+			t.Error("Schedule swallowed an exec failure")
+		}
 	})
 }
 
-// assertNeedsRestartingArgs fails the test if the runCmdFunc invocation does
-// not match the expected `needs-restarting -r` call. Used by Fedora-path
-// tests to catch regressions that would invoke the wrong binary or drop the
-// -r flag.
-func assertNeedsRestartingArgs(t *testing.T, name string, args []string) {
-	t.Helper()
-	if name != "/usr/bin/needs-restarting" {
-		t.Errorf("runCmd called with name=%q, want %q", name, "/usr/bin/needs-restarting")
-	}
-	if len(args) != 1 || args[0] != "-r" {
-		t.Errorf("runCmd called with args=%v, want [-r]", args)
-	}
-}
-
-// exitErrCode returns an *exec.ExitError that reports the given exit code,
-// produced by actually running a tiny shell command. Constructing one
-// directly isn't portable since ProcessState is OS-specific. Skips the test
-// if /bin/sh is not available in PATH (e.g. minimal containers).
-func exitErrCode(t *testing.T, code int) error {
-	t.Helper()
-	shPath, err := exec.LookPath("sh")
-	if err != nil {
-		t.Skipf("skipping test: sh not found in PATH: %v", err)
-	}
-	cmd := exec.Command(shPath, "-c", "exit "+itoa(code))
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	t.Fatalf("expected exit %d to produce an error", code)
-	return nil
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}
-
-func TestIsRequired_DebianFileExists(t *testing.T) {
-	withSeams(t)
-	dir := t.TempDir()
-	fakeFile := filepath.Join(dir, "reboot-required")
-	if err := os.WriteFile(fakeFile, []byte("*** System restart required ***\n"), 0644); err != nil {
+func TestCancel(t *testing.T) {
+	r := exectest.New(exec.Sudo)
+	if err := mgr(t, r).Cancel(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-
-	statFunc = func(name string) (os.FileInfo, error) {
-		if name == "/var/run/reboot-required" {
-			return os.Stat(fakeFile)
-		}
-		return os.Stat(name)
+	cmd := r.Calls()[0]
+	if cmd.Name != "shutdown" || !cmd.Escalate || strings.Join(cmd.Args, " ") != "-c" {
+		t.Errorf("command = %+v, want escalated `shutdown -c`", cmd)
 	}
 
-	if !IsRequired() {
-		t.Error("expected IsRequired() = true when reboot-required file exists")
+	r2 := exectest.New(exec.Sudo)
+	r2.Push(exec.Result{ExitCode: 1}, nil)
+	if err := mgr(t, r2).Cancel(context.Background()); err == nil {
+		t.Error("Cancel swallowed a non-zero exit")
 	}
-}
-
-func TestIsRequired_DebianFileAbsent(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrNotExist
-	}
-	lookPathFunc = func(file string) (string, error) {
-		return "", exec.ErrNotFound
-	}
-
-	if IsRequired() {
-		t.Error("expected IsRequired() = false when no detection method available")
-	}
-}
-
-// An unexpected stat error (e.g. EACCES) must NOT short-circuit to true and
-// must fall through to the needs-restarting branch.
-func TestIsRequired_DebianStatUnexpectedError(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrPermission
-	}
-	lookPathFunc = func(file string) (string, error) {
-		return "", exec.ErrNotFound
-	}
-
-	if IsRequired() {
-		t.Error("expected IsRequired() = false when stat fails with permission error and no fallback")
-	}
-}
-
-func TestIsRequired_FedoraRebootNeeded(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrNotExist
-	}
-	lookPathFunc = func(file string) (string, error) {
-		if file == "needs-restarting" {
-			return "/usr/bin/needs-restarting", nil
-		}
-		return "", exec.ErrNotFound
-	}
-	runCmdFunc = func(name string, args ...string) error {
-		assertNeedsRestartingArgs(t, name, args)
-		return exitErrCode(t, 1)
-	}
-
-	if !IsRequired() {
-		t.Error("expected IsRequired() = true when needs-restarting exits 1")
-	}
-}
-
-func TestIsRequired_FedoraNoReboot(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrNotExist
-	}
-	lookPathFunc = func(file string) (string, error) {
-		return "/usr/bin/needs-restarting", nil
-	}
-	runCmdFunc = func(name string, args ...string) error {
-		assertNeedsRestartingArgs(t, name, args)
-		return nil // exit 0
-	}
-
-	if IsRequired() {
-		t.Error("expected IsRequired() = false when needs-restarting exits 0")
-	}
-}
-
-// needs-restarting exit codes other than 0 and 1 must NOT be interpreted as
-// "reboot needed" — only exit 1 means that.
-func TestIsRequired_FedoraOtherExitCode(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrNotExist
-	}
-	lookPathFunc = func(file string) (string, error) {
-		return "/usr/bin/needs-restarting", nil
-	}
-	runCmdFunc = func(name string, args ...string) error {
-		assertNeedsRestartingArgs(t, name, args)
-		return exitErrCode(t, 2)
-	}
-
-	if IsRequired() {
-		t.Error("expected IsRequired() = false when needs-restarting exits with code 2")
-	}
-}
-
-// If runCmd returns a non-ExitError (e.g. *exec.Error wrapping ENOENT), we
-// must NOT report a reboot — log and return false.
-func TestIsRequired_FedoraRunCmdNonExitError(t *testing.T) {
-	withSeams(t)
-	statFunc = func(name string) (os.FileInfo, error) {
-		return nil, os.ErrNotExist
-	}
-	lookPathFunc = func(file string) (string, error) {
-		return "/usr/bin/needs-restarting", nil
-	}
-	runCmdFunc = func(name string, args ...string) error {
-		assertNeedsRestartingArgs(t, name, args)
-		return &exec.Error{Name: name, Err: errors.New("permission denied")}
-	}
-
-	if IsRequired() {
-		t.Error("expected IsRequired() = false when needs-restarting fails to execute")
-	}
-}
-
-func TestIsRequired_LiveSystem(t *testing.T) {
-	result := IsRequired()
-	t.Logf("IsRequired() = %v (live system)", result)
 }


### PR DESCRIPTION
SDK rework — converts the single-implementation `sys/*` packages off the legacy global escalation path (`sysexec.Privileged`/`Run`) onto the injected `exec.Runner`, following the capability PRs (network #135, firewall #137). Each is a small constructor taking a Runner and returning an interface (osquery keeps its exported `Client` concrete, http.Client-style); mutating ops escalate, reads don't; ctx is on every method. Clean break — the agent migrates later. Held to the bar: 100% coverage + success/fail/weird + real values.

## Packages
- **reboot** — `New(runner) Manager`: `Schedule`/`Cancel` via shutdown (escalated); `IsRequired(ctx)` runs `needs-restarting` through the Runner (unescalated) and keeps the `/var/run/reboot-required` marker probe. Dropped the lookPath/runCmd os/exec seams (the Runner subsumes them).
- **osquery** — `NewClient(runner)` injects the Runner in place of the `execPrivileged` global var; **dropped the no-ctx `Registry` compat wrapper**. Preserved the WS17a sensitive-table **DENY-list** (refused before any exec) and the WS4 **RawSql** escape hatch (ungated). `Client` stays an exported concrete.
- **notify** — `New(runner) Manager`: `NotifyAll`/`NotifyUsers` route wall + loginctl + env/runuser/notify-send through the Runner; best-effort semantics kept; pure loginctl parsers unchanged.
- **inventory** — `New(runner) Collector`: `System`/`OS`/`Disks`/`NetworkInterfaces` (named to avoid colliding with the `SystemInfo`/`OSInfo` types); uname/lsblk/ip run through the Runner (unescalated); `/proc` + os-release parsers kept and path-seamed.

## Tests — 100% statement coverage per package
`exectest.FakeRunner` drives golden argv, scripted output, exit-code→error mapping, and every failure branch; seam-driven file/parse edge cases cover the pure parsers (incl. the defensive `scanner.Err` branches via a directory path). Full SDK suite green; vet + staticcheck clean.

These packages have agent consumers, so the in-tree workspace agent build breaks further until the deferred agent migration — consistent with the established cadence (agent CI pins a frozen SDK; SDK CI runs isolated with GOWORK=off).

Closes manchtools/power-manage-sdk#138