### PR TITLE
fix(fs): make the escalated (sudo/doas) WriteFile symlink-safe

### DIFF
--- a/go/sys/fs/escalated_parent_other.go
+++ b/go/sys/fs/escalated_parent_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package fs
+
+import "fmt"
+
+// escalatedParentSafe is unix-only (it relies on syscall.Stat_t to read the
+// directory's numeric owner). On non-unix platforms — kept buildable for
+// cross-platform `go vet` — the escalated path is unsupported, so it fails
+// closed.
+func escalatedParentSafe(dir string) error {
+	return fmt.Errorf("%w: %s: escalated writes are unsupported on this platform", ErrUnsafeParentDir, dir)
+}

--- a/go/sys/fs/escalated_parent_unix.go
+++ b/go/sys/fs/escalated_parent_unix.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// escalatedParentSafe reports whether dir is safe to host an escalated write —
+// i.e. a non-root user cannot plant a symlink in it during the write. The check
+// is done unprivileged in Go (directory metadata is world-readable) BEFORE any
+// sudo/doas invocation, so an unsafe target is refused without escalating.
+//
+// A directory is safe when it is owned by root AND either has no group/other
+// write bit OR is sticky. The sticky case (e.g. /tmp, mode 1777) is genuinely
+// safe: the sticky bit restricts deletion/rename within the directory to each
+// file's owner, so an attacker cannot delete or replace root's mktemp'd file.
+// For any directory this accepts, only root can change its ownership/mode, so
+// the gap between this check and the subsequent root write cannot be widened by
+// an attacker.
+//
+// Note: this guards the IMMEDIATE parent. Defending every path component against
+// a symlinked-directory swap requires fd-anchored opens, which the shell-based
+// escalated path cannot do without a root helper; the Direct (root agent) path
+// is fd-anchored and is the one used for security-sensitive writes.
+func escalatedParentSafe(dir string) error {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("escalated write: stat parent %s: %w", dir, err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%w: %s: cannot determine ownership", ErrUnsafeParentDir, dir)
+	}
+	groupOrOtherWritable := fi.Mode().Perm()&0o022 != 0
+	sticky := fi.Mode()&os.ModeSticky != 0
+	if st.Uid != 0 || (groupOrOtherWritable && !sticky) {
+		return fmt.Errorf("%w: %s (uid=%d, mode=%#o, sticky=%v) — a non-root user could plant a symlink here",
+			ErrUnsafeParentDir, dir, st.Uid, fi.Mode().Perm(), sticky)
+	}
+	return nil
+}

--- a/go/sys/fs/escalated_parent_unix_test.go
+++ b/go/sys/fs/escalated_parent_unix_test.go
@@ -1,0 +1,46 @@
+//go:build unix
+
+package fs
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestEscalatedParentSafe pins the parent-directory safety rule the escalated
+// WriteFile depends on: a directory is safe only when root-owned AND either not
+// group/other-writable OR sticky.
+func TestEscalatedParentSafe(t *testing.T) {
+	// A root-owned, non-group/other-writable system dir is safe.
+	if err := escalatedParentSafe("/usr"); err != nil {
+		t.Errorf("escalatedParentSafe(/usr) = %v, want nil (root-owned, 0755)", err)
+	}
+
+	// A world-writable, non-sticky directory is refused — regardless of who runs
+	// the test (0777-non-sticky is unsafe whether owned by root or the test user).
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := escalatedParentSafe(dir); !errors.Is(err, ErrUnsafeParentDir) {
+		t.Errorf("escalatedParentSafe(0777 non-sticky) = %v, want ErrUnsafeParentDir", err)
+	}
+
+	// A non-existent directory is an error (cannot be vetted, so cannot be used).
+	if err := escalatedParentSafe(dir + "/does-not-exist"); err == nil {
+		t.Error("escalatedParentSafe(missing) = nil, want an error")
+	}
+
+	// The sticky exception: a root-owned sticky dir (e.g. /tmp) IS safe — the
+	// sticky bit stops a non-root user from deleting/replacing root's temp file.
+	if fi, err := os.Stat("/tmp"); err == nil {
+		st, ok := fi.Sys().(*syscall.Stat_t)
+		if ok && st.Uid == 0 && fi.Mode()&os.ModeSticky != 0 {
+			if err := escalatedParentSafe("/tmp"); err != nil {
+				t.Errorf("escalatedParentSafe(/tmp, root-owned sticky) = %v, want nil (sticky exception)", err)
+			}
+		}
+	}
+}

