### PR TITLE
feat(sys): log read primitive — sys/log (journald + syslog Source) (#156)

### DIFF
--- a/go/sys/log/backends_test.go
+++ b/go/sys/log/backends_test.go
@@ -164,13 +164,16 @@ func TestSyslog_QueryValidationRejects(t *testing.T) {
 }
 
 // A grep pattern that passes the structural guard but is not valid RE2 surfaces
-// as ErrInvalidQuery from the syslog compile (e.g. an unclosed class).
+// as ErrInvalidQuery from the syslog compile — and must do so BEFORE any
+// escalated tail runs (compile-before-privileged-read).
 func TestSyslog_QueryBadRegexCompile(t *testing.T) {
 	withSyslogFixture(t, true)
 	r := exectest.New(exec.Direct)
-	r.Push(exec.Result{Stdout: "x\n"}, nil)
 	s, _ := New(Syslog, r)
 	if _, err := s.Query(context.Background(), Query{Grep: "[unclosed"}); !errors.Is(err, ErrInvalidQuery) {
 		t.Errorf("err = %v, want ErrInvalidQuery for an uncompilable pattern", err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("a malformed grep must fail before any escalated tail runs")
 	}
 }

--- a/go/sys/log/backends_test.go
+++ b/go/sys/log/backends_test.go
@@ -1,0 +1,176 @@
+package log
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func TestSplitLines(t *testing.T) {
+	if got := splitLines(""); len(got) != 0 {
+		t.Errorf("splitLines(empty) = %v, want []", got)
+	}
+	if got := splitLines("a\nb\n"); strings.Join(got, ",") != "a,b" {
+		t.Errorf("splitLines = %v, want [a b] (trailing newline dropped)", got)
+	}
+	if got := splitLines("only"); strings.Join(got, ",") != "only" {
+		t.Errorf("splitLines(no newline) = %v", got)
+	}
+}
+
+func TestJournald_QueryArgv(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "l1\nl2\n"}, nil)
+	s, _ := New(Journald, r)
+	lines, err := s.Query(context.Background(), Query{
+		Unit: "sshd.service", Since: "yesterday", Until: "now",
+		Priority: "warning", Grep: "fail", Lines: 250,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(lines, ",") != "l1,l2" {
+		t.Errorf("lines = %v", lines)
+	}
+	argv := strings.Join(r.Calls()[0].Args, " ")
+	for _, want := range []string{"--no-pager", "-n 250", "-u sshd.service", "--since yesterday", "--until now", "-p warning", "--grep fail"} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("journalctl argv missing %q\n  got: %q", want, argv)
+		}
+	}
+	if !r.Calls()[0].Escalate {
+		t.Error("journald read must escalate")
+	}
+}
+
+func TestJournald_QueryDefaultsAndMinimal(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: ""}, nil)
+	s, _ := New(Journald, r)
+	if _, err := s.Query(context.Background(), Query{}); err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Join(r.Calls()[0].Args, " ")
+	if !strings.Contains(argv, "-n 100") { // default line cap
+		t.Errorf("default lines should be 100: %q", argv)
+	}
+	for _, absent := range []string{"-u ", "--since", "--until", "-p ", "--grep"} {
+		if strings.Contains(argv, absent) {
+			t.Errorf("minimal query must not emit %q: %q", absent, argv)
+		}
+	}
+}
+
+func TestJournald_QueryValidationRejectsBeforeExec(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	s, _ := New(Journald, r)
+	if _, err := s.Query(context.Background(), Query{Grep: "(a+)+"}); !errors.Is(err, ErrInvalidQuery) {
+		t.Errorf("err = %v, want ErrInvalidQuery", err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("an invalid query must run nothing")
+	}
+}
+
+func TestJournald_QueryRunError(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+	s, _ := New(Journald, r)
+	if _, err := s.Query(context.Background(), Query{}); err == nil {
+		t.Error("a journalctl failure must surface")
+	}
+}
+
+// withSyslogFixture points syslogPaths + statFile at a fake existing file.
+func withSyslogFixture(t *testing.T, exists bool) {
+	t.Helper()
+	prevPaths, prevStat := syslogPaths, statFile
+	t.Cleanup(func() { syslogPaths, statFile = prevPaths, prevStat })
+	syslogPaths = []string{"/var/log/syslog"}
+	statFile = func(string) (os.FileInfo, error) {
+		if exists {
+			return nil, nil
+		}
+		return nil, errors.New("not found")
+	}
+}
+
+func TestSyslog_QueryTailAndGrep(t *testing.T) {
+	withSyslogFixture(t, true)
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "alpha error\nbeta ok\ngamma error\n"}, nil)
+	s, _ := New(Syslog, r)
+	lines, err := s.Query(context.Background(), Query{Lines: 50, Grep: "error"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(lines, ",") != "alpha error,gamma error" {
+		t.Errorf("grep-filtered lines = %v, want the two error lines", lines)
+	}
+	argv := strings.Join(r.Calls()[0].Args, " ")
+	if argv != "-n 50 -- /var/log/syslog" || r.Calls()[0].Name != "tail" || !r.Calls()[0].Escalate {
+		t.Errorf("tail argv = %q (name=%s escalate=%v)", argv, r.Calls()[0].Name, r.Calls()[0].Escalate)
+	}
+}
+
+func TestSyslog_QueryNoGrepReturnsAll(t *testing.T) {
+	withSyslogFixture(t, true)
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "a\nb\n"}, nil)
+	s, _ := New(Syslog, r)
+	lines, err := s.Query(context.Background(), Query{})
+	if err != nil || strings.Join(lines, ",") != "a,b" {
+		t.Fatalf("= (%v,%v)", lines, err)
+	}
+}
+
+func TestSyslog_QueryNoFile(t *testing.T) {
+	withSyslogFixture(t, false)
+	r := exectest.New(exec.Direct)
+	s, _ := New(Syslog, r)
+	if _, err := s.Query(context.Background(), Query{}); err == nil {
+		t.Error("missing syslog file must error")
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("no file → no command")
+	}
+}
+
+func TestSyslog_QueryRunError(t *testing.T) {
+	withSyslogFixture(t, true)
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "permission denied"}, nil)
+	s, _ := New(Syslog, r)
+	if _, err := s.Query(context.Background(), Query{}); err == nil {
+		t.Error("a tail failure must surface")
+	}
+}
+
+func TestSyslog_QueryValidationRejects(t *testing.T) {
+	withSyslogFixture(t, true)
+	r := exectest.New(exec.Direct)
+	s, _ := New(Syslog, r)
+	if _, err := s.Query(context.Background(), Query{Priority: "loud"}); !errors.Is(err, ErrInvalidQuery) {
+		t.Errorf("err = %v, want ErrInvalidQuery", err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("invalid query → no command")
+	}
+}
+
+// A grep pattern that passes the structural guard but is not valid RE2 surfaces
+// as ErrInvalidQuery from the syslog compile (e.g. an unclosed class).
+func TestSyslog_QueryBadRegexCompile(t *testing.T) {
+	withSyslogFixture(t, true)
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "x\n"}, nil)
+	s, _ := New(Syslog, r)
+	if _, err := s.Query(context.Background(), Query{Grep: "[unclosed"}); !errors.Is(err, ErrInvalidQuery) {
+		t.Errorf("err = %v, want ErrInvalidQuery for an uncompilable pattern", err)
+	}
+}

