### PR TITLE
feat(exec): force a deterministic environment on every Runner command (#144)

### DIFF
--- a/go/pkg/apt.go
+++ b/go/pkg/apt.go
@@ -23,7 +23,7 @@ type apt struct {
 var _ Manager = (*apt)(nil)
 
 // aptWriteEnv prevents debconf from attempting an interactive frontend when
-// there is no terminal. The C locale is forced separately via Command.CLocale.
+// there is no terminal. The C locale is forced by the Runner on every command.
 var aptWriteEnv = []string{"DEBIAN_FRONTEND=noninteractive"}
 
 // dpkgConfOptions keep dpkg non-interactive when a postinst would otherwise

--- a/go/pkg/dnf_test.go
+++ b/go/pkg/dnf_test.go
@@ -45,8 +45,8 @@ func TestDnf_Install(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
-		if argv(c) != "dnf install -y vim git" || !c.Escalate || !c.CLocale {
-			t.Errorf("argv=%q escalate=%v clocale=%v", argv(c), c.Escalate, c.CLocale)
+		if argv(c) != "dnf install -y vim git" || !c.Escalate {
+			t.Errorf("argv=%q escalate=%v", argv(c), c.Escalate)
 		}
 	})
 	t.Run("pinned version uses name-version", func(t *testing.T) {

--- a/go/pkg/exec.go
+++ b/go/pkg/exec.go
@@ -10,14 +10,14 @@ import (
 )
 
 // runRead executes an unprivileged read-side query (Info / Search / List /
-// Show / version + status probes) through the injected Runner. CLocale forces
-// LANG=C / LC_ALL=C so the output parser sees the stable English form
-// regardless of the host locale. A non-zero exit is reported in Result.ExitCode
-// (NOT as an error) — read callers branch on specific codes (e.g. dnf
-// check-update's 100, dpkg -s's 1) — so the returned error is non-nil only when
-// the command could not be executed at all.
+// Show / version + status probes) through the injected Runner. The Runner forces
+// the C locale on every command, so the output parser always sees the stable
+// English form regardless of the host locale. A non-zero exit is reported in
+// Result.ExitCode (NOT as an error) — read callers branch on specific codes (e.g.
+// dnf check-update's 100, dpkg -s's 1) — so the returned error is non-nil only
+// when the command could not be executed at all.
 func runRead(ctx context.Context, r pmexec.Runner, name string, args ...string) (pmexec.Result, error) {
-	return r.Run(ctx, pmexec.Command{Name: name, Args: args, CLocale: true})
+	return r.Run(ctx, pmexec.Command{Name: name, Args: args})
 }
 
 // probe runs an unprivileged read whose non-zero exit is a benign domain signal
@@ -46,7 +46,6 @@ func runPriv(ctx context.Context, r pmexec.Runner, escalate bool, env []string, 
 		Name:     name,
 		Args:     args,
 		Env:      env,
-		CLocale:  true,
 		Escalate: escalate,
 	})
 }
@@ -79,7 +78,6 @@ func runPrivStdin(ctx context.Context, r pmexec.Runner, escalate bool, env []str
 		Args:     args,
 		Env:      env,
 		Stdin:    in,
-		CLocale:  true,
 		Escalate: escalate,
 	})
 }