--- a/go/sys/fs/fs.go
+++ b/go/sys/fs/fs.go
@@ -41,6 +41,14 @@ import (
 // contains a NUL byte, or starts with `-` and would be interpreted as a flag).
 var ErrInvalidPath = errors.New("invalid filesystem path")
 
+// ErrUnsafeParentDir is returned by the escalated (sudo/doas) WriteFile when the
+// target's parent directory is writable by a non-root user — a directory where
+// an attacker could plant a symlink and redirect a root write. The escalated
+// path fails closed rather than write into such a directory. (The Direct/root
+// path is fd-anchored and does not need this; it is only the shell-based
+// escalated path, used by non-root callers, that cannot openat the target.)
+var ErrUnsafeParentDir = errors.New("parent directory is writable by non-root")
+
 // WriteOptions configures a Manager.WriteFile (or Copy) call.
 type WriteOptions struct {
 	// Mode is the file mode applied before the file is reachable by name. Zero

--- a/go/sys/fs/fs_test.go
+++ b/go/sys/fs/fs_test.go
@@ -146,6 +146,46 @@ func TestWriteFileWithModeAndOwnership(t *testing.T) {
 	}
 }
 
+// TestWriteFile_ReplacesSymlinkTargetNotFollowed is the real-system proof of the
+// symlink-safety fix: when the target path is a pre-planted symlink, the write
+// must REPLACE the symlink with a regular file (rename, via mv -T on the
+// escalated path / O_NOFOLLOW rename on the Direct path) and must NOT follow it
+// to clobber the symlink's destination. /tmp is sticky+root-owned, so the
+// escalated path's parent check admits it.
+func TestWriteFile_ReplacesSymlinkTargetNotFollowed(t *testing.T) {
+	ctx := context.Background()
+	m := intManager(t)
+
+	sentinel := tmpPath(t, "sym-sentinel")
+	link := tmpPath(t, "sym-link")
+	defer cleanup(t, m, sentinel)
+	defer cleanup(t, m, link)
+
+	if err := m.WriteFile(ctx, sentinel, []byte("SENTINEL\n"), fs.WriteOptions{}); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	_ = os.Remove(link)
+	if err := os.Symlink(sentinel, link); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	if err := m.WriteFile(ctx, link, []byte("newcontent\n"), fs.WriteOptions{}); err != nil {
+		t.Fatalf("WriteFile(symlinked target): %v", err)
+	}
+
+	// The symlink's destination must be untouched (the write did not follow it).
+	if got, _ := m.ReadFile(ctx, sentinel); string(got) != "SENTINEL\n" {
+		t.Errorf("sentinel was clobbered through the symlink: %q", got)
+	}
+	// The target path is now a regular file holding the new content.
+	if fi, err := os.Lstat(link); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("target is still a symlink (err=%v, mode=%v); the symlink was followed, not replaced", err, fi.Mode())
+	}
+	if got, _ := m.ReadFile(ctx, link); string(got) != "newcontent\n" {
+		t.Errorf("target content = %q, want the new content", got)
+	}
+}
+
 func TestSetModeAndOwnership(t *testing.T) {
 	ctx := context.Background()
 	m := intManager(t)

--- a/go/sys/fs/manager_test.go
+++ b/go/sys/fs/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -86,156 +87,94 @@ func TestNew_NilRunnerRejected(t *testing.T) {
 // --- WriteFile (escalated path) -------------------------------------------
 
 func TestWriteFile_Escalated_HappyWithOwnership(t *testing.T) {
+	// /etc is root-owned and not group/other-writable, so escalatedParentSafe
+	// admits it and the write proceeds to the (faked) root shell.
 	f, m := sudoMgr(t)
 	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("body\n"),
 		WriteOptions{Mode: 0o640, Owner: "root", Group: "staff"}); err != nil {
 		t.Fatal(err)
 	}
 	calls := f.Calls()
-	if len(calls) != 4 {
-		t.Fatalf("ran %d commands, want 4 (tee, chmod, chown, mv); got %v", len(calls), calls)
+	if len(calls) != 1 {
+		t.Fatalf("ran %d commands, want 1 (a single root sh -c); got %v", len(calls), callNames(calls))
 	}
-	if got := argv(calls[0]); got != "tee -- /etc/app.conf.pm-tmp" {
-		t.Errorf("tee argv = %q", got)
+	c := calls[0]
+	if !c.Escalate {
+		t.Error("the escalated write must run escalated")
 	}
-	if body := stdinOf(t, calls[0]); body != "body\n" {
-		t.Errorf("tee stdin = %q", body)
+	// args: -c <script> sh <target> <mode> <owner:group> <backup>
+	want := []string{"-c", escalatedWriteScript, "sh", "/etc/app.conf", "0640", "root:staff", ""}
+	if c.Name != "sh" || strings.Join(c.Args, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("command = %s %q\nwant   = sh %q", c.Name, c.Args, want)
 	}
-	if got := argv(calls[1]); got != "chmod 0640 -- /etc/app.conf.pm-tmp" {
-		t.Errorf("chmod argv = %q", got)
-	}
-	if got := argv(calls[2]); got != "chown -- root:staff /etc/app.conf.pm-tmp" {
-		t.Errorf("chown argv = %q", got)
-	}
-	if got := argv(calls[3]); got != "mv -f -- /etc/app.conf.pm-tmp /etc/app.conf" {
-		t.Errorf("mv argv = %q", got)
-	}
-	for i, c := range calls {
-		if !c.Escalate {
-			t.Errorf("call %d (%s) not escalated", i, c.Name)
-		}
+	if body := stdinOf(t, c); body != "body\n" {
+		t.Errorf("stdin = %q, want the file content (read by `cat` in the script)", body)
 	}
 }
 
-func TestWriteFile_Escalated_DefaultsModeAndSkipsChownWhenNoOwner(t *testing.T) {
+func TestWriteFile_Escalated_DefaultModeNoOwner(t *testing.T) {
 	f, m := sudoMgr(t)
 	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"), WriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	calls := f.Calls()
-	if len(calls) != 3 {
-		t.Fatalf("ran %d commands, want 3 (tee, chmod, mv) when no owner/group", len(calls))
+	c := f.Calls()[0]
+	if c.Args[4] != "0644" {
+		t.Errorf("mode arg = %q, want default 0644", c.Args[4])
 	}
-	if got := argv(calls[1]); got != "chmod 0644 -- /etc/app.conf.pm-tmp" {
-		t.Errorf("chmod argv = %q, want default 0644", got)
+	if c.Args[5] != "" {
+		t.Errorf("owner arg = %q, want empty (script skips chown)", c.Args[5])
+	}
+	if c.Args[6] != "" {
+		t.Errorf("backup arg = %q, want empty", c.Args[6])
 	}
 }
 
-func TestWriteFile_Escalated_TeeFailureCleansUp(t *testing.T) {
+func TestWriteFile_Escalated_WithBackupArg(t *testing.T) {
+	f, m := sudoMgr(t)
+	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("new"),
+		WriteOptions{Backup: "/etc/app.conf.bak"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.Calls()[0].Args[6]; got != "/etc/app.conf.bak" {
+		t.Errorf("backup arg = %q, want the backup path (the root script does the copy)", got)
+	}
+}
+
+func TestWriteFile_Escalated_ScriptFailure(t *testing.T) {
 	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{ExitCode: 1, Stderr: "tee: No such file or directory"}, nil) // tee
+	f.Push(pmexec.Result{ExitCode: 1, Stderr: "mktemp: cannot create"}, nil)
 	m := mustManager(t, f)
 	err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"), WriteOptions{})
 	if err == nil || !strings.Contains(err.Error(), "write file") {
-		t.Fatalf("err = %v, want a wrapped tee failure", err)
-	}
-	calls := f.Calls()
-	if len(calls) != 2 || calls[1].Name != "rm" {
-		t.Fatalf("want [tee, rm] cleanup, got %v", calls)
+		t.Fatalf("err = %v, want a wrapped write-file failure", err)
 	}
 }
 
-func TestWriteFile_Escalated_ChmodFailureCleansUp(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{ExitCode: 0}, nil)                  // tee ok
-	f.Push(pmexec.Result{ExitCode: 1, Stderr: "chmod"}, nil) // chmod fails
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"), WriteOptions{}); err == nil ||
-		!strings.Contains(err.Error(), "chmod") {
-		t.Fatalf("err = %v, want a wrapped chmod failure", err)
+// TestWriteFile_Escalated_RefusesUnsafeParent: a parent directory a non-root user
+// could write to (here world-writable and not sticky) is refused BEFORE any
+// escalation, so the symlink-plant window never opens. The 0777-non-sticky perms
+// are unsafe whether or not the test runs as root.
+func TestWriteFile_Escalated_RefusesUnsafeParent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
 	}
-	if calls := f.Calls(); calls[len(calls)-1].Name != "rm" {
-		t.Errorf("temp not cleaned up after chmod failure: %v", calls)
+	f, m := sudoMgr(t)
+	err := m.WriteFile(context.Background(), filepath.Join(dir, "f"), []byte("x"), WriteOptions{})
+	if !errors.Is(err, ErrUnsafeParentDir) {
+		t.Fatalf("err = %v, want ErrUnsafeParentDir", err)
 	}
-}
-
-func TestWriteFile_Escalated_ChownFailureCleansUp(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{}, nil)                             // tee
-	f.Push(pmexec.Result{}, nil)                             // chmod
-	f.Push(pmexec.Result{ExitCode: 1, Stderr: "chown"}, nil) // chown fails
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"),
-		WriteOptions{Owner: "root"}); err == nil || !strings.Contains(err.Error(), "chown") {
-		t.Fatalf("err = %v, want a wrapped chown failure", err)
-	}
-}
-
-func TestWriteFile_Escalated_MvFailureCleansUp(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{}, nil)                          // tee
-	f.Push(pmexec.Result{}, nil)                          // chmod
-	f.Push(pmexec.Result{ExitCode: 1, Stderr: "mv"}, nil) // mv fails
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"), WriteOptions{}); err == nil ||
-		!strings.Contains(err.Error(), "move file into place") {
-		t.Fatalf("err = %v, want a wrapped mv failure", err)
-	}
-	if calls := f.Calls(); calls[len(calls)-1].Name != "rm" {
-		t.Errorf("temp not cleaned up after mv failure: %v", calls)
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("ran %d commands; an unsafe parent must be refused before escalating", n)
 	}
 }
 
 func TestWriteFile_Escalated_RunnerErrorPropagates(t *testing.T) {
 	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // tee can't escalate
+	f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // the root shell can't escalate
 	m := mustManager(t, f)
 	if err := m.WriteFile(context.Background(), "/etc/app.conf", []byte("x"), WriteOptions{}); !errors.Is(err, pmexec.ErrEscalationDenied) {
 		t.Fatalf("err = %v, want ErrEscalationDenied", err)
-	}
-}
-
-func TestWriteFile_Escalated_WithBackup_CopiesExisting(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{ExitCode: 0}, nil) // test -e (exists)
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/usr/local/bin/app", []byte("new"),
-		WriteOptions{Backup: "/usr/local/bin/app.bak"}); err != nil {
-		t.Fatal(err)
-	}
-	calls := f.Calls()
-	// test -e, cp, tee, chmod, mv
-	if len(calls) != 5 {
-		t.Fatalf("ran %d commands, want 5 (test, cp, tee, chmod, mv): %v", len(calls), callNames(calls))
-	}
-	if got := argv(calls[1]); got != "cp -f -- /usr/local/bin/app /usr/local/bin/app.bak" {
-		t.Errorf("cp argv = %q", got)
-	}
-}
-
-func TestWriteFile_Escalated_WithBackup_AbsentSkipsCopy(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{ExitCode: 1}, nil) // test -e (absent)
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/usr/local/bin/app", []byte("new"),
-		WriteOptions{Backup: "/usr/local/bin/app.bak"}); err != nil {
-		t.Fatal(err)
-	}
-	for _, c := range f.Calls() {
-		if c.Name == "cp" {
-			t.Fatal("cp ran for a backup of a non-existent file")
-		}
-	}
-}
-
-func TestWriteFile_Escalated_WithBackup_CopyFailure(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{ExitCode: 0}, nil)               // test -e (exists)
-	f.Push(pmexec.Result{ExitCode: 1, Stderr: "cp"}, nil) // cp fails
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/usr/local/bin/app", []byte("new"),
-		WriteOptions{Backup: "/usr/local/bin/app.bak"}); err == nil || !strings.Contains(err.Error(), "backup") {
-		t.Fatalf("err = %v, want a wrapped backup failure", err)
 	}
 }
 
