### PR TITLE
feat(sys): Manager/Querier interfaces for desktop, terminal, osquery (#146)

### DIFF
--- a/docs/sdk-rework-contracts.md
+++ b/docs/sdk-rework-contracts.md
@@ -508,7 +508,7 @@ type NetworkInterface struct { Name, MAC string; Addresses []string; State strin
 ## 11. `desktop`
 
 ```go
-func New(opts ...Option) (Manager, error)
+func New(runner exec.Runner, opts ...Option) (Manager, error) // WithHomeRoot(dir) for tests
 type Manager interface {
     ActiveSessions(ctx context.Context) ([]Session, error)
     HomeUsers(ctx context.Context) ([]Session, error)
@@ -522,6 +522,13 @@ func EnvFor(s Session) []string ; func UserPath(s Session) string // pure helper
 
 - `HomeUsers`/`UsersWithFlatpakInstall` gain `ctx`. `RunAsCommand`'s positional
   `extraEnv` becomes `RunAsOptions`.
+- **Runner-driven probes:** the `loginctl` PROBES (`ActiveSessions` and helpers)
+  run through the injected Runner, so they inherit the forced **C locale** — the
+  no-logind / no-session stderr fingerprints are matched against stable English
+  regardless of host locale. **`RunAsCommand` is the deliberate exception:** it
+  builds a command run ON BEHALF OF a signed-in user (Flatpak install, user
+  script) whose output the SDK does NOT parse, so it does NOT go through the
+  Runner and keeps the **user's own locale** — forcing C there would be wrong.
 - **Preserved:** absolute `loginctl`/`runuser` paths, env-wholesaling (agent env
   NOT inherited; curated `UserPath` applied last), forced `Home` workdir.
 
@@ -530,9 +537,9 @@ func EnvFor(s Session) []string ; func UserPath(s Session) string // pure helper
 ## 12. `osquery`
 
 ```go
-func New(opts ...Option) (Querier, error) // was NewClient; lazy-init preserved
+func New(runner exec.Runner) (Querier, error) // was NewClient; eager ErrNotInstalled probe preserved
 type Querier interface {
-    IsInstalled(ctx context.Context) bool
+    IsInstalled(ctx context.Context) bool // LIVE re-probe (detects removal at runtime)
     ListTables(ctx context.Context) ([]string, error)
     Query(ctx context.Context, q *pb.OSQuery) (*pb.OSQueryResult, error)
     QueryTable(ctx context.Context, table string) ([]*pb.OSQueryRow, error)
@@ -540,6 +547,12 @@ type Querier interface {
 }
 var ErrNotInstalled, ErrQueryFailed error
 ```
+
+- `New` keeps the current **eager** behaviour: it probes for the osqueryi binary
+  and returns `ErrNotInstalled` when absent (a caller learns at construction).
+  The free `IsInstalled()` function is removed — `IsInstalled(ctx)` is a Querier
+  method that re-probes live so a binary removed during the agent's lifetime is
+  reported as gone. No `opts ...Option` — there is no real option to configure.
 
 - **Preserved verbatim — the security core:** the credential-table **deny-list**
   (`shadow`, `process_envs`, `crontab`, `shell_history`, `sudoers`),
@@ -556,9 +569,9 @@ var ErrNotInstalled, ErrQueryFailed error
 ## 13. `terminal`
 
 ```go
-func New(opts ...Option) (Manager, error)
+func New() (Manager, error) // NO Runner — a PTY is a long-lived stream the captured-output Runner can't model
 type Manager interface {
-    Open(ctx context.Context, cfg SessionConfig) (*Session, error) // was Start(cfg) — gains ctx
+    Open(ctx context.Context, cfg SessionConfig) (*Session, error) // was Start(cfg) — ctx gates ALLOCATION only
 }
 type SessionConfig struct {
     User, Shell string

--- a/docs/sdk-rework-design.md
+++ b/docs/sdk-rework-design.md
@@ -539,6 +539,16 @@ methods — accepted, because the interface *is* the full intended surface.
 > `service`/`user`, which name their one backend explicitly against a future
 > second). Their constructor is `New(runner, opts...)` — no `Backend` argument,
 > but still the required `exec.Runner` so the construction shape matches.
+>
+> **One exception: `terminal`.** A PTY session is a long-lived, bidirectional
+> stream, not a captured one-shot `Command` → `Result`, so the Runner abstraction
+> cannot model it. `terminal.New()` therefore takes **no** Runner; honesty (no
+> dead parameter) wins over shape-uniformity here. The privilege to switch UID
+> comes from the agent already running as root (the child's `syscall.Credential`).
+> `osquery` and `desktop` do take the Runner — osquery runs every query through
+> it; desktop runs its `loginctl` probes through it (and gains the forced-C locale
+> for stable stderr parsing), while `RunAsCommand` builds a direct `*exec.Cmd`
+> that intentionally keeps the *user's* locale.
 
 ---
 

--- a/go/sys/desktop/desktop.go
+++ b/go/sys/desktop/desktop.go
@@ -1,0 +1,126 @@
+// Package desktop discovers active graphical desktop sessions on the host so
+// user-scoped actions (Flatpak --user installs, shell scripts that need a real
+// $HOME and DBus session bus, etc.) can fan out to every currently-signed-in
+// user instead of running under the agent's own root context.
+//
+//	r, _ := exec.NewRunner(exec.Direct) // the agent runs as root
+//	m, err := desktop.New(r)
+//	if err != nil { ... }
+//	sessions, err := m.ActiveSessions(ctx)
+//
+// The discovery contract is intentionally narrow: only sessions that
+//   - are local (Remote=no)
+//   - are graphical (Type ∈ {x11, wayland, mir})
+//   - are active (Active=yes)
+//
+// count. SSH sessions, getty TTYs, headless sessions, and inactive graphical
+// sessions are filtered out — they don't have a usable XDG_RUNTIME_DIR / DBus
+// session bus that user-scoped commands need.
+//
+// desktop is a single-implementation capability (design §3.8): it exposes the
+// Manager interface for shape-uniformity with the rest of the SDK. There is no
+// Backend argument — only the required Runner.
+//
+// # Locale handling
+//
+// The loginctl PROBES (ActiveSessions and its helpers) run through the injected
+// Runner, which forces the C locale; this is deliberate — the SDK parses
+// loginctl's stderr to distinguish "no logind here" from a real fault, and that
+// matching must be locale-stable. RunAsCommand is the opposite case: it builds a
+// command that runs ON BEHALF OF a signed-in user (a Flatpak install, a user
+// script) whose output the SDK does NOT parse, so it does NOT go through the
+// Runner and does NOT force C — the user keeps their own locale.
+package desktop
+
+import (
+	"context"
+	"errors"
+	osexec "os/exec"
+	"os/user"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// defaultHomeRoot is the directory HomeUsers enumerates unless overridden with
+// WithHomeRoot.
+const defaultHomeRoot = "/home"
+
+// loginctlPath is the absolute path to the loginctl binary. Pinned to
+// /usr/bin/loginctl because that's where systemd installs it on every supported
+// distro and absolute paths sidestep PATH-injection concerns when the agent
+// runs as root.
+const loginctlPath = "/usr/bin/loginctl"
+
+// runuserPath pins the absolute path to runuser. Like loginctlPath, pinning
+// sidesteps PATH-injection concerns when the agent runs as root and matches what
+// every supported distro ships.
+const runuserPath = "/usr/sbin/runuser"
+
+// Test seams. They default to the real lookups and are overridden only by tests
+// to exercise branches that are otherwise host-dependent (loginctl absent, a
+// passwd entry that does not resolve or carries a non-numeric uid/gid).
+// Production never reassigns them.
+var (
+	lookPath   = osexec.LookPath
+	lookupID   = user.LookupId
+	lookupUser = user.Lookup
+)
+
+// RunAsOptions carries the optional inputs to Manager.RunAsCommand.
+type RunAsOptions struct {
+	// ExtraEnv is merged on top of the per-user desktop environment. Entries win
+	// over the defaults on a duplicate key (Go's exec honours the last
+	// occurrence) — except PATH, which RunAsCommand always re-applies last with
+	// the curated UserPath so an action cannot override it.
+	ExtraEnv []string
+}
+
+// Manager is the desktop discovery + user-scoped-command surface.
+type Manager interface {
+	// ActiveSessions returns every active local graphical session on the host,
+	// ready for fanning a user-scoped command out to each. It returns an empty
+	// slice (not an error) when loginctl is missing or no logind is reachable.
+	ActiveSessions(ctx context.Context) ([]Session, error)
+	// HomeUsers enumerates every Linux account whose home lives directly under
+	// the configured home root (default /home). It is the primitive for
+	// "do something for every offline user".
+	HomeUsers(ctx context.Context) ([]Session, error)
+	// UsersWithFlatpakInstall returns the subset of HomeUsers whose per-user
+	// Flatpak repository contains appID.
+	UsersWithFlatpakInstall(ctx context.Context, appID string) ([]Session, error)
+	// RunAsCommand builds (but does not run) an *exec.Cmd that runs name+args as
+	// the user owning s, with the per-user desktop environment. See the package
+	// doc for why this path keeps the user's locale rather than forcing C.
+	RunAsCommand(ctx context.Context, s Session, opts RunAsOptions, name string, args ...string) (*osexec.Cmd, error)
+}
+
+// manager is the single Manager implementation.
+type manager struct {
+	r        pmexec.Runner
+	homeRoot string
+}
+
+// Option configures a Manager at construction.
+type Option func(*manager)
+
+// WithHomeRoot overrides the directory HomeUsers enumerates (default /home).
+// Primarily for tests; production uses the default.
+func WithHomeRoot(dir string) Option {
+	return func(m *manager) { m.homeRoot = dir }
+}
+
+// New builds a desktop Manager driven by runner. A nil runner is rejected
+// (fail-closed). New is pure — it does not probe the host.
+func New(runner pmexec.Runner, opts ...Option) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("desktop: runner is required")
+	}
+	m := &manager{r: runner, homeRoot: defaultHomeRoot}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m, nil
+}
+
+// ensure the single implementation satisfies the interface.
+var _ Manager = (*manager)(nil)

--- a/go/sys/desktop/desktop.go
+++ b/go/sys/desktop/desktop.go
@@ -117,7 +117,9 @@ func New(runner pmexec.Runner, opts ...Option) (Manager, error) {
 	}
 	m := &manager{r: runner, homeRoot: defaultHomeRoot}
 	for _, opt := range opts {
-		opt(m)
+		if opt != nil { // tolerate a nil option rather than panicking the agent
+			opt(m)
+		}
 	}
 	return m, nil
 }

--- a/go/sys/desktop/desktop_test.go
+++ b/go/sys/desktop/desktop_test.go
@@ -70,3 +70,16 @@ func TestNew_WithHomeRoot(t *testing.T) {
 		t.Errorf("WithHomeRoot homeRoot = %q, want /custom/home", m.homeRoot)
 	}
 }
+
+// TestNew_NilOptionIgnored pins that a nil entry in opts... is skipped rather
+// than panicking the constructor (and the agent process with it); a non-nil
+// option in the same call still applies.
+func TestNew_NilOptionIgnored(t *testing.T) {
+	m, err := New(exectest.New(exec.Direct), nil, WithHomeRoot("/custom/home"), nil)
+	if err != nil {
+		t.Fatalf("New with a nil option returned error: %v", err)
+	}
+	if m.(*manager).homeRoot != "/custom/home" {
+		t.Errorf("a nil option must be skipped and the real one applied; homeRoot = %q", m.(*manager).homeRoot)
+	}
+}

--- a/go/sys/desktop/desktop_test.go
+++ b/go/sys/desktop/desktop_test.go
@@ -1,0 +1,72 @@
+package desktop
+
+import (
+	"errors"
+	"os/user"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// newManager builds a Manager backed by a fresh FakeRunner and returns both so
+// a test can Push loginctl results and inspect recorded calls.
+func newManager(t *testing.T, opts ...Option) (*manager, *exectest.FakeRunner) {
+	t.Helper()
+	r := exectest.New(exec.Direct)
+	m, err := New(r, opts...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m.(*manager), r
+}
+
+// stubLookPath makes lookPath report loginctl present (found=true) or absent,
+// restoring the previous value on cleanup.
+func stubLookPath(t *testing.T, found bool) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(string) (string, error) {
+		if found {
+			return loginctlPath, nil
+		}
+		return "", errors.New("loginctl: not found")
+	}
+}
+
+// stubLookupID overrides the passwd-by-uid lookup for the duration of t.
+func stubLookupID(t *testing.T, fn func(string) (*user.User, error)) {
+	t.Helper()
+	prev := lookupID
+	t.Cleanup(func() { lookupID = prev })
+	lookupID = fn
+}
+
+// stubLookupUser overrides the passwd-by-name lookup for the duration of t.
+func stubLookupUser(t *testing.T, fn func(string) (*user.User, error)) {
+	t.Helper()
+	prev := lookupUser
+	t.Cleanup(func() { lookupUser = prev })
+	lookupUser = fn
+}
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error; a nil runner must be rejected")
+	}
+}
+
+func TestNew_DefaultHomeRoot(t *testing.T) {
+	m, _ := newManager(t)
+	if m.homeRoot != defaultHomeRoot {
+		t.Errorf("default homeRoot = %q, want %q", m.homeRoot, defaultHomeRoot)
+	}
+}
+
+func TestNew_WithHomeRoot(t *testing.T) {
+	m, _ := newManager(t, WithHomeRoot("/custom/home"))
+	if m.homeRoot != "/custom/home" {
+		t.Errorf("WithHomeRoot homeRoot = %q, want /custom/home", m.homeRoot)
+	}
+}