--- a/go/pkg/exec_test.go
+++ b/go/pkg/exec_test.go
@@ -9,7 +9,7 @@ import (
 	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
-func TestRunRead_BuildsUnprivilegedCLocaleCommand(t *testing.T) {
+func TestRunRead_BuildsUnprivilegedCommand(t *testing.T) {
 	f := newFake()
 	ok(f, "stdout-here")
 	res, err := runRead(context.Background(), f, "apt", "search", "vim")
@@ -26,9 +26,8 @@ func TestRunRead_BuildsUnprivilegedCLocaleCommand(t *testing.T) {
 	if c.Escalate {
 		t.Error("reads must not escalate")
 	}
-	if !c.CLocale {
-		t.Error("reads must force the C locale for stable parsing")
-	}
+	// Locale stability is the Runner's invariant (TestRunner_ForcesDeterministicEnv),
+	// not a per-command flag — nothing to assert on the Command here.
 }
 
 func TestRunRead_PropagatesExecError(t *testing.T) {
@@ -48,9 +47,6 @@ func TestRunPriv_EscalatesAndCarriesEnv(t *testing.T) {
 	c := f.Calls()[0]
 	if !c.Escalate {
 		t.Error("runPriv(escalate=true) must set Escalate")
-	}
-	if !c.CLocale {
-		t.Error("runPriv must force the C locale")
 	}
 	if len(c.Env) != 1 || c.Env[0] != "DEBIAN_FRONTEND=noninteractive" {
 		t.Errorf("env = %v", c.Env)

--- a/go/sys/exec/env.go
+++ b/go/sys/exec/env.go
@@ -17,6 +17,24 @@ var ErrInvalidEnvVar = errors.New("invalid env entry")
 // RunStreaming caller doesn't have to remember the check.
 var ErrBlockedEnvVar = errors.New("env var blocked by hijack-prevention allowlist")
 
+// ErrReservedEnvVar is returned when an env entry tries to set a variable the
+// Runner forces for deterministic output (the locale family + NO_COLOR). The SDK
+// parses standardized tool output, so a consumer must not be able to change the
+// locale/color of a command — these are imposed by the Runner, not negotiable.
+var ErrReservedEnvVar = errors.New("env var reserved by the SDK for deterministic output")
+
+// isReservedEnvVar reports whether name is one the Runner forces and a caller
+// therefore may not set via Command.Env: the whole LC_* family, LANG, LANGUAGE
+// (all neutralised by the forced LC_ALL=C), and NO_COLOR. Case-insensitive.
+func isReservedEnvVar(name string) bool {
+	upper := strings.ToUpper(name)
+	switch upper {
+	case "LANG", "LANGUAGE", "NO_COLOR":
+		return true
+	}
+	return strings.HasPrefix(upper, "LC_")
+}
+
 // ValidEnvVarName matches safe environment variable names (letters, digits, underscore).
 var ValidEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 

--- a/go/sys/exec/runner.go
+++ b/go/sys/exec/runner.go
@@ -31,13 +31,17 @@ const (
 // required. The capability layer fills this in and sets Escalate per operation;
 // it is escalation-method-agnostic. The Runner alone turns Escalate into the
 // concrete sudo/doas/bare invocation.
+//
+// There is no locale knob: the Runner ALWAYS forces a deterministic environment
+// (LC_ALL=C, LANG=C, NO_COLOR=1) on every command so the SDK's parsing of tool
+// output is locale/format-stable by construction. It is not overridable — those
+// names are rejected if passed via Env. (TZ is deliberately left to the device.)
 type Command struct {
 	Name      string    // resolved to an absolute path before escalation
 	Args      []string  // operands; the caller pre-applies SeparatePositionals
 	Dir       string    // "" = inherit cwd
 	Env       []string  // extra KEY=VALUE; screened by the env hijack blocklist
 	Stdin     io.Reader // "" = no stdin
-	CLocale   bool      // force LC_ALL=C / LANG=C for stable English-only parsing
 	ChildPath string    // explicit, isolating child PATH; "" = inherit/sanitized
 	Escalate  bool      // run through the privilege backend
 }
@@ -202,25 +206,44 @@ func detectEscalationDenied(b PrivilegeBackend, res Result) error {
 	return nil
 }
 
-// buildChildEnv composes and validates the Command's child environment. The
-// hijack blocklist (LD_PRELOAD, PATH, BASH_ENV, …) is enforced on Command.Env;
+// forcedEnv is the deterministic environment the Runner imposes on EVERY command
+// so the SDK's parsing of tool output is locale/format-stable by construction:
+// English C locale (which also pins LC_NUMERIC/LC_TIME/LC_COLLATE, not just
+// messages) and NO_COLOR to suppress ANSI escapes. It is appended LAST so it wins
+// over any inherited or caller-supplied value; callers cannot set these (they are
+// rejected in validateEnvVars). TZ is intentionally NOT forced — the SDK parses
+// no timestamps and a consumer expects the device-local zone.
+var forcedEnv = []string{"LC_ALL=C", "LANG=C", "NO_COLOR=1"}
+
+// buildChildEnv composes and validates the Command's child environment, then
+// imposes forcedEnv (non-overridable). The hijack blocklist (LD_PRELOAD, PATH,
+// BASH_ENV, …) plus the forced-locale/NO_COLOR names are enforced on Command.Env;
 // a curated PATH goes through ChildPath, which REPLACES (never augments) the
-// parent env — the isolation the per-user runuser fan-out needs. A nil return
-// means "inherit the parent fully" (the contract when no customization is
-// requested).
+// parent env — the isolation the per-user runuser fan-out needs. The default
+// (no ChildPath, no Env) inherits the parent fully; in every case forcedEnv is
+// appended last so the deterministic vars always win.
 func buildChildEnv(c Command) ([]string, error) {
-	extra := append([]string(nil), c.Env...)
-	if c.CLocale {
-		extra = append(extra, "LC_ALL=C", "LANG=C")
-	}
-	if err := validateEnvVars(extra); err != nil {
+	if err := validateEnvVars(c.Env); err != nil {
 		return nil, err
 	}
-	if c.ChildPath != "" {
-		return composeEnv(c.ChildPath, extra), nil // curated PATH; parent NOT inherited
+	// The forced-locale/NO_COLOR names are the Runner's invariant — a consumer
+	// may not set them via Env (they'd be silently overridden anyway; reject
+	// explicitly so a mistake surfaces).
+	for _, e := range c.Env {
+		if key, _, _ := strings.Cut(e, "="); isReservedEnvVar(key) {
+			return nil, fmt.Errorf("%w: %q is forced by the Runner (LC_ALL=C/LANG=C/NO_COLOR=1) and may not be set via Command.Env", ErrReservedEnvVar, key)
+		}
 	}
-	if len(extra) > 0 {
-		return composeEnv(os.Getenv("PATH"), extra), nil // sanitized parent PATH + extras
+	switch {
+	case c.ChildPath != "":
+		// Curated, isolating env (runuser fan-out): PATH + caller Env + forced.
+		return append(composeEnv(c.ChildPath, c.Env), forcedEnv...), nil
+	case len(c.Env) > 0:
+		// Sanitized parent PATH + caller Env + forced (the env-only contract).
+		return append(composeEnv(os.Getenv("PATH"), c.Env), forcedEnv...), nil
+	default:
+		// Inherit the parent fully, then force the deterministic vars on top.
+		env := append([]string(nil), os.Environ()...)
+		return append(env, forcedEnv...), nil
 	}
-	return nil, nil // inherit parent fully
 }

--- a/go/sys/exec/runner_test.go
+++ b/go/sys/exec/runner_test.go
@@ -211,18 +211,44 @@ func TestRunner_AllowedEnvReachesChild(t *testing.T) {
 	}
 }
 
-// CLocale forces LC_ALL=C / LANG=C so the agent's English-only output parsers
-// are stable regardless of the host locale.
-func TestRunner_CLocaleForcesC(t *testing.T) {
+// The Runner forces a deterministic environment (LC_ALL=C, LANG=C, NO_COLOR=1)
+// on EVERY command — not a per-command opt-in — so the SDK's parsing of tool
+// output is locale/format-stable regardless of the host locale.
+func TestRunner_ForcesDeterministicEnv(t *testing.T) {
 	res, err := directRunner(t).Run(context.Background(), Command{
-		Name: "sh", Args: []string{"-c", "printf %s \"$LC_ALL\""},
-		CLocale: true,
+		Name: "sh", Args: []string{"-c", `printf '%s|%s|%s' "$LC_ALL" "$LANG" "$NO_COLOR"`},
 	})
 	if err != nil {
 		t.Fatalf("Run err = %v", err)
 	}
-	if strings.TrimSpace(res.Stdout) != "C" {
-		t.Errorf("LC_ALL in child = %q, want C", res.Stdout)
+	if got := strings.TrimSpace(res.Stdout); got != "C|C|1" {
+		t.Errorf("forced LC_ALL|LANG|NO_COLOR = %q, want \"C|C|1\"", got)
+	}
+}
+
+// A consumer cannot override the forced deterministic env via Command.Env — the
+// reserved names are rejected before the command runs.
+func TestRunner_RejectsReservedEnv(t *testing.T) {
+	for _, e := range []string{"LANG=ja_JP.UTF-8", "LC_ALL=ja_JP.UTF-8", "LC_NUMERIC=de_DE.UTF-8", "LANGUAGE=ja", "NO_COLOR="} {
+		_, err := directRunner(t).Run(context.Background(), Command{Name: "true", Env: []string{e}})
+		if !errors.Is(err, ErrReservedEnvVar) {
+			t.Errorf("Run with Env %q err = %v, want ErrReservedEnvVar", e, err)
+		}
+	}
+}
+
+// The forced env is an OVERRIDE, not a replacement: a plain command still
+// inherits the parent environment; only the deterministic vars are pinned.
+func TestRunner_InheritsParentEnvWhilePinningLocale(t *testing.T) {
+	t.Setenv("PM_TEST_INHERIT", "visible")
+	res, err := directRunner(t).Run(context.Background(), Command{
+		Name: "sh", Args: []string{"-c", `printf '%s|%s' "$PM_TEST_INHERIT" "$LC_ALL"`},
+	})
+	if err != nil {
+		t.Fatalf("Run err = %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != "visible|C" {
+		t.Errorf("got %q, want \"visible|C\" (parent var inherited + locale pinned)", got)
 	}
 }
 

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -132,12 +132,12 @@ func (m *manager) direct() bool { return m.r.Backend() == pmexec.Direct }
 // Result.ExitCode (not the error); the error is non-nil only when the command
 // could not be executed or escalation failed.
 //
-// CLocale forces LC_ALL=C / LANG=C so any stderr/stdout the caller parses is the
+// The Runner forces the C locale so any stderr/stdout the caller parses is the
 // stable English form regardless of host locale — ReadFile's "No such file"
 // missing-file detection depends on it (a localized cat error would otherwise be
 // misread as a hard failure).
 func (m *manager) runPriv(ctx context.Context, name string, args ...string) (pmexec.Result, error) {
-	return m.r.Run(ctx, pmexec.Command{Name: name, Args: args, CLocale: true, Escalate: true})
+	return m.r.Run(ctx, pmexec.Command{Name: name, Args: args, Escalate: true})
 }
 
 // runPrivStdin is runPriv with stdin (the tee write path).
@@ -146,17 +146,17 @@ func (m *manager) runPrivStdin(ctx context.Context, stdin string, name string, a
 	if stdin != "" {
 		in = strings.NewReader(stdin)
 	}
-	cmd := pmexec.Command{Name: name, Args: args, CLocale: true, Escalate: true}
+	cmd := pmexec.Command{Name: name, Args: args, Escalate: true}
 	if in != nil {
 		cmd.Stdin = in
 	}
 	return m.r.Run(ctx, cmd)
 }
 
-// runQuery runs an unprivileged read (findmnt) through the Runner. CLocale keeps
-// the output parse locale-stable, matching runPriv.
+// runQuery runs an unprivileged read (findmnt) through the Runner. The Runner
+// forces the C locale, keeping the output parse locale-stable.
 func (m *manager) runQuery(ctx context.Context, name string, args ...string) (pmexec.Result, error) {
-	return m.r.Run(ctx, pmexec.Command{Name: name, Args: args, CLocale: true})
+	return m.r.Run(ctx, pmexec.Command{Name: name, Args: args})
 }
 
 // cmdError turns a completed command's Result into a typed error when its exit

--- a/go/sys/fs/manager_test.go
+++ b/go/sys/fs/manager_test.go
@@ -287,11 +287,9 @@ func TestReadFile_ReturnsStdoutVerbatim(t *testing.T) {
 	if got := argv(f.Calls()[0]); got != "cat -- /etc/app.conf" {
 		t.Errorf("cat argv = %q", got)
 	}
-	// cat must run under a forced C locale so the "No such file" stderr check in
-	// ReadFile is reliable on non-English hosts.
-	if !f.Calls()[0].CLocale {
-		t.Error("cat Command must set CLocale for locale-stable error parsing")
-	}
+	// Locale stability (the "No such file" check working on non-English hosts) is
+	// the Runner's invariant now, pinned by exec.TestRunner_ForcesDeterministicEnv
+	// + the fs integration suite running under ja_JP — not a per-Command flag.
 }
 
 func TestReadFile_DoesNotReAddNewline(t *testing.T) {


### PR DESCRIPTION
Closes #144.

The SDK parses/returns standardized tool output, so the Runner now imposes a **deterministic environment on every command** instead of relying on a per-command opt-in (`Command.CLocale`) — which was easy to forget (missed on `fs.ReadFile`, causing a missing-file misread under non-English locales; caught by CodeRabbit on #143).

## Changes
- **`buildChildEnv` always appends `LC_ALL=C`, `LANG=C`, `NO_COLOR=1` last** (override) on top of the existing composition (full-parent-inherit / curated `ChildPath` / `+Env`). `LC_ALL=C` also pins `LC_NUMERIC`/`LC_TIME`/`LC_COLLATE` (number/date/sort), not just messages; `NO_COLOR=1` suppresses ANSI escapes. **`TZ` is deliberately not forced** — the SDK parses no timestamps and a consumer expects the device-local zone.
- **Non-overridable:** `LC_*`/`LANG`/`LANGUAGE`/`NO_COLOR` in `Command.Env` are rejected with `ErrReservedEnvVar`.
- **Drop the `Command.CLocale` field** (clean break); remove `CLocale: true` from the pkg/fs callers. Locale stability is now a Runner invariant, pinned once by `TestRunner_ForcesDeterministicEnv` rather than per-command assertions.
- **Side benefit:** `detectEscalationDenied` (matches English sudo/doas refusal text) is reliable under any host locale, since escalated commands now always run under C.

## Tests
- `TestRunner_ForcesDeterministicEnv` (LC_ALL|LANG|NO_COLOR = C|C|1), `TestRunner_RejectsReservedEnv`, `TestRunner_InheritsParentEnvWhilePinningLocale` (override, not replace).
- Verified the forced-C holds even when the **process** runs under `LC_ALL=ja_JP.UTF-8`.
- build / vet / `go test -race` (whole SDK) / staticcheck green.

Follow-up to #143 (which added the foreign-locale integration suite that guards real-tool paths *bypassing* the Runner).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent locale handling by enforcing deterministic locale settings globally for all operations

* **Improvements**
  * System now guarantees C locale and NO_COLOR variables are applied to all commands for consistent output
  * Added validation preventing accidental override of reserved environment variables that control output formatting and locale behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->