@@ -746,16 +685,6 @@ func TestWriteFile_Direct_SafeReplaceError(t *testing.T) {
 	if err := m.WriteFile(context.Background(), dest, []byte("x"), WriteOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "write file") {
 		t.Fatalf("err = %v, want a wrapped write failure", err)
-	}
-}
-
-func TestWriteFile_Escalated_BackupExistsProbeError(t *testing.T) {
-	f := exectest.New(pmexec.Sudo)
-	f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // test -e cannot run
-	m := mustManager(t, f)
-	if err := m.WriteFile(context.Background(), "/usr/local/bin/app", []byte("x"),
-		WriteOptions{Backup: "/usr/local/bin/app.bak"}); !errors.Is(err, pmexec.ErrEscalationDenied) {
-		t.Fatalf("err = %v, want the probe's runner error to propagate", err)
 	}
 }
 

--- a/go/sys/fs/write.go
+++ b/go/sys/fs/write.go
@@ -18,9 +18,11 @@ import (
 // attacker redirect the root agent's write to an arbitrary file.
 //
 // Under Sudo/Doas (a non-root caller, e.g. CI or a dev tool) the escalated path
-// is used: it cannot openat as root, so it shells the write through the
-// privilege backend (tee → chmod → chown → mv). That path is NOT symlink-safe,
-// but the security-relevant consumer — the root agent — never takes it.
+// is used: it cannot openat as root, so it is also made symlink-safe by refusing
+// any target whose parent directory a non-root user could write to (the only
+// place a symlink could be planted) and then writing atomically in a single root
+// shell — mktemp + write + `mv -T` over the target (a rename replaces a symlinked
+// target, never follows it). See writeEscalated.
 func (m *manager) WriteFile(ctx context.Context, path string, data []byte, opts WriteOptions) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -72,73 +74,56 @@ func writeDirect(path string, data []byte, opts WriteOptions) error {
 }
 
 // writeEscalated is the privilege-backend (sudo/doas) path for non-root callers.
-// Predictable temp + tee/mv; not symlink-safe (see WriteFile's doc for why that
-// is acceptable).
+// It is symlink-safe. First it refuses, unprivileged, any target whose parent
+// directory a non-root user could write to (escalatedParentSafe) — the only
+// place an attacker could plant a symlink. Then it performs the entire write in
+// a SINGLE root shell: mktemp a random temp in the target's directory (O_EXCL,
+// nothing to follow), write it from stdin, set mode/owner, and atomically
+// `mv -T` it over the target (a rename REPLACES a symlinked target, it does not
+// follow it). The Direct/root path (writeDirect) is fd-anchored and is preferred
+// for security-sensitive writes; this shell path serves non-root callers that
+// cannot openat the target as root.
 func (m *manager) writeEscalated(ctx context.Context, path string, data []byte, opts WriteOptions) error {
 	perm := opts.Mode
 	if perm == 0 {
 		perm = 0o644
 	}
-	if opts.Backup != "" {
-		if err := m.backupEscalated(ctx, path, opts.Backup); err != nil {
-			return err
-		}
-	}
-	tmpPath := path + ".pm-tmp"
-	if err := m.writeTee(ctx, tmpPath, data); err != nil {
-		m.bestEffortRemove(ctx, tmpPath)
-		return fmt.Errorf("write file %s: %w", tmpPath, err)
-	}
-	if err := m.applyModeOwner(ctx, tmpPath, perm, opts.Owner, opts.Group); err != nil {
-		m.bestEffortRemove(ctx, tmpPath)
+	if err := escalatedParentSafe(filepath.Dir(path)); err != nil {
 		return err
 	}
-	if err := m.runChecked(ctx, "mv", "-f", "--", tmpPath, path); err != nil {
-		m.bestEffortRemove(ctx, tmpPath)
-		return fmt.Errorf("move file into place: %w", err)
-	}
-	return nil
-}
-
-// writeTee streams data to path through an escalated `tee`. A non-zero tee exit
-// (e.g. the parent directory does not exist) is surfaced as an error.
-func (m *manager) writeTee(ctx context.Context, path string, data []byte) error {
-	res, err := m.runPrivStdin(ctx, string(data), "tee", "--", path)
+	res, err := m.runPrivStdin(ctx, string(data), "sh", "-c", escalatedWriteScript,
+		"sh", path, modeArg(perm), Ownership(opts.Owner, opts.Group), opts.Backup)
 	if err != nil {
-		return err
+		return fmt.Errorf("write file %s: %w", path, err)
 	}
-	return cmdError("tee", res)
-}
-
-// applyModeOwner chmods (always) and chowns (when owner/group set) a path
-// through the escalated backend.
-func (m *manager) applyModeOwner(ctx context.Context, path string, perm os.FileMode, owner, group string) error {
-	if err := m.runChecked(ctx, "chmod", modeArg(perm), "--", path); err != nil {
-		return fmt.Errorf("chmod: %w", err)
-	}
-	if owner != "" || group != "" {
-		if err := m.runChecked(ctx, "chown", "--", Ownership(owner, group), path); err != nil {
-			return fmt.Errorf("chown: %w", err)
-		}
+	if cerr := cmdError("write file", res); cerr != nil {
+		return fmt.Errorf("write file %s: %w", path, cerr)
 	}
 	return nil
 }
 
-// backupEscalated copies the existing file at path to backup before it is
-// replaced. A path that does not yet exist is a no-op (nothing to back up).
-func (m *manager) backupEscalated(ctx context.Context, path, backup string) error {
-	exists, err := m.Exists(ctx, path)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return nil
-	}
-	if err := m.runChecked(ctx, "cp", "-f", "--", path, backup); err != nil {
-		return fmt.Errorf("backup %s to %s: %w", path, backup, err)
-	}
-	return nil
-}
+// escalatedWriteScript performs an atomic, symlink-safe write entirely as root in
+// one process, so there is no cross-process TOCTOU window. Positional args:
+// $1=target, $2=chmod mode, $3=chown owner (":group" form, "" to skip),
+// $4=backup path ("" to skip). The file content is read from stdin. The parent
+// directory's safety is vetted in Go (escalatedParentSafe) before this runs, so
+// only root can have influenced the directory this writes into.
+const escalatedWriteScript = `set -eu
+target=$1; mode=$2; owner=$3; backup=$4
+dir=$(dirname -- "$target")
+if [ -n "$backup" ] && [ -e "$target" ]; then
+	cp -f -- "$target" "$backup"
+fi
+tmp=$(mktemp "$dir/.pm-XXXXXXXXXX")
+trap 'rm -f -- "$tmp"' EXIT
+cat > "$tmp"
+chmod "$mode" -- "$tmp"
+if [ -n "$owner" ]; then
+	chown "$owner" -- "$tmp"
+fi
+mv -T -- "$tmp" "$target"
+trap - EXIT
+`
 
 // runChecked runs an escalated command and folds a runner error and a non-zero
 // exit into a single error (nil only on a clean exit).
@@ -148,12 +133,6 @@ func (m *manager) runChecked(ctx context.Context, name string, args ...string) e
 		return err
 	}
 	return cmdError(name, res)
-}
-
-// bestEffortRemove deletes path through the escalated backend, ignoring the
-// outcome — used to clean up a temp file on a failure path.
-func (m *manager) bestEffortRemove(ctx context.Context, path string) {
-	_, _ = m.runPriv(ctx, "rm", "-f", "--", path)
 }
 
 // Copy copies src to dst (plain cp, no -p) and applies opts to dst. opts.Mode of


