### PR TITLE
feat(sys): host-telemetry read primitives — smart + timesync (#154)

### DIFF
--- a/go/sys/smart/example_test.go
+++ b/go/sys/smart/example_test.go
@@ -1,0 +1,33 @@
+package smart_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/smart"
+)
+
+// ExampleNew scans for devices and prints each one's health.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Direct) // smartctl needs root
+	if err != nil {
+		log.Fatal(err)
+	}
+	c, err := smart.New(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	devs, err := c.Scan(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, d := range devs {
+		info, err := c.Device(context.Background(), d.Name)
+		if err != nil {
+			continue
+		}
+		fmt.Printf("%s healthy=%v %d°C\n", info.Name, info.Healthy, info.TemperatureC)
+	}
+}

--- a/go/sys/smart/integration_test.go
+++ b/go/sys/smart/integration_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package smart_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/smart"
+)
+
+// READ-ONLY: Scan (and a per-device read for whatever it finds). Skips when
+// smartctl is absent or unusable (no root / no devices, common in CI/VMs).
+func TestScan_Integration(t *testing.T) {
+	if _, err := exec.LookPath("smartctl"); err != nil {
+		t.Skip("smartctl not present")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	c, err := smart.New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	devs, err := c.Scan(context.Background())
+	if err != nil {
+		t.Skipf("smartctl --scan unusable here (no privilege/devices): %v", err)
+	}
+	for _, d := range devs {
+		if _, err := c.Device(context.Background(), d.Name); err != nil {
+			t.Logf("Device(%s): %v", d.Name, err) // not fatal — a device may be unreadable
+		}
+	}
+}

--- a/go/sys/smart/smart.go
+++ b/go/sys/smart/smart.go
@@ -1,0 +1,184 @@
+// Package smart reads S.M.A.R.T. disk health via smartctl (smartmontools)
+// through an injected exec.Runner.
+//
+//	r, _ := exec.NewRunner(exec.Direct) // smartctl needs root
+//	c, err := smart.New(r)
+//	if err != nil { ... }
+//	devs, _ := c.Scan(ctx)
+//	for _, d := range devs {
+//	    info, _ := c.Device(ctx, d.Name)
+//	    fmt.Println(info.Name, info.Healthy, info.TemperatureC)
+//	}
+//
+// smart is a single-implementation, read-only Collector (§3.8): smartctl is the
+// one tool. It exposes an interface for shape-uniformity with the rest of the
+// SDK. Probes escalate through the Runner (smartctl needs root to open a device).
+package smart
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// ErrInvalidDevice is returned when a device path is unsafe to pass to smartctl
+// (empty, not absolute, contains "..", or flag-shaped).
+var ErrInvalidDevice = errors.New("smart: invalid device path")
+
+// ScanDevice is one entry from `smartctl --scan`.
+type ScanDevice struct {
+	Name string // e.g. /dev/sda
+	Type string // smartctl device type, e.g. "sat", "nvme"
+}
+
+// Device is the parsed health summary for one device.
+type Device struct {
+	Name         string // the device passed to Device()
+	Model        string
+	Serial       string
+	Healthy      bool // smart_status.passed
+	TemperatureC int  // temperature.current (0 if unreported)
+	PowerOnHours int  // power_on_time.hours (0 if unreported)
+}
+
+// Collector is the S.M.A.R.T. read surface.
+type Collector interface {
+	// Scan lists the devices smartctl can inspect.
+	Scan(ctx context.Context) ([]ScanDevice, error)
+	// Device returns the health summary for one device path.
+	Device(ctx context.Context, dev string) (Device, error)
+}
+
+type collector struct {
+	r exec.Runner
+}
+
+// New builds a smart Collector driven by runner. A nil runner is rejected. New is
+// pure — it does not probe for smartctl (a missing binary surfaces at call time).
+func New(runner exec.Runner) (Collector, error) {
+	if runner == nil {
+		return nil, errors.New("smart: runner is required")
+	}
+	return &collector{r: runner}, nil
+}
+
+// validateDevice rejects a device path that is unsafe as a positional argument.
+func validateDevice(dev string) error {
+	if dev == "" || !strings.HasPrefix(dev, "/") || strings.HasPrefix(dev, "-") || strings.Contains(dev, "..") || strings.ContainsRune(dev, 0) {
+		return fmt.Errorf("%w: %q (must be an absolute /dev path, no '..' or flag prefix)", ErrInvalidDevice, dev)
+	}
+	return nil
+}
+
+// scanResult mirrors `smartctl --scan -j`.
+type scanResult struct {
+	Devices []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"devices"`
+}
+
+// Scan lists inspectable devices.
+func (c *collector) Scan(ctx context.Context) ([]ScanDevice, error) {
+	out, err := c.run(ctx, "--scan", "-j")
+	if err != nil {
+		return nil, err
+	}
+	var sr scanResult
+	if err := json.Unmarshal([]byte(out), &sr); err != nil {
+		return nil, fmt.Errorf("smart: parse scan output: %w", err)
+	}
+	devs := make([]ScanDevice, 0, len(sr.Devices))
+	for _, d := range sr.Devices {
+		devs = append(devs, ScanDevice{Name: d.Name, Type: d.Type})
+	}
+	return devs, nil
+}
+
+// deviceResult mirrors the subset of `smartctl -j -a <dev>` we consume.
+type deviceResult struct {
+	ModelName    string `json:"model_name"`
+	SerialNumber string `json:"serial_number"`
+	SMARTStatus  struct {
+		Passed bool `json:"passed"`
+	} `json:"smart_status"`
+	Temperature struct {
+		Current int `json:"current"`
+	} `json:"temperature"`
+	PowerOnTime struct {
+		Hours int `json:"hours"`
+	} `json:"power_on_time"`
+	Smartctl struct {
+		ExitStatus int `json:"exit_status"`
+		Messages   []struct {
+			String string `json:"string"`
+		} `json:"messages"`
+	} `json:"smartctl"`
+}
+
+// smartctlFatalBits are the smartctl exit-status bits that mean the COMMAND
+// failed (bit 0 = command-line parse error, bit 1 = device open failed). Bits 2+
+// report device/SMART health (e.g. failing self-assessment) and are NOT execution
+// failures — smart_status.passed already conveys health, so they must not be
+// treated as an error.
+const smartctlFatalBits = 0x03
+
+// Device returns the health summary for dev.
+func (c *collector) Device(ctx context.Context, dev string) (Device, error) {
+	if err := validateDevice(dev); err != nil {
+		return Device{}, err
+	}
+	out, err := c.run(ctx, "-j", "-a", dev)
+	if err != nil {
+		return Device{}, err
+	}
+	var dr deviceResult
+	if err := json.Unmarshal([]byte(out), &dr); err != nil {
+		return Device{}, fmt.Errorf("smart: parse device output for %s: %w", dev, err)
+	}
+	if dr.Smartctl.ExitStatus&smartctlFatalBits != 0 {
+		return Device{}, fmt.Errorf("smart: smartctl could not inspect %s: %s", dev, joinMessages(dr.Smartctl.Messages))
+	}
+	return Device{
+		Name:         dev,
+		Model:        dr.ModelName,
+		Serial:       dr.SerialNumber,
+		Healthy:      dr.SMARTStatus.Passed,
+		TemperatureC: dr.Temperature.Current,
+		PowerOnHours: dr.PowerOnTime.Hours,
+	}, nil
+}
+
+// run executes smartctl escalated and returns stdout. smartctl's non-zero exit
+// is a HEALTH bitmask, not (usually) an exec failure, so we do not treat a
+// non-zero exit as an error here — the caller's JSON parse + the fatal-bits check
+// classify it. A nil error from the Runner with empty stdout still yields a parse
+// error downstream. Only a Runner-level failure (binary missing, escalation
+// denied) is surfaced here.
+func (c *collector) run(ctx context.Context, args ...string) (string, error) {
+	res, err := c.r.Run(ctx, exec.Command{Name: "smartctl", Args: args, Escalate: true})
+	if err != nil {
+		return "", fmt.Errorf("smart: run smartctl: %w", err)
+	}
+	return res.Stdout, nil
+}
+
+// joinMessages flattens smartctl's message strings for an error.
+func joinMessages(msgs []struct {
+	String string `json:"string"`
+}) string {
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		if s := strings.TrimSpace(m.String); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) == 0 {
+		return "no diagnostic message"
+	}
+	return strings.Join(parts, "; ")
+}

--- a/go/sys/smart/smart.go
+++ b/go/sys/smart/smart.go
@@ -66,10 +66,14 @@ func New(runner exec.Runner) (Collector, error) {
 	return &collector{r: runner}, nil
 }
 
-// validateDevice rejects a device path that is unsafe as a positional argument.
+// validateDevice rejects a device path that is unsafe to pass to escalated
+// smartctl. It must be under /dev/ (smartctl inspects block devices; restricting
+// to /dev keeps the privileged probe off arbitrary files like /etc/passwd),
+// contain no ".." traversal, and no NUL. The /dev/ prefix also rules out a
+// flag-shaped argument.
 func validateDevice(dev string) error {
-	if dev == "" || !strings.HasPrefix(dev, "/") || strings.HasPrefix(dev, "-") || strings.Contains(dev, "..") || strings.ContainsRune(dev, 0) {
-		return fmt.Errorf("%w: %q (must be an absolute /dev path, no '..' or flag prefix)", ErrInvalidDevice, dev)
+	if !strings.HasPrefix(dev, "/dev/") || strings.Contains(dev, "..") || strings.ContainsRune(dev, 0) {
+		return fmt.Errorf("%w: %q (must be a /dev/* path with no '..')", ErrInvalidDevice, dev)
 	}
 	return nil
 }

--- a/go/sys/smart/smart_test.go
+++ b/go/sys/smart/smart_test.go
@@ -33,6 +33,7 @@ func TestValidateDevice(t *testing.T) {
 		"":             false,
 		"sda":          false, // not absolute
 		"-rf":          false, // flag-shaped
+		"/etc/passwd":  false, // absolute but NOT under /dev — escalated probe must not reach it
 		"/dev/../etc":  false, // dotdot
 		"/dev/s\x00a":  false, // NUL
 	}

--- a/go/sys/smart/smart_test.go
+++ b/go/sys/smart/smart_test.go
@@ -1,0 +1,152 @@
+package smart
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func newColl(t *testing.T) (*collector, *exectest.FakeRunner) {
+	t.Helper()
+	r := exectest.New(exec.Direct)
+	c, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c.(*collector), r
+}
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Error("New(nil) returned nil error")
+	}
+}
+
+func TestValidateDevice(t *testing.T) {
+	cases := map[string]bool{ // path -> valid
+		"/dev/sda":     true,
+		"/dev/nvme0n1": true,
+		"":             false,
+		"sda":          false, // not absolute
+		"-rf":          false, // flag-shaped
+		"/dev/../etc":  false, // dotdot
+		"/dev/s\x00a":  false, // NUL
+	}
+	for dev, valid := range cases {
+		err := validateDevice(dev)
+		if valid && err != nil {
+			t.Errorf("validateDevice(%q) = %v, want nil", dev, err)
+		}
+		if !valid && err == nil {
+			t.Errorf("validateDevice(%q) = nil, want error", dev)
+		}
+	}
+}
+
+func TestScan(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{Stdout: `{"devices":[{"name":"/dev/sda","type":"sat"},{"name":"/dev/nvme0","type":"nvme"}]}`}, nil)
+	devs, err := c.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(devs) != 2 || devs[0].Name != "/dev/sda" || devs[0].Type != "sat" || devs[1].Name != "/dev/nvme0" {
+		t.Fatalf("Scan = %+v", devs)
+	}
+	if argv := strings.Join(r.Calls()[0].Args, " "); argv != "--scan -j" || !r.Calls()[0].Escalate {
+		t.Errorf("scan argv = %q (escalate=%v), want escalated `--scan -j`", argv, r.Calls()[0].Escalate)
+	}
+}
+
+func TestScan_RunError(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{}, errors.New("smartctl not found"))
+	if _, err := c.Scan(context.Background()); err == nil {
+		t.Error("Scan must surface a Runner error")
+	}
+}
+
+func TestScan_BadJSON(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{Stdout: "not json"}, nil)
+	if _, err := c.Scan(context.Background()); err == nil {
+		t.Error("Scan must surface a parse error")
+	}
+}
+
+func TestDevice_Success(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{Stdout: `{"model_name":"Samsung SSD 870","serial_number":"S123",` +
+		`"smart_status":{"passed":true},"temperature":{"current":35},"power_on_time":{"hours":1200},` +
+		`"smartctl":{"exit_status":0}}`}, nil)
+	d, err := c.Device(context.Background(), "/dev/sda")
+	if err != nil {
+		t.Fatalf("Device: %v", err)
+	}
+	want := Device{Name: "/dev/sda", Model: "Samsung SSD 870", Serial: "S123", Healthy: true, TemperatureC: 35, PowerOnHours: 1200}
+	if d != want {
+		t.Errorf("Device = %+v, want %+v", d, want)
+	}
+	if argv := strings.Join(r.Calls()[0].Args, " "); argv != "-j -a /dev/sda" || !r.Calls()[0].Escalate {
+		t.Errorf("device argv = %q (escalate=%v)", argv, r.Calls()[0].Escalate)
+	}
+}
+
+func TestDevice_UnhealthyStillReturned(t *testing.T) {
+	// A failing self-assessment sets exit bits >= 4 (not fatal): the device is
+	// reported with Healthy=false, NOT an error.
+	c, r := newColl(t)
+	r.Push(exec.Result{ExitCode: 8, Stdout: `{"model_name":"OldDisk","smart_status":{"passed":false},"smartctl":{"exit_status":8}}`}, nil)
+	d, err := c.Device(context.Background(), "/dev/sda")
+	if err != nil {
+		t.Fatalf("Device must not error on an unhealthy-but-readable disk: %v", err)
+	}
+	if d.Healthy {
+		t.Error("Healthy should be false for a failed self-assessment")
+	}
+}
+
+func TestDevice_FatalBitsError(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{ExitCode: 2, Stdout: `{"smartctl":{"exit_status":2,"messages":[{"string":"Smartctl open device: /dev/sdz failed"}]}}`}, nil)
+	_, err := c.Device(context.Background(), "/dev/sdz")
+	if err == nil || !strings.Contains(err.Error(), "open device") {
+		t.Errorf("Device with a device-open failure must error naming it, got %v", err)
+	}
+}
+
+func TestDevice_BadDevice(t *testing.T) {
+	c, r := newColl(t)
+	if _, err := c.Device(context.Background(), "-rf"); !errors.Is(err, ErrInvalidDevice) {
+		t.Errorf("err = %v, want ErrInvalidDevice", err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("a bad device must run nothing")
+	}
+}
+
+func TestDevice_RunError(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{}, errors.New("escalation denied"))
+	if _, err := c.Device(context.Background(), "/dev/sda"); err == nil {
+		t.Error("Device must surface a Runner error")
+	}
+}
+
+func TestDevice_BadJSON(t *testing.T) {
+	c, r := newColl(t)
+	r.Push(exec.Result{Stdout: "garbage"}, nil)
+	if _, err := c.Device(context.Background(), "/dev/sda"); err == nil {
+		t.Error("Device must surface a parse error")
+	}
+}
+
+func TestJoinMessages_Empty(t *testing.T) {
+	if got := joinMessages(nil); got != "no diagnostic message" {
+		t.Errorf("joinMessages(nil) = %q", got)
+	}
+}

--- a/go/sys/timesync/backends_test.go
+++ b/go/sys/timesync/backends_test.go
@@ -97,6 +97,21 @@ func TestChrony_StatusNotSynchronised(t *testing.T) {
 	}
 }
 
+func TestChrony_UnknownLeapStatus(t *testing.T) {
+	// An unrecognised leap status means the CSV schema drifted → fail closed,
+	// don't silently report synchronized.
+	csv := `id,src,3,t,0.0,0,0,0,0,0,0,0,64,Bogus`
+	if _, err := parseChronyTracking(csv); err == nil {
+		t.Error("an unrecognised leap status must error (schema-drift guard)")
+	}
+	// A leap-second variant still counts as synchronized.
+	csv = `id,src,3,t,0.0,0,0,0,0,0,0,0,64,Insert second`
+	st, err := parseChronyTracking(csv)
+	if err != nil || !st.Synchronized {
+		t.Errorf("'Insert second' must be synchronized: st=%+v err=%v", st, err)
+	}
+}
+
 func TestChrony_StatusRunError(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{}, errors.New("chronyc gone"))

--- a/go/sys/timesync/backends_test.go
+++ b/go/sys/timesync/backends_test.go
@@ -1,0 +1,125 @@
+package timesync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func TestTimedatectl_Status(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "NTP=yes\nNTPSynchronized=yes\n"}, nil)
+	m, _ := New(Timedatectl, r)
+	st, err := m.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Enabled || !st.Synchronized {
+		t.Errorf("Status = %+v, want enabled+synchronized", st)
+	}
+	if argv := r.Calls()[0].Args; argv[0] != "show" || r.Calls()[0].Escalate {
+		t.Errorf("argv=%v escalate=%v, want unescalated show", argv, r.Calls()[0].Escalate)
+	}
+}
+
+func TestTimedatectl_StatusUnsynced(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "NTP=no\nNTPSynchronized=no\n"}, nil)
+	m, _ := New(Timedatectl, r)
+	st, err := m.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Enabled || st.Synchronized {
+		t.Errorf("Status = %+v, want disabled+unsynced", st)
+	}
+}
+
+func TestTimedatectl_StatusRunError(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "fail"}, nil)
+	m, _ := New(Timedatectl, r)
+	if _, err := m.Status(context.Background()); err == nil {
+		t.Error("Status must surface a run error")
+	}
+}
+
+func TestParseKV_SkipsMalformed(t *testing.T) {
+	kv := parseKV("NTP=yes\n\njustakey\n  NTPSynchronized = no \n")
+	if kv["NTP"] != "yes" || kv["NTPSynchronized"] != "no" {
+		t.Errorf("parseKV = %v", kv)
+	}
+	if _, ok := kv["justakey"]; ok {
+		t.Error("a line without = must be skipped")
+	}
+}
+
+// A representative chronyc -c tracking line (14 CSV fields).
+const chronyTrackingCSV = `A0F03C2C,203.0.113.1,3,1718000000.0,0.000123456,0.000100,0.000200,1.5,0.1,0.05,0.001,0.002,64,Normal`
+
+func TestChrony_Status(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: chronyTrackingCSV + "\n"}, nil)
+	m, _ := New(Chrony, r)
+	st, err := m.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Synchronized || !st.Enabled {
+		t.Errorf("Status = %+v, want synchronized+enabled", st)
+	}
+	if st.Source != "203.0.113.1" {
+		t.Errorf("Source = %q, want 203.0.113.1", st.Source)
+	}
+	if st.OffsetSeconds != 0.000123456 {
+		t.Errorf("OffsetSeconds = %v, want 0.000123456", st.OffsetSeconds)
+	}
+	if argv := r.Calls()[0].Args; argv[0] != "-c" || argv[1] != "tracking" {
+		t.Errorf("argv = %v, want `-c tracking`", argv)
+	}
+}
+
+func TestChrony_StatusNotSynchronised(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	// Leap status "Not synchronised" → Synchronized false.
+	csv := `00000000,,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,Not synchronised`
+	r.Push(exec.Result{Stdout: csv}, nil)
+	m, _ := New(Chrony, r)
+	st, err := m.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Synchronized {
+		t.Error("a 'Not synchronised' leap status must yield Synchronized=false")
+	}
+}
+
+func TestChrony_StatusRunError(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{}, errors.New("chronyc gone"))
+	m, _ := New(Chrony, r)
+	if _, err := m.Status(context.Background()); err == nil {
+		t.Error("Status must surface a run error")
+	}
+}
+
+func TestParseChronyTracking_Errors(t *testing.T) {
+	if _, err := parseChronyTracking("   "); err == nil {
+		t.Error("empty output must error")
+	}
+	if _, err := parseChronyTracking("a,b,c"); err == nil {
+		t.Error("too-few fields must error")
+	}
+	// A non-numeric offset is tolerated (stays 0), not a hard error.
+	csv := `id,src,3,t,NOTANUMBER,0,0,0,0,0,0,0,64,Normal`
+	st, err := parseChronyTracking(csv)
+	if err != nil {
+		t.Fatalf("non-numeric offset should not be fatal: %v", err)
+	}
+	if st.OffsetSeconds != 0 {
+		t.Errorf("OffsetSeconds = %v, want 0 for an unparseable offset", st.OffsetSeconds)
+	}
+}

--- a/go/sys/timesync/chrony.go
+++ b/go/sys/timesync/chrony.go
@@ -1,0 +1,52 @@
+package timesync
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// chronyManager queries chrony via `chronyc -c tracking` (CSV report).
+type chronyManager struct {
+	r exec.Runner
+}
+
+// Status reads chrony's tracking report.
+func (m *chronyManager) Status(ctx context.Context) (Status, error) {
+	out, err := runRead(ctx, m.r, "chronyc", "-c", "tracking")
+	if err != nil {
+		return Status{}, err
+	}
+	return parseChronyTracking(out)
+}
+
+// chronyTrackingFields is the field count of `chronyc -c tracking` CSV; the
+// fields we read are: [1] reference source, [4] system-time offset (signed
+// seconds), [13] leap status.
+const chronyTrackingFields = 14
+
+// parseChronyTracking parses the single-line CSV from `chronyc -c tracking`.
+func parseChronyTracking(out string) (Status, error) {
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return Status{}, fmt.Errorf("timesync: empty chronyc tracking output")
+	}
+	f := strings.Split(line, ",")
+	if len(f) < chronyTrackingFields {
+		return Status{}, fmt.Errorf("timesync: unexpected chronyc tracking format (%d fields, want %d)", len(f), chronyTrackingFields)
+	}
+	st := Status{
+		Enabled: true, // chronyc answered, so the daemon is running
+		Source:  f[1],
+		// Leap status "Not synchronised" is the only unsynced value; "Normal" and
+		// the leap-second variants all mean the clock is disciplined.
+		Synchronized: f[13] != "Not synchronised",
+	}
+	if off, err := strconv.ParseFloat(f[4], 64); err == nil {
+		st.OffsetSeconds = off
+	}
+	return st, nil
+}

--- a/go/sys/timesync/chrony.go
+++ b/go/sys/timesync/chrony.go
@@ -35,15 +35,29 @@ func parseChronyTracking(out string) (Status, error) {
 		return Status{}, fmt.Errorf("timesync: empty chronyc tracking output")
 	}
 	f := strings.Split(line, ",")
+	// Require AT LEAST the known field count (not exactly): chrony's CSV is not
+	// guaranteed fixed across versions, and a newer version can append trailing
+	// fields — those are harmless since we read by fixed leading index. A short
+	// line, however, means a layout we don't understand → fail closed. The
+	// leap-status check below is the real schema-drift guard (a reordered layout
+	// yields an unrecognised leap value).
 	if len(f) < chronyTrackingFields {
-		return Status{}, fmt.Errorf("timesync: unexpected chronyc tracking format (%d fields, want %d)", len(f), chronyTrackingFields)
+		return Status{}, fmt.Errorf("timesync: unexpected chronyc tracking format (%d fields, want >= %d)", len(f), chronyTrackingFields)
 	}
 	st := Status{
 		Enabled: true, // chronyc answered, so the daemon is running
 		Source:  f[1],
-		// Leap status "Not synchronised" is the only unsynced value; "Normal" and
-		// the leap-second variants all mean the clock is disciplined.
-		Synchronized: f[13] != "Not synchronised",
+	}
+	// Validate the leap status against chrony's known set rather than a bare
+	// inequality: an unrecognised value means the CSV schema drifted, so fail
+	// closed instead of silently reporting "synchronized".
+	switch strings.TrimSpace(f[13]) {
+	case "Not synchronised":
+		st.Synchronized = false
+	case "Normal", "Insert second", "Delete second":
+		st.Synchronized = true
+	default:
+		return Status{}, fmt.Errorf("timesync: unrecognised chronyc leap status %q (CSV schema drift?)", strings.TrimSpace(f[13]))
 	}
 	if off, err := strconv.ParseFloat(f[4], 64); err == nil {
 		st.OffsetSeconds = off

--- a/go/sys/timesync/detect.go
+++ b/go/sys/timesync/detect.go
@@ -1,0 +1,26 @@
+package timesync
+
+import (
+	"context"
+	osexec "os/exec"
+)
+
+// lookPath is a package-var seam so Detect is deterministically testable.
+var lookPath = osexec.LookPath
+
+// Detect reports the time-sync backends usable on THIS host: Timedatectl when
+// timedatectl is on PATH, Chrony when chronyc is. It lists; it never picks. The
+// consumer reads the list, picks one, and passes it to New.
+//
+// The ctx is accepted for signature uniformity; the probe is a pure PATH lookup.
+func Detect(ctx context.Context) []Backend {
+	_ = ctx
+	var out []Backend
+	if _, err := lookPath("timedatectl"); err == nil {
+		out = append(out, Timedatectl)
+	}
+	if _, err := lookPath("chronyc"); err == nil {
+		out = append(out, Chrony)
+	}
+	return out
+}

--- a/go/sys/timesync/example_test.go
+++ b/go/sys/timesync/example_test.go
@@ -1,0 +1,27 @@
+package timesync_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/timesync"
+)
+
+// ExampleNew reads the clock-sync status from chrony.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		log.Fatal(err)
+	}
+	m, err := timesync.New(timesync.Chrony, r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	st, err := m.Status(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("synchronized=%v source=%s offset=%.6fs\n", st.Synchronized, st.Source, st.OffsetSeconds)
+}

--- a/go/sys/timesync/integration_test.go
+++ b/go/sys/timesync/integration_test.go
@@ -1,0 +1,34 @@
+//go:build integration
+
+package timesync_test
+
+import (
+	"context"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/timesync"
+)
+
+// READ-ONLY: Detect + a real Status read from whichever backend is present.
+// `timedatectl show` and `chronyc tracking` are both unprivileged.
+func TestStatus_Integration(t *testing.T) {
+	backends := timesync.Detect(context.Background())
+	if len(backends) == 0 {
+		t.Skip("no time-sync backend on PATH")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	for _, b := range backends {
+		m, err := timesync.New(b, r)
+		if err != nil {
+			t.Fatalf("New(%v): %v", b, err)
+		}
+		if _, err := m.Status(context.Background()); err != nil {
+			// chronyc present but daemon not running, etc. — informative, not fatal.
+			t.Logf("Status(%v): %v", b, err)
+		}
+	}
+}

--- a/go/sys/timesync/timedatectl.go
+++ b/go/sys/timesync/timedatectl.go
@@ -1,0 +1,45 @@
+package timesync
+
+import (
+	"context"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// timedatectlManager queries systemd-timesyncd via `timedatectl show`.
+type timedatectlManager struct {
+	r exec.Runner
+}
+
+// Status reports whether NTP sync is enabled and whether the clock is currently
+// synchronized. timedatectl does not expose the reference source or offset, so
+// those Status fields stay zero (use the Chrony backend for them).
+func (m *timedatectlManager) Status(ctx context.Context) (Status, error) {
+	out, err := runRead(ctx, m.r, "timedatectl", "show", "-p", "NTP", "-p", "NTPSynchronized")
+	if err != nil {
+		return Status{}, err
+	}
+	kv := parseKV(out)
+	return Status{
+		Enabled:      kv["NTP"] == "yes",
+		Synchronized: kv["NTPSynchronized"] == "yes",
+	}, nil
+}
+
+// parseKV parses `key=value` lines (timedatectl show's property form).
+func parseKV(s string) map[string]string {
+	out := make(map[string]string)
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return out
+}

--- a/go/sys/timesync/timesync.go
+++ b/go/sys/timesync/timesync.go
@@ -1,0 +1,95 @@
+// Package timesync reads a host's clock-synchronization status through an
+// injected exec.Runner.
+//
+//	r, _ := exec.NewRunner(exec.Direct)
+//	m, err := timesync.New(timesync.Chrony, r)
+//	if err != nil { ... }
+//	st, _ := m.Status(ctx)
+//	fmt.Println(st.Synchronized, st.Source, st.OffsetSeconds)
+//
+// Two backends are implemented: Timedatectl (systemd; reports synchronized +
+// service-enabled) and Chrony (chronyc; reports synchronized + reference source
+// + estimated offset). Reads are unprivileged. Detect lists the tools on PATH;
+// the consumer picks one and passes it to New (no auto-detection, no globals).
+package timesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// Backend selects the time-sync daemon to query. The zero value is invalid; only
+// implemented backends exist (ntpd/openntpd are intentionally absent).
+type Backend int
+
+const (
+	// Timedatectl queries systemd via `timedatectl show`.
+	Timedatectl Backend = iota + 1
+	// Chrony queries chrony via `chronyc -c tracking`.
+	Chrony
+)
+
+// String renders the backend as its canonical tool name.
+func (b Backend) String() string {
+	switch b {
+	case Timedatectl:
+		return "timedatectl"
+	case Chrony:
+		return "chrony"
+	default:
+		return fmt.Sprintf("Backend(%d)", int(b))
+	}
+}
+
+// ErrUnknownBackend is returned by New for the zero value or any unimplemented
+// backend.
+var ErrUnknownBackend = errors.New("timesync: unknown backend")
+
+// Status is a snapshot of the host clock's synchronization state. Fields a
+// backend cannot report are left at their zero value (Timedatectl does not
+// expose source/offset; both are populated by Chrony).
+type Status struct {
+	Synchronized  bool    // the clock is currently disciplined to a source
+	Enabled       bool    // a time-sync service is enabled/running
+	Source        string  // reference source (server name/IP)
+	OffsetSeconds float64 // estimated offset from true time (signed)
+}
+
+// Manager is the time-sync read surface.
+type Manager interface {
+	// Status reads the current synchronization state.
+	Status(ctx context.Context) (Status, error)
+}
+
+// New returns a Manager for the named backend, driven by runner. Pure: validates
+// the backend; does not probe (use Detect). Nil runner and unknown backend are
+// rejected.
+func New(b Backend, runner exec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("timesync: runner is required")
+	}
+	switch b {
+	case Timedatectl:
+		return &timedatectlManager{r: runner}, nil
+	case Chrony:
+		return &chronyManager{r: runner}, nil
+	default:
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+}
+
+// runRead runs an unprivileged query and returns stdout, mapping a non-zero exit
+// (or exec failure) into an error.
+func runRead(ctx context.Context, r exec.Runner, name string, args ...string) (string, error) {
+	res, err := r.Run(ctx, exec.Command{Name: name, Args: args})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", &exec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res.Stdout, nil
+}

--- a/go/sys/timesync/timesync_test.go
+++ b/go/sys/timesync/timesync_test.go
@@ -47,32 +47,35 @@ func TestBackendString(t *testing.T) {
 
 func TestDetect(t *testing.T) {
 	cases := []struct {
+		name    string
 		present map[string]bool
 		want    []Backend
 	}{
-		{map[string]bool{}, nil},
-		{map[string]bool{"timedatectl": true}, []Backend{Timedatectl}},
-		{map[string]bool{"chronyc": true}, []Backend{Chrony}},
-		{map[string]bool{"timedatectl": true, "chronyc": true}, []Backend{Timedatectl, Chrony}},
+		{"none", map[string]bool{}, nil},
+		{"timedatectl only", map[string]bool{"timedatectl": true}, []Backend{Timedatectl}},
+		{"chronyc only", map[string]bool{"chronyc": true}, []Backend{Chrony}},
+		{"both", map[string]bool{"timedatectl": true, "chronyc": true}, []Backend{Timedatectl, Chrony}},
 	}
 	for _, tc := range cases {
-		prev := lookPath
-		lookPath = func(name string) (string, error) {
-			if tc.present[name] {
-				return "/usr/bin/" + name, nil
+		t.Run(tc.name, func(t *testing.T) {
+			prev := lookPath
+			t.Cleanup(func() { lookPath = prev }) // restored even if an assertion fails
+			lookPath = func(name string) (string, error) {
+				if tc.present[name] {
+					return "/usr/bin/" + name, nil
+				}
+				return "", errors.New("not found")
 			}
-			return "", errors.New("not found")
-		}
-		got := Detect(context.Background())
-		lookPath = prev
-		if len(got) != len(tc.want) {
-			t.Fatalf("Detect(%v) = %v, want %v", tc.present, got, tc.want)
-		}
-		for i := range got {
-			if got[i] != tc.want[i] {
-				t.Errorf("Detect[%d] = %v, want %v", i, got[i], tc.want[i])
+			got := Detect(context.Background())
+			if len(got) != len(tc.want) {
+				t.Fatalf("Detect(%v) = %v, want %v", tc.present, got, tc.want)
 			}
-		}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("Detect[%d] = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }
 

--- a/go/sys/timesync/timesync_test.go
+++ b/go/sys/timesync/timesync_test.go
@@ -1,0 +1,98 @@
+package timesync
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(Chrony, nil); err == nil {
+		t.Error("New(_, nil) returned nil error")
+	}
+}
+
+func TestNew_UnknownBackend(t *testing.T) {
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, exectest.New(exec.Direct)); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+	}
+}
+
+func TestNew_Backends(t *testing.T) {
+	if m, err := New(Timedatectl, exectest.New(exec.Direct)); err != nil {
+		t.Errorf("New(Timedatectl): %v", err)
+	} else if _, ok := m.(*timedatectlManager); !ok {
+		t.Errorf("New(Timedatectl) = %T", m)
+	}
+	if m, err := New(Chrony, exectest.New(exec.Direct)); err != nil {
+		t.Errorf("New(Chrony): %v", err)
+	} else if _, ok := m.(*chronyManager); !ok {
+		t.Errorf("New(Chrony) = %T", m)
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	cases := map[Backend]string{Timedatectl: "timedatectl", Chrony: "chrony", Backend(0): "Backend(0)"}
+	for b, want := range cases {
+		if got := b.String(); got != want {
+			t.Errorf("Backend(%d).String() = %q, want %q", int(b), got, want)
+		}
+	}
+}
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		present map[string]bool
+		want    []Backend
+	}{
+		{map[string]bool{}, nil},
+		{map[string]bool{"timedatectl": true}, []Backend{Timedatectl}},
+		{map[string]bool{"chronyc": true}, []Backend{Chrony}},
+		{map[string]bool{"timedatectl": true, "chronyc": true}, []Backend{Timedatectl, Chrony}},
+	}
+	for _, tc := range cases {
+		prev := lookPath
+		lookPath = func(name string) (string, error) {
+			if tc.present[name] {
+				return "/usr/bin/" + name, nil
+			}
+			return "", errors.New("not found")
+		}
+		got := Detect(context.Background())
+		lookPath = prev
+		if len(got) != len(tc.want) {
+			t.Fatalf("Detect(%v) = %v, want %v", tc.present, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("Detect[%d] = %v, want %v", i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestRunRead_ErrorMapping(t *testing.T) {
+	ctx := context.Background()
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+	if _, err := runRead(ctx, r, "chronyc"); err == nil {
+		t.Error("runRead must map a non-zero exit to an error")
+	}
+	r.Push(exec.Result{}, errors.New("gone"))
+	if _, err := runRead(ctx, r, "chronyc"); err == nil {
+		t.Error("runRead must surface an exec error")
+	}
+	// unprivileged
+	r.Push(exec.Result{Stdout: "x"}, nil)
+	if _, err := runRead(ctx, r, "chronyc"); err != nil {
+		t.Fatal(err)
+	}
+	if r.Calls()[2].Escalate {
+		t.Error("timesync reads must not escalate")
+	}
+}


### PR DESCRIPTION
Closes #154. Read-only host-telemetry primitives in the rework Manager idiom over the injected Runner. No consumer yet — these are reader primitives ahead of a future observability / metric-history consumer.

## `sys/smart` (single-impl `Collector` over smartctl)
- `New(runner) (Collector, error)`; `Scan(ctx) ([]ScanDevice)` (`smartctl --scan -j`); `Device(ctx, dev) (Device)` (`smartctl -j -a <dev>`) → model / serial / health (PASSED) / temperature / power-on-hours.
- **smartctl's bitmask exit code is parsed correctly**: only the command-line (bit 0) and device-open (bit 1) bits are exec failures; the health bits (2+) are NOT — `smart_status.passed` already conveys health, so an unhealthy-but-readable disk returns `Healthy=false`, not an error. Device path validated; probes escalate.

## `sys/timesync` (backend-pattern: Timedatectl + Chrony)
- `New(b Backend, runner) (Manager, error)`; `Status(ctx) (Status)` — synchronized / enabled / source / offset.
- Timedatectl parses `timedatectl show` (NTP + NTPSynchronized); Chrony parses `chronyc -c tracking` CSV (source, signed offset seconds, leap status). Reads unprivileged; `Detect` lists the tools on PATH.

## Tests
- **100% statement coverage** each (FakeRunner argv + JSON/CSV fixtures + every error path), read-only integration legs (skip when the tool/privilege is absent) + runnable `Example`s. Pass the no-global-backend fitness function.

CA-trust (the third workplan telemetry sub-primitive) is intentionally a **separate follow-up**: p11-kit `trust` enumeration is distro-variable and has no consumer yet — flagged rather than rushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S.M.A.R.T. disk health monitoring with device scanning and per-device health/temperature reporting.
  * Added time synchronization status monitoring with backend detection and support for timedatectl and chrony.
* **Tests**
  * Added comprehensive unit tests for device path validation, JSON parsing/command behavior, backend detection, and status parsing.
  * Added integration tests (opt-in) to validate scanning and status collection when required binaries are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->