### PR TITLE
feat(sys): catrust capability — manage system CA trust anchors (#162)

### DIFF
--- a/go/sys/catrust/catrust.go
+++ b/go/sys/catrust/catrust.go
@@ -1,0 +1,229 @@
+// Package catrust manages the host's system-wide CA trust anchors through an
+// injected exec.Runner (plus the fs.Manager for the privileged file writes).
+//
+//	r, _ := exec.NewRunner(exec.Direct) // writing trust anchors needs root
+//	m, err := catrust.New(catrust.CaCertificates, r)
+//	if err != nil { ... }
+//	err = m.Install(ctx, "acme-corp-root", pemBytes) // every TLS client now trusts it
+//
+// This installs/removes an operator-supplied CA into the system trust store — the
+// mechanism for distributing a private/internal CA across a fleet so devices
+// trust internal services or a TLS-inspecting proxy. It is a high-trust,
+// privilege-amplifying operation: a CA the host trusts can transparently MITM any
+// TLS connection, so Install validates the certificate (well-formed, IsCA,
+// currently valid) and the name (safe filename) BEFORE writing. Authorization of
+// the request itself is the caller's concern (the agent gates it with a CA-signed
+// action, as for other sensitive ops).
+//
+// Two backends: CaCertificates (Debian/Ubuntu) and P11Kit (Fedora/RHEL/SUSE).
+// Distrusting a distro-shipped root (a separate blocklist mechanism) is out of
+// scope — this manages anchors WE add.
+package catrust
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/fs"
+)
+
+// Backend selects the trust-store mechanism. Zero is invalid; only implemented
+// backends exist.
+type Backend int
+
+const (
+	// CaCertificates is the Debian/Ubuntu update-ca-certificates flow.
+	CaCertificates Backend = iota + 1
+	// P11Kit is the Fedora/RHEL/SUSE p11-kit update-ca-trust flow.
+	P11Kit
+)
+
+// String renders the backend as its canonical name.
+func (b Backend) String() string {
+	switch b {
+	case CaCertificates:
+		return "ca-certificates"
+	case P11Kit:
+		return "p11-kit"
+	default:
+		return fmt.Sprintf("Backend(%d)", int(b))
+	}
+}
+
+// ErrUnknownBackend is returned by New for the zero value or any unimplemented
+// backend.
+var ErrUnknownBackend = errors.New("catrust: unknown backend")
+
+// Anchor is an installed trust anchor this package manages.
+type Anchor struct {
+	Name    string // the operator-chosen name (the anchor's filename without .crt)
+	Subject string // certificate subject DN
+	Issuer  string // certificate issuer DN
+}
+
+// Manager is the CA-trust surface.
+type Manager interface {
+	// Install adds (or replaces) a CA anchor under name. certPEM must be a single
+	// PEM CA certificate; it is validated before being written.
+	Install(ctx context.Context, name string, certPEM []byte) error
+	// Remove deletes the anchor previously installed under name and refreshes the
+	// trust store. It is idempotent: removing an absent name is a no-op success.
+	Remove(ctx context.Context, name string) error
+	// List reports the anchors this package manages (not the full system bundle).
+	List(ctx context.Context) ([]Anchor, error)
+}
+
+// backendConfig captures the per-backend file location + refresh commands. The
+// install and remove refreshes differ for ca-certificates (a plain run adds; a
+// --fresh run rebuilds without a removed file); p11-kit's extract is a full
+// idempotent rebuild for both.
+type backendConfig struct {
+	anchorsDir     string
+	installRefresh []string // [name, args...]
+	removeRefresh  []string
+}
+
+var backends = map[Backend]backendConfig{
+	CaCertificates: {
+		anchorsDir:     "/usr/local/share/ca-certificates",
+		installRefresh: []string{"update-ca-certificates"},
+		removeRefresh:  []string{"update-ca-certificates", "--fresh"},
+	},
+	P11Kit: {
+		anchorsDir:     "/etc/pki/ca-trust/source/anchors",
+		installRefresh: []string{"update-ca-trust", "extract"},
+		removeRefresh:  []string{"update-ca-trust", "extract"},
+	},
+}
+
+// fsManager is the narrow slice of fs.Manager catrust uses for the privileged
+// anchor writes/removes; a small interface so tests inject a fake via newFS.
+type fsManager interface {
+	WriteFile(ctx context.Context, path string, data []byte, opts fs.WriteOptions) error
+	Remove(ctx context.Context, path string) error
+}
+
+// newFS builds the fs.Manager over the same Runner. A package var for tests.
+var newFS = func(r exec.Runner) (fsManager, error) { return fs.New(r) }
+
+// Read seams (the anchors dirs are world-readable, so List needs no escalation).
+var (
+	readDir  = os.ReadDir
+	readFile = os.ReadFile
+)
+
+type manager struct {
+	r   exec.Runner
+	fsm fsManager
+	cfg backendConfig
+}
+
+// New returns a Manager for the named backend. Pure: validates the backend; nil
+// runner and unknown backend are rejected.
+func New(b Backend, runner exec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, errors.New("catrust: runner is required")
+	}
+	cfg, ok := backends[b]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
+	}
+	fsm, err := newFS(runner)
+	if err != nil {
+		return nil, err
+	}
+	return &manager{r: runner, fsm: fsm, cfg: cfg}, nil
+}
+
+// anchorPath is the on-disk path for a named anchor.
+func (m *manager) anchorPath(name string) string {
+	return m.cfg.anchorsDir + "/" + name + anchorExt
+}
+
+const anchorExt = ".crt"
+
+// Install validates name + certPEM, writes the anchor, and refreshes the store.
+func (m *manager) Install(ctx context.Context, name string, certPEM []byte) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if err := validateCACert(certPEM); err != nil {
+		return err
+	}
+	path := m.anchorPath(name)
+	if err := m.fsm.WriteFile(ctx, path, certPEM, fs.WriteOptions{Mode: 0o644, Owner: "root", Group: "root"}); err != nil {
+		return fmt.Errorf("catrust: write %s: %w", path, err)
+	}
+	if err := m.refresh(ctx, m.cfg.installRefresh); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Remove deletes the named anchor (idempotent) and refreshes the store.
+func (m *manager) Remove(ctx context.Context, name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	path := m.anchorPath(name)
+	if _, err := readFile(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil // already absent — nothing to do
+		}
+		return fmt.Errorf("catrust: stat %s: %w", path, err)
+	}
+	if err := m.fsm.Remove(ctx, path); err != nil {
+		return fmt.Errorf("catrust: remove %s: %w", path, err)
+	}
+	if err := m.refresh(ctx, m.cfg.removeRefresh); err != nil {
+		return err
+	}
+	return nil
+}
+
+// List enumerates the managed anchors by parsing the .crt files in the backend's
+// anchors dir. A missing dir means none. Unparseable files are skipped.
+func (m *manager) List(ctx context.Context) ([]Anchor, error) {
+	entries, err := readDir(m.cfg.anchorsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Anchor{}, nil
+		}
+		return nil, fmt.Errorf("catrust: read %s: %w", m.cfg.anchorsDir, err)
+	}
+	out := make([]Anchor, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !hasAnchorExt(e.Name()) {
+			continue
+		}
+		data, err := readFile(m.cfg.anchorsDir + "/" + e.Name())
+		if err != nil {
+			continue
+		}
+		cert, err := parseCert(data)
+		if err != nil {
+			continue
+		}
+		out = append(out, Anchor{
+			Name:    e.Name()[:len(e.Name())-len(anchorExt)],
+			Subject: cert.Subject.String(),
+			Issuer:  cert.Issuer.String(),
+		})
+	}
+	return out, nil
+}
+
+// refresh runs the backend's escalated trust-store rebuild command.
+func (m *manager) refresh(ctx context.Context, cmd []string) error {
+	res, err := m.r.Run(ctx, exec.Command{Name: cmd[0], Args: cmd[1:], Escalate: true})
+	if err != nil {
+		return fmt.Errorf("catrust: run %s: %w", cmd[0], err)
+	}
+	if res.ExitCode != 0 {
+		return &exec.CommandError{Name: cmd[0], ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return nil
+}

--- a/go/sys/catrust/catrust_test.go
+++ b/go/sys/catrust/catrust_test.go
@@ -1,0 +1,435 @@
+package catrust
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io/fs"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+	sdkfs "github.com/manchtools/power-manage/sdk/go/sys/fs"
+)
+
+// genCert builds a self-signed cert PEM with the given CA flag and validity
+// window — the fixture for the validation matrix and the List parse.
+func genCert(t *testing.T, cn string, isCA bool, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn, Organization: []string{"Test"}},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func validCAPEM(t *testing.T) []byte {
+	return genCert(t, "ACME Root", true, time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour))
+}
+
+// fakeFS records WriteFile/Remove calls and replays scripted errors.
+type fakeFS struct {
+	writes    []fakeWrite
+	removed   []string
+	writeErr  error
+	removeErr error
+}
+type fakeWrite struct {
+	path string
+	data []byte
+	opts sdkfs.WriteOptions
+}
+
+func (f *fakeFS) WriteFile(_ context.Context, path string, data []byte, opts sdkfs.WriteOptions) error {
+	f.writes = append(f.writes, fakeWrite{path, data, opts})
+	return f.writeErr
+}
+func (f *fakeFS) Remove(_ context.Context, path string) error {
+	f.removed = append(f.removed, path)
+	return f.removeErr
+}
+
+func withFakeFS(t *testing.T, ff *fakeFS) {
+	t.Helper()
+	prev := newFS
+	t.Cleanup(func() { newFS = prev })
+	newFS = func(exec.Runner) (fsManager, error) { return ff, nil }
+}
+
+func newMgr(t *testing.T, b Backend, ff *fakeFS) (*manager, *exectest.FakeRunner) {
+	t.Helper()
+	withFakeFS(t, ff)
+	r := exectest.New(exec.Direct)
+	m, err := New(b, r)
+	if err != nil {
+		t.Fatalf("New(%v): %v", b, err)
+	}
+	return m.(*manager), r
+}
+
+func TestNew_NilRunner(t *testing.T) {
+	if _, err := New(CaCertificates, nil); err == nil {
+		t.Error("New(_, nil) returned nil error")
+	}
+}
+
+func TestNew_UnknownBackend(t *testing.T) {
+	for _, b := range []Backend{0, Backend(-1), Backend(99)} {
+		if _, err := New(b, exectest.New(exec.Direct)); !errors.Is(err, ErrUnknownBackend) {
+			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
+		}
+	}
+}
+
+func TestNew_Backends(t *testing.T) {
+	withFakeFS(t, &fakeFS{})
+	for _, b := range []Backend{CaCertificates, P11Kit} {
+		if _, err := New(b, exectest.New(exec.Direct)); err != nil {
+			t.Errorf("New(%v): %v", b, err)
+		}
+	}
+}
+
+// TestNew_UsesRealFS exercises the production newFS closure (fs.New) — the other
+// tests stub it.
+func TestNew_UsesRealFS(t *testing.T) {
+	if _, err := New(CaCertificates, exectest.New(exec.Direct)); err != nil {
+		t.Errorf("New with the real fs.Manager: %v", err)
+	}
+}
+
+func TestNew_PropagatesFSError(t *testing.T) {
+	prev := newFS
+	t.Cleanup(func() { newFS = prev })
+	sentinel := errors.New("fs boom")
+	newFS = func(exec.Runner) (fsManager, error) { return nil, sentinel }
+	if _, err := New(CaCertificates, exectest.New(exec.Direct)); !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want the fs error", err)
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	cases := map[Backend]string{CaCertificates: "ca-certificates", P11Kit: "p11-kit", Backend(0): "Backend(0)"}
+	for b, want := range cases {
+		if got := b.String(); got != want {
+			t.Errorf("Backend(%d).String() = %q, want %q", int(b), got, want)
+		}
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	cases := map[string]bool{
+		"acme-corp-root": true, "ca_1.crt": true, "A": true,
+		"": false, "-x": false, "a/b": false, "../etc/x": false, "a..b": false,
+		strings.Repeat("a", 64): false,
+	}
+	for name, valid := range cases {
+		err := validateName(name)
+		if valid != (err == nil) {
+			t.Errorf("validateName(%q): err=%v wantValid=%v", name, err, valid)
+		}
+	}
+}
+
+func TestValidateCACert(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name    string
+		pem     []byte
+		wantErr bool
+	}{
+		{"valid CA", genCert(t, "CA", true, now.Add(-time.Hour), now.Add(time.Hour)), false},
+		{"not a CA (leaf)", genCert(t, "leaf", false, now.Add(-time.Hour), now.Add(time.Hour)), true},
+		{"expired", genCert(t, "old", true, now.Add(-48*time.Hour), now.Add(-time.Hour)), true},
+		{"not yet valid", genCert(t, "future", true, now.Add(time.Hour), now.Add(48*time.Hour)), true},
+		{"garbage", []byte("not a pem"), true},
+		{"wrong pem type", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte{1, 2, 3}}), true},
+		{"corrupt der", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte{1, 2, 3}}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCACert(tc.pem)
+			if tc.wantErr && !errors.Is(err, ErrInvalidCert) {
+				t.Errorf("validateCACert = %v, want ErrInvalidCert", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateCACert = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestInstall_CaCertificates(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, CaCertificates, ff)
+	r.Push(exec.Result{}, nil) // update-ca-certificates
+	cert := validCAPEM(t)
+	if err := m.Install(context.Background(), "acme-root", cert); err != nil {
+		t.Fatal(err)
+	}
+	if len(ff.writes) != 1 || ff.writes[0].path != "/usr/local/share/ca-certificates/acme-root.crt" {
+		t.Fatalf("writes = %v", ff.writes)
+	}
+	if string(ff.writes[0].data) != string(cert) || ff.writes[0].opts.Owner != "root" {
+		t.Errorf("write data/opts wrong: %+v", ff.writes[0].opts)
+	}
+	c := r.Calls()[0]
+	if strings.Join(append([]string{c.Name}, c.Args...), " ") != "update-ca-certificates" || !c.Escalate {
+		t.Errorf("refresh = %v (escalate=%v), want escalated update-ca-certificates", append([]string{c.Name}, c.Args...), c.Escalate)
+	}
+}
+
+func TestInstall_P11Kit(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, P11Kit, ff)
+	r.Push(exec.Result{}, nil)
+	if err := m.Install(context.Background(), "acme-root", validCAPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	if ff.writes[0].path != "/etc/pki/ca-trust/source/anchors/acme-root.crt" {
+		t.Errorf("p11kit path = %q", ff.writes[0].path)
+	}
+	c := r.Calls()[0]
+	if strings.Join(append([]string{c.Name}, c.Args...), " ") != "update-ca-trust extract" {
+		t.Errorf("p11kit refresh = %v", append([]string{c.Name}, c.Args...))
+	}
+}
+
+func TestInstall_Rejections(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, CaCertificates, ff)
+	if err := m.Install(context.Background(), "-bad", validCAPEM(t)); !errors.Is(err, ErrInvalidName) {
+		t.Errorf("bad name err = %v", err)
+	}
+	if err := m.Install(context.Background(), "ok", []byte("garbage")); !errors.Is(err, ErrInvalidCert) {
+		t.Errorf("bad cert err = %v", err)
+	}
+	if len(ff.writes) != 0 || len(r.Calls()) != 0 {
+		t.Error("a rejected Install must write nothing and run nothing")
+	}
+}
+
+func TestInstall_WriteAndRefreshErrors(t *testing.T) {
+	m, _ := newMgr(t, CaCertificates, &fakeFS{writeErr: errors.New("ro fs")})
+	if err := m.Install(context.Background(), "x", validCAPEM(t)); err == nil {
+		t.Error("a write failure must propagate")
+	}
+	ff := &fakeFS{}
+	m2, r := newMgr(t, CaCertificates, ff)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+	if err := m2.Install(context.Background(), "x", validCAPEM(t)); err == nil {
+		t.Error("a refresh non-zero exit must propagate")
+	}
+	// refresh Runner error (e.g. update-ca-certificates not installed)
+	ff3 := &fakeFS{}
+	m3, r3 := newMgr(t, CaCertificates, ff3)
+	r3.Push(exec.Result{}, errors.New("update-ca-certificates not found"))
+	if err := m3.Install(context.Background(), "x", validCAPEM(t)); err == nil {
+		t.Error("a refresh Runner error must propagate")
+	}
+}
+
+func TestRemove_Success(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, CaCertificates, ff)
+	prev := readFile
+	t.Cleanup(func() { readFile = prev })
+	readFile = func(string) ([]byte, error) { return []byte("present"), nil } // exists
+	r.Push(exec.Result{}, nil)                                                // update-ca-certificates --fresh
+	if err := m.Remove(context.Background(), "acme-root"); err != nil {
+		t.Fatal(err)
+	}
+	if len(ff.removed) != 1 || ff.removed[0] != "/usr/local/share/ca-certificates/acme-root.crt" {
+		t.Fatalf("removed = %v", ff.removed)
+	}
+	c := r.Calls()[0]
+	if strings.Join(append([]string{c.Name}, c.Args...), " ") != "update-ca-certificates --fresh" || !c.Escalate {
+		t.Errorf("remove refresh = %v", append([]string{c.Name}, c.Args...))
+	}
+}
+
+func TestRemove_IdempotentWhenAbsent(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, CaCertificates, ff)
+	prev := readFile
+	t.Cleanup(func() { readFile = prev })
+	readFile = func(string) ([]byte, error) { return nil, os.ErrNotExist }
+	if err := m.Remove(context.Background(), "absent"); err != nil {
+		t.Errorf("removing an absent anchor must be a no-op success, got %v", err)
+	}
+	if len(ff.removed) != 0 || len(r.Calls()) != 0 {
+		t.Error("absent remove must do nothing")
+	}
+}
+
+func TestRemove_Errors(t *testing.T) {
+	prev := readFile
+	t.Cleanup(func() { readFile = prev })
+
+	// stat error other than not-exist
+	ff := &fakeFS{}
+	m, _ := newMgr(t, CaCertificates, ff)
+	readFile = func(string) ([]byte, error) { return nil, errors.New("permission denied") }
+	if err := m.Remove(context.Background(), "x"); err == nil {
+		t.Error("a non-notexist stat error must propagate")
+	}
+
+	// remove error
+	readFile = func(string) ([]byte, error) { return []byte("x"), nil }
+	ff2 := &fakeFS{removeErr: errors.New("rm failed")}
+	m2, _ := newMgr(t, CaCertificates, ff2)
+	if err := m2.Remove(context.Background(), "x"); err == nil {
+		t.Error("a remove error must propagate")
+	}
+
+	// refresh error
+	ff3 := &fakeFS{}
+	m3, r := newMgr(t, CaCertificates, ff3)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "boom"}, nil)
+	if err := m3.Remove(context.Background(), "x"); err == nil {
+		t.Error("a refresh error must propagate")
+	}
+
+	// bad name
+	m4, _ := newMgr(t, CaCertificates, &fakeFS{})
+	if err := m4.Remove(context.Background(), "-bad"); !errors.Is(err, ErrInvalidName) {
+		t.Errorf("bad name err = %v", err)
+	}
+}
+
+// fakeDirEntry is a minimal os.DirEntry for List tests.
+type fakeDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e fakeDirEntry) Name() string               { return e.name }
+func (e fakeDirEntry) IsDir() bool                { return e.dir }
+func (e fakeDirEntry) Type() fs.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+func TestList(t *testing.T) {
+	ff := &fakeFS{}
+	m, _ := newMgr(t, CaCertificates, ff)
+	caPEM := validCAPEM(t)
+
+	prevRD, prevRF := readDir, readFile
+	t.Cleanup(func() { readDir, readFile = prevRD, prevRF })
+	readDir = func(string) ([]os.DirEntry, error) {
+		return []os.DirEntry{
+			fakeDirEntry{name: "acme-root.crt"},
+			fakeDirEntry{name: "subdir", dir: true}, // skipped
+			fakeDirEntry{name: "README.txt"},        // non-.crt, skipped
+			fakeDirEntry{name: "corrupt.crt"},       // unparseable, skipped
+		}, nil
+	}
+	readFile = func(path string) ([]byte, error) {
+		if strings.HasSuffix(path, "acme-root.crt") {
+			return caPEM, nil
+		}
+		if strings.HasSuffix(path, "corrupt.crt") {
+			return []byte("not a cert"), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	got, err := m.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "acme-root" || !strings.Contains(got[0].Subject, "ACME Root") {
+		t.Fatalf("List = %+v, want one acme-root anchor", got)
+	}
+}
+
+func TestList_MissingDirIsEmpty(t *testing.T) {
+	m, _ := newMgr(t, CaCertificates, &fakeFS{})
+	prev := readDir
+	t.Cleanup(func() { readDir = prev })
+	readDir = func(string) ([]os.DirEntry, error) { return nil, os.ErrNotExist }
+	got, err := m.List(context.Background())
+	if err != nil || got == nil || len(got) != 0 {
+		t.Errorf("List(missing dir) = (%v,%v), want empty non-nil", got, err)
+	}
+}
+
+func TestList_ReadDirError(t *testing.T) {
+	m, _ := newMgr(t, CaCertificates, &fakeFS{})
+	prev := readDir
+	t.Cleanup(func() { readDir = prev })
+	readDir = func(string) ([]os.DirEntry, error) { return nil, errors.New("permission denied") }
+	if _, err := m.List(context.Background()); err == nil {
+		t.Error("a non-notexist readDir error must propagate")
+	}
+}
+
+// readFile-error-while-listing skips that entry (covered: corrupt.crt path
+// returns ErrNotExist in TestList and is skipped).
+func TestList_ReadFileErrorSkipsEntry(t *testing.T) {
+	m, _ := newMgr(t, CaCertificates, &fakeFS{})
+	prevRD, prevRF := readDir, readFile
+	t.Cleanup(func() { readDir, readFile = prevRD, prevRF })
+	readDir = func(string) ([]os.DirEntry, error) {
+		return []os.DirEntry{fakeDirEntry{name: "unreadable.crt"}}, nil
+	}
+	readFile = func(string) ([]byte, error) { return nil, errors.New("EACCES") }
+	got, err := m.List(context.Background())
+	if err != nil || len(got) != 0 {
+		t.Errorf("List = (%v,%v), want empty (unreadable entry skipped)", got, err)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		name    string
+		present map[string]bool
+		want    []Backend
+	}{
+		{"none", map[string]bool{}, nil},
+		{"debian", map[string]bool{"update-ca-certificates": true}, []Backend{CaCertificates}},
+		{"fedora", map[string]bool{"update-ca-trust": true}, []Backend{P11Kit}},
+		{"both", map[string]bool{"update-ca-certificates": true, "update-ca-trust": true}, []Backend{CaCertificates, P11Kit}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := lookPath
+			t.Cleanup(func() { lookPath = prev })
+			lookPath = func(name string) (string, error) {
+				if tc.present[name] {
+					return "/usr/sbin/" + name, nil
+				}
+				return "", errors.New("no")
+			}
+			got := Detect(context.Background())
+			if len(got) != len(tc.want) {
+				t.Fatalf("Detect = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("Detect[%d] = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/sys/catrust/detect.go
+++ b/go/sys/catrust/detect.go
@@ -1,0 +1,26 @@
+package catrust
+
+import (
+	"context"
+	osexec "os/exec"
+)
+
+// lookPath is a package-var seam so Detect is deterministically testable.
+var lookPath = osexec.LookPath
+
+// Detect reports the trust-store backends usable on THIS host: CaCertificates
+// when update-ca-certificates is on PATH, P11Kit when update-ca-trust is. It
+// lists; the consumer picks one and passes it to New.
+//
+// The ctx is accepted for signature uniformity; the probe is a pure PATH lookup.
+func Detect(ctx context.Context) []Backend {
+	_ = ctx
+	var out []Backend
+	if _, err := lookPath("update-ca-certificates"); err == nil {
+		out = append(out, CaCertificates)
+	}
+	if _, err := lookPath("update-ca-trust"); err == nil {
+		out = append(out, P11Kit)
+	}
+	return out
+}

--- a/go/sys/catrust/example_test.go
+++ b/go/sys/catrust/example_test.go
@@ -1,0 +1,38 @@
+package catrust_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/catrust"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// ExampleNew installs an org CA into the system trust store, then lists the
+// managed anchors.
+func ExampleNew() {
+	r, err := exec.NewRunner(exec.Direct) // writing trust anchors needs root
+	if err != nil {
+		log.Fatal(err)
+	}
+	m, err := catrust.New(catrust.CaCertificates, r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pem, err := os.ReadFile("/path/to/acme-root.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := m.Install(context.Background(), "acme-corp-root", pem); err != nil {
+		log.Fatal(err)
+	}
+	anchors, err := m.List(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, a := range anchors {
+		fmt.Printf("%s: %s\n", a.Name, a.Subject)
+	}
+}

--- a/go/sys/catrust/integration_test.go
+++ b/go/sys/catrust/integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package catrust_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/catrust"
+	pmexec "github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// bundlePath is the consolidated trust bundle each backend rebuilds — where an
+// installed anchor must actually appear for clients to trust it.
+var bundlePath = map[catrust.Backend]string{
+	catrust.CaCertificates: "/etc/ssl/certs/ca-certificates.crt",
+	catrust.P11Kit:         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+}
+
+// genCA returns a self-signed CA as (PEM, DER) so the test can match the exact
+// certificate inside the system bundle.
+func genCA(t *testing.T) (pemBytes, der []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "PM Integration Test CA", Organization: []string{"power-manage-test"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err = x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), der
+}
+
+// bundleContainsDER reports whether the consolidated bundle holds a cert with
+// the exact DER (resilient to PEM re-encoding/whitespace).
+func bundleContainsDER(t *testing.T, path string, der []byte) bool {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read bundle %s: %v", path, err)
+	}
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			return false
+		}
+		if block.Type == "CERTIFICATE" && bytes.Equal(block.Bytes, der) {
+			return true
+		}
+	}
+}
+
+func integrationRunner(t *testing.T) pmexec.Runner {
+	t.Helper()
+	backend := pmexec.Direct
+	if os.Geteuid() != 0 {
+		if _, err := osexec.LookPath("sudo"); err != nil {
+			t.Skip("not root and no sudo; cannot write trust anchors")
+		}
+		if err := osexec.Command("sudo", "-n", "true").Run(); err != nil {
+			t.Skipf("sudo present but non-interactive escalation unavailable: %v", err)
+		}
+		backend = pmexec.Sudo
+	}
+	r, err := pmexec.NewRunner(backend)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	return r
+}
+
+// TestRoundTrip_Integration is the real end-to-end test: in a disposable
+// container, install a freshly-generated CA, prove it lands in the system trust
+// bundle and List, then remove it and prove it's gone. Runs whichever backend
+// the container ships (CaCertificates on Debian, P11Kit on Fedora).
+func TestRoundTrip_Integration(t *testing.T) {
+	backends := catrust.Detect(context.Background())
+	if len(backends) == 0 {
+		t.Skip("no CA-trust backend on PATH")
+	}
+	r := integrationRunner(t)
+	ctx := context.Background()
+
+	for _, b := range backends {
+		t.Run(b.String(), func(t *testing.T) {
+			m, err := catrust.New(b, r)
+			if err != nil {
+				t.Fatalf("New(%v): %v", b, err)
+			}
+			const name = "pm-integration-test-ca"
+			pemBytes, der := genCA(t)
+			t.Cleanup(func() { _ = m.Remove(ctx, name) })
+
+			if err := m.Install(ctx, name, pemBytes); err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+
+			// List must report it.
+			anchors, err := m.List(ctx)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			found := false
+			for _, a := range anchors {
+				if a.Name == name {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("List does not show the installed anchor %q: %+v", name, anchors)
+			}
+
+			// The real proof: the CA is now in the consolidated system bundle.
+			if bp := bundlePath[b]; bp != "" {
+				if !bundleContainsDER(t, bp, der) {
+					t.Errorf("installed CA not present in system bundle %s", bp)
+				}
+			}
+
+			// Remove and prove it's gone from both List and the bundle.
+			if err := m.Remove(ctx, name); err != nil {
+				t.Fatalf("Remove: %v", err)
+			}
+			anchors, err = m.List(ctx)
+			if err != nil {
+				t.Fatalf("List after remove: %v", err)
+			}
+			for _, a := range anchors {
+				if a.Name == name {
+					t.Errorf("anchor %q still listed after Remove", name)
+				}
+			}
+			if bp := bundlePath[b]; bp != "" {
+				if bundleContainsDER(t, bp, der) {
+					t.Errorf("CA still in system bundle %s after Remove", bp)
+				}
+			}
+		})
+	}
+}

--- a/go/sys/catrust/validate.go
+++ b/go/sys/catrust/validate.go
@@ -1,0 +1,69 @@
+package catrust
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ErrInvalidName is returned when an anchor name is unsafe as a filename.
+var ErrInvalidName = errors.New("catrust: invalid anchor name")
+
+// ErrInvalidCert is returned when the supplied certificate is not a usable CA.
+var ErrInvalidCert = errors.New("catrust: invalid CA certificate")
+
+// validName matches a safe anchor name: leading alphanumeric (never flag-shaped),
+// then alphanumerics plus . _ -, up to 63 chars. It becomes a filename in a
+// root-owned directory, so no '/' and no path traversal.
+var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$`)
+
+// validateName rejects an unsafe anchor name.
+func validateName(name string) error {
+	if !validName.MatchString(name) || strings.Contains(name, "..") {
+		return fmt.Errorf("%w: %q (use [A-Za-z0-9._-], no '/' or '..')", ErrInvalidName, name)
+	}
+	return nil
+}
+
+// validateCACert parses certPEM and requires a well-formed CA certificate that is
+// currently valid. Installing a non-CA or expired cert is virtually always a
+// mistake, so it fails closed.
+func validateCACert(certPEM []byte) error {
+	cert, err := parseCert(certPEM)
+	if err != nil {
+		return err
+	}
+	if !cert.IsCA {
+		return fmt.Errorf("%w: certificate %q is not a CA (BasicConstraints CA=false)", ErrInvalidCert, cert.Subject.CommonName)
+	}
+	now := time.Now()
+	if now.Before(cert.NotBefore) {
+		return fmt.Errorf("%w: certificate is not valid until %s", ErrInvalidCert, cert.NotBefore.UTC())
+	}
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("%w: certificate expired on %s", ErrInvalidCert, cert.NotAfter.UTC())
+	}
+	return nil
+}
+
+// parseCert decodes a single PEM CERTIFICATE block.
+func parseCert(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("%w: input is not a PEM CERTIFICATE block", ErrInvalidCert)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCert, err)
+	}
+	return cert, nil
+}
+
+// hasAnchorExt reports whether a filename is a managed anchor (.crt).
+func hasAnchorExt(name string) bool {
+	return strings.HasSuffix(name, anchorExt)
+}


### PR DESCRIPTION
Closes #162. Install/remove/list an org CA in the **system-wide TLS trust store** — the mechanism for distributing a private/internal CA across a fleet — in the rework Manager idiom over the injected Runner + fs.Manager.

## Surface
- `New(b Backend, runner exec.Runner) (Manager, error)` — pure, fail-closed nil runner + `ErrUnknownBackend`.
- Backends: **CaCertificates** (Debian/Ubuntu: `/usr/local/share/ca-certificates` + `update-ca-certificates`, `--fresh` on remove) and **P11Kit** (Fedora/RHEL/SUSE: `/etc/pki/ca-trust/source/anchors` + `update-ca-trust extract`).
- `Install(ctx, name, certPEM)` / `Remove(ctx, name)` (idempotent) / `List(ctx) []Anchor`, keyed by an operator-chosen `name`.

## Security (high-trust, privilege-amplifying — a trusted CA can MITM all host TLS)
- **Validate-before-write**: `name` must be a safe filename (no `/`, no `..`); `certPEM` must be a well-formed **CA** cert (`x509` parse, `IsCA`, **currently valid** — expired and not-yet-valid are refused). Anchor written root:root via the fs.Manager; the refresh command escalates.
- Authorization of the request stays with the caller (agent CA-signed action). Distrusting distro-shipped roots (a blocklist mechanism) is out of scope.

## Tests
- **100% unit coverage**: FakeRunner argv + fs-fake + x509 fixtures (valid CA / non-CA / expired / not-yet-valid / garbage / wrong-PEM-type / corrupt-DER), both backends, idempotent remove, List parse/skip, Detect.
- **Real in-container round-trip integration**: generate a self-signed CA → `Install` → assert its DER is present in the consolidated **system bundle** (`/etc/ssl/certs/ca-certificates.crt` / p11-kit extracted bundle) **and** `List` → `Remove` → assert gone from both. Runs `CaCertificates` on the Debian matrix and `P11Kit` on the Fedora matrix (skip-when-tool-absent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CA trust anchor management system supporting multiple Linux trust-store backends
  * Install, remove, and list CA certificates through a unified interface
  * Automatic backend detection to identify available trust stores on the system
  * Certificate validation to ensure proper CA configuration and validity requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->