### PR DESCRIPTION
Second SDK behaviour/security fix. The escalated `WriteFile` used a predictable temp (`path+".pm-tmp"`) through `sudo tee`, which follows a pre-planted symlink — a local privesc when the target's directory is attacker-writable.

**Now (your choice: fully symlink-safe, fail-closed on unsafe parent):**
- Go-side `escalatedParentSafe` (unprivileged, before escalating): parent must be root-owned AND (not group/other-writable OR sticky). Sticky exception keeps /tmp usable and is genuinely safe. Unsafe → `ErrUnsafeParentDir`.
- single root `sh -c`: `mktemp` (O_EXCL) + write + `mv -T` (rename replaces a symlinked target, never follows it) — one root process, no cross-process TOCTOU.
- Direct/root path (fd-anchored) unchanged. Dead tee/chmod/chown/mv/backup helpers removed.

**TDD/validation:** escalated unit tests rewritten for the single-script shape; `escalatedParentSafe` unit test (safe / world-writable-refused / sticky); real-system integration test proving a planted symlink target is replaced, not followed; script mechanics validated independently. Whole-SDK build/vet, fs race, integration-compile, staticcheck all green; local cr clean.

Sibling note: `pkg/pacman.go` writes /etc/pacman.conf via `tee` (parent /etc is root-only, so not the exploitable class) — hardened for consistency in the upcoming pkg PR. Closes #170.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parent directory permission validation for privileged file writes to prevent unsafe operations.

* **Bug Fixes**
  * Improved symlink safety during escalated writes with atomic replacement mechanism.
  * Added platform-specific handling for unsupported systems with appropriate error reporting.

* **Tests**
  * Enhanced test coverage for symlink safety and escalated write operations.
  * Added validation tests for parent directory permission checks across various filesystem conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->