### PR TITLE
feat(sys): antivirus capability — Manager over Runner (ClamAV) (#160)

### DIFF
--- a/go/sys/antivirus/antivirus.go
+++ b/go/sys/antivirus/antivirus.go
@@ -1,0 +1,107 @@
+// Package antivirus manages an on-host antivirus engine through an injected
+// exec.Runner.
+//
+//	r, _ := exec.NewRunner(exec.Direct) // a full scan / signature update needs root
+//	m, err := antivirus.New(antivirus.ClamAV, r)
+//	if err != nil { ... }
+//	res, _ := m.Scan(ctx, "/home")
+//	for _, inf := range res.Infected { fmt.Println(inf.File, inf.Signature) }
+//
+// V1 implements the ClamAV backend (clamscan / freshclam). This is the
+// configure/operate half of AV management — scan on demand, update signatures,
+// read engine/signature versions — complementary to the alert-ingestion path
+// (a SIEM / compliance-event forwarder). On-access / real-time protection
+// (ClamAV's clamonacc) and EDR engines (Defender/Falcon/SentinelOne, which use
+// cloud APIs rather than a CLI) are out of V1 scope.
+//
+// Reads (Version) run unprivileged; Scan and UpdateSignatures escalate.
+package antivirus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// Backend selects the AV engine. The zero value is invalid; only implemented
+// backends exist.
+type Backend int
+
+// ClamAV is the clamscan/freshclam backend.
+const ClamAV Backend = iota + 1
+
+// String renders the backend as its canonical name.
+func (b Backend) String() string {
+	switch b {
+	case ClamAV:
+		return "clamav"
+	default:
+		return fmt.Sprintf("Backend(%d)", int(b))
+	}
+}
+
+// ErrUnknownBackend is returned by New for the zero value or any unimplemented
+// backend.
+var ErrUnknownBackend = errors.New("antivirus: unknown backend")
+
+// ErrInvalidPath is returned when a scan path is unsafe (empty, NUL, or
+// flag-shaped).
+var ErrInvalidPath = errors.New("antivirus: invalid scan path")
+
+// Infection is one detected threat.
+type Infection struct {
+	File      string // the infected file path
+	Signature string // the signature/threat name that matched
+}
+
+// ScanResult is the outcome of a Scan.
+type ScanResult struct {
+	Path     string      // the path that was scanned
+	Infected []Infection // detected threats (empty ⇒ clean)
+}
+
+// Clean reports whether the scan found no threats.
+func (r ScanResult) Clean() bool { return len(r.Infected) == 0 }
+
+// Version describes the installed engine + signature database.
+type Version struct {
+	Engine    string // engine version, e.g. "1.0.1"
+	Signature string // signature DB version, e.g. "27000"
+}
+
+// Manager is the antivirus surface.
+type Manager interface {
+	// Scan scans path recursively and returns any detected infections. A clean
+	// scan and an infected scan both succeed (inspect ScanResult); only an engine
+	// failure returns an error.
+	Scan(ctx context.Context, path string) (ScanResult, error)
+	// UpdateSignatures refreshes the engine's signature database.
+	UpdateSignatures(ctx context.Context) error
+	// Version reports the engine and signature-database versions.
+	Version(ctx context.Context) (Version, error)
+}
+
+// New returns a Manager for the named backend, driven by runner. Pure: validates
+// the backend; nil runner and unknown backend are rejected.
+func New(b Backend, runner exec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("antivirus: runner is required")
+	}
+	switch b {
+	case ClamAV:
+		return &clamavManager{r: runner}, nil
+	default:
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+}
+
+// validatePath rejects a scan path that is unsafe as a positional argument.
+func validatePath(path string) error {
+	if path == "" || strings.HasPrefix(path, "-") || strings.ContainsRune(path, 0) {
+		return fmt.Errorf("%w: %q", ErrInvalidPath, path)
+	}
+	return nil
+}

--- a/go/sys/antivirus/antivirus_test.go
+++ b/go/sys/antivirus/antivirus_test.go
@@ -165,6 +165,44 @@ func TestVersion_Errors(t *testing.T) {
 	}
 }
 
