### PR TITLE
fix(terminal): serialise pty.Setsize against Close to fix a data race (#158)

### DIFF
--- a/go/sys/terminal/terminal.go
+++ b/go/sys/terminal/terminal.go
@@ -110,6 +110,14 @@ type Session struct {
 	cmd *exec.Cmd
 	pty *os.File
 
+	// fdMu serialises operations that read the raw fd via (*os.File).Fd()
+	// (Resize → pty.Setsize) against the two sites that close the PTY (reap and
+	// Close). os.File.Fd() concurrent with Close() is an unsynchronised access to
+	// the file's internal fd state — a data race the -race detector flags.
+	// Read/Write are NOT guarded: they go through the os poll runtime, which is
+	// already safe against a concurrent Close.
+	fdMu sync.Mutex
+
 	closeOnce sync.Once
 	closeErr  error
 
@@ -230,7 +238,9 @@ func (s *Session) reap() {
 			s.exitCode = s.cmd.ProcessState.ExitCode()
 		}
 	})
+	s.fdMu.Lock()
 	_ = s.pty.Close()
+	s.fdMu.Unlock()
 	close(s.done)
 }
 
@@ -259,6 +269,10 @@ func (s *Session) Resize(cols, rows uint16) error {
 	if err := validateDims(cols, rows); err != nil {
 		return err
 	}
+	// pty.Setsize reads the raw fd via (*os.File).Fd(); hold fdMu so it cannot
+	// race the reaper/Close closing the PTY out from under it.
+	s.fdMu.Lock()
+	defer s.fdMu.Unlock()
 	if err := pty.Setsize(s.pty, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
 		return fmt.Errorf("terminal: resize: %w", err)
 	}
@@ -304,8 +318,12 @@ func (s *Session) Close() error {
 		}
 		// Closing the master also sends SIGHUP to the group, which is
 		// the polite shell-termination signal. ErrClosed is expected if
-		// the reaper or a concurrent caller already closed it.
-		if err := ptyClose(s.pty); err != nil && !errors.Is(err, os.ErrClosed) {
+		// the reaper or a concurrent caller already closed it. fdMu serialises
+		// this against a concurrent Resize (which reads the fd via Setsize).
+		s.fdMu.Lock()
+		err := ptyClose(s.pty)
+		s.fdMu.Unlock()
+		if err != nil && !errors.Is(err, os.ErrClosed) {
 			s.closeErr = err
 		}
 	})

--- a/go/sys/terminal/terminal_test.go
+++ b/go/sys/terminal/terminal_test.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -400,6 +401,25 @@ func TestSession_ResizeBeforeExit(t *testing.T) {
 		t.Errorf("write after resize: %v", err)
 	}
 	drain(t, s, 5*time.Second)
+}
+
+// TestSession_ConcurrentResizeAndClose pins the fd-race fix: Resize (which reads
+// the raw fd via pty.Setsize) running concurrently with Close + the reaper (which
+// close the PTY) must be data-race-free. Meaningful only under `go test -race`.
+func TestSession_ConcurrentResizeAndClose(t *testing.T) {
+	cur := requireLinuxCurrentUser(t)
+	s := startSessionOrSkip(t, SessionConfig{User: cur.Username, Shell: pickShell(t)})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = s.Resize(80, 24) // an error after Close is fine; a data race is not
+		}
+	}()
+	_ = s.Close() // races the resizes and the reaper's pty.Close
+	wg.Wait()
 }
 
 func TestSession_CloseUnblocksWait(t *testing.T) {


### PR DESCRIPTION
Closes #158. The `-race` sweep intermittently flagged a data race in `sys/terminal` (seen on PR #157's CI): `Resize` → `pty.Setsize` reads the raw fd via `(*os.File).Fd()` concurrently with the reaper's `s.pty.Close()` (fired on child exit). `os.File.Fd()` concurrent with `Close()` is an unsynchronised access to the file's internal fd state. It's a **real production race** (a consumer resizing the terminal while the child exits), pre-existing the #147 rework — #147 just added Resize-exercising tests that raised the hit rate.

**Fix:** a per-`Session` `fdMu` mutex serialising the fd-extracting `Setsize` (Resize) against the two close sites (reap + `Close`). `Read`/`Write` are left unguarded — they go through the os poll runtime, which is already safe against a concurrent `Close` (only the `Fd()` extraction races).

Adds a concurrent Resize+Close stress regression test (meaningful under `-race`); verified clean over 20 `-race` runs locally + a full `-race` sweep. 100% coverage retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data race conditions in concurrent terminal resize and close operations.

* **Tests**
  * Added test coverage for concurrent terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->