--- a/go/sys/desktop/example_test.go
+++ b/go/sys/desktop/example_test.go
@@ -1,0 +1,37 @@
+package desktop_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/desktop"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// ExampleManager_ActiveSessions shows fanning a user-scoped command out to every
+// active graphical session. The loginctl probe runs through the Runner (forced
+// C locale); RunAsCommand builds a command that keeps the user's own locale.
+func ExampleManager_ActiveSessions() {
+	r, err := exec.NewRunner(exec.Direct) // the agent runs as root
+	if err != nil {
+		log.Fatal(err)
+	}
+	m, err := desktop.New(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	sessions, err := m.ActiveSessions(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, s := range sessions {
+		cmd, err := m.RunAsCommand(ctx, s, desktop.RunAsOptions{}, "/usr/bin/flatpak", "--user", "update", "-y")
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		_ = cmd.Run() // run the per-user command (errors handled per the caller's policy)
+	}
+}

--- a/go/sys/desktop/runas.go
+++ b/go/sys/desktop/runas.go
@@ -3,14 +3,9 @@ package desktop
 import (
 	"context"
 	"fmt"
-	"os/exec"
+	osexec "os/exec"
 	"strings"
 )
-
-// runuserPath pins the absolute path to runuser. Like loginctlPath,
-// pinning sidesteps PATH-injection concerns when the agent runs as
-// root and matches what every supported distro ships.
-const runuserPath = "/usr/sbin/runuser"
 
 // EnvFor builds the minimum environment a user-scoped command needs
 // to behave like it was launched from inside that user's desktop
@@ -22,7 +17,7 @@ const runuserPath = "/usr/sbin/runuser"
 // PATH is not added here — callers append it (via UserPath) so they can
 // pick a curated value rather than inherit the agent's PATH. RunAsCommand
 // does this for the non-streaming path; the streaming caller passes
-// UserPath(s) as the trusted child PATH to exec.RunStreamingChildPath.
+// UserPath(s) as the trusted child PATH.
 func EnvFor(s Session) []string {
 	return []string{
 		"HOME=" + s.Home,
@@ -56,7 +51,7 @@ func UserPath(s Session) string {
 
 // RunAsCommand returns an *exec.Cmd that runs `name args...` as the
 // user owning the given session, with the per-user environment from
-// EnvFor plus the caller-supplied extraEnv merged on top.
+// EnvFor plus the caller-supplied opts.ExtraEnv merged on top.
 //
 // The wrapper is `runuser -u <name> -- <name> <args...>`. We use
 // runuser rather than `sudo -u` because runuser doesn't go through
@@ -64,14 +59,20 @@ func UserPath(s Session) string {
 // failures) and has been part of util-linux on every supported
 // distro since well before the lowest target.
 //
-// extraEnv may include PATH or anything action-specific; entries win
-// over the per-user defaults if both set the same key (Go's exec
-// honors the last occurrence).
+// This path does NOT go through the SDK Runner and does NOT force the C
+// locale: the command runs ON BEHALF OF a real user (a Flatpak install, a
+// user script) whose output the SDK never parses, so the user keeps their
+// own locale. The Runner's forced-C is for SDK-parsed probes only.
 //
-// Returns an error if name is empty (programming bug) — runuser's
-// own error in that case is a confusing "exec: required") so
-// short-circuit with something meaningful.
-func RunAsCommand(ctx context.Context, s Session, extraEnv []string, name string, args ...string) (*exec.Cmd, error) {
+// opts.ExtraEnv may include anything action-specific; entries win over the
+// per-user defaults if both set the same key (Go's exec honors the last
+// occurrence) — except PATH, which is always re-applied last with the curated
+// UserPath so an action cannot override it.
+//
+// Returns an error if name is empty (programming bug — runuser's own error in
+// that case is a confusing "exec: required") or if the session has no Username
+// (would silently run as the agent's own UID).
+func (m *manager) RunAsCommand(ctx context.Context, s Session, opts RunAsOptions, name string, args ...string) (*osexec.Cmd, error) {
 	if name == "" {
 		return nil, fmt.Errorf("desktop.RunAsCommand: name is required")
 	}
@@ -79,14 +80,14 @@ func RunAsCommand(ctx context.Context, s Session, extraEnv []string, name string
 		return nil, fmt.Errorf("desktop.RunAsCommand: session has empty Username")
 	}
 	full := append([]string{"-u", s.Username, "--", name}, args...)
-	cmd := exec.CommandContext(ctx, runuserPath, full...)
+	cmd := osexec.CommandContext(ctx, runuserPath, full...)
 	// Replace inherited env wholesale — agent's env (LD_PRELOAD,
 	// LD_LIBRARY_PATH, etc.) must not leak into a user-scoped command.
-	// Caller's extraEnv is merged on top, then the curated user PATH is
+	// Caller's ExtraEnv is merged on top, then the curated user PATH is
 	// applied LAST so it wins under exec's last-occurrence semantics: an
 	// action must not be able to override PATH (parity with the
 	// streaming path, which refuses a caller-supplied PATH outright).
-	env := append(EnvFor(s), extraEnv...)
+	env := append(EnvFor(s), opts.ExtraEnv...)
 	env = append(env, "PATH="+UserPath(s))
 	cmd.Env = env
 	cmd.Dir = s.Home

--- a/go/sys/desktop/runas_test.go
+++ b/go/sys/desktop/runas_test.go
@@ -7,27 +7,30 @@ import (
 )
 
 func TestRunAsCommand_RequiresName(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{Username: "alice", UID: 1000, Home: "/home/alice"}
-	if _, err := RunAsCommand(context.Background(), s, nil, ""); err == nil {
+	if _, err := m.RunAsCommand(context.Background(), s, RunAsOptions{}, ""); err == nil {
 		t.Fatal("expected error for empty name — caller bug, runuser would fail with a confusing message")
 	}
 }
 
 func TestRunAsCommand_RequiresUsername(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{UID: 1000, Home: "/home/alice"}
-	if _, err := RunAsCommand(context.Background(), s, nil, "/bin/true"); err == nil {
+	if _, err := m.RunAsCommand(context.Background(), s, RunAsOptions{}, "/bin/true"); err == nil {
 		t.Fatal("expected error for session with empty Username — would silently run as the agent's own UID")
 	}
 }
 
 func TestRunAsCommand_BuildsRunuserInvocation(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{
 		Username:   "alice",
 		UID:        1000,
 		Home:       "/home/alice",
 		RuntimeDir: "/run/user/1000",
 	}
-	cmd, err := RunAsCommand(context.Background(), s, nil, "/usr/bin/flatpak", "--user", "info", "org.example.App")
+	cmd, err := m.RunAsCommand(context.Background(), s, RunAsOptions{}, "/usr/bin/flatpak", "--user", "info", "org.example.App")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,13 +61,14 @@ func TestRunAsCommand_BuildsRunuserInvocation(t *testing.T) {
 }
 
 func TestRunAsCommand_EnvIsolatesAgentEnvironment(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{
 		Username:   "alice",
 		UID:        1000,
 		Home:       "/home/alice",
 		RuntimeDir: "/run/user/1000",
 	}
-	cmd, err := RunAsCommand(context.Background(), s, []string{"PATH=/usr/bin:/bin", "FLATPAK_USER_DIR=/foo"}, "/bin/true")
+	cmd, err := m.RunAsCommand(context.Background(), s, RunAsOptions{ExtraEnv: []string{"PATH=/usr/bin:/bin", "FLATPAK_USER_DIR=/foo"}}, "/bin/true")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,11 +116,12 @@ func TestRunAsCommand_EnvIsolatesAgentEnvironment(t *testing.T) {
 
 func TestRunAsCommand_ExtraEnvWinsOnDuplicateKey(t *testing.T) {
 	// Pin Go's exec.Cmd contract: when cmd.Env contains duplicate
-	// keys, the *last* occurrence wins. Our wrapper appends extraEnv
-	// after EnvFor, so an extraEnv override (e.g. a custom HOME for
+	// keys, the *last* occurrence wins. Our wrapper appends ExtraEnv
+	// after EnvFor, so an ExtraEnv override (e.g. a custom HOME for
 	// a specific action) reliably beats the desktop default.
+	m, _ := newManager(t)
 	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
-	cmd, err := RunAsCommand(context.Background(), s, []string{"HOME=/var/empty"}, "/bin/true")
+	cmd, err := m.RunAsCommand(context.Background(), s, RunAsOptions{ExtraEnv: []string{"HOME=/var/empty"}}, "/bin/true")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -127,6 +132,6 @@ func TestRunAsCommand_ExtraEnvWinsOnDuplicateKey(t *testing.T) {
 		}
 	}
 	if lastHome != "HOME=/var/empty" {
-		t.Errorf("last HOME entry: got %q, want %q (extraEnv must win on duplicate keys)", lastHome, "HOME=/var/empty")
+		t.Errorf("last HOME entry: got %q, want %q (ExtraEnv must win on duplicate keys)", lastHome, "HOME=/var/empty")
 	}
 }

--- a/go/sys/desktop/sessions.go
+++ b/go/sys/desktop/sessions.go
@@ -1,31 +1,12 @@
-// Package desktop discovers active graphical desktop sessions on the
-// host so user-scoped actions (Flatpak --user installs, shell scripts
-// that need a real $HOME and DBus session bus, etc.) can fan out to
-// every currently-signed-in user instead of running under the agent's
-// own root context.
-//
-// The discovery contract is intentionally narrow: only sessions that
-//   - are local (Remote=no)
-//   - are graphical (Type ∈ {x11, wayland, mir})
-//   - are active (Active=yes)
-//
-// count. SSH sessions, getty TTYs, headless sessions, and inactive
-// graphical sessions are filtered out — they don't have a usable
-// XDG_RUNTIME_DIR / DBus session bus that user-scoped commands need.
-//
-// All discovery goes through systemd-logind (`loginctl`). Hosts
-// without systemd return an empty list with no error so callers can
-// uniformly treat "no signed-in users" as a no-op.
 package desktop
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os/exec"
-	"os/user"
 	"strconv"
 	"strings"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 // Session is a single active graphical desktop session.
@@ -57,12 +38,6 @@ type Session struct {
 	Type string
 }
 
-// loginctlPath is the absolute path to the loginctl binary. Pinned to
-// /usr/bin/loginctl because that's where systemd installs it on every
-// supported distro and absolute paths sidestep PATH-injection
-// concerns when the agent runs as root.
-const loginctlPath = "/usr/bin/loginctl"
-
 // ActiveSessions returns every active local graphical session on the
 // host, ready for fanning a user-scoped command out to each.
 //
@@ -74,8 +49,8 @@ const loginctlPath = "/usr/bin/loginctl"
 // Returns an error only when loginctl is present but its output is
 // malformed or the per-session detail probe fails for a reason other
 // than the session disappearing mid-call.
-func ActiveSessions(ctx context.Context) ([]Session, error) {
-	if _, err := exec.LookPath(loginctlPath); err != nil {
+func (m *manager) ActiveSessions(ctx context.Context) ([]Session, error) {
+	if _, err := lookPath(loginctlPath); err != nil {
 		// Host doesn't ship systemd-logind. Treat as "no sessions" so
 		// the caller's empty-set policy (skip-with-warn vs fail) drives
 		// the user-facing behavior consistently regardless of the
@@ -83,14 +58,14 @@ func ActiveSessions(ctx context.Context) ([]Session, error) {
 		return nil, nil
 	}
 
-	ids, err := listSessionIDs(ctx)
+	ids, err := m.listSessionIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	out := make([]Session, 0, len(ids))
 	for _, id := range ids {
-		s, ok, err := loadSession(ctx, id)
+		s, ok, err := m.loadSession(ctx, id)
 		if err != nil {
 			return nil, fmt.Errorf("loginctl show-session %q: %w", id, err)
 		}
@@ -102,89 +77,86 @@ func ActiveSessions(ctx context.Context) ([]Session, error) {
 	return out, nil
 }
 
-// listSessionIDs runs `loginctl list-sessions --no-legend` and returns
-// the bare session IDs from the first column. The --no-legend flag
-// suppresses the trailing "N sessions listed" line which would
-// otherwise leak into the parse loop on older systemd builds.
+// listSessionIDs runs `loginctl list-sessions --no-legend` through the Runner
+// and returns the bare session IDs from the first column. The --no-legend flag
+// suppresses the trailing "N sessions listed" line which would otherwise leak
+// into the parse loop on older systemd builds.
 //
-// Returns ([], nil) — not an error — when systemd-logind isn't
-// running on the host. Loginctl reports this in two distinct ways
-// depending on the underlying failure mode:
+// The command runs through the Runner (no escalation needed for loginctl), so it
+// inherits the forced C locale — the no-logind stderr fingerprints below are
+// therefore matched against stable English text regardless of the host locale.
+//
+// Returns ([], nil) — not an error — when systemd-logind isn't running on the
+// host. Loginctl reports this in two distinct ways depending on the underlying
+// failure mode:
 //
 //   - "System has not been booted with systemd as init system (PID 1).
-//     Can't operate." — typical inside docker/podman containers, CI
-//     runners, and minimal Linux setups using SysV/OpenRC. The binary
-//     is on PATH but logind has nothing to connect to.
-//   - "Failed to connect to bus: ..." — loginctl is present and
-//     systemd is PID 1, but the user dbus / system bus path is
-//     unavailable (sandbox restrictions, namespace gaps).
+//     Can't operate." — typical inside docker/podman containers, CI runners, and
+//     minimal Linux setups using SysV/OpenRC. The binary is on PATH but logind
+//     has nothing to connect to.
+//   - "Failed to connect to bus: ..." — loginctl is present and systemd is
+//     PID 1, but the user dbus / system bus path is unavailable (sandbox
+//     restrictions, namespace gaps).
 //
-// Either case is "no usable logind, no sessions to report" rather
-// than a true probe failure — the caller's empty-set policy
-// (skip-with-Warn for installs, no-op for uninstalls) gives the
-// right end-user behavior. Only loginctl errors that AREN'T one of
-// those two patterns get surfaced as an actual error so genuine
-// permission/IO faults still page operators.
-func listSessionIDs(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(ctx, loginctlPath, "list-sessions", "--no-legend")
-	stdout, err := cmd.Output()
+// Either case is "no usable logind, no sessions to report" rather than a true
+// probe failure — the caller's empty-set policy (skip-with-Warn for installs,
+// no-op for uninstalls) gives the right end-user behavior. Only loginctl errors
+// that AREN'T one of those two patterns get surfaced as an actual error so
+// genuine permission/IO faults still page operators.
+func (m *manager) listSessionIDs(ctx context.Context) ([]string, error) {
+	res, err := m.r.Run(ctx, pmexec.Command{Name: loginctlPath, Args: []string{"list-sessions", "--no-legend"}})
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if isLoginctlNoLogindStderr(string(exitErr.Stderr)) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("loginctl list-sessions failed: %w (stderr: %s)", err, string(exitErr.Stderr))
-		}
 		return nil, fmt.Errorf("loginctl list-sessions: %w", err)
 	}
+	if res.ExitCode != 0 {
+		if isLoginctlNoLogindStderr(res.Stderr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loginctl list-sessions failed (exit %d): %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
 	var ids []string
-	for _, line := range strings.Split(string(stdout), "\n") {
+	for _, line := range strings.Split(res.Stdout, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
-		}
-		ids = append(ids, fields[0])
+		// A non-empty trimmed line always has a first field; take it as the ID.
+		ids = append(ids, strings.Fields(line)[0])
 	}
 	return ids, nil
 }
 
-// loadSession runs `loginctl show-session <id> -p ...` and returns a
-// fully-populated Session if the session passes the active+local+
+// loadSession runs `loginctl show-session <id> -p ...` through the Runner and
+// returns a fully-populated Session if the session passes the active+local+
 // graphical filter, or (zero, false, nil) if it should be skipped.
 //
-// Returns an error only on truly-broken probes: a missing session
-// (race with logout) is treated as "skip" rather than failing the
-// whole ActiveSessions call.
-func loadSession(ctx context.Context, id string) (Session, bool, error) {
-	cmd := exec.CommandContext(ctx, loginctlPath, "show-session", id,
+// Returns an error only on truly-broken probes: a missing session (race with
+// logout) is treated as "skip" rather than failing the whole ActiveSessions
+// call.
+func (m *manager) loadSession(ctx context.Context, id string) (Session, bool, error) {
+	res, err := m.r.Run(ctx, pmexec.Command{Name: loginctlPath, Args: []string{
+		"show-session", id,
 		"--property=Name",
 		"--property=User",
 		"--property=Type",
 		"--property=Active",
 		"--property=Remote",
-	)
-	stdout, err := cmd.Output()
+	}})
 	if err != nil {
-		// Session disappeared between list-sessions and show-session
-		// — common when a user logs out concurrently with our probe.
-		// loginctl exits 1 with "Failed to get session: No session
-		// 'X'." on stderr in that case. Skip rather than fail.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if strings.Contains(string(exitErr.Stderr), "No session") {
-				return Session{}, false, nil
-			}
-			return Session{}, false, fmt.Errorf("%w (stderr: %s)", err, string(exitErr.Stderr))
+		return Session{}, false, fmt.Errorf("loginctl show-session: %w", err)
+	}
+	if res.ExitCode != 0 {
+		// Session disappeared between list-sessions and show-session — common
+		// when a user logs out concurrently with our probe. loginctl exits
+		// non-zero with "Failed to get session: No session 'X'." on stderr in
+		// that case. Skip rather than fail.
+		if strings.Contains(res.Stderr, "No session") {
+			return Session{}, false, nil
 		}
-		return Session{}, false, err
+		return Session{}, false, fmt.Errorf("exit %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
 
-	props := parseLoginctlProperties(string(stdout))
+	props := parseLoginctlProperties(res.Stdout)
 	if props["Remote"] != "no" {
 		return Session{}, false, nil
 	}
@@ -201,15 +173,14 @@ func loadSession(ctx context.Context, id string) (Session, bool, error) {
 		return Session{}, false, fmt.Errorf("loginctl returned non-numeric User=%q for session %q", uidStr, id)
 	}
 
-	// passwd lookup for Home + GID. Username from logind is
-	// authoritative for "who's signed in," but we still need the
-	// passwd entry for $HOME — logind's session metadata doesn't
-	// carry it.
-	u, err := user.LookupId(uidStr)
+	// passwd lookup for Home + GID. Username from logind is authoritative for
+	// "who's signed in," but we still need the passwd entry for $HOME — logind's
+	// session metadata doesn't carry it.
+	u, err := lookupID(uidStr)
 	if err != nil {
-		// Account exists in logind but not in passwd — extremely
-		// unusual (would mean the user was deleted while logged in).
-		// Skip rather than synthesize a fake $HOME.
+		// Account exists in logind but not in passwd — extremely unusual (would
+		// mean the user was deleted while logged in). Skip rather than
+		// synthesize a fake $HOME.
 		return Session{}, false, nil
 	}
 	gid, err := strconv.Atoi(u.Gid)
@@ -266,10 +237,11 @@ func isGraphicalType(t string) bool {
 // which should still surface to the caller.
 //
 // Match on substrings rather than exact equality so the helper
-// survives a localised systemd build (rare on the agent's target
-// distros but cheap to be tolerant of) or a future systemd that
-// rewords the message slightly. The substrings chosen are stable
-// across every systemd version since v220 (2015) on Linux.
+// survives a future systemd that rewords the message slightly. The
+// substrings chosen are stable across every systemd version since v220
+// (2015) on Linux. The loginctl probe runs under the forced C locale
+// (it goes through the Runner), so these English fingerprints are not
+// defeated by the host's configured language.
 func isLoginctlNoLogindStderr(stderr string) bool {
 	switch {
 	case strings.Contains(stderr, "has not been booted with systemd"):

--- a/go/sys/desktop/sessions.go
+++ b/go/sys/desktop/sessions.go
@@ -50,12 +50,15 @@ type Session struct {
 // malformed or the per-session detail probe fails for a reason other
 // than the session disappearing mid-call.
 func (m *manager) ActiveSessions(ctx context.Context) ([]Session, error) {
-	if _, err := lookPath(loginctlPath); err != nil {
+	if _, pathErr := lookPath(loginctlPath); pathErr != nil {
 		// Host doesn't ship systemd-logind. Treat as "no sessions" so
 		// the caller's empty-set policy (skip-with-warn vs fail) drives
 		// the user-facing behavior consistently regardless of the
-		// underlying init system.
-		return nil, nil
+		// underlying init system. Return a non-nil empty slice to match
+		// the documented contract and the success path's make(). (pathErr
+		// is named distinctly from err so the nilerr linter sees this is
+		// an intentional "absent → empty, no error" mapping.)
+		return []Session{}, nil
 	}
 
 	ids, err := m.listSessionIDs(ctx)

--- a/go/sys/desktop/sessions_test.go
+++ b/go/sys/desktop/sessions_test.go
@@ -133,6 +133,11 @@ func TestActiveSessions_NoLoginctl(t *testing.T) {
 	if len(got) != 0 {
 		t.Errorf("want no sessions, got %v", got)
 	}
+	// Contract: "returns an empty slice" — pin non-nil so a caller comparing
+	// against nil, or marshalling to JSON, sees [] not null.
+	if got == nil {
+		t.Error("ActiveSessions must return a non-nil empty slice when loginctl is absent")
+	}
 	if n := len(r.Calls()); n != 0 {
 		t.Errorf("loginctl absent must run nothing, but %d calls ran", n)
 	}

--- a/go/sys/desktop/sessions_test.go
+++ b/go/sys/desktop/sessions_test.go
@@ -1,9 +1,13 @@
 package desktop
 
 import (
-	"os/exec"
+	"context"
+	"errors"
+	"os/user"
 	"strings"
 	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
 )
 
 func TestParseLoginctlProperties(t *testing.T) {
@@ -110,37 +114,237 @@ func TestIsLoginctlNoLogindStderr(t *testing.T) {
 	}
 }
 
-func TestActiveSessions_NoLogindReturnsEmpty(t *testing.T) {
-	// End-to-end: when loginctl is on PATH but reports no logind,
-	// ActiveSessions must return ([], nil) so the caller's
-	// empty-set policy fires. This is the regression fix for the
-	// agent CI containers (debian/arch/fedora/opensuse) where
-	// loginctl is installed but PID 1 isn't systemd. The detector
-	// lives in isLoginctlNoLogindStderr; this test pins the wiring
-	// from listSessionIDs back up to ActiveSessions so a future
-	// refactor doesn't drop the empty-on-no-logind contract.
-	//
-	// Skipped if loginctl IS available and reports a real session
-	// list — that means the test host has a working logind and
-	// can't exercise the empty path here. The negative case above
-	// already exercises the matcher in isolation.
-	if _, err := exec.LookPath(loginctlPath); err != nil {
-		t.Skipf("loginctl not on PATH (%v) — covered by the missing-binary branch instead", err)
+// liveResultUser is the passwd fixture loadSession resolves the kept session
+// against. Returned by the stubbed lookupID in the build/append tests.
+var liveResultUser = &user.User{Uid: "1000", Gid: "1000", Username: "alice", HomeDir: "/home/alice"}
+
+// graphicalSessionProps is the loginctl show-session output for a kept session.
+const graphicalSessionProps = "Name=alice\nUser=1000\nType=wayland\nActive=yes\nRemote=no\n"
+
+func TestActiveSessions_NoLoginctl(t *testing.T) {
+	// Host without systemd-logind: lookPath fails → ([], nil), and the Runner
+	// is never invoked.
+	stubLookPath(t, false)
+	m, r := newManager(t)
+	got, err := m.ActiveSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveSessions: %v", err)
 	}
-	sessions, err := ActiveSessions(t.Context())
-	if err == nil {
-		// Either we're on a host without logind (sessions == nil,
-		// the contract pin) or we're on a host WITH logind (any
-		// number of sessions). Either way, a successful call with
-		// no error is fine — the load-bearing assertion is "no
-		// error from the no-logind path."
-		_ = sessions
-		return
+	if len(got) != 0 {
+		t.Errorf("want no sessions, got %v", got)
 	}
-	// If err is non-nil the agent CI would now fail. That's the
-	// regression we're guarding against. Surface the stderr so a
-	// future flavor of "no logind" we missed is visible.
-	t.Errorf("ActiveSessions returned error on no-logind host (regression #88): %v", err)
+	if n := len(r.Calls()); n != 0 {
+		t.Errorf("loginctl absent must run nothing, but %d calls ran", n)
+	}
+}
+
+func TestActiveSessions_NoLogind(t *testing.T) {
+	// loginctl present but no logind bus → ([], nil) so the caller's empty-set
+	// policy fires (the agent-CI-container regression).
+	stubLookPath(t, true)
+	m, r := newManager(t)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "Failed to connect to bus: No such file or directory"}, nil)
+	got, err := m.ActiveSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveSessions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("no-logind must yield zero sessions, got %v", got)
+	}
+}
+
+func TestActiveSessions_ListError(t *testing.T) {
+	// A non-zero exit whose stderr is NOT a no-logind fingerprint is a genuine
+	// fault and must surface.
+	stubLookPath(t, true)
+	m, r := newManager(t)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "Permission denied"}, nil)
+	if _, err := m.ActiveSessions(context.Background()); err == nil {
+		t.Error("ActiveSessions swallowed a genuine list-sessions failure")
+	}
+}
+
+func TestActiveSessions_ListRunError(t *testing.T) {
+	// The Runner itself failing (binary vanished mid-call, escalation error) is
+	// surfaced, not silently treated as "no sessions".
+	stubLookPath(t, true)
+	m, r := newManager(t)
+	r.Push(exec.Result{}, errors.New("boom"))
+	if _, err := m.ActiveSessions(context.Background()); err == nil {
+		t.Error("ActiveSessions swallowed a Runner error")
+	}
+}
+
+func TestActiveSessions_FiltersAndBuilds(t *testing.T) {
+	// End-to-end: two sessions listed; one graphical+active+local is kept and
+	// fully built, one remote is filtered out.
+	stubLookPath(t, true)
+	stubLookupID(t, func(string) (*user.User, error) { return liveResultUser, nil })
+	m, r := newManager(t)
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0\nc2 1001 bob\n"}, nil)                      // list-sessions
+	r.Push(exec.Result{Stdout: graphicalSessionProps}, nil)                                     // show-session c1 (kept)
+	r.Push(exec.Result{Stdout: "Name=bob\nUser=1001\nType=x11\nActive=yes\nRemote=yes\n"}, nil) // c2 (remote, skipped)
+
+	got, err := m.ActiveSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveSessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want exactly the one local graphical session, got %d: %v", len(got), got)
+	}
+	s := got[0]
+	want := Session{ID: "c1", Username: "alice", UID: 1000, GID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000", Type: "wayland"}
+	if s != want {
+		t.Errorf("built session = %+v, want %+v", s, want)
+	}
+	// The probe is unescalated (loginctl needs no root) — pin it so a refactor
+	// doesn't start running it through sudo.
+	for _, c := range r.Calls() {
+		if c.Escalate {
+			t.Errorf("loginctl probe must not escalate: %+v", c)
+		}
+		if c.Name != loginctlPath {
+			t.Errorf("probe ran %q, want %q", c.Name, loginctlPath)
+		}
+	}
+}
+
+func TestActiveSessions_LoadErrorPropagates(t *testing.T) {
+	// A non-skippable per-session probe failure aborts the whole call.
+	stubLookPath(t, true)
+	m, r := newManager(t)
+	r.Push(exec.Result{Stdout: "c1 1000 alice\n"}, nil)                // list
+	r.Push(exec.Result{ExitCode: 1, Stderr: "Permission denied"}, nil) // show-session c1 → hard error
+	if _, err := m.ActiveSessions(context.Background()); err == nil {
+		t.Error("a hard show-session failure must propagate")
+	}
+}
+
+// loadSession branch coverage — driven directly (one Run each) so each filter /
+// rejection path is isolated.
+func TestLoadSession_Branches(t *testing.T) {
+	props := func(name, uid, typ, active, remote string) string {
+		return "Name=" + name + "\nUser=" + uid + "\nType=" + typ + "\nActive=" + active + "\nRemote=" + remote + "\n"
+	}
+
+	t.Run("run error", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{}, errors.New("boom"))
+		if _, _, err := m.loadSession(context.Background(), "c1"); err == nil {
+			t.Error("want error on Runner failure")
+		}
+	})
+	t.Run("no session race skipped", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "Failed to get session: No session 'c1'."}, nil)
+		_, ok, err := m.loadSession(context.Background(), "c1")
+		if err != nil || ok {
+			t.Errorf("a logged-out session must skip cleanly: ok=%v err=%v", ok, err)
+		}
+	})
+	t.Run("other non-zero exit errors", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "Permission denied"}, nil)
+		if _, _, err := m.loadSession(context.Background(), "c1"); err == nil {
+			t.Error("a non-race non-zero exit must error")
+		}
+	})
+	t.Run("remote skipped", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "wayland", "yes", "yes")}, nil)
+		if _, ok, _ := m.loadSession(context.Background(), "c1"); ok {
+			t.Error("remote session must be filtered out")
+		}
+	})
+	t.Run("inactive skipped", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "wayland", "no", "no")}, nil)
+		if _, ok, _ := m.loadSession(context.Background(), "c1"); ok {
+			t.Error("inactive session must be filtered out")
+		}
+	})
+	t.Run("non-graphical skipped", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "tty", "yes", "no")}, nil)
+		if _, ok, _ := m.loadSession(context.Background(), "c1"); ok {
+			t.Error("tty session must be filtered out")
+		}
+	})
+	t.Run("non-numeric user errors", func(t *testing.T) {
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "notanumber", "wayland", "yes", "no")}, nil)
+		if _, _, err := m.loadSession(context.Background(), "c1"); err == nil {
+			t.Error("a non-numeric User= must error")
+		}
+	})
+	t.Run("passwd miss skipped", func(t *testing.T) {
+		stubLookupID(t, func(string) (*user.User, error) { return nil, errors.New("no such user") })
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "wayland", "yes", "no")}, nil)
+		_, ok, err := m.loadSession(context.Background(), "c1")
+		if err != nil || ok {
+			t.Errorf("a uid in logind but not passwd must skip: ok=%v err=%v", ok, err)
+		}
+	})
+	t.Run("non-numeric gid errors", func(t *testing.T) {
+		stubLookupID(t, func(uid string) (*user.User, error) {
+			return &user.User{Uid: uid, Gid: "notanumber", Username: "alice", HomeDir: "/home/alice"}, nil
+		})
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "wayland", "yes", "no")}, nil)
+		if _, _, err := m.loadSession(context.Background(), "c1"); err == nil {
+			t.Error("a passwd entry with a non-numeric gid must error")
+		}
+	})
+	t.Run("success builds session", func(t *testing.T) {
+		stubLookupID(t, func(string) (*user.User, error) { return liveResultUser, nil })
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("alice", "1000", "x11", "yes", "no")}, nil)
+		s, ok, err := m.loadSession(context.Background(), "c9")
+		if err != nil || !ok {
+			t.Fatalf("loadSession = (%+v,%v,%v), want a built session", s, ok, err)
+		}
+		want := Session{ID: "c9", Username: "alice", UID: 1000, GID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000", Type: "x11"}
+		if s != want {
+			t.Errorf("session = %+v, want %+v", s, want)
+		}
+	})
+}
+
+func TestListSessionIDs_ParsesAndSkipsBlankLines(t *testing.T) {
+	m, r := newManager(t)
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0\n\n  c2 1001 bob \n"}, nil)
+	ids, err := m.listSessionIDs(context.Background())
+	if err != nil {
+		t.Fatalf("listSessionIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "c1" || ids[1] != "c2" {
+		t.Errorf("ids = %v, want [c1 c2]", ids)
+	}
+}
+
+// TestActiveSessions_RealLoginctl is the integration leg: it builds a Manager
+// over a REAL runner and runs the actual loginctl. On a host without logind
+// (the agent's CI containers) it must return ([], nil) — the regression fix for
+// manchtools/power-manage-sdk#88. On a host WITH logind any count is fine; the
+// load-bearing assertion is "no error from the no-logind path".
+func TestActiveSessions_RealLoginctl(t *testing.T) {
+	if _, err := lookPath(loginctlPath); err != nil {
+		t.Skipf("loginctl not on PATH (%v) — the missing-binary branch covers this", err)
+	}
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	m, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	sessions, err := m.ActiveSessions(context.Background())
+	if err != nil {
+		t.Errorf("ActiveSessions returned error on this host (regression #88): %v", err)
+	}
+	_ = sessions
 }
 
 func TestEnvFor_HasMinimumDesktopEnv(t *testing.T) {

--- a/go/sys/desktop/userpath_test.go
+++ b/go/sys/desktop/userpath_test.go
@@ -55,8 +55,9 @@ func TestUserPath(t *testing.T) {
 // commands ran with no PATH / runuser's compiled-in default rather than
 // the user's, and ~/.local/bin was never on PATH.
 func TestRunAsCommand_SetsCuratedUserPath(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
-	cmd, err := RunAsCommand(context.Background(), s, nil, "true")
+	cmd, err := m.RunAsCommand(context.Background(), s, RunAsOptions{}, "true")
 	if err != nil {
 		t.Fatalf("RunAsCommand: %v", err)
 	}
@@ -70,8 +71,9 @@ func TestRunAsCommand_SetsCuratedUserPath(t *testing.T) {
 // user PATH — the curated value is applied last so it wins, matching the
 // streaming path which refuses a caller-supplied PATH outright.
 func TestRunAsCommand_CuratedPathWinsOverExtraEnv(t *testing.T) {
+	m, _ := newManager(t)
 	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
-	cmd, err := RunAsCommand(context.Background(), s, []string{"PATH=/attacker/bin"}, "true")
+	cmd, err := m.RunAsCommand(context.Background(), s, RunAsOptions{ExtraEnv: []string{"PATH=/attacker/bin"}}, "true")
 	if err != nil {
 		t.Fatalf("RunAsCommand: %v", err)
 	}

--- a/go/sys/desktop/users.go
+++ b/go/sys/desktop/users.go
@@ -1,53 +1,50 @@
 package desktop
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 )
 
-// homeRoot is the root directory enumerated by HomeUsers. Pinned as a
-// var so tests can swap it for a fixture; production code never
-// reassigns it.
-var homeRoot = "/home"
-
 // HomeUsers enumerates every Linux account on the host whose home
-// directory lives directly under /home/<name>. For each /home/<name>
-// subdir we call os/user.Lookup to confirm a real account exists
-// (catches stale `userdel`-without-`-r` directories) and to recover
-// the canonical UID/GID/Home from passwd or NSS.
+// directory lives directly under <homeRoot>/<name> (homeRoot defaults to
+// /home; override with WithHomeRoot). For each subdir we call os/user.Lookup
+// to confirm a real account exists (catches stale `userdel`-without-`-r`
+// directories) and to recover the canonical UID/GID/Home from passwd or NSS.
 //
 // This is the primitive for "do something for every offline user" —
 // the install / online path uses ActiveSessions, the uninstall /
 // passive path (and similar "clean up every user's home" sweeps)
 // uses HomeUsers.
 //
-// Returns an empty slice — not an error — when /home is missing or
-// empty. Returns an error only when /home exists but cannot be read
-// (permission denied, IO error). Per-user lookup failures are
-// silently skipped: a non-resolving home dir means a stale entry,
-// not a fault we want to surface.
+// Returns an empty slice — not an error — when the home root is missing or
+// empty. Returns an error only when it exists but cannot be read (permission
+// denied, IO error). Per-user lookup failures are silently skipped: a
+// non-resolving home dir means a stale entry, not a fault we want to surface.
+//
+// The ctx is accepted for shape-uniformity and future cancellation; the
+// enumeration itself is local filesystem + passwd lookups.
 //
 // Limitations (intentional, documented for callers picking the
 // right helper):
-//   - Custom $HOME paths outside /home/ (LDAP /home/<domain>/<user>,
+//   - Custom $HOME paths outside the home root (LDAP /home/<domain>/<user>,
 //     /auto.home/<user>, etc.) are missed. Those layouts are
 //     uncommon on managed Linux endpoints; passwd-iterating
 //     wouldn't catch them either if the home dir is auto-mounted
 //     on first access.
-//   - Encrypted homes (ecryptfs) appear as a single /home/<name>
+//   - Encrypted homes (ecryptfs) appear as a single <homeRoot>/<name>
 //     dir but the contents are unreadable without the user's
 //     session. Per-user state inside the encrypted volume is
 //     invisible to a sweep that runs while the user is offline.
-func HomeUsers() ([]Session, error) {
-	entries, err := os.ReadDir(homeRoot)
+func (m *manager) HomeUsers(ctx context.Context) ([]Session, error) {
+	entries, err := os.ReadDir(m.homeRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("read %s: %w", homeRoot, err)
+		return nil, fmt.Errorf("read %s: %w", m.homeRoot, err)
 	}
 
 	out := make([]Session, 0, len(entries))
@@ -70,11 +67,11 @@ func HomeUsers() ([]Session, error) {
 	return out, nil
 }
 
-// homeUserFor builds a Session for the given /home/<name> subdir if
+// homeUserFor builds a Session for the given <homeRoot>/<name> subdir if
 // it resolves to a real account. Returns (zero, false) on any lookup
 // failure — callers treat that as "not a real user, skip silently."
 func homeUserFor(name string) (Session, bool) {
-	u, err := user.Lookup(name)
+	u, err := lookupUser(name)
 	if err != nil {
 		return Session{}, false
 	}
@@ -88,7 +85,7 @@ func homeUserFor(name string) (Session, bool) {
 	}
 	// Trust the canonical home from the lookup over the directory
 	// name — a system with /etc/skel symlinks or unusual NSS modules
-	// can have /home/<name> exist while the canonical home is
+	// can have <homeRoot>/<name> exist while the canonical home is
 	// elsewhere; using the lookup result keeps us aligned with what
 	// runuser will see.
 	return Session{
@@ -110,7 +107,7 @@ func homeUserFor(name string) (Session, bool) {
 // Errors:
 //   - returns an error if appID is empty (caller bug — would otherwise
 //     glob "every per-user flatpak install on the box")
-//   - propagates the error from HomeUsers when /home itself is
+//   - propagates the error from HomeUsers when the home root itself is
 //     unreadable (permission denied, IO error). The caller treats
 //     that as fail-the-whole-uninstall, since we can't say the action
 //     converged when we can't even enumerate the candidate set.
@@ -121,11 +118,11 @@ func homeUserFor(name string) (Session, bool) {
 // the next reconciliation tick re-checks once the access issue
 // resolves. The caller still logs per-user uninstall errors from the
 // returned set itself.
-func UsersWithFlatpakInstall(appID string) ([]Session, error) {
+func (m *manager) UsersWithFlatpakInstall(ctx context.Context, appID string) ([]Session, error) {
 	if appID == "" {
 		return nil, fmt.Errorf("UsersWithFlatpakInstall: appID required")
 	}
-	users, err := HomeUsers()
+	users, err := m.HomeUsers(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/sys/desktop/users.go
+++ b/go/sys/desktop/users.go
@@ -42,7 +42,10 @@ func (m *manager) HomeUsers(ctx context.Context) ([]Session, error) {
 	entries, err := os.ReadDir(m.homeRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			// Missing home root is "no users", not a fault. Return a non-nil
+			// empty slice to match the documented contract and the success
+			// path below (which always make()s a slice).
+			return []Session{}, nil
 		}
 		return nil, fmt.Errorf("read %s: %w", m.homeRoot, err)
 	}

--- a/go/sys/desktop/users_test.go
+++ b/go/sys/desktop/users_test.go
@@ -1,21 +1,14 @@
 package desktop
 
 import (
+	"context"
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"testing"
 )
-
-// withHomeRoot swaps the package-level homeRoot for the duration of t.
-// Restores on cleanup so tests can run in any order.
-func withHomeRoot(t *testing.T, dir string) {
-	t.Helper()
-	prev := homeRoot
-	homeRoot = dir
-	t.Cleanup(func() { homeRoot = prev })
-}
 
 // currentUserSession builds a Session pointing at the running test
 // user's home, used as the fixture identity. Skips when the test
@@ -38,8 +31,8 @@ func currentUserSession(t *testing.T) (user.User, int, int) {
 }
 
 func TestHomeUsers_EmptyHomeRoot(t *testing.T) {
-	withHomeRoot(t, t.TempDir())
-	got, err := HomeUsers()
+	m, _ := newManager(t, WithHomeRoot(t.TempDir()))
+	got, err := m.HomeUsers(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error on empty /home: %v", err)
 	}
@@ -53,8 +46,8 @@ func TestHomeUsers_MissingHomeRoot(t *testing.T) {
 	// error. Containers and minimal systems sometimes lack /home
 	// entirely; the agent still needs to make a uninstall-loop
 	// decision without exiting the action with a hard error.
-	withHomeRoot(t, filepath.Join(t.TempDir(), "does-not-exist"))
-	got, err := HomeUsers()
+	m, _ := newManager(t, WithHomeRoot(filepath.Join(t.TempDir(), "does-not-exist")))
+	got, err := m.HomeUsers(context.Background())
 	if err != nil {
 		t.Fatalf("missing /home should not error, got: %v", err)
 	}
@@ -63,9 +56,26 @@ func TestHomeUsers_MissingHomeRoot(t *testing.T) {
 	}
 }
 
+func TestHomeUsers_UnreadableHomeRoot(t *testing.T) {
+	// A home root that exists but cannot be read is a genuine fault and must
+	// surface (distinct from "missing" → empty). Root bypasses directory perms,
+	// so skip when running privileged.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions; cannot exercise the unreadable path")
+	}
+	root := filepath.Join(t.TempDir(), "noperm")
+	if err := os.Mkdir(root, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) }) // so t.TempDir cleanup can remove it
+	m, _ := newManager(t, WithHomeRoot(root))
+	if _, err := m.HomeUsers(context.Background()); err == nil {
+		t.Error("an unreadable home root must surface an error, not return empty")
+	}
+}
+
 func TestHomeUsers_SkipsNonDirectoryAndDotPrefixed(t *testing.T) {
 	root := t.TempDir()
-	withHomeRoot(t, root)
 
 	// Files, dot-prefixed dirs, and lost+found must all be skipped
 	// before we even try to resolve a username — otherwise a stray
@@ -81,12 +91,14 @@ func TestHomeUsers_SkipsNonDirectoryAndDotPrefixed(t *testing.T) {
 	}
 
 	// Bait: a dir whose name resolves to no real user. Should be
-	// silently skipped (no failure surfaced to the caller).
+	// silently skipped (no failure surfaced to the caller). This uses the
+	// REAL user.Lookup, exercising homeUserFor's lookup-failure branch.
 	if err := os.Mkdir(filepath.Join(root, "_definitely_not_a_real_user_name_pmtest"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := HomeUsers()
+	m, _ := newManager(t, WithHomeRoot(root))
+	got, err := m.HomeUsers(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,16 +107,45 @@ func TestHomeUsers_SkipsNonDirectoryAndDotPrefixed(t *testing.T) {
 	}
 }
 
+func TestHomeUsers_SkipsNonNumericUIDOrGID(t *testing.T) {
+	// homeUserFor must skip a passwd entry whose uid or gid is non-numeric
+	// rather than build a corrupt Session. Driven via the lookupUser seam since
+	// a real passwd cannot carry such values.
+	root := t.TempDir()
+	for _, d := range []string{"baduid", "badgid"} {
+		if err := os.Mkdir(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubLookupUser(t, func(name string) (*user.User, error) {
+		switch name {
+		case "baduid":
+			return &user.User{Username: name, Uid: "not-a-number", Gid: "1000", HomeDir: "/h"}, nil
+		case "badgid":
+			return &user.User{Username: name, Uid: "1000", Gid: "not-a-number", HomeDir: "/h"}, nil
+		}
+		return nil, errors.New("no such user")
+	})
+	m, _ := newManager(t, WithHomeRoot(root))
+	got, err := m.HomeUsers(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("non-numeric uid/gid entries must be skipped, got %v", got)
+	}
+}
+
 func TestHomeUsers_ResolvesRealAccount(t *testing.T) {
 	u, uid, gid := currentUserSession(t)
 
 	root := t.TempDir()
-	withHomeRoot(t, root)
 	if err := os.Mkdir(filepath.Join(root, u.Username), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := HomeUsers()
+	m, _ := newManager(t, WithHomeRoot(root))
+	got, err := m.HomeUsers(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,41 +176,68 @@ func TestHomeUsers_ResolvesRealAccount(t *testing.T) {
 }
 
 func TestUsersWithFlatpakInstall_RequiresAppID(t *testing.T) {
-	if _, err := UsersWithFlatpakInstall(""); err == nil {
+	m, _ := newManager(t)
+	if _, err := m.UsersWithFlatpakInstall(context.Background(), ""); err == nil {
 		t.Fatal("expected error for empty appID — guards against silently uninstalling for everyone")
 	}
 }
 
-func TestUsersWithFlatpakInstall_FiltersByInstallDir(t *testing.T) {
-	u, _, _ := currentUserSession(t)
-
-	root := t.TempDir()
-	withHomeRoot(t, root)
-	if err := os.Mkdir(filepath.Join(root, u.Username), 0o755); err != nil {
+func TestUsersWithFlatpakInstall_PropagatesHomeUsersError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	root := filepath.Join(t.TempDir(), "noperm")
+	if err := os.Mkdir(root, 0o000); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+	m, _ := newManager(t, WithHomeRoot(root))
+	if _, err := m.UsersWithFlatpakInstall(context.Background(), "com.example.App"); err == nil {
+		t.Error("an unreadable home root must fail the flatpak enumeration, not return empty")
+	}
+}
 
+// flatpakFixture mounts a fake user "alice" whose authoritative $HOME is a temp
+// dir, so the per-user flatpak install dir can be created without touching the
+// developer's real home. Returns the Manager and the user's home dir.
+func flatpakFixture(t *testing.T) (Manager, string) {
+	t.Helper()
+	root := t.TempDir()
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "alice"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stubLookupUser(t, func(string) (*user.User, error) {
+		return &user.User{Username: "alice", Uid: "1000", Gid: "1000", HomeDir: home}, nil
+	})
+	m, _ := newManager(t, WithHomeRoot(root))
+	return m, home
+}
+
+func TestUsersWithFlatpakInstall_ReturnsUsersWithTheApp(t *testing.T) {
 	const appID = "com.example.PmTest"
-
-	// First pass: nobody has the app installed in the synthetic
-	// home root — should be empty.
-	got, err := UsersWithFlatpakInstall(appID)
+	m, home := flatpakFixture(t)
+	appDir := filepath.Join(home, ".local", "share", "flatpak", "app", appID)
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.UsersWithFlatpakInstall(context.Background(), appID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, s := range got {
-		if s.Username == u.Username && s.Home == filepath.Join(root, u.Username) {
-			// Only fail if the lookup-derived home actually points
-			// into our test root (production runs have a real
-			// HomeDir from passwd, which we should exclude here).
-			t.Errorf("did not expect current user pre-install: %v", s)
-		}
+	if len(got) != 1 || got[0].Username != "alice" {
+		t.Fatalf("want [alice] (the user with the app installed), got %v", got)
 	}
+}
 
-	// We can't fabricate the install dir under the real $HOME from
-	// inside a unit test (would clobber the dev's actual home), so
-	// the positive direction is exercised by inspecting the filter
-	// path in users.go and trusting the negative case above. The
-	// rotation tests cover the loop behavior end-to-end via the
-	// agent's executor tests.
+func TestUsersWithFlatpakInstall_ExcludesUsersWithoutTheApp(t *testing.T) {
+	const appID = "com.example.PmTest"
+	m, _ := flatpakFixture(t) // no app dir created
+	got, err := m.UsersWithFlatpakInstall(context.Background(), appID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a user without the per-user install must be excluded, got %v", got)
+	}
 }

--- a/go/sys/desktop/users_test.go
+++ b/go/sys/desktop/users_test.go
@@ -54,6 +54,11 @@ func TestHomeUsers_MissingHomeRoot(t *testing.T) {
 	if len(got) != 0 {
 		t.Errorf("expected zero users for missing /home, got %d", len(got))
 	}
+	// Contract: "empty slice — not an error". Pin non-nil so missing and empty
+	// home roots are indistinguishable to the caller (and JSON-marshal to []).
+	if got == nil {
+		t.Error("HomeUsers must return a non-nil empty slice for a missing home root")
+	}
 }
 
 func TestHomeUsers_UnreadableHomeRoot(t *testing.T) {

--- a/go/sys/osquery/example_test.go
+++ b/go/sys/osquery/example_test.go
@@ -1,0 +1,38 @@
+package osquery_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/osquery"
+)
+
+// ExampleNew shows the construct-a-handle flow: pick a Runner, build a Querier,
+// and query a benign table. The credential-table deny-list and table-name
+// validation are enforced inside QueryTable/Query.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Sudo) // the consumer picks the escalation backend
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	q, err := osquery.New(r)
+	if errors.Is(err, osquery.ErrNotInstalled) {
+		// osquery isn't installed on this host — skip osquery-dependent features.
+		return
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rows, err := q.QueryTable(context.Background(), "os_version")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, row := range rows {
+		fmt.Println(row.Data["name"])
+	}
+}

--- a/go/sys/osquery/osquery.go
+++ b/go/sys/osquery/osquery.go
@@ -1,13 +1,20 @@
 // Package osquery integrates the osquery binary for system queries through an
 // injected exec.Runner.
 //
-// Build a Client with a Runner and call its methods; every query is escalated
+// Build a Querier with a Runner and call its methods; every query is escalated
 // through the Runner. The convenience table path refuses a curated deny-list of
 // credential-bearing tables before running anything; the signed RawSql escape
 // hatch is the operator's explicit path and is intentionally not gated.
 //
 //	r, _ := exec.NewRunner(exec.Sudo)
-//	c, err := osquery.NewClient(r) // ErrNotInstalled if osqueryi is absent
+//	q, err := osquery.New(r) // ErrNotInstalled if osqueryi is absent
+//	if err != nil { ... }
+//	rows, err := q.QueryTable(ctx, "os_version")
+//
+// New is a single-implementation capability (design §3.8): it exposes the
+// Querier interface for shape-uniformity with the backend-pattern packages even
+// though osquery is the only implementation. There is no Backend argument — only
+// the required Runner.
 package osquery
 
 import (
@@ -67,15 +74,43 @@ var (
 	defaultTimeout = 30 * time.Second
 )
 
-// Client wraps osquery binary execution over an injected Runner.
-type Client struct {
+// Querier is the osquery surface: a small, ctx-first interface over the osquery
+// binary. It is single-implementation by nature (§3.8) — there is no second way
+// to run osquery — but it is an interface so a consumer learns the same
+// construct-a-handle shape as every other capability.
+type Querier interface {
+	// IsInstalled reports, live, whether an osqueryi binary is currently
+	// reachable. New already fails closed with ErrNotInstalled when the binary
+	// is absent at construction; IsInstalled re-probes so a caller can detect
+	// the binary being removed during the agent's lifetime. The ctx is accepted
+	// for shape-uniformity; the probe itself is a filesystem lookup.
+	IsInstalled(ctx context.Context) bool
+	// ListTables returns the names of the available osquery tables.
+	ListTables(ctx context.Context) ([]string, error)
+	// Query runs a structured query. The RawSql escape hatch (the operator's
+	// CA-signed path) is NOT gated by the deny-list; the table path refuses the
+	// credential-bearing deny-list before building any SQL. A query failure is
+	// folded into the returned *pb.OSQueryResult (Success=false), not returned
+	// as a Go error.
+	Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResult, error)
+	// QueryTable runs SELECT * FROM <table> after the same validity + deny-list
+	// checks as Query's table path; there is no RawSql bypass here.
+	QueryTable(ctx context.Context, tableName string) ([]*pb.OSQueryRow, error)
+	// QuerySQL runs raw SQL and parses the JSON result rows.
+	QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, error)
+}
+
+// client is the single Querier implementation; it wraps osquery binary
+// execution over an injected Runner.
+type client struct {
 	binaryPath string
 	r          exec.Runner
 }
 
-// NewClient creates an osquery client driven by runner. Returns ErrNotInstalled
-// when the osqueryi binary is not found, and an error when runner is nil.
-func NewClient(runner exec.Runner) (*Client, error) {
+// New creates an osquery Querier driven by runner. Returns ErrNotInstalled when
+// the osqueryi binary is not found (eager fail-closed probe, so a caller learns
+// at construction that osquery is unavailable), and an error when runner is nil.
+func New(runner exec.Runner) (Querier, error) {
 	if runner == nil {
 		return nil, errors.New("osquery: runner is required")
 	}
@@ -83,11 +118,12 @@ func NewClient(runner exec.Runner) (*Client, error) {
 	if path == "" {
 		return nil, ErrNotInstalled
 	}
-	return &Client{binaryPath: path, r: runner}, nil
+	return &client{binaryPath: path, r: runner}, nil
 }
 
-// IsInstalled checks if osquery is installed on the system.
-func IsInstalled() bool {
+// IsInstalled re-probes for the osqueryi binary so callers can detect removal at
+// runtime. See the Querier.IsInstalled contract.
+func (c *client) IsInstalled(ctx context.Context) bool {
 	return findOsqueryBinary() != ""
 }
 
@@ -116,7 +152,7 @@ func findOsqueryBinary() string {
 }
 
 // ListTables returns a list of available osquery tables.
-func (c *Client) ListTables(ctx context.Context) ([]string, error) {
+func (c *client) ListTables(ctx context.Context) ([]string, error) {
 	output, err := c.execQuery(ctx, ".tables")
 	if err != nil {
 		return nil, err
@@ -144,7 +180,7 @@ var tableSQL = map[string]string{
 }
 
 // Query executes an osquery SQL query and returns the results.
-func (c *Client) Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResult, error) {
+func (c *client) Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResult, error) {
 	var sql string
 	if query.RawSql != "" {
 		sql = query.RawSql
@@ -185,7 +221,7 @@ func (c *Client) Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResul
 }
 
 // QuerySQL executes a raw SQL query against osquery.
-func (c *Client) QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, error) {
+func (c *client) QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, error) {
 	output, err := c.execQuery(ctx, sql)
 	if err != nil {
 		return nil, err
@@ -205,7 +241,7 @@ func (c *Client) QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, er
 }
 
 // QueryTable queries a specific table by name.
-func (c *Client) QueryTable(ctx context.Context, tableName string) ([]*pb.OSQueryRow, error) {
+func (c *client) QueryTable(ctx context.Context, tableName string) ([]*pb.OSQueryRow, error) {
 	sql, ok := tableSQL[tableName]
 	if !ok {
 		if !validTableName.MatchString(tableName) {
@@ -221,7 +257,7 @@ func (c *Client) QueryTable(ctx context.Context, tableName string) ([]*pb.OSQuer
 
 // execQuery executes an osquery command (escalated through the Runner) and
 // returns its stdout.
-func (c *Client) execQuery(ctx context.Context, query string) (string, error) {
+func (c *client) execQuery(ctx context.Context, query string) (string, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)

--- a/go/sys/osquery/osquery_coverage_test.go
+++ b/go/sys/osquery/osquery_coverage_test.go
@@ -15,7 +15,7 @@ func TestListTables(t *testing.T) {
 	// Bare table names are kept; "=>"-prefixed lines, "+" header noise, and
 	// blanks are skipped.
 	r.Push(exec.Result{Stdout: "os_version\nuptime\n+ ignore me\n\n=> skip me\nsystem_info\n"}, nil)
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	tables, err := c.ListTables(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -38,7 +38,7 @@ func TestListTables(t *testing.T) {
 func TestListTables_ExecError(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	if _, err := c.ListTables(context.Background()); err == nil {
 		t.Error("ListTables swallowed a query failure")
 	}
@@ -47,7 +47,7 @@ func TestListTables_ExecError(t *testing.T) {
 func TestQuery_CustomTableSQL(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: "[]"}, nil)
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", Table: "authorized_keys"})
 	if err != nil || !res.Success {
 		t.Fatalf("Query(authorized_keys) = (%+v,%v)", res, err)
@@ -60,7 +60,7 @@ func TestQuery_CustomTableSQL(t *testing.T) {
 func TestQuery_QuerySQLErrorSurfacesInResult(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: "not json"}, nil) // parse failure inside QuerySQL
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", Table: "os_version"})
 	if err != nil {
 		t.Fatalf("Query should fold the SQL error into the result, not return it: %v", err)
@@ -74,7 +74,7 @@ func TestQueryTable(t *testing.T) {
 	t.Run("benign", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{Stdout: `[{"name":"x"}]`}, nil)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		rows, err := c.QueryTable(context.Background(), "os_version")
 		if err != nil || len(rows) != 1 {
 			t.Fatalf("QueryTable = (%v,%v), want one row", rows, err)
@@ -83,7 +83,7 @@ func TestQueryTable(t *testing.T) {
 	t.Run("custom tableSQL", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{Stdout: "[]"}, nil)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QueryTable(context.Background(), "authorized_keys"); err != nil {
 			t.Fatal(err)
 		}
@@ -93,7 +93,7 @@ func TestQueryTable(t *testing.T) {
 	})
 	t.Run("invalid name rejected before exec", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QueryTable(context.Background(), "bad name!"); err == nil {
 			t.Error("QueryTable accepted an invalid name")
 		}
@@ -103,7 +103,7 @@ func TestQueryTable(t *testing.T) {
 	})
 	t.Run("sensitive table refused before exec", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QueryTable(context.Background(), "shadow"); err == nil {
 			t.Error("QueryTable returned a sensitive table")
 		}

--- a/go/sys/osquery/osquery_sensitive_test.go
+++ b/go/sys/osquery/osquery_sensitive_test.go
@@ -19,7 +19,7 @@ import (
 func TestQuery_DeniesSensitiveTables(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: "[]"}, nil) // consumed only by the benign os_version run
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	ctx := context.Background()
 
 	// present-but-wrong: each sensitive table is regex-valid but policy-forbidden.
@@ -72,7 +72,7 @@ func TestQuery_DeniesSensitiveTables(t *testing.T) {
 func TestQuery_RawSqlBypassesDenyList(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: `[{"hash":"x"}]`}, nil)
-	c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", RawSql: "SELECT * FROM shadow"})
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +89,7 @@ func TestExecQuery_Failures(t *testing.T) {
 	t.Run("exec error", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{}, errors.New("sudo: a password is required"))
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); !errors.Is(err, ErrQueryFailed) {
 			t.Errorf("err = %v, want ErrQueryFailed", err)
 		}
@@ -97,7 +97,7 @@ func TestExecQuery_Failures(t *testing.T) {
 	t.Run("non-zero exit with stderr", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{ExitCode: 1, Stderr: "no such table: bogus"}, nil)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		_, err := c.QuerySQL(context.Background(), "SELECT * FROM bogus")
 		if !errors.Is(err, ErrQueryFailed) || !strings.Contains(err.Error(), "no such table") {
 			t.Errorf("err = %v, want ErrQueryFailed naming the stderr", err)
@@ -106,7 +106,7 @@ func TestExecQuery_Failures(t *testing.T) {
 	t.Run("non-zero exit no stderr", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{ExitCode: 2}, nil)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); !errors.Is(err, ErrQueryFailed) {
 			t.Errorf("err = %v, want ErrQueryFailed", err)
 		}
@@ -114,7 +114,7 @@ func TestExecQuery_Failures(t *testing.T) {
 	t.Run("unparseable JSON", func(t *testing.T) {
 		r := exectest.New(exec.Direct)
 		r.Push(exec.Result{Stdout: "not json"}, nil)
-		c := &Client{binaryPath: "/usr/bin/osqueryi", r: r}
+		c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 		if _, err := c.QuerySQL(context.Background(), "SELECT 1"); err == nil ||
 			!strings.Contains(err.Error(), "parse osquery output") {
 			t.Errorf("err = %v, want a parse failure", err)

--- a/go/sys/osquery/osquery_test.go
+++ b/go/sys/osquery/osquery_test.go
@@ -1,6 +1,7 @@
 package osquery
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -83,32 +84,33 @@ func TestFindOsqueryBinary_DiscoveryOrder(t *testing.T) {
 	}
 }
 
-// TestNewClient_NotInstalled covers the lazy-init failure path: when
-// no osqueryi binary is reachable, NewClient must return ErrNotInstalled
-// rather than a half-constructed Client.
-func TestNewClient_NotInstalled(t *testing.T) {
+// TestNew_NotInstalled covers the eager fail-closed probe: when no
+// osqueryi binary is reachable, New must return ErrNotInstalled rather
+// than a half-constructed Querier, so a caller learns at construction
+// that osquery is unavailable.
+func TestNew_NotInstalled(t *testing.T) {
 	restore := lookPath
 	defer func() { lookPath = restore }()
 	lookPath = func(string) (string, error) {
 		return "", errors.New("not found")
 	}
 
-	c, err := NewClient(exectest.New(exec.Direct))
+	q, err := New(exectest.New(exec.Direct))
 	if !errors.Is(err, ErrNotInstalled) {
-		t.Errorf("NewClient: want ErrNotInstalled, got %v", err)
+		t.Errorf("New: want ErrNotInstalled, got %v", err)
 	}
-	if c != nil {
-		t.Errorf("NewClient: want nil client on failure, got %+v", c)
-	}
-}
-
-func TestNewClient_NilRunner(t *testing.T) {
-	if _, err := NewClient(nil); err == nil {
-		t.Error("NewClient(nil) returned nil error")
+	if q != nil {
+		t.Errorf("New: want nil Querier on failure, got %+v", q)
 	}
 }
 
-func TestNewClient_Success(t *testing.T) {
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error")
+	}
+}
+
+func TestNew_Success(t *testing.T) {
 	restore := lookPath
 	defer func() { lookPath = restore }()
 	lookPath = func(name string) (string, error) {
@@ -117,27 +119,36 @@ func TestNewClient_Success(t *testing.T) {
 		}
 		return "", errors.New("not found")
 	}
-	c, err := NewClient(exectest.New(exec.Direct))
-	if err != nil || c == nil {
-		t.Fatalf("NewClient = (%v,%v), want a client", c, err)
+	q, err := New(exectest.New(exec.Direct))
+	if err != nil || q == nil {
+		t.Fatalf("New = (%v,%v), want a Querier", q, err)
+	}
+	c, ok := q.(*client)
+	if !ok {
+		t.Fatalf("New returned %T, want *client", q)
 	}
 	if c.binaryPath != "/usr/bin/osqueryi" {
 		t.Errorf("binaryPath = %q", c.binaryPath)
 	}
 }
 
-// TestIsInstalled mirrors NewClient_NotInstalled but exercises the
-// pure-bool entry point that callers (e.g. inventory collectors) use
-// to gate optional osquery features without paying for client init.
+// TestIsInstalled exercises the live re-probe contract: IsInstalled
+// re-resolves the binary on every call (it does NOT trust the path
+// captured at New), so a binary removed during the agent's lifetime is
+// reported as absent and a later re-install is picked up.
 func TestIsInstalled(t *testing.T) {
 	restore := lookPath
 	defer func() { lookPath = restore }()
+	// Construct directly so the test can drive IsInstalled across both
+	// states without New's eager probe gating construction.
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: exectest.New(exec.Direct)}
+	ctx := context.Background()
 
 	lookPath = func(string) (string, error) {
 		return "", errors.New("not found")
 	}
-	if IsInstalled() {
-		t.Errorf("IsInstalled() = true with no installed paths")
+	if c.IsInstalled(ctx) {
+		t.Errorf("IsInstalled() = true with no installed paths (removal not detected)")
 	}
 
 	lookPath = func(name string) (string, error) {
@@ -146,7 +157,7 @@ func TestIsInstalled(t *testing.T) {
 		}
 		return "", errors.New("not found")
 	}
-	if !IsInstalled() {
+	if !c.IsInstalled(ctx) {
 		t.Errorf("IsInstalled() = false with /usr/bin/osqueryi installed")
 	}
 }

--- a/go/sys/terminal/example_test.go
+++ b/go/sys/terminal/example_test.go
@@ -1,0 +1,37 @@
+package terminal_test
+
+import (
+	"context"
+	"io"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/terminal"
+)
+
+// ExampleManager_Open shows the construct-a-handle flow: build a Manager, open a
+// PTY session as a user, drive it, and clean up. The Manager takes no Runner — a
+// PTY is a long-lived bidirectional stream, not a captured one-shot command.
+func ExampleManager_Open() {
+	m, err := terminal.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// ctx governs allocation only; the session outlives it (terminate with Close).
+	sess, err := m.Open(context.Background(), terminal.SessionConfig{
+		User: "alice",
+		Cols: 80,
+		Rows: 24,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sess.Close()
+
+	if _, err := io.WriteString(sess, "echo hello\nexit\n"); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := sess.Wait(); err != nil {
+		log.Print(err)
+	}
+}

--- a/go/sys/terminal/terminal.go
+++ b/go/sys/terminal/terminal.go
@@ -6,9 +6,23 @@
 // This package is the SDK foundation for the remote terminal feature; the
 // agent is responsible for wiring it to the bidirectional gateway stream
 // and enforcing authentication, audit, and session limits.
+//
+//	m, _ := terminal.New()
+//	sess, err := m.Open(ctx, terminal.SessionConfig{User: "alice"})
+//	if err != nil { ... }
+//	defer sess.Close()
+//
+// terminal is a single-implementation capability (design §3.8): it exposes the
+// Manager interface for shape-uniformity with the rest of the SDK. Unlike the
+// other capabilities it takes NO exec.Runner — a PTY session is a long-lived,
+// bidirectional stream, not a captured one-shot command, so the Runner
+// abstraction (which returns a completed Result) cannot model it. The privilege
+// to switch UID comes from the agent already running as root, applied via the
+// child's syscall.Credential.
 package terminal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +37,38 @@ import (
 
 	"github.com/creack/pty"
 )
+
+// Manager constructs PTY shell sessions. See the package doc for why it carries
+// no Runner.
+type Manager interface {
+	// Open allocates a PTY and spawns a login shell as cfg.User. ctx governs the
+	// allocation only: the returned Session OUTLIVES ctx, so cancelling ctx
+	// after Open returns does NOT stop the session — terminate it with Close.
+	Open(ctx context.Context, cfg SessionConfig) (*Session, error)
+}
+
+// Test seams. These default to the real syscalls/lookups and are overridden
+// only by tests to exercise branches that are otherwise unreachable without
+// root or a malformed passwd entry (the parse-uid/gid errors, the
+// credential-switch branch, and the rare pty-close error). Production never
+// reassigns them.
+var (
+	lookupUser = user.Lookup
+	getuid     = os.Getuid
+	getgid     = os.Getgid
+	ptyClose   = func(f *os.File) error { return f.Close() }
+)
+
+// manager is the single Manager implementation. It is stateless.
+type manager struct{}
+
+// New returns a terminal Manager. It takes no arguments — no Runner (see the
+// package doc), no backend — and does not fail today; the error return matches
+// the SDK's uniform New(...) (T, error) shape so a future fallible option is
+// additive rather than a breaking signature change.
+func New() (Manager, error) {
+	return &manager{}, nil
+}
 
 // Defaults applied when SessionConfig fields are zero.
 const (
@@ -55,7 +101,7 @@ type SessionConfig struct {
 }
 
 // Session represents a running PTY shell session. The zero value is not
-// usable; obtain a Session via Start.
+// usable; obtain a Session via Manager.Open.
 //
 // Read, Write, and Resize are safe for concurrent use from independent
 // goroutines (the typical reader+writer pattern). Close, Wait, and Done
@@ -74,15 +120,25 @@ type Session struct {
 	done chan struct{}
 }
 
-// Start allocates a PTY, spawns a shell as cfg.User, and returns a Session.
+// Open allocates a PTY, spawns a shell as cfg.User, and returns a Session.
 // The caller must call Close (or Wait followed by reaping done) to release
-// resources. Start returns an error if the user cannot be looked up, the
-// shell binary is missing, or the PTY cannot be allocated.
-func Start(cfg SessionConfig) (*Session, error) {
+// resources. Open returns an error if the context is already cancelled, the
+// user cannot be looked up, the shell binary is missing, or the PTY cannot be
+// allocated.
+//
+// ctx governs allocation only. The returned Session is detached from ctx and
+// outlives it; cancelling ctx after Open returns does not terminate the
+// session — use Close.
+func (m *manager) Open(ctx context.Context, cfg SessionConfig) (*Session, error) {
+	// Fail closed on an already-cancelled context — never allocate a PTY for a
+	// dead request.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if cfg.User == "" {
 		return nil, errors.New("terminal: user is required")
 	}
-	u, err := user.Lookup(cfg.User)
+	u, err := lookupUser(cfg.User)
 	if err != nil {
 		return nil, fmt.Errorf("terminal: lookup user %q: %w", cfg.User, err)
 	}
@@ -140,7 +196,7 @@ func Start(cfg SessionConfig) (*Session, error) {
 	// reject it. Skipping the call when not needed avoids that and
 	// matches the common case where the caller is already the target
 	// user (e.g., agent running as the TTY user directly).
-	if uint32(uid) != uint32(os.Getuid()) || uint32(gid) != uint32(os.Getgid()) {
+	if uint32(uid) != uint32(getuid()) || uint32(gid) != uint32(getgid()) {
 		cmd.SysProcAttr.Credential = &syscall.Credential{
 			Uid: uint32(uid),
 			Gid: uint32(gid),
@@ -192,9 +248,29 @@ func (s *Session) Write(data []byte) (int, error) {
 
 // Resize changes the window size of the PTY. The shell receives SIGWINCH
 // and applications using ncurses (vim, top, etc.) re-render accordingly.
+//
+// The dimensions are validated before the ioctl (WS15): a zero cols or rows is
+// rejected rather than passed to TIOCSWINSZ — a zero-size window confuses
+// curses applications and is never a legitimate request. The wire-level upper
+// bound (<= 65535) is already enforced by the uint16 type at this boundary; the
+// agent additionally rejects out-of-range uint32 values before narrowing, so a
+// truncated value can never reach here.
 func (s *Session) Resize(cols, rows uint16) error {
+	if err := validateDims(cols, rows); err != nil {
+		return err
+	}
 	if err := pty.Setsize(s.pty, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
 		return fmt.Errorf("terminal: resize: %w", err)
+	}
+	return nil
+}
+
+// validateDims rejects a zero terminal dimension. Sourced from the wire intent
+// (proto's gt=0), not from any artifact. It is the SDK's defence-in-depth
+// alongside the agent's own boundary check.
+func validateDims(cols, rows uint16) error {
+	if cols == 0 || rows == 0 {
+		return fmt.Errorf("terminal: invalid dimensions cols=%d rows=%d (both must be > 0)", cols, rows)
 	}
 	return nil
 }
@@ -229,7 +305,7 @@ func (s *Session) Close() error {
 		// Closing the master also sends SIGHUP to the group, which is
 		// the polite shell-termination signal. ErrClosed is expected if
 		// the reaper or a concurrent caller already closed it.
-		if err := s.pty.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		if err := ptyClose(s.pty); err != nil && !errors.Is(err, os.ErrClosed) {
 			s.closeErr = err
 		}
 	})
@@ -293,3 +369,6 @@ func buildEnv(extra []string, u *user.User, shell string) []string {
 
 // ensure io.ReadWriter compliance — Session embeds plumbing for both.
 var _ io.ReadWriter = (*Session)(nil)
+
+// ensure the single implementation satisfies the interface.
+var _ Manager = (*manager)(nil)

--- a/go/sys/terminal/terminal_test.go
+++ b/go/sys/terminal/terminal_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -23,13 +24,25 @@ func isSandboxStartErr(err error) bool {
 		errors.Is(err, os.ErrPermission)
 }
 
+// openSession builds a Manager and opens a session with a background
+// context. It is the single seam the rest of the tests use so the
+// Manager.Open contract is exercised everywhere a session is created.
+func openSession(t *testing.T, cfg SessionConfig) (*Session, error) {
+	t.Helper()
+	m, err := New()
+	if err != nil {
+		t.Fatalf("terminal.New: %v", err)
+	}
+	return m.Open(context.Background(), cfg)
+}
+
 // startSessionOrSkip is the canonical helper for tests that need a live
 // session: it returns the Session on success, skips the test on a
-// sandbox-related Start failure, and fatally fails the test on any other
+// sandbox-related Open failure, and fatally fails the test on any other
 // error so real bugs are not silently masked.
 func startSessionOrSkip(t *testing.T, cfg SessionConfig) *Session {
 	t.Helper()
-	s, err := Start(cfg)
+	s, err := openSession(t, cfg)
 	if err != nil {
 		if isSandboxStartErr(err) {
 			t.Skipf("start session: sandbox restriction: %v", err)
@@ -56,8 +69,8 @@ func requireLinuxCurrentUser(t *testing.T) *user.User {
 	return cur
 }
 
-func TestStart_EmptyUser(t *testing.T) {
-	_, err := Start(SessionConfig{})
+func TestOpen_EmptyUser(t *testing.T) {
+	_, err := openSession(t, SessionConfig{})
 	if err == nil {
 		t.Fatal("expected error for empty user")
 	}
@@ -66,8 +79,8 @@ func TestStart_EmptyUser(t *testing.T) {
 	}
 }
 
-func TestStart_UnknownUser(t *testing.T) {
-	_, err := Start(SessionConfig{User: "this-user-definitely-does-not-exist-pm-12345"})
+func TestOpen_UnknownUser(t *testing.T) {
+	_, err := openSession(t, SessionConfig{User: "this-user-definitely-does-not-exist-pm-12345"})
 	if err == nil {
 		t.Fatal("expected error for unknown user")
 	}
@@ -77,12 +90,12 @@ func TestStart_UnknownUser(t *testing.T) {
 	}
 }
 
-func TestStart_MissingShell(t *testing.T) {
+func TestOpen_MissingShell(t *testing.T) {
 	cur, err := user.Current()
 	if err != nil {
 		t.Skipf("user.Current() failed: %v", err)
 	}
-	_, err = Start(SessionConfig{
+	_, err = openSession(t, SessionConfig{
 		User:  cur.Username,
 		Shell: "/no/such/shell/binary",
 	})
@@ -94,12 +107,12 @@ func TestStart_MissingShell(t *testing.T) {
 	}
 }
 
-func TestStart_ShellIsDirectory(t *testing.T) {
+func TestOpen_ShellIsDirectory(t *testing.T) {
 	cur, err := user.Current()
 	if err != nil {
 		t.Skipf("user.Current() failed: %v", err)
 	}
-	_, err = Start(SessionConfig{User: cur.Username, Shell: "/tmp"})
+	_, err = openSession(t, SessionConfig{User: cur.Username, Shell: "/tmp"})
 	if err == nil {
 		t.Fatal("expected error when shell is a directory")
 	}
@@ -108,12 +121,12 @@ func TestStart_ShellIsDirectory(t *testing.T) {
 	}
 }
 
-func TestStart_ShellNotAbsolute(t *testing.T) {
+func TestOpen_ShellNotAbsolute(t *testing.T) {
 	cur, err := user.Current()
 	if err != nil {
 		t.Skipf("user.Current() failed: %v", err)
 	}
-	_, err = Start(SessionConfig{User: cur.Username, Shell: "bash"})
+	_, err = openSession(t, SessionConfig{User: cur.Username, Shell: "bash"})
 	if err == nil {
 		t.Fatal("expected error for non-absolute shell path")
 	}
@@ -122,7 +135,7 @@ func TestStart_ShellNotAbsolute(t *testing.T) {
 	}
 }
 
-func TestStart_ShellNotExecutable(t *testing.T) {
+func TestOpen_ShellNotExecutable(t *testing.T) {
 	cur, err := user.Current()
 	if err != nil {
 		t.Skipf("user.Current() failed: %v", err)
@@ -133,12 +146,190 @@ func TestStart_ShellNotExecutable(t *testing.T) {
 	if err := os.WriteFile(notExec, []byte("#!/bin/sh\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err = Start(SessionConfig{User: cur.Username, Shell: notExec})
+	_, err = openSession(t, SessionConfig{User: cur.Username, Shell: notExec})
 	if err == nil {
 		t.Fatal("expected error for non-executable shell")
 	}
 	if !strings.Contains(err.Error(), "not executable") {
 		t.Errorf("expected not-executable error, got: %v", err)
+	}
+}
+
+// TestNew pins that the constructor returns a usable Manager and never
+// fails today (its error return exists only for forward-compatibility).
+func TestNew(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if m == nil {
+		t.Fatal("New() returned a nil Manager")
+	}
+}
+
+// TestOpen_ContextCancelled proves Open fails closed on an already-cancelled
+// context before it touches the user database, the filesystem, or forks a PTY —
+// the allocation gate. We pass an unknown user so that, were the ctx check
+// absent, the call would fail with a user-lookup error instead; observing
+// context.Canceled confirms the ctx short-circuit ran first.
+func TestOpen_ContextCancelled(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = m.Open(ctx, SessionConfig{User: "this-user-definitely-does-not-exist-pm-12345"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Open(cancelled) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestValidateDims covers the WS15 dimension contract: a zero in either axis is
+// rejected; any non-zero uint16 pair (including the type maximum) is accepted.
+// The invalid cases are sourced from the wire intent (gt=0), not from the
+// implementation under test.
+func TestValidateDims(t *testing.T) {
+	cases := []struct {
+		name       string
+		cols, rows uint16
+		wantErr    bool
+	}{
+		{"both valid", 80, 24, false},
+		{"max valid", 65535, 65535, false},
+		{"min valid", 1, 1, false},
+		{"zero cols", 0, 24, true},
+		{"zero rows", 80, 0, true},
+		{"both zero", 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDims(tc.cols, tc.rows)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateDims(%d,%d) = nil, want error", tc.cols, tc.rows)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateDims(%d,%d) = %v, want nil", tc.cols, tc.rows, err)
+			}
+		})
+	}
+}
+
+// TestSession_ResizeRejectsZeroDims exercises the validation on a LIVE session:
+// a zero dimension is refused before the ioctl, and a subsequent valid resize
+// still works (the rejected call did not wedge the PTY).
+func TestSession_ResizeRejectsZeroDims(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username, Shell: pickShell(t)})
+	defer s.Close()
+
+	if err := s.Resize(0, 24); err == nil {
+		t.Error("Resize(0,24) accepted a zero dimension")
+	}
+	if err := s.Resize(80, 0); err == nil {
+		t.Error("Resize(80,0) accepted a zero dimension")
+	}
+	if err := s.Resize(100, 30); err != nil {
+		t.Errorf("Resize(100,30) after a rejected resize failed: %v", err)
+	}
+}
+
+// TestOpen_NonNumericUID drives the parse-uid failure path via the lookupUser
+// seam: a passwd entry whose Uid is not an integer is rejected before any PTY
+// is allocated. (A real passwd cannot carry a non-numeric uid, so the seam is
+// the only way to exercise the defensive parse.)
+func TestOpen_NonNumericUID(t *testing.T) {
+	restore := lookupUser
+	defer func() { lookupUser = restore }()
+	lookupUser = func(string) (*user.User, error) {
+		return &user.User{Username: "x", Uid: "not-a-number", Gid: "1000", HomeDir: "/tmp"}, nil
+	}
+	_, err := openSession(t, SessionConfig{User: "x"})
+	if err == nil || !strings.Contains(err.Error(), "parse uid") {
+		t.Errorf("Open with non-numeric uid: err = %v, want a parse-uid error", err)
+	}
+}
+
+// TestOpen_NonNumericGID is the gid twin of TestOpen_NonNumericUID.
+func TestOpen_NonNumericGID(t *testing.T) {
+	restore := lookupUser
+	defer func() { lookupUser = restore }()
+	lookupUser = func(string) (*user.User, error) {
+		return &user.User{Username: "x", Uid: "1000", Gid: "not-a-number", HomeDir: "/tmp"}, nil
+	}
+	_, err := openSession(t, SessionConfig{User: "x"})
+	if err == nil || !strings.Contains(err.Error(), "parse gid") {
+		t.Errorf("Open with non-numeric gid: err = %v, want a parse-gid error", err)
+	}
+}
+
+// TestOpen_DefaultShell covers the empty-Shell → DefaultShell defaulting branch
+// by opening a live session with no Shell set.
+func TestOpen_DefaultShell(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+	info, err := os.Stat(DefaultShell)
+	if err != nil || info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		t.Skipf("default shell %s not usable on this host", DefaultShell)
+	}
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username}) // Shell:"" → DefaultShell
+	defer s.Close()
+	if _, err := io.WriteString(s, "exit\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	drain(t, s, 5*time.Second)
+}
+
+// TestOpen_SwitchesCredentialWhenUIDDiffers exercises the credential-switch
+// branch (uid/gid != process uid/gid) without root: the getgid seam reports a
+// gid different from the looked-up user's, so the branch is taken and the
+// child's Credential is set to the user's OWN uid/gid — a setres-to-self that
+// needs no privilege, so the session still starts.
+func TestOpen_SwitchesCredentialWhenUIDDiffers(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+	restore := getgid
+	defer func() { getgid = restore }()
+	getgid = func() int { return os.Getgid() + 1 }
+
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username, Shell: pickShell(t)})
+	defer s.Close()
+	if _, err := io.WriteString(s, "exit\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	drain(t, s, 5*time.Second)
+}
+
+// TestSession_ResizeAfterCloseFails covers the pty.Setsize error path: after
+// Close the PTY fd is gone, so a (valid-dimension) resize fails at the ioctl.
+func TestSession_ResizeAfterCloseFails(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username, Shell: pickShell(t)})
+	_ = s.Close()
+	<-s.Done()
+	if err := s.Resize(80, 24); err == nil {
+		t.Error("Resize after Close should fail (PTY closed)")
+	} else if !strings.Contains(err.Error(), "resize") {
+		t.Errorf("Resize after Close: err = %v, want a resize error", err)
+	}
+}
+
+// TestSession_CloseSurfacesPTYError covers the branch where pty.Close returns a
+// non-ErrClosed error: the ptyClose seam closes the fd (no leak) but returns a
+// synthetic error, which Close must surface as its result.
+func TestSession_CloseSurfacesPTYError(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username, Shell: pickShell(t)})
+
+	restore := ptyClose
+	defer func() { ptyClose = restore }()
+	sentinel := errors.New("synthetic pty close failure")
+	ptyClose = func(f *os.File) error {
+		_ = f.Close() // actually release the fd so the child/session is not leaked
+		return sentinel
+	}
+
+	if err := s.Close(); !errors.Is(err, sentinel) {
+		t.Errorf("Close() = %v, want the surfaced pty-close error %v", err, sentinel)
 	}
 }
 


### PR DESCRIPTION
Closes #146. Finishes the §3.8 single-implementation cleanups in the SDK rework — the three remaining single-impl capabilities now expose a small interface from a `New(...)` constructor, matching the construct-a-handle shape of the backend-pattern packages.

## osquery
- `NewClient` → `New(runner) (Querier, error)`; `Client` unexported → `client`.
- `IsInstalled` is now a **`Querier` method that re-probes live** (detects a binary removed at runtime); the free `IsInstalled()` function is dropped.
- `New` keeps the **eager `ErrNotInstalled`** probe. Deny-list (`shadow`, `process_envs`, `crontab`, `shell_history`, `sudoers`), table-name regex, and the `RawSql` escape-hatch gating are preserved verbatim.

## terminal
- Add `Manager` + `New()`; `Start(cfg)` → `Manager.Open(ctx, cfg)`. **ctx gates PTY allocation only** — the session outlives ctx (terminate with `Close`).
- `Resize` now **validates dims (WS15)**: a zero cols/rows is rejected before `TIOCSWINSZ`.
- **No Runner**: a PTY is a long-lived bidirectional stream the captured-output Runner can't model — a documented, deliberate exception to the §3.8 `New(runner,...)` shape (honesty over a dead parameter).

## desktop
- Add `Manager` + `New(runner, opts...)` with `WithHomeRoot`; `ActiveSessions`/`HomeUsers`/`UsersWithFlatpakInstall`/`RunAsCommand` become methods.
- `HomeUsers`/`UsersWithFlatpakInstall` gain `ctx`; `RunAsCommand`'s positional `extraEnv` → `RunAsOptions`.
- **`loginctl` probes now run through the Runner**, inheriting the forced **C locale** so the no-logind / no-session stderr matching is locale-stable. `RunAsCommand` deliberately stays a direct `*exec.Cmd` builder that keeps the **user's** locale (its output is not parsed by the SDK).

## Tests
- Runner injection makes the `loginctl` path unit-testable for the first time.
- **100% of statements** for all three packages, plus real-system legs (live PTY sessions; real `loginctl` integration; real `/home` enumeration).
- Full suite re-run under **`ja_JP.UTF-8`** (the standing foreign-locale practice) — green.
- Adds runnable `Example`s and reconciles the rework design/contracts docs with the shipped signatures.

No SDK-internal callers of these three packages exist; the agent (which pins an older SDK) is migrated in the final rework PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined SDK API contracts for `desktop`, `osquery`, and `terminal` packages with updated constructor and method signatures.

* **New Features**
  * Desktop session discovery and user-scoped command execution for graphical environments.
  * Terminal manager for PTY allocation with context-aware session control.
  * Osquery querier interface with runtime installation probing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->