--- a/go/sys/log/detect.go
+++ b/go/sys/log/detect.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"context"
+	osexec "os/exec"
+)
+
+// lookPath is a package-var seam so Detect is deterministically testable.
+var lookPath = osexec.LookPath
+
+// Detect reports the log backends usable on THIS host: Journald when journalctl
+// is on PATH, Syslog when a classic log file exists. It lists; the consumer picks
+// one and passes it to New.
+//
+// The ctx is accepted for signature uniformity; the probe is PATH/stat lookups.
+func Detect(ctx context.Context) []Backend {
+	_ = ctx
+	var out []Backend
+	if _, err := lookPath("journalctl"); err == nil {
+		out = append(out, Journald)
+	}
+	if _, err := syslogPath(); err == nil {
+		out = append(out, Syslog)
+	}
+	return out
+}

--- a/go/sys/log/example_test.go
+++ b/go/sys/log/example_test.go
@@ -1,0 +1,33 @@
+package log_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	syslog "github.com/manchtools/power-manage/sdk/go/sys/log"
+)
+
+// ExampleNew reads recent warnings from a unit's journal.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Direct) // the system journal needs root
+	if err != nil {
+		log.Fatal(err)
+	}
+	s, err := syslog.New(syslog.Journald, r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	lines, err := s.Query(context.Background(), syslog.Query{
+		Unit:     "sshd.service",
+		Priority: "warning",
+		Lines:    200,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, l := range lines {
+		fmt.Println(l)
+	}
+}

--- a/go/sys/log/grepguard.go
+++ b/go/sys/log/grepguard.go
@@ -82,6 +82,18 @@ func isPathologicalGrepPattern(p string) string {
 			top := stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
 			depth--
+			// Propagate the closed group's quantifier/alternation state up to its
+			// parent, so an outer quantifier still sees an unbounded quantifier or
+			// alternation nested one level deeper — `((a+))+`, `((a|ab))+`,
+			// `((.*a)){2}` would otherwise bypass the guard.
+			if len(stack) > 0 {
+				if top.hasInnerQuant {
+					stack[len(stack)-1].hasInnerQuant = true
+				}
+				if top.hasAlt {
+					stack[len(stack)-1].hasAlt = true
+				}
+			}
 			// Is the closing paren followed by an unbounded quantifier?
 			if i+1 < len(p) {
 				next := p[i+1]

--- a/go/sys/log/grepguard.go
+++ b/go/sys/log/grepguard.go
@@ -1,0 +1,186 @@
+package log
+
+import (
+	"strconv"
+	"strings"
+)
+
+// This file is ported VERBATIM from the agent's log-query handler (audit F-35).
+// It is the structural ReDoS guard for grep patterns. Until the agent migrates
+// onto this package the two copies coexist; keep them in sync, and prefer this
+// one as the source of truth thereafter.
+
+// isPathologicalGrepPattern flags regex shapes that are known to
+// drive PCRE / RE2 into catastrophic backtracking (audit F-35).
+// Returns a non-empty reason string when the pattern is rejected.
+//
+// The detector is intentionally conservative — it rejects on
+// structural heuristics rather than trying to actually evaluate
+// catastrophic-backtracking risk (which is undecidable in general).
+// False positives are acceptable here: a rejected pattern returns a
+// clean error to the caller; the worst-case is the operator has to
+// rephrase a query. False negatives are not: a pathological pattern
+// that slips through hangs `journalctl --grep` on the agent and
+// denies log-query service.
+//
+// Rules (each independently disqualifying):
+//   - nested quantifier on a group: `(...)*`, `(...)+`, `(...){n,}`
+//     where the inner group contains its own quantifier (`*`, `+`,
+//     `{n,}`). Classic `(a+)+`, `(a*)*`, `(a{1,})+` shapes.
+//   - overlapping alternation under a quantifier: `(a|a)+`,
+//     `(a|ab)+` — flagged by any `|` inside a quantified group.
+//   - more than 5 unbounded quantifiers (`*`, `+`, `{n,}`) total —
+//     compounds with the above rules to catch staircase patterns.
+func isPathologicalGrepPattern(p string) string {
+	// Count unbounded quantifiers — `*`, `+`, `{n,}`. `\` escapes
+	// the following metachar so we skip a pair when we see one.
+	unbounded := 0
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if c == '\\' && i+1 < len(p) {
+			i++
+			continue
+		}
+		switch c {
+		case '*', '+':
+			unbounded++
+		case '{':
+			if quantifierUnbounded(p[i:]) {
+				unbounded++
+			}
+		}
+	}
+	if unbounded > 5 {
+		return "too many unbounded quantifiers (max 5)"
+	}
+
+	// Walk groups and look for nested-quantifier / alternation-
+	// under-quantifier shapes.
+	depth := 0
+	type groupState struct {
+		start         int
+		hasAlt        bool
+		hasInnerQuant bool
+	}
+	var stack []groupState
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		// Skip escapes — `\(` and `\|` are literal characters, not
+		// regex metas.
+		if c == '\\' && i+1 < len(p) {
+			i++
+			continue
+		}
+		switch c {
+		case '(':
+			stack = append(stack, groupState{start: i})
+			depth++
+		case ')':
+			if depth == 0 {
+				continue
+			}
+			top := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			depth--
+			// Is the closing paren followed by an unbounded quantifier?
+			if i+1 < len(p) {
+				next := p[i+1]
+				if next == '*' || next == '+' || (next == '{' && quantifierUnbounded(p[i+1:])) {
+					if top.hasInnerQuant {
+						return "nested unbounded quantifier (catastrophic backtracking shape)"
+					}
+					if top.hasAlt {
+						return "alternation under unbounded quantifier (catastrophic backtracking shape)"
+					}
+				}
+				// Bounded `{n}`/`{n,m}` repetition of a group that itself
+				// contains an unbounded quantifier is degree-N polynomial
+				// backtracking — `(.*a){11}` is catastrophic even though `{11}`
+				// is "bounded". The UPPER bound drives the worst case, so
+				// `(.*a){1,11}` is just as bad as `(.*a){11}` (lo=1 is
+				// irrelevant). Flag when the max repetition count is >= 2.
+				// (Alternation under a BOUNDED repeat is fine — bounded
+				// branching — so only hasInnerQuant qualifies here.)
+				if next == '{' && top.hasInnerQuant {
+					if _, hi, ok := boundedRepeatBounds(p[i+1:]); ok && hi >= 2 {
+						return "bounded repetition of an unbounded group (catastrophic backtracking shape)"
+					}
+				}
+			}
+		case '|':
+			if depth > 0 {
+				stack[len(stack)-1].hasAlt = true
+			}
+		case '*', '+':
+			if depth > 0 {
+				stack[len(stack)-1].hasInnerQuant = true
+			}
+		case '{':
+			if j := strings.IndexByte(p[i:], '}'); j > 0 && quantifierUnbounded(p[i:]) {
+				if depth > 0 {
+					stack[len(stack)-1].hasInnerQuant = true
+				}
+				i += j
+			}
+		}
+	}
+	return ""
+}
+
+// boundedRepeatBounds parses a BOUNDED `{n}` or `{n,m}` token starting at p[0]
+// and returns (lo, hi, ok). For `{n}`, lo==hi==n. Returns ok=false for a
+// non-quantifier, a malformed token, or an unbounded `{n,}` (those are handled
+// by quantifierUnbounded). The HI bound is what drives worst-case backtracking
+// when the repeated group contains an unbounded quantifier — `(...){1,1000}`
+// can still try up to 1000 repetitions.
+func boundedRepeatBounds(p string) (lo, hi int, ok bool) {
+	if len(p) == 0 || p[0] != '{' {
+		return 0, 0, false
+	}
+	j := strings.IndexByte(p, '}')
+	if j <= 0 {
+		return 0, 0, false
+	}
+	body := p[1:j]
+	if strings.HasSuffix(body, ",") {
+		return 0, 0, false // `{n,}` — unbounded
+	}
+	k := strings.IndexByte(body, ',')
+	if k < 0 {
+		// `{n}` — lo == hi == n
+		n, err := strconv.Atoi(strings.TrimSpace(body))
+		if err != nil {
+			return 0, 0, false
+		}
+		return n, n, true
+	}
+	// `{n,m}` — lo = n, hi = m
+	n, err := strconv.Atoi(strings.TrimSpace(body[:k]))
+	if err != nil {
+		return 0, 0, false
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(body[k+1:]))
+	if err != nil {
+		return 0, 0, false
+	}
+	return n, m, true
+}
+
+// quantifierUnbounded reports whether a `{n,m?}` token starting at
+// p[0] is unbounded — `{n,}` is unbounded; `{n}` and `{n,m}` are
+// bounded.
+func quantifierUnbounded(p string) bool {
+	if len(p) == 0 || p[0] != '{' {
+		return false
+	}
+	j := strings.IndexByte(p, '}')
+	if j <= 0 {
+		return false
+	}
+	body := p[1:j]
+	if !strings.Contains(body, ",") {
+		return false // `{n}` — bounded
+	}
+	parts := strings.SplitN(body, ",", 2)
+	return len(parts) == 2 && parts[1] == "" // `{n,}` — unbounded
+}

--- a/go/sys/log/grepguard_test.go
+++ b/go/sys/log/grepguard_test.go
@@ -26,6 +26,11 @@ func TestIsPathologicalGrepPattern(t *testing.T) {
 		{"six unbounded too many", "a*b*c*d*e*f*", true},
 		{"bounded repeat of unbounded group", "(.*a){11}", true},
 		{"bounded range repeat of unbounded group", "(.*a){1,11}", true},
+		// Nested-group bypasses: an inner group's quantifier/alternation must
+		// propagate to a quantified outer group (else these slip through).
+		{"nested-group nested quant", "((a+))+", true},
+		{"nested-group alternation under quant", "((a|ab))+", true},
+		{"nested-group bounded repeat of unbounded", "((.*a)){2}", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/sys/log/grepguard_test.go
+++ b/go/sys/log/grepguard_test.go
@@ -1,0 +1,79 @@
+package log
+
+import "testing"
+
+func TestIsPathologicalGrepPattern(t *testing.T) {
+	cases := []struct {
+		name     string
+		pat      string
+		rejected bool
+	}{
+		{"empty", "", false},
+		{"plain literal", "error: connection refused", false},
+		{"simple quantifiers", "a+b*c?", false},
+		{"group no inner quant", "(abc)+", false},
+		{"bounded repeat of plain group", "(ab){5}", false},
+		{"five unbounded ok", "a*b*c*d*e*", false},
+		{"escaped parens are literal", `\(a+\)+`, false},
+		{"bounded {1} of unbounded group ok", "(.*a){1}", false},
+		{"unmatched close paren tolerated", "a)b", false},
+
+		{"nested quant star", "(a*)*", true},
+		{"nested quant plus", "(a+)+", true},
+		{"nested quant unbounded brace", "(a{1,})+", true},
+		{"alternation under quant", "(a|a)+", true},
+		{"alternation under quant overlapping", "(a|ab)+", true},
+		{"six unbounded too many", "a*b*c*d*e*f*", true},
+		{"bounded repeat of unbounded group", "(.*a){11}", true},
+		{"bounded range repeat of unbounded group", "(.*a){1,11}", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := isPathologicalGrepPattern(tc.pat)
+			if tc.rejected && reason == "" {
+				t.Errorf("isPathologicalGrepPattern(%q) accepted; want rejected", tc.pat)
+			}
+			if !tc.rejected && reason != "" {
+				t.Errorf("isPathologicalGrepPattern(%q) rejected (%s); want accepted", tc.pat, reason)
+			}
+		})
+	}
+}
+
+func TestBoundedRepeatBounds(t *testing.T) {
+	cases := []struct {
+		in     string
+		lo, hi int
+		ok     bool
+	}{
+		{"{5}", 5, 5, true},
+		{"{1,11}", 1, 11, true},
+		{"{1,}", 0, 0, false}, // unbounded
+		{"{x}", 0, 0, false},
+		{"{x,5}", 0, 0, false}, // bad low bound
+		{"{1,x}", 0, 0, false}, // bad high bound
+		{"x", 0, 0, false},
+		{"{nodelim", 0, 0, false},
+	}
+	for _, tc := range cases {
+		lo, hi, ok := boundedRepeatBounds(tc.in)
+		if ok != tc.ok || (ok && (lo != tc.lo || hi != tc.hi)) {
+			t.Errorf("boundedRepeatBounds(%q) = (%d,%d,%v), want (%d,%d,%v)", tc.in, lo, hi, ok, tc.lo, tc.hi, tc.ok)
+		}
+	}
+}
+
+func TestQuantifierUnbounded(t *testing.T) {
+	cases := map[string]bool{
+		"{1,}":     true,
+		"{1,5}":    false,
+		"{5}":      false,
+		"x":        false,
+		"{nodelim": false,
+	}
+	for in, want := range cases {
+		if got := quantifierUnbounded(in); got != want {
+			t.Errorf("quantifierUnbounded(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/go/sys/log/integration_test.go
+++ b/go/sys/log/integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package log_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+	syslog "github.com/manchtools/power-manage/sdk/go/sys/log"
+)
+
+// READ-ONLY: Detect + a small real Query against journald if present. Skips when
+// the tool/privilege is unavailable (common in unprivileged CI).
+func TestQuery_Integration(t *testing.T) {
+	for _, b := range syslog.Detect(context.Background()) {
+		if b != syslog.Journald && b != syslog.Syslog {
+			t.Errorf("Detect returned unexpected backend %v", b)
+		}
+	}
+	if _, err := exec.LookPath("journalctl"); err != nil {
+		t.Skip("journalctl not present")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	s, err := syslog.New(syslog.Journald, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := s.Query(context.Background(), syslog.Query{Lines: 5}); err != nil {
+		t.Skipf("journalctl read unusable here (no privilege/journal): %v", err)
+	}
+}

--- a/go/sys/log/journald.go
+++ b/go/sys/log/journald.go
@@ -1,0 +1,54 @@
+package log
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// journaldSource reads the systemd journal via journalctl.
+type journaldSource struct {
+	r exec.Runner
+}
+
+// Query builds and runs a journalctl invocation. Every dynamic value is an
+// option-ARGUMENT (`-u <unit>`, `--grep <pat>`, …), never a positional operand,
+// so none can be reinterpreted as a flag. Filters are validated first.
+func (s *journaldSource) Query(ctx context.Context, q Query) ([]string, error) {
+	if err := validateQuery(q); err != nil {
+		return nil, err
+	}
+	args := []string{"--no-pager", "-n", strconv.Itoa(cappedLines(q.Lines))}
+	if q.Unit != "" {
+		args = append(args, "-u", q.Unit)
+	}
+	if q.Since != "" {
+		args = append(args, "--since", q.Since)
+	}
+	if q.Until != "" {
+		args = append(args, "--until", q.Until)
+	}
+	if q.Priority != "" {
+		args = append(args, "-p", q.Priority)
+	}
+	if q.Grep != "" {
+		args = append(args, "--grep", q.Grep)
+	}
+	out, err := runEscalated(ctx, s.r, nil, "journalctl", args...)
+	if err != nil {
+		return nil, err
+	}
+	return splitLines(out), nil
+}
+
+// splitLines splits captured stdout into lines, dropping a single trailing
+// empty line (the final newline). Returns a non-nil empty slice for empty input.
+func splitLines(out string) []string {
+	out = strings.TrimSuffix(out, "\n")
+	if out == "" {
+		return []string{}
+	}
+	return strings.Split(out, "\n")
+}

--- a/go/sys/log/log.go
+++ b/go/sys/log/log.go
@@ -1,0 +1,155 @@
+// Package log reads system logs through an injected exec.Runner.
+//
+//	r, _ := exec.NewRunner(exec.Direct) // the system journal needs root
+//	s, err := log.New(log.Journald, r)
+//	if err != nil { ... }
+//	lines, _ := s.Query(ctx, log.Query{Unit: "sshd.service", Lines: 200, Priority: "warning"})
+//
+// Two backends are implemented: Journald (journalctl) and Syslog
+// (/var/log/{syslog,messages}). The query filters and their hardening — line
+// cap, priority allow-list, grep length cap, and the structural ReDoS guard —
+// are shared and applied before any tool runs (validate-then-execute). Reads
+// escalate through the Runner (system logs are root-readable). Detect lists the
+// backends usable on the host.
+//
+// The signing/authorization of a remote log request is the consumer's concern
+// (the agent verifies a CA signature before calling this); this package is the
+// reader.
+package log
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// Backend selects the log source. The zero value is invalid; only implemented
+// backends exist.
+type Backend int
+
+const (
+	// Journald reads the systemd journal via journalctl.
+	Journald Backend = iota + 1
+	// Syslog reads the classic /var/log/{syslog,messages} files.
+	Syslog
+)
+
+// String renders the backend as its canonical name.
+func (b Backend) String() string {
+	switch b {
+	case Journald:
+		return "journald"
+	case Syslog:
+		return "syslog"
+	default:
+		return fmt.Sprintf("Backend(%d)", int(b))
+	}
+}
+
+// ErrUnknownBackend is returned by New for the zero value or any unimplemented
+// backend.
+var ErrUnknownBackend = errors.New("log: unknown backend")
+
+// ErrInvalidQuery is returned when a Query field is unsafe or out of range (bad
+// priority, an over-long or catastrophic-backtracking grep pattern).
+var ErrInvalidQuery = errors.New("log: invalid query")
+
+// Query selects which log entries to return.
+type Query struct {
+	// Unit filters by systemd unit (Journald only; ignored by Syslog).
+	Unit string
+	// Since and Until bound the time range (journalctl's --since/--until forms;
+	// Journald only).
+	Since, Until string
+	// Priority filters by syslog priority (Journald only). Allowed values:
+	// 0-7 or emerg/alert/crit/err/warning/notice/info/debug.
+	Priority string
+	// Grep keeps only entries matching this pattern. Capped at 256 chars and
+	// refused if it is a catastrophic-backtracking shape (ReDoS guard).
+	Grep string
+	// Lines caps the number of entries returned. <=0 means 100; values above
+	// 10000 are clamped to 10000.
+	Lines int
+}
+
+const (
+	defaultLines = 100
+	maxLines     = 10000
+	maxGrepLen   = 256
+)
+
+// Source is the log read surface.
+type Source interface {
+	// Query returns the matching log lines, most-recent-last, after validating
+	// the query (validate-then-execute: an invalid query runs no command).
+	Query(ctx context.Context, q Query) ([]string, error)
+}
+
+// New returns a Source for the named backend, driven by runner. Pure: validates
+// the backend; does not probe (use Detect). Nil runner and unknown backend are
+// rejected.
+func New(b Backend, runner exec.Runner) (Source, error) {
+	if runner == nil {
+		return nil, errors.New("log: runner is required")
+	}
+	switch b {
+	case Journald:
+		return &journaldSource{r: runner}, nil
+	case Syslog:
+		return &syslogSource{r: runner}, nil
+	default:
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+}
+
+// cappedLines applies the default/clamp policy to Query.Lines.
+func cappedLines(n int) int {
+	if n <= 0 {
+		return defaultLines
+	}
+	if n > maxLines {
+		return maxLines
+	}
+	return n
+}
+
+// validPriorities is the journald priority allow-list (names + numeric levels).
+var validPriorities = map[string]bool{
+	"0": true, "1": true, "2": true, "3": true, "4": true, "5": true, "6": true, "7": true,
+	"emerg": true, "alert": true, "crit": true, "err": true,
+	"warning": true, "notice": true, "info": true, "debug": true,
+}
+
+// validateQuery enforces the shared, security-relevant query constraints before
+// any backend builds a command. Priority is validated whenever set (even for
+// Syslog, which ignores it) so a bad value is never silently accepted.
+func validateQuery(q Query) error {
+	if q.Priority != "" && !validPriorities[q.Priority] {
+		return fmt.Errorf("%w: priority %q is not a valid syslog priority", ErrInvalidQuery, q.Priority)
+	}
+	if q.Grep != "" {
+		if len(q.Grep) > maxGrepLen {
+			return fmt.Errorf("%w: grep pattern too long (%d > %d)", ErrInvalidQuery, len(q.Grep), maxGrepLen)
+		}
+		if reason := isPathologicalGrepPattern(q.Grep); reason != "" {
+			return fmt.Errorf("%w: grep pattern rejected: %s", ErrInvalidQuery, reason)
+		}
+	}
+	return nil
+}
+
+// runEscalated runs a read that needs root (system logs) and returns stdout. A
+// non-zero exit becomes a *CommandError unless it is in okExitCodes (some tools,
+// e.g. grep, use a non-zero exit to mean "no matches", which is not a failure).
+func runEscalated(ctx context.Context, r exec.Runner, okExitCodes map[int]bool, name string, args ...string) (string, error) {
+	res, err := r.Run(ctx, exec.Command{Name: name, Args: args, Escalate: true})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 && !okExitCodes[res.ExitCode] {
+		return "", &exec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res.Stdout, nil
+}

--- a/go/sys/log/log_test.go
+++ b/go/sys/log/log_test.go
@@ -1,0 +1,160 @@
+package log
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(Journald, nil); err == nil {
+		t.Error("New(_, nil) returned nil error")
+	}
+}
+
+func TestNew_UnknownBackend(t *testing.T) {
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, exectest.New(exec.Direct)); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+	}
+}
+
+func TestNew_Backends(t *testing.T) {
+	if s, err := New(Journald, exectest.New(exec.Direct)); err != nil {
+		t.Errorf("New(Journald): %v", err)
+	} else if _, ok := s.(*journaldSource); !ok {
+		t.Errorf("New(Journald) = %T", s)
+	}
+	if s, err := New(Syslog, exectest.New(exec.Direct)); err != nil {
+		t.Errorf("New(Syslog): %v", err)
+	} else if _, ok := s.(*syslogSource); !ok {
+		t.Errorf("New(Syslog) = %T", s)
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	cases := map[Backend]string{Journald: "journald", Syslog: "syslog", Backend(0): "Backend(0)"}
+	for b, want := range cases {
+		if got := b.String(); got != want {
+			t.Errorf("Backend(%d).String() = %q, want %q", int(b), got, want)
+		}
+	}
+}
+
+func TestCappedLines(t *testing.T) {
+	cases := map[int]int{0: defaultLines, -5: defaultLines, 50: 50, 10000: 10000, 20000: maxLines}
+	for in, want := range cases {
+		if got := cappedLines(in); got != want {
+			t.Errorf("cappedLines(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestValidateQuery(t *testing.T) {
+	cases := []struct {
+		name    string
+		q       Query
+		wantErr bool
+	}{
+		{"empty ok", Query{}, false},
+		{"valid priority name", Query{Priority: "warning"}, false},
+		{"valid priority num", Query{Priority: "3"}, false},
+		{"valid grep", Query{Grep: "error|fail"}, false},
+		{"bad priority", Query{Priority: "loud"}, true},
+		{"grep too long", Query{Grep: string(make([]byte, maxGrepLen+1))}, true},
+		{"grep ReDoS", Query{Grep: "(a+)+"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateQuery(tc.q)
+			if tc.wantErr && !errors.Is(err, ErrInvalidQuery) {
+				t.Errorf("validateQuery(%+v) = %v, want ErrInvalidQuery", tc.q, err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateQuery(%+v) = %v, want nil", tc.q, err)
+			}
+		})
+	}
+}
+
+func TestRunEscalated(t *testing.T) {
+	ctx := context.Background()
+	t.Run("escalates and returns stdout", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{Stdout: "line\n"}, nil)
+		out, err := runEscalated(ctx, r, nil, "journalctl", "-n", "1")
+		if err != nil || out != "line\n" {
+			t.Fatalf("= (%q,%v)", out, err)
+		}
+		if !r.Calls()[0].Escalate {
+			t.Error("log reads must escalate (system logs need root)")
+		}
+	})
+	t.Run("non-zero exit errors", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+		if _, err := runEscalated(ctx, r, nil, "journalctl"); err == nil {
+			t.Error("non-zero exit must error")
+		}
+	})
+	t.Run("okExitCodes tolerated", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{ExitCode: 1, Stdout: ""}, nil) // grep "no match"
+		if _, err := runEscalated(ctx, r, map[int]bool{1: true}, "grep", "x"); err != nil {
+			t.Errorf("exit 1 in okExitCodes must be tolerated, got %v", err)
+		}
+	})
+	t.Run("exec error", func(t *testing.T) {
+		r := exectest.New(exec.Direct)
+		r.Push(exec.Result{}, errors.New("gone"))
+		if _, err := runEscalated(ctx, r, nil, "journalctl"); err == nil {
+			t.Error("exec error must surface")
+		}
+	})
+}
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		name      string
+		journalct bool
+		syslog    bool
+		want      []Backend
+	}{
+		{"none", false, false, nil},
+		{"journald only", true, false, []Backend{Journald}},
+		{"syslog only", false, true, []Backend{Syslog}},
+		{"both", true, true, []Backend{Journald, Syslog}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prevLP, prevStat := lookPath, statFile
+			t.Cleanup(func() { lookPath, statFile = prevLP, prevStat })
+			lookPath = func(string) (string, error) {
+				if tc.journalct {
+					return "/usr/bin/journalctl", nil
+				}
+				return "", errors.New("nope")
+			}
+			statFile = func(string) (os.FileInfo, error) {
+				if tc.syslog {
+					return nil, nil
+				}
+				return nil, errors.New("nope")
+			}
+			got := Detect(context.Background())
+			if len(got) != len(tc.want) {
+				t.Fatalf("Detect = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("Detect[%d] = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/sys/log/log_test.go
+++ b/go/sys/log/log_test.go
@@ -120,10 +120,10 @@ func TestRunEscalated(t *testing.T) {
 
 func TestDetect(t *testing.T) {
 	cases := []struct {
-		name      string
-		journalct bool
-		syslog    bool
-		want      []Backend
+		name       string
+		journalctl bool
+		syslog     bool
+		want       []Backend
 	}{
 		{"none", false, false, nil},
 		{"journald only", true, false, []Backend{Journald}},
@@ -135,7 +135,7 @@ func TestDetect(t *testing.T) {
 			prevLP, prevStat := lookPath, statFile
 			t.Cleanup(func() { lookPath, statFile = prevLP, prevStat })
 			lookPath = func(string) (string, error) {
-				if tc.journalct {
+				if tc.journalctl {
 					return "/usr/bin/journalctl", nil
 				}
 				return "", errors.New("nope")

--- a/go/sys/log/syslog.go
+++ b/go/sys/log/syslog.go
@@ -1,0 +1,71 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// syslogPaths are the classic plain-text log files, in preference order.
+var syslogPaths = []string{"/var/log/syslog", "/var/log/messages"}
+
+// statFile is a seam (os.Stat) so backend-selection is testable; existence only
+// needs a traversable /var/log, not read access to the file.
+var statFile = os.Stat
+
+// syslogSource reads the classic /var/log/{syslog,messages} files. Unlike
+// Journald it has no unit/priority concept — those Query fields are validated
+// (so a bad value still errors) but ignored. Grep is applied as a Go RE2 regex
+// over the most-recent Lines entries (limit-then-filter), so it filters within
+// the tail window rather than the whole file.
+type syslogSource struct {
+	r exec.Runner
+}
+
+// Query tails the active syslog file and applies the grep filter.
+func (s *syslogSource) Query(ctx context.Context, q Query) ([]string, error) {
+	if err := validateQuery(q); err != nil {
+		return nil, err
+	}
+	path, err := syslogPath()
+	if err != nil {
+		return nil, err
+	}
+	// Bounded read: tail the last N lines (`--` ends options so a path can't be
+	// read as a flag — though our paths are constants).
+	out, err := runEscalated(ctx, s.r, nil, "tail", "-n", strconv.Itoa(cappedLines(q.Lines)), "--", path)
+	if err != nil {
+		return nil, err
+	}
+	lines := splitLines(out)
+	if q.Grep == "" {
+		return lines, nil
+	}
+	// The structural guard already ran in validateQuery; RE2 is linear-time, so
+	// this compile is DoS-safe. A compile error is a malformed pattern.
+	re, err := regexp.Compile(q.Grep)
+	if err != nil {
+		return nil, fmt.Errorf("%w: grep pattern: %v", ErrInvalidQuery, err)
+	}
+	matched := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if re.MatchString(l) {
+			matched = append(matched, l)
+		}
+	}
+	return matched, nil
+}
+
+// syslogPath returns the first existing syslog file.
+func syslogPath() (string, error) {
+	for _, p := range syslogPaths {
+		if _, err := statFile(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("log: no syslog file found (looked in %v)", syslogPaths)
+}

--- a/go/sys/log/syslog.go
+++ b/go/sys/log/syslog.go
@@ -31,6 +31,16 @@ func (s *syslogSource) Query(ctx context.Context, q Query) ([]string, error) {
 	if err := validateQuery(q); err != nil {
 		return nil, err
 	}
+	// Compile the grep pattern BEFORE any privileged read, so a malformed
+	// pattern fails closed without triggering an escalated tail. The structural
+	// guard already ran in validateQuery; RE2 is linear-time, so this is DoS-safe.
+	var re *regexp.Regexp
+	if q.Grep != "" {
+		var err error
+		if re, err = regexp.Compile(q.Grep); err != nil {
+			return nil, fmt.Errorf("%w: grep pattern: %v", ErrInvalidQuery, err)
+		}
+	}
 	path, err := syslogPath()
 	if err != nil {
 		return nil, err
@@ -42,14 +52,8 @@ func (s *syslogSource) Query(ctx context.Context, q Query) ([]string, error) {
 		return nil, err
 	}
 	lines := splitLines(out)
-	if q.Grep == "" {
+	if re == nil {
 		return lines, nil
-	}
-	// The structural guard already ran in validateQuery; RE2 is linear-time, so
-	// this compile is DoS-safe. A compile error is a malformed pattern.
-	re, err := regexp.Compile(q.Grep)
-	if err != nil {
-		return nil, fmt.Errorf("%w: grep pattern: %v", ErrInvalidQuery, err)
 	}
 	matched := make([]string, 0, len(lines))
 	for _, l := range lines {


### PR DESCRIPTION
Closes #156. Extracts the agent's hardened log reader into a shared SDK `sys/log` over the injected Runner. Per the agreed **2-part plan**: ship SDK-side now (the ReDoS guard is duplicated with the agent's copy temporarily); the agent's copy is removed when the agent migrates onto this package.

## Surface
- `New(b Backend, runner exec.Runner) (Source, error)` — `Journald` (journalctl) + `Syslog` (`/var/log/{syslog,messages}`); pure, fail-closed nil runner + `ErrUnknownBackend`.
- `Source.Query(ctx, Query) ([]string, error)`; `Query{Unit, Since, Until, Priority, Grep string; Lines int}`. Validate-then-execute (an invalid query runs nothing).

## Security (ported VERBATIM from the agent's `OnLogQuery`, audit F-35)
- Line cap (1..10000, default 100), priority allow-list (0-7 / emerg..debug), grep length cap (≤256) + the `isPathologicalGrepPattern` structural **ReDoS guard** (nested quantifiers, alternation-under-quantifier, bounded-repeat-of-unbounded-group, >5 unbounded quantifiers).
- Every dynamic value is an **option-argument** (`-u <unit>`, `--grep <pat>`, …), never a positional operand → no flag injection.

## Backends
- **Journald**: unit/since/until/priority/grep via journalctl flags, **escalated** (system journal needs root).
- **Syslog**: tails the last N lines (bounded read) and applies grep as a Go **RE2** regex (limit-then-filter; `Unit`/`Priority` are journald-only and documented as ignored). `Detect` lists the available backends.

## Tests
- **100% statement coverage** (FakeRunner argv + the full ReDoS-guard matrix + every error path), read-only integration leg + `Example`. Passes the no-global-backend fitness function.

Relates to sdk #28 (ACTION_TYPE_AUDIT). The duplicate ReDoS guard is intentional and tracked — removed in the agent migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified log-reading interface supporting journald and syslog backends with automatic backend detection.
  * Implemented queryable log access with validated filtering by unit, time range, priority, and pattern matching.
  * Integrated safety measures to prevent malicious regex patterns from impacting system performance.

* **Tests**
  * Comprehensive unit, integration, and example tests for all log backends and query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->