### PR TITLE
fix(exec): sanitize inherited env + errors.Is-matchable ErrBackendUnavailable

### DIFF
--- a/docs/02-concepts/03-errors.md
+++ b/docs/02-concepts/03-errors.md
@@ -23,7 +23,7 @@ if errors.Is(err, svc.ErrUnknownBackend) {
 
 Each multi-backend package exports `ErrUnknownBackend`.
 
-<!-- docref: begin src=go/sys/exec/command_error.go#ErrEscalationUnavailable:851a220b,go/sys/exec/command_error.go#ErrEscalationDenied:851a220b -->
+<!-- docref: begin src=go/sys/exec/command_error.go#@escalation-sentinels:89446e95 -->
 The `exec` package adds sentinels for the escalation path —
 `ErrEscalationUnavailable` (sudo/doas not installed) and `ErrEscalationDenied`
 (escalation would need a password, which the agent can't supply) — so a runner

--- a/go/sys/exec/command_error.go
+++ b/go/sys/exec/command_error.go
@@ -14,6 +14,7 @@ var (
 	// default escalation).
 	ErrUnknownBackend = errors.New("unknown privilege backend")
 
+	// docref: begin escalation-sentinels
 	// ErrEscalationUnavailable is returned when the chosen escalation tool
 	// (sudo/doas) is not installed on this host.
 	ErrEscalationUnavailable = errors.New("escalation tool not installed")
@@ -22,12 +23,20 @@ var (
 	// password (no NOPASSWD rule) — the agent never has a terminal to type one,
 	// so this fails closed rather than hanging.
 	ErrEscalationDenied = errors.New("escalation requires a password")
+	// docref: end escalation-sentinels
 
 	// ErrRunnerRequired is returned by a capability constructor (New) when the
 	// caller passes a nil Runner. It is shared by every capability package so a
 	// nil runner is rejected identically everywhere and callers can match it with
 	// errors.Is regardless of which capability they constructed.
 	ErrRunnerRequired = errors.New("runner is required")
+
+	// ErrBackendUnavailable is returned when the command/tool a capability needs
+	// is not available on this host — the Runner cannot resolve the binary on
+	// PATH. It is errors.Is-matchable so a caller can treat "tool not installed"
+	// distinctly from a real failure (e.g. IsRequired-style probes report a
+	// missing tool as "no, and that's fine" rather than an error).
+	ErrBackendUnavailable = errors.New("backend unavailable")
 )
 
 // CommandError is the typed error the capability layer wraps a failed command

--- a/go/sys/exec/runner.go
+++ b/go/sys/exec/runner.go
@@ -108,7 +108,7 @@ func (r *runner) exec(ctx context.Context, c Command, onLine OutputCallback) (Re
 	// deterministic regardless of the child's PATH.
 	absPath, err := resolveAbsolute(c.Name)
 	if err != nil {
-		return Result{}, fmt.Errorf("command not found: %s", c.Name)
+		return Result{}, fmt.Errorf("%w: command not found: %s", ErrBackendUnavailable, c.Name)
 	}
 	// When escalating through a wrapper, the wrapper itself must be installed —
 	// fail closed with ErrEscalationUnavailable rather than running unescalated.
@@ -242,8 +242,18 @@ func buildChildEnv(c Command) ([]string, error) {
 		// Sanitized parent PATH + caller Env + forced (the env-only contract).
 		return append(composeEnv(os.Getenv("PATH"), c.Env), forcedEnv...), nil
 	default:
-		// Inherit the parent fully, then force the deterministic vars on top.
-		env := append([]string(nil), os.Environ()...)
+		// Inherit the parent env, but DROP hijack vars (LD_PRELOAD, BASH_ENV, …)
+		// exactly as Command.Env is filtered — the SDK's own process environment
+		// must not leak a library/path injection into a child that may be
+		// escalated to root. forcedEnv is appended last so the deterministic
+		// locale still wins over any inherited value.
+		var env []string
+		for _, e := range os.Environ() {
+			if key, _, ok := strings.Cut(e, "="); !ok || !IsAllowedEnvVar(key) {
+				continue
+			}
+			env = append(env, e)
+		}
 		return append(env, forcedEnv...), nil
 	}
 }

--- a/go/sys/exec/runner_test.go
+++ b/go/sys/exec/runner_test.go
@@ -119,8 +119,46 @@ func TestRunner_RejectsEmptyNameAndUnknownBinary(t *testing.T) {
 	if _, err := directRunner(t).Run(context.Background(), Command{Name: ""}); err == nil {
 		t.Error("Run with empty Name returned nil error, want a failure-to-execute error")
 	}
-	if _, err := directRunner(t).Run(context.Background(), Command{Name: "definitely-not-a-real-binary-xyz"}); err == nil {
-		t.Error("Run with a nonexistent binary returned nil error, want command-not-found")
+	if _, err := directRunner(t).Run(context.Background(), Command{Name: "definitely-not-a-real-binary-xyz"}); !errors.Is(err, ErrBackendUnavailable) {
+		t.Errorf("Run with a nonexistent binary err = %v, want ErrBackendUnavailable (errors.Is-matchable)", err)
+	}
+}
+
+// TestBuildChildEnv_DefaultBranchDropsHijackVars pins that the inherit-the-parent
+// branch (no ChildPath, no Command.Env) does NOT leak a hijack variable from the
+// SDK's OWN process environment into a child (which may be escalated to root).
+// Command.Env is already filtered; the inherited env must be filtered the same
+// way. Benign inherited vars are kept, and the forced locale still wins.
+func TestBuildChildEnv_DefaultBranchDropsHijackVars(t *testing.T) {
+	t.Setenv("LD_PRELOAD", "/tmp/evil.so")    // a classic injection var
+	t.Setenv("BASH_ENV", "/tmp/evil.sh")      // another
+	t.Setenv("PM_BENIGN_TEST_VAR", "keep-me") // a normal var that must survive
+	t.Setenv("LANG", "de_DE.UTF-8")           // reserved; forced LANG=C must win
+
+	env, err := buildChildEnv(Command{}) // default branch: inherit parent
+	if err != nil {
+		t.Fatalf("buildChildEnv: %v", err)
+	}
+	has := func(prefix string) bool {
+		for _, e := range env {
+			if strings.HasPrefix(e, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+	if has("LD_PRELOAD=") {
+		t.Error("LD_PRELOAD leaked from the parent env into the child")
+	}
+	if has("BASH_ENV=") {
+		t.Error("BASH_ENV leaked from the parent env into the child")
+	}
+	if !has("PM_BENIGN_TEST_VAR=keep-me") {
+		t.Error("a benign inherited var was dropped; the default branch must still inherit safe vars")
+	}
+	// forcedEnv is appended last, so the deterministic locale wins over inherited LANG.
+	if got := env[len(env)-3:]; got[0] != "LC_ALL=C" || got[1] != "LANG=C" || got[2] != "NO_COLOR=1" {
+		t.Errorf("tail = %v, want forcedEnv last (LC_ALL=C, LANG=C, NO_COLOR=1)", got)
 	}
 }
 


### PR DESCRIPTION
First of the SDK behaviour/security fixes (pre-1.0; the agent migration will be the real proof).

**1. Inherited-env injection.** `buildChildEnv`'s default branch inherited the SDK process's full `os.Environ()` unfiltered → a hijack var (LD_PRELOAD/BASH_ENV/GCONV_PATH/…) in the SDK's own env leaked into an escalated child. Now filtered through `IsAllowedEnvVar` (same check `Command.Env` gets); benign vars kept, forcedEnv still wins.

**2. `ErrBackendUnavailable`.** command-not-found returned an ad-hoc `fmt.Errorf`; added a sentinel + wrapped it so "tool not installed" is `errors.Is`-matchable (message still contains "command not found").

TDD (both cases RED→GREEN), exec package 100% coverage, sibling-swept, full SDK builds. Local cr clean. Closes #168.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unavailable backend tools and commands.
  * Subprocess execution now filters inherited environment variables, removing potentially unsafe entries while preserving safe system variables.

* **Tests**
  * Added test coverage for environment variable filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->