### PR TITLE
fix(sys): unify nil-runner rejection on shared exec.ErrRunnerRequired + CR nitpicks

### DIFF
--- a/go/archtest/runner_required_sentinel_test.go
+++ b/go/archtest/runner_required_sentinel_test.go
@@ -1,0 +1,236 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// runnerRequiredAllowlist enumerates capability constructors that legitimately
+// reject a nil exec.Runner WITHOUT the shared exec.ErrRunnerRequired sentinel.
+// It should stay EMPTY: nil-runner rejection is identical everywhere, so every
+// capability funnels it through the one generic sentinel and callers can match
+// it with errors.Is regardless of which capability they built. Entries are keyed
+// by "<rel>:<funcName>" and stale-guarded by assertNoStale.
+var runnerRequiredAllowlist = map[string]string{}
+
+// TestNilRunnerUsesSharedSentinel locks the rule that EVERY capability
+// constructor taking an exec.Runner rejects a nil runner with the single shared
+// exec.ErrRunnerRequired sentinel — never an ad-hoc errors.New / fmt.Errorf
+// string. This is what makes the rejection errors.Is-matchable and uniform.
+//
+// It is self-discovering: it finds every function under go/sys and go/pkg that
+// takes an exec.Runner parameter and guards it with `<param> == nil`, then
+// requires that guard's body to reference exec.ErrRunnerRequired. A NEW
+// capability that hand-rolls its own "runner is required" error fails the build.
+// The companion guard (no per-package runner-required sentinel survives) and the
+// per-package New(_, nil) unit tests (errors.Is at runtime) complete the pin.
+func TestNilRunnerUsesSharedSentinel(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "gen/") || strings.HasPrefix(rel, "go/archtest/") {
+			return false
+		}
+		// The exec package DEFINES the sentinel and constructs Runners rather
+		// than consuming one, so it has no nil-runner constructor guard to check.
+		if strings.HasPrefix(rel, "go/sys/exec/") {
+			return false
+		}
+		return strings.HasPrefix(rel, "go/sys/") || strings.HasPrefix(rel, "go/pkg/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero capability Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(runnerRequiredAllowlist)
+	guards := 0
+
+	for _, gf := range files {
+		execName := sdkExecLocalName(gf)
+		if execName == "" {
+			continue // this file does not import the SDK exec package, so no exec.Runner param
+		}
+		for _, decl := range gf.ast.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			params := runnerParamNames(fn, execName)
+			if len(params) == 0 {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				ifs, ok := n.(*ast.IfStmt)
+				if !ok || !isNilCheckOn(ifs.Cond, params) {
+					return true
+				}
+				guards++
+				if blockReferences(ifs.Body, "ErrRunnerRequired") {
+					return true
+				}
+				if allow.exempt(gf.rel + ":" + fn.Name.Name) {
+					return true
+				}
+				t.Errorf("%s:%d: %s rejects a nil runner without the shared %s.ErrRunnerRequired sentinel — "+
+					"return it (wrapped, e.g. fmt.Errorf(\"%s: %%w\", %s.ErrRunnerRequired)) so callers can errors.Is",
+					gf.rel, gf.line(ifs), fn.Name.Name, execName, gf.ast.Name.Name, execName)
+				return true
+			})
+		}
+	}
+
+	if guards == 0 {
+		t.Fatal("matches-zero guard: found no `runner == nil` constructor guard at all — the detector is broken")
+	}
+	allow.assertNoStale(t)
+}
+
+// TestNoPerPackageRunnerRequiredSentinel forbids a package from declaring its own
+// Err*RunnerRequired / "runner is required" sentinel: the generic one in exec is
+// the single source so "everything uses our generic error". A duplicate would let
+// two distinct sentinels drift apart and break uniform errors.Is matching.
+func TestNoPerPackageRunnerRequiredSentinel(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "gen/") || strings.HasPrefix(rel, "go/archtest/") {
+			return false
+		}
+		if strings.HasPrefix(rel, "go/sys/exec/") {
+			return false // the one legitimate home of the shared sentinel
+		}
+		return strings.HasPrefix(rel, "go/sys/") || strings.HasPrefix(rel, "go/pkg/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero capability Go files — detector is mis-scoped")
+	}
+
+	inspected := 0
+	for _, gf := range files {
+		for _, decl := range gf.ast.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					inspected++
+					// A var named like a runner-required error...
+					if !strings.Contains(strings.ToLower(name.Name), "runnerrequired") {
+						// ...or one whose errors.New/fmt.Errorf literal says so.
+						if i < len(vs.Values) && constructsRunnerRequired(vs.Values[i]) {
+							t.Errorf("%s:%d: %s constructs a 'runner is required' error — use the shared exec.ErrRunnerRequired instead of a per-package sentinel",
+								gf.rel, gf.line(name), name.Name)
+						}
+						continue
+					}
+					t.Errorf("%s:%d: package-level %s — there must be only ONE runner-required sentinel (exec.ErrRunnerRequired); drop this per-package one",
+						gf.rel, gf.line(name), name.Name)
+				}
+			}
+		}
+	}
+	if inspected == 0 {
+		t.Fatal("matches-zero guard: inspected no package-level vars — detector is broken")
+	}
+}
+
+// sdkExecLocalName returns the local name the SDK exec package is imported under
+// in gf (its alias, or "exec" by default), or "" if gf does not import it.
+func sdkExecLocalName(gf *goFile) string {
+	for _, imp := range gf.ast.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if !strings.HasSuffix(path, "/sys/exec") {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return "exec"
+	}
+	return ""
+}
+
+// runnerParamNames returns the parameter names of fn whose type is
+// <execName>.Runner (the injected SDK runner).
+func runnerParamNames(fn *ast.FuncDecl, execName string) []string {
+	var names []string
+	if fn.Type.Params == nil {
+		return names
+	}
+	for _, field := range fn.Type.Params.List {
+		sel, ok := field.Type.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Runner" {
+			continue
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != execName {
+			continue
+		}
+		for _, id := range field.Names {
+			names = append(names, id.Name)
+		}
+	}
+	return names
+}
+
+// isNilCheckOn reports whether cond is `<p> == nil` for one of params.
+func isNilCheckOn(cond ast.Expr, params []string) bool {
+	be, ok := cond.(*ast.BinaryExpr)
+	if !ok || be.Op != token.EQL {
+		return false
+	}
+	var ident *ast.Ident
+	switch {
+	case isNilIdent(be.Y):
+		ident, _ = be.X.(*ast.Ident)
+	case isNilIdent(be.X):
+		ident, _ = be.Y.(*ast.Ident)
+	}
+	if ident == nil {
+		return false
+	}
+	for _, p := range params {
+		if p == ident.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func isNilIdent(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == "nil"
+}
+
+// blockReferences reports whether any identifier named want appears anywhere in
+// block (covers both a bare ErrRunnerRequired and the Sel of exec.ErrRunnerRequired).
+func blockReferences(block *ast.BlockStmt, want string) bool {
+	found := false
+	ast.Inspect(block, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == want {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// constructsRunnerRequired reports whether expr is an errors.New / fmt.Errorf
+// call whose first string-literal argument mentions "runner is required".
+func constructsRunnerRequired(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	return strings.Contains(strings.ToLower(lit.Value), "runner is required")
+}

--- a/go/archtest/runner_required_sentinel_test.go
+++ b/go/archtest/runner_required_sentinel_test.go
@@ -228,6 +228,19 @@ func constructsRunnerRequired(expr ast.Expr) bool {
 	if !ok || len(call.Args) == 0 {
 		return false
 	}
+	// Restrict to the error constructors so an unrelated helper that merely takes
+	// such a string (e.g. a log call) is not flagged.
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if !((pkg.Name == "errors" && sel.Sel.Name == "New") || (pkg.Name == "fmt" && sel.Sel.Name == "Errorf")) {
+		return false
+	}
 	lit, ok := call.Args[0].(*ast.BasicLit)
 	if !ok || lit.Kind != token.STRING {
 		return false

--- a/go/archtest/runner_required_sentinel_test.go
+++ b/go/archtest/runner_required_sentinel_test.go
@@ -107,6 +107,8 @@ func TestNoPerPackageRunnerRequiredSentinel(t *testing.T) {
 
 	inspected := 0
 	for _, gf := range files {
+		errorsName := importLocalName(gf, "errors")
+		fmtName := importLocalName(gf, "fmt")
 		for _, decl := range gf.ast.Decls {
 			gd, ok := decl.(*ast.GenDecl)
 			if !ok || gd.Tok != token.VAR {
@@ -122,7 +124,7 @@ func TestNoPerPackageRunnerRequiredSentinel(t *testing.T) {
 					// A var named like a runner-required error...
 					if !strings.Contains(strings.ToLower(name.Name), "runnerrequired") {
 						// ...or one whose errors.New/fmt.Errorf literal says so.
-						if i < len(vs.Values) && constructsRunnerRequired(vs.Values[i]) {
+						if i < len(vs.Values) && constructsRunnerRequired(vs.Values[i], errorsName, fmtName) {
 							t.Errorf("%s:%d: %s constructs a 'runner is required' error — use the shared exec.ErrRunnerRequired instead of a per-package sentinel",
 								gf.rel, gf.line(name), name.Name)
 						}
@@ -223,7 +225,11 @@ func blockReferences(block *ast.BlockStmt, want string) bool {
 
 // constructsRunnerRequired reports whether expr is an errors.New / fmt.Errorf
 // call whose first string-literal argument mentions "runner is required".
-func constructsRunnerRequired(expr ast.Expr) bool {
+// errorsName/fmtName are the LOCAL names the "errors" and "fmt" packages are
+// imported under in this file (resolved from imports, so an aliased import like
+// `goerrors "errors"` cannot bypass the guard); "" means the package is not
+// imported, so the corresponding constructor cannot be called here.
+func constructsRunnerRequired(expr ast.Expr, errorsName, fmtName string) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok || len(call.Args) == 0 {
 		return false
@@ -238,7 +244,9 @@ func constructsRunnerRequired(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	if !((pkg.Name == "errors" && sel.Sel.Name == "New") || (pkg.Name == "fmt" && sel.Sel.Name == "Errorf")) {
+	isErrorsNew := errorsName != "" && pkg.Name == errorsName && sel.Sel.Name == "New"
+	isFmtErrorf := fmtName != "" && pkg.Name == fmtName && sel.Sel.Name == "Errorf"
+	if !isErrorsNew && !isFmtErrorf {
 		return false
 	}
 	lit, ok := call.Args[0].(*ast.BasicLit)
@@ -246,4 +254,23 @@ func constructsRunnerRequired(expr ast.Expr) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(lit.Value), "runner is required")
+}
+
+// importLocalName returns the local name an exact import path is bound to in gf
+// (its alias, or the path's last segment by default), or "" if gf does not
+// import it.
+func importLocalName(gf *goFile, fullPath string) string {
+	for _, imp := range gf.ast.Imports {
+		if strings.Trim(imp.Path.Value, `"`) != fullPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		if i := strings.LastIndex(fullPath, "/"); i >= 0 {
+			return fullPath[i+1:]
+		}
+		return fullPath
+	}
+	return ""
 }

--- a/go/pkg/pkg.go
+++ b/go/pkg/pkg.go
@@ -170,7 +170,7 @@ func WithUserScope() Option {
 // the host; use Detect to learn which backends are installed.
 func New(b Backend, runner pmexec.Runner, opts ...Option) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("pkg: runner is required")
+		return nil, fmt.Errorf("pkg: %w", pmexec.ErrRunnerRequired)
 	}
 	cfg := config{system: true}
 	for _, o := range opts {

--- a/go/pkg/pkg_test.go
+++ b/go/pkg/pkg_test.go
@@ -79,7 +79,7 @@ func TestNew_RejectsUnknownBackend(t *testing.T) {
 func TestNew_RejectsNilRunner(t *testing.T) {
 	_, err := New(Apt, nil)
 	if !errors.Is(err, pmexec.ErrRunnerRequired) {
-		t.Errorf("New(Apt, nil) error = %v, want exec.ErrRunnerRequired", err)
+		t.Errorf("New(Apt, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/pkg/pkg_test.go
+++ b/go/pkg/pkg_test.go
@@ -78,8 +78,8 @@ func TestNew_RejectsUnknownBackend(t *testing.T) {
 
 func TestNew_RejectsNilRunner(t *testing.T) {
 	_, err := New(Apt, nil)
-	if err == nil || !strings.Contains(err.Error(), "runner is required") {
-		t.Errorf("New(Apt, nil) error = %v, want 'runner is required'", err)
+	if !errors.Is(err, pmexec.ErrRunnerRequired) {
+		t.Errorf("New(Apt, nil) error = %v, want exec.ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/antivirus/antivirus.go
+++ b/go/sys/antivirus/antivirus.go
@@ -88,7 +88,7 @@ type Manager interface {
 // the backend; nil runner and unknown backend are rejected.
 func New(b Backend, runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("antivirus: runner is required")
+		return nil, fmt.Errorf("antivirus: %w", exec.ErrRunnerRequired)
 	}
 	switch b {
 	case ClamAV:

--- a/go/sys/antivirus/antivirus_test.go
+++ b/go/sys/antivirus/antivirus_test.go
@@ -21,7 +21,7 @@ func newClam(t *testing.T) (*clamavManager, *exectest.FakeRunner) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(ClamAV, nil); err == nil {
+	if _, err := New(ClamAV, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(_, nil) returned nil error")
 	}
 }

--- a/go/sys/antivirus/antivirus_test.go
+++ b/go/sys/antivirus/antivirus_test.go
@@ -22,7 +22,7 @@ func newClam(t *testing.T) (*clamavManager, *exectest.FakeRunner) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(ClamAV, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(_, nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/catrust/catrust.go
+++ b/go/sys/catrust/catrust.go
@@ -113,6 +113,7 @@ var newFS = func(r exec.Runner) (fsManager, error) { return fs.New(r) }
 var (
 	readDir  = os.ReadDir
 	readFile = os.ReadFile
+	stat     = os.Stat
 )
 
 type manager struct {
@@ -125,7 +126,7 @@ type manager struct {
 // runner and unknown backend are rejected.
 func New(b Backend, runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("catrust: runner is required")
+		return nil, fmt.Errorf("catrust: %w", exec.ErrRunnerRequired)
 	}
 	cfg, ok := backends[b]
 	if !ok {
@@ -169,7 +170,7 @@ func (m *manager) Remove(ctx context.Context, name string) error {
 		return err
 	}
 	path := m.anchorPath(name)
-	if _, err := readFile(path); err != nil {
+	if _, err := stat(path); err != nil {
 		if os.IsNotExist(err) {
 			return nil // already absent — nothing to do
 		}

--- a/go/sys/catrust/catrust_test.go
+++ b/go/sys/catrust/catrust_test.go
@@ -90,7 +90,7 @@ func newMgr(t *testing.T, b Backend, ff *fakeFS) (*manager, *exectest.FakeRunner
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(CaCertificates, nil); err == nil {
+	if _, err := New(CaCertificates, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(_, nil) returned nil error")
 	}
 }
@@ -254,10 +254,10 @@ func TestInstall_WriteAndRefreshErrors(t *testing.T) {
 func TestRemove_Success(t *testing.T) {
 	ff := &fakeFS{}
 	m, r := newMgr(t, CaCertificates, ff)
-	prev := readFile
-	t.Cleanup(func() { readFile = prev })
-	readFile = func(string) ([]byte, error) { return []byte("present"), nil } // exists
-	r.Push(exec.Result{}, nil)                                                // update-ca-certificates --fresh
+	prev := stat
+	t.Cleanup(func() { stat = prev })
+	stat = func(string) (os.FileInfo, error) { return nil, nil } // exists
+	r.Push(exec.Result{}, nil)                                   // update-ca-certificates --fresh
 	if err := m.Remove(context.Background(), "acme-root"); err != nil {
 		t.Fatal(err)
 	}
@@ -273,9 +273,9 @@ func TestRemove_Success(t *testing.T) {
 func TestRemove_IdempotentWhenAbsent(t *testing.T) {
 	ff := &fakeFS{}
 	m, r := newMgr(t, CaCertificates, ff)
-	prev := readFile
-	t.Cleanup(func() { readFile = prev })
-	readFile = func(string) ([]byte, error) { return nil, os.ErrNotExist }
+	prev := stat
+	t.Cleanup(func() { stat = prev })
+	stat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	if err := m.Remove(context.Background(), "absent"); err != nil {
 		t.Errorf("removing an absent anchor must be a no-op success, got %v", err)
 	}
@@ -285,19 +285,19 @@ func TestRemove_IdempotentWhenAbsent(t *testing.T) {
 }
 
 func TestRemove_Errors(t *testing.T) {
-	prev := readFile
-	t.Cleanup(func() { readFile = prev })
+	prev := stat
+	t.Cleanup(func() { stat = prev })
 
 	// stat error other than not-exist
 	ff := &fakeFS{}
 	m, _ := newMgr(t, CaCertificates, ff)
-	readFile = func(string) ([]byte, error) { return nil, errors.New("permission denied") }
+	stat = func(string) (os.FileInfo, error) { return nil, errors.New("permission denied") }
 	if err := m.Remove(context.Background(), "x"); err == nil {
 		t.Error("a non-notexist stat error must propagate")
 	}
 
 	// remove error
-	readFile = func(string) ([]byte, error) { return []byte("x"), nil }
+	stat = func(string) (os.FileInfo, error) { return nil, nil } // exists
 	ff2 := &fakeFS{removeErr: errors.New("rm failed")}
 	m2, _ := newMgr(t, CaCertificates, ff2)
 	if err := m2.Remove(context.Background(), "x"); err == nil {

--- a/go/sys/catrust/catrust_test.go
+++ b/go/sys/catrust/catrust_test.go
@@ -91,7 +91,7 @@ func newMgr(t *testing.T, b Backend, ff *fakeFS) (*manager, *exectest.FakeRunner
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(CaCertificates, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(_, nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/catrust/example_test.go
+++ b/go/sys/catrust/example_test.go
@@ -13,7 +13,10 @@ import (
 // ExampleNew installs an org CA into the system trust store, then lists the
 // managed anchors.
 func ExampleNew() {
-	r, err := exec.NewRunner(exec.Direct) // writing trust anchors needs root
+	// Writing trust anchors requires root: exec.Direct assumes the process is
+	// already root; from an unprivileged process use exec.NewRunner(exec.Sudo)
+	// (or exec.Doas) so the writes and update-ca-trust refresh are escalated.
+	r, err := exec.NewRunner(exec.Direct)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/sys/catrust/integration_test.go
+++ b/go/sys/catrust/integration_test.go
@@ -28,16 +28,24 @@ var bundlePath = map[catrust.Backend]string{
 	catrust.P11Kit:         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
 }
 
-// genCA returns a self-signed CA as (PEM, DER) so the test can match the exact
-// certificate inside the system bundle.
-func genCA(t *testing.T) (pemBytes, der []byte) {
+// genCA returns a self-signed CA as (PEM, DER) plus the cert's parsed Subject
+// DN string so the test can match both the exact certificate inside the system
+// bundle and the Subject/Issuer reported by List. The CA is self-signed, so its
+// Issuer equals its Subject.
+func genCA(t *testing.T) (pemBytes, der []byte, subject string) {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// RFC 5280 §5.1.2.2: serial numbers should be large random values, not
+	// derived from a clock (which can collide). 128 random bits is conventional.
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatal(err)
+	}
 	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		SerialNumber:          serial,
 		Subject:               pkix.Name{CommonName: "PM Integration Test CA", Organization: []string{"power-manage-test"}},
 		NotBefore:             time.Now().Add(-time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
@@ -49,7 +57,11 @@ func genCA(t *testing.T) (pemBytes, der []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), der
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), der, cert.Subject.String()
 }
 
 // bundleContainsDER reports whether the consolidated bundle holds a cert with
@@ -110,7 +122,7 @@ func TestRoundTrip_Integration(t *testing.T) {
 				t.Fatalf("New(%v): %v", b, err)
 			}
 			const name = "pm-integration-test-ca"
-			pemBytes, der := genCA(t)
+			pemBytes, der, subject := genCA(t)
 			t.Cleanup(func() { _ = m.Remove(ctx, name) })
 
 			if err := m.Install(ctx, name, pemBytes); err != nil {
@@ -126,6 +138,13 @@ func TestRoundTrip_Integration(t *testing.T) {
 			for _, a := range anchors {
 				if a.Name == name {
 					found = true
+					// Self-signed: Subject and Issuer both equal the CA's subject.
+					if a.Subject != subject {
+						t.Errorf("anchor Subject = %q, want %q", a.Subject, subject)
+					}
+					if a.Issuer != subject {
+						t.Errorf("anchor Issuer = %q, want %q (self-signed)", a.Issuer, subject)
+					}
 				}
 			}
 			if !found {

--- a/go/sys/desktop/desktop.go
+++ b/go/sys/desktop/desktop.go
@@ -34,7 +34,7 @@ package desktop
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	osexec "os/exec"
 	"os/user"
 
@@ -113,7 +113,7 @@ func WithHomeRoot(dir string) Option {
 // (fail-closed). New is pure — it does not probe the host.
 func New(runner pmexec.Runner, opts ...Option) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("desktop: runner is required")
+		return nil, fmt.Errorf("desktop: %w", pmexec.ErrRunnerRequired)
 	}
 	m := &manager{r: runner, homeRoot: defaultHomeRoot}
 	for _, opt := range opts {

--- a/go/sys/desktop/desktop_test.go
+++ b/go/sys/desktop/desktop_test.go
@@ -52,7 +52,7 @@ func stubLookupUser(t *testing.T, fn func(string) (*user.User, error)) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error; a nil runner must be rejected")
 	}
 }

--- a/go/sys/desktop/desktop_test.go
+++ b/go/sys/desktop/desktop_test.go
@@ -53,7 +53,7 @@ func stubLookupUser(t *testing.T, fn func(string) (*user.User, error)) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error; a nil runner must be rejected")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/dns/dns.go
+++ b/go/sys/dns/dns.go
@@ -106,7 +106,7 @@ var newFS = func(r exec.Runner) (fsManager, error) { return fs.New(r) }
 // a nil runner is rejected.
 func New(b Backend, runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("dns: runner is required")
+		return nil, fmt.Errorf("dns: %w", exec.ErrRunnerRequired)
 	}
 	switch b {
 	case Resolved:

--- a/go/sys/dns/dns_test.go
+++ b/go/sys/dns/dns_test.go
@@ -44,7 +44,7 @@ func withFakeFS(t *testing.T, ff *fakeFS) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(Resolved, nil); err == nil {
+	if _, err := New(Resolved, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(Resolved, nil) returned nil error; a nil runner must be rejected")
 	}
 }

--- a/go/sys/dns/dns_test.go
+++ b/go/sys/dns/dns_test.go
@@ -45,7 +45,7 @@ func withFakeFS(t *testing.T, ff *fakeFS) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(Resolved, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(Resolved, nil) returned nil error; a nil runner must be rejected")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/encryption/encryption.go
+++ b/go/sys/encryption/encryption.go
@@ -80,7 +80,7 @@ func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
 		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
 	}
 	if runner == nil {
-		return nil, fmt.Errorf("encryption: runner is required")
+		return nil, fmt.Errorf("encryption: %w", exec.ErrRunnerRequired)
 	}
 	return &luks{r: runner}, nil
 }

--- a/go/sys/encryption/encryption_test.go
+++ b/go/sys/encryption/encryption_test.go
@@ -113,7 +113,7 @@ func TestNew_FailClosed(t *testing.T) {
 		}
 	}
 	if _, err := New(LUKS, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New with nil runner returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 	if _, err := New(LUKS, r); err != nil {
 		t.Errorf("New(LUKS, runner) err = %v, want nil", err)

--- a/go/sys/encryption/encryption_test.go
+++ b/go/sys/encryption/encryption_test.go
@@ -112,7 +112,7 @@ func TestNew_FailClosed(t *testing.T) {
 			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
 		}
 	}
-	if _, err := New(LUKS, nil); err == nil {
+	if _, err := New(LUKS, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New with nil runner returned nil error")
 	}
 	if _, err := New(LUKS, r); err != nil {

--- a/go/sys/exec/command_error.go
+++ b/go/sys/exec/command_error.go
@@ -22,6 +22,12 @@ var (
 	// password (no NOPASSWD rule) — the agent never has a terminal to type one,
 	// so this fails closed rather than hanging.
 	ErrEscalationDenied = errors.New("escalation requires a password")
+
+	// ErrRunnerRequired is returned by a capability constructor (New) when the
+	// caller passes a nil Runner. It is shared by every capability package so a
+	// nil runner is rejected identically everywhere and callers can match it with
+	// errors.Is regardless of which capability they constructed.
+	ErrRunnerRequired = errors.New("runner is required")
 )
 
 // CommandError is the typed error the capability layer wraps a failed command

--- a/go/sys/firewall/firewall.go
+++ b/go/sys/firewall/firewall.go
@@ -215,7 +215,7 @@ func New(b Backend, namespace string, runner exec.Runner, _ ...Option) (Manager,
 		return nil, err
 	}
 	if runner == nil {
-		return nil, fmt.Errorf("firewall: runner is required")
+		return nil, fmt.Errorf("firewall: %w", exec.ErrRunnerRequired)
 	}
 	fsm, err := newFS(runner)
 	if err != nil {

--- a/go/sys/firewall/firewall_test.go
+++ b/go/sys/firewall/firewall_test.go
@@ -91,7 +91,7 @@ func TestNew_FailClosed(t *testing.T) {
 			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
 		}
 	}
-	if _, err := New(Nftables, "app", nil); err == nil {
+	if _, err := New(Nftables, "app", nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New with nil runner returned nil error")
 	}
 	for _, b := range []Backend{Nftables, Firewalld, UFW} {

--- a/go/sys/firewall/firewall_test.go
+++ b/go/sys/firewall/firewall_test.go
@@ -92,7 +92,7 @@ func TestNew_FailClosed(t *testing.T) {
 		}
 	}
 	if _, err := New(Nftables, "app", nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New with nil runner returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 	for _, b := range []Backend{Nftables, Firewalld, UFW} {
 		m, err := New(b, "app", r)

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -119,7 +119,7 @@ type manager struct {
 // (fail-closed). New is pure — it does not probe the host.
 func New(runner pmexec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("fs: runner is required")
+		return nil, fmt.Errorf("fs: %w", pmexec.ErrRunnerRequired)
 	}
 	return &manager{r: runner}, nil
 }

--- a/go/sys/fs/manager_test.go
+++ b/go/sys/fs/manager_test.go
@@ -75,7 +75,7 @@ func stdinOf(t *testing.T, c pmexec.Command) string {
 }
 
 func TestNew_NilRunnerRejected(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, pmexec.ErrRunnerRequired) {
 		t.Fatal("New(nil) = nil error, want a fail-closed rejection")
 	}
 	if _, err := New(exectest.New(pmexec.Sudo)); err != nil {

--- a/go/sys/fs/manager_test.go
+++ b/go/sys/fs/manager_test.go
@@ -76,7 +76,7 @@ func stdinOf(t *testing.T, c pmexec.Command) string {
 
 func TestNew_NilRunnerRejected(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, pmexec.ErrRunnerRequired) {
-		t.Fatal("New(nil) = nil error, want a fail-closed rejection")
+		t.Fatalf("New(nil) error = %v, want ErrRunnerRequired", err)
 	}
 	if _, err := New(exectest.New(pmexec.Sudo)); err != nil {
 		t.Fatalf("New(runner) = %v, want nil", err)

--- a/go/sys/inventory/inventory.go
+++ b/go/sys/inventory/inventory.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -85,7 +84,7 @@ type Collector interface {
 // New returns a Collector driven by runner. A nil runner is rejected.
 func New(runner exec.Runner) (Collector, error) {
 	if runner == nil {
-		return nil, errors.New("inventory: runner is required")
+		return nil, fmt.Errorf("inventory: %w", exec.ErrRunnerRequired)
 	}
 	return &collector{r: runner}, nil
 }

--- a/go/sys/inventory/inventory_test.go
+++ b/go/sys/inventory/inventory_test.go
@@ -34,7 +34,7 @@ func writeTemp(t *testing.T, content string) string {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error")
 	}
 }

--- a/go/sys/inventory/inventory_test.go
+++ b/go/sys/inventory/inventory_test.go
@@ -35,7 +35,7 @@ func writeTemp(t *testing.T, content string) string {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/log/log.go
+++ b/go/sys/log/log.go
@@ -92,7 +92,7 @@ type Source interface {
 // rejected.
 func New(b Backend, runner exec.Runner) (Source, error) {
 	if runner == nil {
-		return nil, errors.New("log: runner is required")
+		return nil, fmt.Errorf("log: %w", exec.ErrRunnerRequired)
 	}
 	switch b {
 	case Journald:

--- a/go/sys/log/log_test.go
+++ b/go/sys/log/log_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(Journald, nil); err == nil {
+	if _, err := New(Journald, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(_, nil) returned nil error")
 	}
 }

--- a/go/sys/log/log_test.go
+++ b/go/sys/log/log_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(Journald, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(_, nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/netconfig/netconfig.go
+++ b/go/sys/netconfig/netconfig.go
@@ -132,7 +132,7 @@ type base struct {
 // rejected.
 func New(b Backend, runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("netconfig: runner is required")
+		return nil, fmt.Errorf("netconfig: %w", exec.ErrRunnerRequired)
 	}
 	switch b {
 	case NetworkManager:

--- a/go/sys/netconfig/netconfig_test.go
+++ b/go/sys/netconfig/netconfig_test.go
@@ -36,7 +36,7 @@ func withFakeFS(t *testing.T, ff *fakeFS) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(NetworkManager, nil); err == nil {
+	if _, err := New(NetworkManager, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(_, nil) returned nil error; a nil runner must be rejected")
 	}
 }

--- a/go/sys/netconfig/netconfig_test.go
+++ b/go/sys/netconfig/netconfig_test.go
@@ -37,7 +37,7 @@ func withFakeFS(t *testing.T, ff *fakeFS) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(NetworkManager, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(_, nil) returned nil error; a nil runner must be rejected")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/network/network.go
+++ b/go/sys/network/network.go
@@ -114,7 +114,7 @@ func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
 		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
 	}
 	if runner == nil {
-		return nil, fmt.Errorf("network: runner is required")
+		return nil, fmt.Errorf("network: %w", exec.ErrRunnerRequired)
 	}
 	return &networkManager{r: runner}, nil
 }

--- a/go/sys/network/network_test.go
+++ b/go/sys/network/network_test.go
@@ -137,7 +137,7 @@ func TestNew_FailClosed(t *testing.T) {
 		}
 	}
 	if _, err := New(NetworkManager, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New with nil runner returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 	if _, err := New(NetworkManager, r); err != nil {
 		t.Errorf("New(NetworkManager, runner) err = %v, want nil", err)

--- a/go/sys/network/network_test.go
+++ b/go/sys/network/network_test.go
@@ -136,7 +136,7 @@ func TestNew_FailClosed(t *testing.T) {
 			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
 		}
 	}
-	if _, err := New(NetworkManager, nil); err == nil {
+	if _, err := New(NetworkManager, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New with nil runner returned nil error")
 	}
 	if _, err := New(NetworkManager, r); err != nil {

--- a/go/sys/notify/notify.go
+++ b/go/sys/notify/notify.go
@@ -10,7 +10,6 @@ package notify
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -50,7 +49,7 @@ type Manager interface {
 // New returns a Manager driven by runner. A nil runner is rejected.
 func New(runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("notify: runner is required")
+		return nil, fmt.Errorf("notify: %w", exec.ErrRunnerRequired)
 	}
 	return &notifier{r: runner}, nil
 }

--- a/go/sys/notify/notify_runner_test.go
+++ b/go/sys/notify/notify_runner_test.go
@@ -33,7 +33,7 @@ func seamPresent(t *testing.T) {
 func argv(c exec.Command) string { return c.Name + " " + strings.Join(c.Args, " ") }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error")
 	}
 }

--- a/go/sys/notify/notify_runner_test.go
+++ b/go/sys/notify/notify_runner_test.go
@@ -34,7 +34,7 @@ func argv(c exec.Command) string { return c.Name + " " + strings.Join(c.Args, " 
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/osquery/osquery.go
+++ b/go/sys/osquery/osquery.go
@@ -112,7 +112,7 @@ type client struct {
 // at construction that osquery is unavailable), and an error when runner is nil.
 func New(runner exec.Runner) (Querier, error) {
 	if runner == nil {
-		return nil, errors.New("osquery: runner is required")
+		return nil, fmt.Errorf("osquery: %w", exec.ErrRunnerRequired)
 	}
 	path := findOsqueryBinary()
 	if path == "" {

--- a/go/sys/osquery/osquery_test.go
+++ b/go/sys/osquery/osquery_test.go
@@ -106,7 +106,7 @@ func TestNew_NotInstalled(t *testing.T) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/osquery/osquery_test.go
+++ b/go/sys/osquery/osquery_test.go
@@ -105,7 +105,7 @@ func TestNew_NotInstalled(t *testing.T) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error")
 	}
 }

--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -48,7 +48,7 @@ type Manager interface {
 // New returns a Manager driven by runner. A nil runner is rejected.
 func New(runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("reboot: runner is required")
+		return nil, fmt.Errorf("reboot: %w", exec.ErrRunnerRequired)
 	}
 	return &rebooter{r: runner}, nil
 }

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -30,7 +30,7 @@ func withStat(t *testing.T, fn func(string) (os.FileInfo, error)) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error")
 	}
 }

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -31,7 +31,7 @@ func withStat(t *testing.T, fn func(string) (os.FileInfo, error)) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/service/service.go
+++ b/go/sys/service/service.go
@@ -76,7 +76,7 @@ func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
 		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
 	}
 	if runner == nil {
-		return nil, fmt.Errorf("service: runner is required")
+		return nil, fmt.Errorf("service: %w", exec.ErrRunnerRequired)
 	}
 	fsm, err := newFS(runner)
 	if err != nil {

--- a/go/sys/service/service_test.go
+++ b/go/sys/service/service_test.go
@@ -45,7 +45,7 @@ func TestNew_FailClosed(t *testing.T) {
 			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
 		}
 	}
-	if _, err := New(Systemd, nil); err == nil {
+	if _, err := New(Systemd, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New with nil runner returned nil error")
 	}
 	if _, err := New(Systemd, f); err != nil {

--- a/go/sys/service/service_test.go
+++ b/go/sys/service/service_test.go
@@ -46,7 +46,7 @@ func TestNew_FailClosed(t *testing.T) {
 		}
 	}
 	if _, err := New(Systemd, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New with nil runner returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 	if _, err := New(Systemd, f); err != nil {
 		t.Errorf("New(Systemd, runner) err = %v, want nil", err)

--- a/go/sys/smart/smart.go
+++ b/go/sys/smart/smart.go
@@ -61,7 +61,7 @@ type collector struct {
 // pure — it does not probe for smartctl (a missing binary surfaces at call time).
 func New(runner exec.Runner) (Collector, error) {
 	if runner == nil {
-		return nil, errors.New("smart: runner is required")
+		return nil, fmt.Errorf("smart: %w", exec.ErrRunnerRequired)
 	}
 	return &collector{r: runner}, nil
 }

--- a/go/sys/smart/smart_test.go
+++ b/go/sys/smart/smart_test.go
@@ -21,7 +21,7 @@ func newColl(t *testing.T) (*collector, *exectest.FakeRunner) {
 }
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(nil); err == nil {
+	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(nil) returned nil error")
 	}
 }

--- a/go/sys/smart/smart_test.go
+++ b/go/sys/smart/smart_test.go
@@ -22,7 +22,7 @@ func newColl(t *testing.T) (*collector, *exectest.FakeRunner) {
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/timesync/timesync.go
+++ b/go/sys/timesync/timesync.go
@@ -69,7 +69,7 @@ type Manager interface {
 // rejected.
 func New(b Backend, runner exec.Runner) (Manager, error) {
 	if runner == nil {
-		return nil, errors.New("timesync: runner is required")
+		return nil, fmt.Errorf("timesync: %w", exec.ErrRunnerRequired)
 	}
 	switch b {
 	case Timedatectl:

--- a/go/sys/timesync/timesync_test.go
+++ b/go/sys/timesync/timesync_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNew_NilRunner(t *testing.T) {
 	if _, err := New(Chrony, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New(_, nil) returned nil error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 }
 

--- a/go/sys/timesync/timesync_test.go
+++ b/go/sys/timesync/timesync_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNew_NilRunner(t *testing.T) {
-	if _, err := New(Chrony, nil); err == nil {
+	if _, err := New(Chrony, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New(_, nil) returned nil error")
 	}
 }

--- a/go/sys/user/user.go
+++ b/go/sys/user/user.go
@@ -117,7 +117,7 @@ func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
 		return nil, fmt.Errorf("%w: %d", ErrUnknownBackend, int(b))
 	}
 	if runner == nil {
-		return nil, fmt.Errorf("user: runner is required")
+		return nil, fmt.Errorf("user: %w", exec.ErrRunnerRequired)
 	}
 	fsm, err := newFS(runner)
 	if err != nil {

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -48,7 +48,7 @@ func TestNew_FailClosed(t *testing.T) {
 			t.Errorf("New(%d) err = %v, want ErrUnknownBackend", b, err)
 		}
 	}
-	if _, err := New(ShadowUtils, nil); err == nil {
+	if _, err := New(ShadowUtils, nil); !errors.Is(err, exec.ErrRunnerRequired) {
 		t.Error("New with nil runner returned nil error, want a required-runner error")
 	}
 	if _, err := New(ShadowUtils, f); err != nil {

--- a/go/sys/user/user_test.go
+++ b/go/sys/user/user_test.go
@@ -49,7 +49,7 @@ func TestNew_FailClosed(t *testing.T) {
 		}
 	}
 	if _, err := New(ShadowUtils, nil); !errors.Is(err, exec.ErrRunnerRequired) {
-		t.Error("New with nil runner returned nil error, want a required-runner error")
+		t.Errorf("New(_, nil) error = %v, want ErrRunnerRequired", err)
 	}
 	if _, err := New(ShadowUtils, f); err != nil {
 		t.Errorf("New(ShadowUtils, runner) err = %v, want nil", err)


### PR DESCRIPTION
## Why

CodeRabbit's reviews on #161 (antivirus) and #163 (catrust) included nitpicks that lived in the PR **review body** (the `pulls/{n}/reviews` API), which weren't surfaced before those PRs merged. This follow-up addresses them — and the systemic pattern one of them revealed.

## Shared `exec.ErrRunnerRequired` sentinel (the main change)

Every capability `New()` rejected a nil runner with an ad-hoc `errors.New`/`fmt.Errorf("<pkg>: runner is required")` — not `errors.Is`-matchable. CR flagged the antivirus instance; the same pattern was in **all 19** capability packages (sibling sweep).

- Add **one shared `exec.ErrRunnerRequired`** (the runner *is* an `exec.Runner`; `exec` already owns shared sentinels like `ErrUnknownBackend`). A single generic error, not 19 per-package ones.
- All 19 `New()`s now `return fmt.Errorf("<pkg>: %w", exec.ErrRunnerRequired)`.
- All 19 `New(_, nil)` tests upgraded from `err != nil` to `errors.Is(err, exec.ErrRunnerRequired)`.

## Self-discovering fitness test

`go/archtest/runner_required_sentinel_test.go` (stdlib AST, matches-zero guarded):
1. every `exec.Runner`-taking constructor's `runner == nil` branch must reference the shared sentinel — a new capability that hand-rolls a raw error fails the build;
2. no package may re-declare its own runner-required sentinel.

Red-checked: reverting one package to an ad-hoc error fails guard #1 with the exact file:line.

## catrust nitpicks
- Remove uses an `os.Stat` seam (not `readFile`, which read the whole cert just to test existence — and matches the "stat" error message)
- example clarifies the root / `exec.Sudo` privilege requirement
- integration test uses a `crypto/rand` certificate serial (RFC 5280 §5.1.2.2), not `time.Now().UnixNano()`
- integration test asserts Subject/Issuer in the List round-trip

## Verification
build / vet / staticcheck / `-race` full suite (31 ok, 0 fail) all green (GOWORK=off); touched packages 100% coverage; integration-tag compile clean.

Closes #164. Follow-up to #160/#162.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added architecture checks to enforce consistent “nil runner” handling across capability constructors.
* **Bug Fixes**
  * Trust-anchor removal is now idempotent when the anchor is already absent.
* **Tests**
  * Updated constructor tests to validate the shared, matchable sentinel error (via error matching instead of message text).
  * Improved integration test assertions and CA generation coverage.
* **Documentation**
  * Clarified privilege expectations in the trust-anchor example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->