+func TestParseClamscanVersion(t *testing.T) {
+	// Contract: accept ONLY the canonical "ClamAV <engine>/<sig>[/<date>]" line —
+	// the literal "ClamAV " prefix is required and BOTH engine and signature must
+	// be present and non-empty. The rejection cases are derived from that contract
+	// (a version line must carry the prefix + both fields), not from the parser's
+	// current behaviour, so an under-specified parser is caught.
+	valid := map[string]Version{
+		"ClamAV 1.0.1/27000/Wed Jun 18 09:00:00 2025\n": {Engine: "1.0.1", Signature: "27000"},
+		"  ClamAV 1.0.1/27000  ":                        {Engine: "1.0.1", Signature: "27000"}, // no date, surrounding whitespace
+	}
+	for in, want := range valid {
+		got, err := parseClamscanVersion(in)
+		if err != nil {
+			t.Errorf("parseClamscanVersion(%q) unexpected err: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseClamscanVersion(%q) = %+v, want %+v", in, got, want)
+		}
+	}
+	reject := []string{
+		"",                   // empty
+		"garbage",            // no prefix, no slash
+		"1.0.1/27000",        // missing "ClamAV " prefix entirely
+		"1.0.1/27000/date",   // missing prefix, otherwise full shape
+		"ClamXV 1.0.1/27000", // wrong prefix
+		"ClamAV ",            // prefix only, nothing after
+		"ClamAV 1.0.1",       // engine but no signature field
+		"ClamAV 1.0.1//date", // empty signature
+		"ClamAV /27000/date", // empty engine
+	}
+	for _, in := range reject {
+		if v, err := parseClamscanVersion(in); err == nil {
+			t.Errorf("parseClamscanVersion(%q) = %+v, want error", in, v)
+		}
+	}
+}
+
 func TestParseClamscanInfected_SkipsNoise(t *testing.T) {
 	// Summary/blank lines and malformed FOUND lines are ignored.
 	inf := parseClamscanInfected("\n----------- SCAN SUMMARY -----------\nInfected files: 1\nFOUND\nnoColonButEndsWith FOUND\n/a/b: Sig FOUND\n")

--- a/go/sys/antivirus/antivirus_test.go
+++ b/go/sys/antivirus/antivirus_test.go
@@ -1,0 +1,192 @@
+package antivirus
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+func newClam(t *testing.T) (*clamavManager, *exectest.FakeRunner) {
+	t.Helper()
+	r := exectest.New(exec.Direct)
+	m, err := New(ClamAV, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m.(*clamavManager), r
+}
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(ClamAV, nil); err == nil {
+		t.Error("New(_, nil) returned nil error")
+	}
+}
+
+func TestNew_UnknownBackend(t *testing.T) {
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, exectest.New(exec.Direct)); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	if ClamAV.String() != "clamav" || Backend(0).String() != "Backend(0)" {
+		t.Errorf("String = %q / %q", ClamAV.String(), Backend(0).String())
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	cases := map[string]bool{"/home": true, "/tmp/x": true, "": false, "-rf": false, "/a\x00b": false}
+	for p, valid := range cases {
+		err := validatePath(p)
+		if valid != (err == nil) {
+			t.Errorf("validatePath(%q): err=%v, wantValid=%v", p, err, valid)
+		}
+	}
+}
+
+func TestScan_Clean(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{ExitCode: 0, Stdout: ""}, nil) // clean
+	res, err := m.Scan(context.Background(), "/home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Clean() || res.Path != "/home" {
+		t.Errorf("res = %+v, want clean for /home", res)
+	}
+	argv := strings.Join(r.Calls()[0].Args, " ")
+	if argv != "-r --no-summary --infected -- /home" || !r.Calls()[0].Escalate {
+		t.Errorf("scan argv = %q (escalate=%v)", argv, r.Calls()[0].Escalate)
+	}
+}
+
+func TestScan_Infected(t *testing.T) {
+	m, r := newClam(t)
+	// Exit 1 = found (NOT an error).
+	r.Push(exec.Result{ExitCode: 1, Stdout: "/home/u/evil.com: Win.Test.EICAR_HDB-1 FOUND\n/home/u/x.bin: Unix.Trojan.Foo-2 FOUND\n"}, nil)
+	res, err := m.Scan(context.Background(), "/home")
+	if err != nil {
+		t.Fatalf("exit 1 (infected) must not be an error: %v", err)
+	}
+	if res.Clean() || len(res.Infected) != 2 {
+		t.Fatalf("infected = %+v, want 2", res.Infected)
+	}
+	if res.Infected[0] != (Infection{File: "/home/u/evil.com", Signature: "Win.Test.EICAR_HDB-1"}) {
+		t.Errorf("infection[0] = %+v", res.Infected[0])
+	}
+	if res.Infected[1].Signature != "Unix.Trojan.Foo-2" {
+		t.Errorf("infection[1] = %+v", res.Infected[1])
+	}
+}
+
+func TestScan_EngineError(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{ExitCode: 2, Stderr: "database not found"}, nil) // exit 2 = error
+	if _, err := m.Scan(context.Background(), "/home"); err == nil {
+		t.Error("exit 2 must be an error")
+	}
+}
+
+func TestScan_BadPath(t *testing.T) {
+	m, r := newClam(t)
+	if _, err := m.Scan(context.Background(), "-rf"); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("err = %v, want ErrInvalidPath", err)
+	}
+	if len(r.Calls()) != 0 {
+		t.Error("a bad path must run nothing")
+	}
+}
+
+func TestScan_RunError(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{}, errors.New("clamscan not found"))
+	if _, err := m.Scan(context.Background(), "/home"); err == nil {
+		t.Error("a Runner error must surface")
+	}
+}
+
+func TestUpdateSignatures(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{ExitCode: 0}, nil)
+	if err := m.UpdateSignatures(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if r.Calls()[0].Name != "freshclam" || !r.Calls()[0].Escalate {
+		t.Errorf("update call = %+v, want escalated freshclam", r.Calls()[0])
+	}
+}
+
+func TestUpdateSignatures_Errors(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "mirror error"}, nil)
+	if err := m.UpdateSignatures(context.Background()); err == nil {
+		t.Error("a non-zero freshclam exit must error")
+	}
+	r.Push(exec.Result{}, errors.New("gone"))
+	if err := m.UpdateSignatures(context.Background()); err == nil {
+		t.Error("a Runner error must surface")
+	}
+}
+
+func TestVersion(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{Stdout: "ClamAV 1.0.1/27000/Wed Jun 18 09:00:00 2025\n"}, nil)
+	v, err := m.Version(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Engine != "1.0.1" || v.Signature != "27000" {
+		t.Errorf("version = %+v, want engine 1.0.1 / sig 27000", v)
+	}
+	if r.Calls()[0].Escalate {
+		t.Error("Version must not escalate")
+	}
+}
+
+func TestVersion_Errors(t *testing.T) {
+	m, r := newClam(t)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "x"}, nil)
+	if _, err := m.Version(context.Background()); err == nil {
+		t.Error("non-zero exit must error")
+	}
+	r.Push(exec.Result{}, errors.New("gone"))
+	if _, err := m.Version(context.Background()); err == nil {
+		t.Error("Runner error must surface")
+	}
+	r.Push(exec.Result{Stdout: "garbage"}, nil)
+	if _, err := m.Version(context.Background()); err == nil {
+		t.Error("unparseable version must error")
+	}
+}
+
+func TestParseClamscanInfected_SkipsNoise(t *testing.T) {
+	// Summary/blank lines and malformed FOUND lines are ignored.
+	inf := parseClamscanInfected("\n----------- SCAN SUMMARY -----------\nInfected files: 1\nFOUND\nnoColonButEndsWith FOUND\n/a/b: Sig FOUND\n")
+	if len(inf) != 1 || inf[0].File != "/a/b" {
+		t.Errorf("parsed = %+v, want one /a/b (noise + a FOUND line lacking ': ' skipped)", inf)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(string) (string, error) { return "", errors.New("no") }
+	if got := Detect(context.Background()); len(got) != 0 {
+		t.Errorf("Detect (absent) = %v, want empty", got)
+	}
+	lookPath = func(name string) (string, error) {
+		if name == "clamscan" {
+			return "/usr/bin/clamscan", nil
+		}
+		return "", errors.New("no")
+	}
+	if got := Detect(context.Background()); len(got) != 1 || got[0] != ClamAV {
+		t.Errorf("Detect (present) = %v, want [ClamAV]", got)
+	}
+}

--- a/go/sys/antivirus/clamav.go
+++ b/go/sys/antivirus/clamav.go
@@ -82,9 +82,12 @@ func parseClamscanInfected(out string) []Infection {
 // parseClamscanVersion parses the "ClamAV <engine>/<sig>/<date>" version line.
 func parseClamscanVersion(out string) (Version, error) {
 	line := strings.TrimSpace(out)
+	if !strings.HasPrefix(line, "ClamAV ") {
+		return Version{}, fmt.Errorf("antivirus: unexpected clamscan --version output: %q", out)
+	}
 	line = strings.TrimPrefix(line, "ClamAV ")
 	parts := strings.SplitN(line, "/", 3)
-	if len(parts) < 2 || parts[0] == "" {
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return Version{}, fmt.Errorf("antivirus: unexpected clamscan --version output: %q", out)
 	}
 	return Version{Engine: parts[0], Signature: parts[1]}, nil

--- a/go/sys/antivirus/clamav.go
+++ b/go/sys/antivirus/clamav.go
@@ -1,0 +1,91 @@
+package antivirus
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// clamavManager drives ClamAV via clamscan + freshclam.
+type clamavManager struct {
+	r exec.Runner
+}
+
+// Scan runs `clamscan -r --no-summary --infected -- <path>`. clamscan's exit
+// codes: 0 = clean, 1 = virus(es) found, 2 = error. Exit 1 is NOT a failure — it
+// is the "found something" signal — so 0 and 1 both parse the infected lines;
+// only exit 2 (or a Runner failure) is an error.
+func (m *clamavManager) Scan(ctx context.Context, path string) (ScanResult, error) {
+	if err := validatePath(path); err != nil {
+		return ScanResult{}, err
+	}
+	args := append([]string{"-r", "--no-summary", "--infected"}, exec.SeparatePositionals(nil, path)...)
+	res, err := m.r.Run(ctx, exec.Command{Name: "clamscan", Args: args, Escalate: true})
+	if err != nil {
+		return ScanResult{}, fmt.Errorf("antivirus: run clamscan: %w", err)
+	}
+	if res.ExitCode != 0 && res.ExitCode != 1 {
+		return ScanResult{}, &exec.CommandError{Name: "clamscan", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return ScanResult{Path: path, Infected: parseClamscanInfected(res.Stdout)}, nil
+}
+
+// UpdateSignatures runs freshclam to refresh the signature database.
+func (m *clamavManager) UpdateSignatures(ctx context.Context) error {
+	res, err := m.r.Run(ctx, exec.Command{Name: "freshclam", Escalate: true})
+	if err != nil {
+		return fmt.Errorf("antivirus: run freshclam: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return &exec.CommandError{Name: "freshclam", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return nil
+}
+
+// Version parses `clamscan --version` (unprivileged), e.g.
+// "ClamAV 1.0.1/27000/Wed Jun 18 09:00:00 2025".
+func (m *clamavManager) Version(ctx context.Context) (Version, error) {
+	res, err := m.r.Run(ctx, exec.Command{Name: "clamscan", Args: []string{"--version"}})
+	if err != nil {
+		return Version{}, fmt.Errorf("antivirus: run clamscan --version: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return Version{}, &exec.CommandError{Name: "clamscan", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return parseClamscanVersion(res.Stdout)
+}
+
+// parseClamscanInfected extracts (file, signature) pairs from clamscan
+// --infected output lines of the form "<file>: <signature> FOUND".
+func parseClamscanInfected(out string) []Infection {
+	var infected []Infection
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		rest, ok := strings.CutSuffix(line, " FOUND")
+		if !ok {
+			continue
+		}
+		// The signature carries no ": ", so the LAST ": " separates file from
+		// signature (a path may contain a colon, but not the "<colon><space>"
+		// pair clamscan emits).
+		i := strings.LastIndex(rest, ": ")
+		if i < 0 {
+			continue
+		}
+		infected = append(infected, Infection{File: rest[:i], Signature: rest[i+2:]})
+	}
+	return infected
+}
+
+// parseClamscanVersion parses the "ClamAV <engine>/<sig>/<date>" version line.
+func parseClamscanVersion(out string) (Version, error) {
+	line := strings.TrimSpace(out)
+	line = strings.TrimPrefix(line, "ClamAV ")
+	parts := strings.SplitN(line, "/", 3)
+	if len(parts) < 2 || parts[0] == "" {
+		return Version{}, fmt.Errorf("antivirus: unexpected clamscan --version output: %q", out)
+	}
+	return Version{Engine: parts[0], Signature: parts[1]}, nil
+}

--- a/go/sys/antivirus/detect.go
+++ b/go/sys/antivirus/detect.go
@@ -1,0 +1,21 @@
+package antivirus
+
+import (
+	"context"
+	osexec "os/exec"
+)
+
+// lookPath is a package-var seam so Detect is deterministically testable.
+var lookPath = osexec.LookPath
+
+// Detect reports the AV backends usable on THIS host: ClamAV when clamscan is on
+// PATH. It lists; the consumer picks one and passes it to New.
+//
+// The ctx is accepted for signature uniformity; the probe is a pure PATH lookup.
+func Detect(ctx context.Context) []Backend {
+	_ = ctx
+	if _, err := lookPath("clamscan"); err != nil {
+		return nil
+	}
+	return []Backend{ClamAV}
+}

--- a/go/sys/antivirus/example_test.go
+++ b/go/sys/antivirus/example_test.go
@@ -1,0 +1,32 @@
+package antivirus_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/antivirus"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// ExampleNew updates signatures then scans a path, printing any detections.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Direct) // a full scan / update needs root
+	if err != nil {
+		log.Fatal(err)
+	}
+	m, err := antivirus.New(antivirus.ClamAV, r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := m.UpdateSignatures(context.Background()); err != nil {
+		log.Print(err) // non-fatal: scan with current signatures anyway
+	}
+	res, err := m.Scan(context.Background(), "/home")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, inf := range res.Infected {
+		fmt.Printf("%s: %s\n", inf.File, inf.Signature)
+	}
+}

--- a/go/sys/antivirus/integration_test.go
+++ b/go/sys/antivirus/integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package antivirus_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/antivirus"
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// READ-ONLY: Detect + Version against a real clamscan if present. No Scan/Update
+// (a full scan / signature pull is slow and network-bound).
+func TestVersion_Integration(t *testing.T) {
+	for _, b := range antivirus.Detect(context.Background()) {
+		if b != antivirus.ClamAV {
+			t.Errorf("Detect returned unexpected backend %v", b)
+		}
+	}
+	if _, err := exec.LookPath("clamscan"); err != nil {
+		t.Skip("clamscan not present")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	m, err := antivirus.New(antivirus.ClamAV, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	v, err := m.Version(context.Background())
+	if err != nil {
+		t.Fatalf("Version against real clamscan: %v", err)
+	}
+	if v.Engine == "" {
+		t.Errorf("Version().Engine empty: %+v", v)
+	}
+}


### PR DESCRIPTION
Closes #160. Antivirus management in the rework Manager idiom over the injected Runner — the **configure/operate** half of AV (scan / update signatures / version), complementary to an alert-ingestion/SIEM path (e.g. server#48).

## Surface
- `New(b Backend, runner exec.Runner) (Manager, error)` — pure, fail-closed nil runner + `ErrUnknownBackend`. Backend: `ClamAV` (only implemented).
- `Scan(ctx, path) (ScanResult, error)` — `clamscan -r --no-summary --infected -- <path>`. **clamscan exit 1 = "infected found" (NOT an error)** vs 2 = engine error — both 0 and 1 parse the `<file>: <sig> FOUND` lines; only 2 errors. Path validated (no flag/NUL); escalated. `ScanResult.Clean()` + `Infected []{File, Signature}`.
- `UpdateSignatures(ctx)` — `freshclam`, escalated.
- `Version(ctx) (Version)` — engine + signature DB version from `clamscan --version`, unprivileged.
- **Out of V1 scope (documented):** on-access/real-time protection (ClamAV's clamonacc needs fanotify config) and EDR engines (Defender/Falcon/SentinelOne — cloud APIs, a much bigger lift than a CLI backend).

## Tests
- **100% statement coverage** (FakeRunner argv + clean/infected/error exit codes + version parse + every error path), read-only integration leg (Detect + Version) + `Example`. Passes the no-global-backend fitness function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Antivirus scanning capability with ClamAV backend support
  * Automatic detection and initialization of available antivirus tools
  * Signature update functionality
  * Engine and signature version reporting

* **Tests**
  * Comprehensive test suite with integration tests for system-level verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->