### PR TITLE
fix(user): validate account fields + reject negative UID/GID + LockedKnown

### DIFF
--- a/go/sys/user/edge_test.go
+++ b/go/sys/user/edge_test.go
@@ -46,6 +46,9 @@ func TestGet_StarLockedIsDetected(t *testing.T) {
 	if !info.Locked {
 		t.Error("'*'-prefixed shadow entry not detected as locked")
 	}
+	if !info.LockedKnown {
+		t.Error("LockedKnown = false after a successful shadow read; Locked is authoritative here")
+	}
 }
 
 // Get tolerates extra surrounding whitespace / CR in getent output.

--- a/go/sys/user/errors_test.go
+++ b/go/sys/user/errors_test.go
@@ -179,4 +179,7 @@ func TestGet_ShadowUnreadableLeavesUnlocked(t *testing.T) {
 	if info.Locked {
 		t.Error("Locked = true, want false when shadow is unreadable")
 	}
+	if info.LockedKnown {
+		t.Error("LockedKnown = true, want false when the shadow read failed — unknown must not look unlocked")
+	}
 }

--- a/go/sys/user/field_validation_test.go
+++ b/go/sys/user/field_validation_test.go
@@ -1,0 +1,94 @@
+package user
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// noRun asserts the Runner was never invoked — an invalid request must be
+// rejected before any useradd/usermod/groupadd runs.
+func noRun(t *testing.T, f *exectest.FakeRunner) {
+	t.Helper()
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("an invalid request reached the Runner (%d calls): %+v", n, f.Calls())
+	}
+}
+
+func TestCreate_RejectsNegativeUID(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{UID: -1}); err == nil ||
+		!strings.Contains(err.Error(), "UID") {
+		t.Fatalf("Create(UID=-1) err = %v, want an invalid-UID error", err)
+	}
+	noRun(t, f)
+}
+
+func TestGroupCreate_RejectsNegativeGID(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).GroupCreate(context.Background(), "staff", GroupCreateOptions{GID: -5}); err == nil ||
+		!strings.Contains(err.Error(), "GID") {
+		t.Fatalf("GroupCreate(GID=-5) err = %v, want an invalid-GID error", err)
+	}
+	noRun(t, f)
+}
+
+// TestCreate_RejectsFieldInjection: free-form account fields written into
+// /etc/passwd (or the -G list) must reject control characters and the field
+// separators ':' / ',' so a caller cannot corrupt the file or inject extra
+// fields/records (GECOS injection, extra supplementary groups).
+func TestCreate_RejectsFieldInjection(t *testing.T) {
+	cases := map[string]CreateOptions{
+		"newline in comment":      {Comment: "Real Name\nroot:x:0:0::/root:/bin/sh"},
+		"colon in comment":        {Comment: "a:b"},
+		"NUL in home dir":         {HomeDir: "/home/x\x00y"},
+		"newline in shell":        {Shell: "/bin/sh\n/bin/evil"},
+		"colon in shell":          {Shell: "/bin/sh:x"},
+		"comma in primary group":  {PrimaryGroup: "wheel,root"},
+		"colon in supplementary":  {Groups: []string{"ok", "bad:grp"}},
+		"comma in supplementary":  {Groups: []string{"a,b"}},
+		"control char in comment": {Comment: "tab\there"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Create(context.Background(), "deploy", opts); err == nil {
+				t.Errorf("Create(%+v) = nil, want a field-validation error", opts)
+			}
+			noRun(t, f)
+		})
+	}
+}
+
+func TestModify_RejectsFieldInjection(t *testing.T) {
+	cases := map[string]ModifyOptions{
+		"newline in comment":     {Comment: "x\ny"},
+		"colon in shell":         {Shell: "/bin/sh:x"},
+		"comma in primary group": {PrimaryGroup: "a,b"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Modify(context.Background(), "deploy", opts); err == nil {
+				t.Errorf("Modify(%+v) = nil, want a field-validation error", opts)
+			}
+			noRun(t, f)
+		})
+	}
+}
+
+// A clean Comment with GECOS commas (the legitimate sub-field separator) must be
+// accepted — the validation rejects the dangerous bytes, not normal content.
+func TestCreate_AllowsCommasInComment(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if err := mgr(t, f).Create(context.Background(), "deploy",
+		CreateOptions{Comment: "Jane Doe,Room 1,555-1234"}); err != nil {
+		t.Fatalf("Create with a comma-bearing GECOS comment = %v, want nil", err)
+	}
+	if n := len(f.Calls()); n != 1 {
+		t.Fatalf("ran %d commands, want 1 useradd", n)
+	}
+}

--- a/go/sys/user/group.go
+++ b/go/sys/user/group.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -80,6 +81,9 @@ func (u *shadowUtils) GroupMembers(ctx context.Context, name string) ([]string, 
 func (u *shadowUtils) GroupCreate(ctx context.Context, name string, opts GroupCreateOptions) error {
 	if err := validateName("group name", name); err != nil {
 		return err
+	}
+	if opts.GID < 0 {
+		return fmt.Errorf("invalid GID %d: must be >= 0 (0 = auto-assign)", opts.GID)
 	}
 	args := make([]string, 0, 4)
 	if opts.GID > 0 {

--- a/go/sys/user/user.go
+++ b/go/sys/user/user.go
@@ -38,6 +38,12 @@ type Info struct {
 	Shell   string
 	Groups  []string // supplementary groups (excluding the primary)
 	Locked  bool
+	// LockedKnown reports whether Locked is authoritative. The locked state lives
+	// in the root-only shadow file; if reading it failed or escalation was not
+	// authorized, Locked is left false and LockedKnown is false — so a caller can
+	// tell "not locked" (Locked=false, LockedKnown=true) apart from "unknown"
+	// (Locked=false, LockedKnown=false) and not treat unknown as unlocked.
+	LockedKnown bool
 }
 
 // CreateOptions configures Create. The zero value creates a normal interactive
@@ -176,6 +182,12 @@ func (u *shadowUtils) Create(ctx context.Context, name string, opts CreateOption
 	if err := validateUsername(name); err != nil {
 		return err
 	}
+	if opts.UID < 0 {
+		return fmt.Errorf("invalid UID %d: must be >= 0 (0 = auto-assign)", opts.UID)
+	}
+	if err := validateAccountFields(opts.Comment, opts.HomeDir, opts.Shell, opts.PrimaryGroup, opts.Groups); err != nil {
+		return err
+	}
 
 	args := make([]string, 0, 16)
 	if opts.UID > 0 {
@@ -238,6 +250,9 @@ func (u *shadowUtils) Create(ctx context.Context, name string, opts CreateOption
 // nothing is set it is a no-op (no usermod run).
 func (u *shadowUtils) Modify(ctx context.Context, name string, opts ModifyOptions) error {
 	if err := validateUsername(name); err != nil {
+		return err
+	}
+	if err := validateAccountFields(opts.Comment, opts.HomeDir, opts.Shell, opts.PrimaryGroup, nil); err != nil {
 		return err
 	}
 	args := make([]string, 0, 8)
@@ -334,6 +349,7 @@ func (u *shadowUtils) Get(ctx context.Context, name string) (Info, error) {
 		sf := strings.Split(strings.TrimSpace(res.Stdout), ":")
 		if len(sf) >= 2 {
 			info.Locked = strings.HasPrefix(sf[1], "!") || strings.HasPrefix(sf[1], "*")
+			info.LockedKnown = true // the shadow read succeeded; Locked is authoritative
 		}
 	}
 	return info, nil
@@ -432,3 +448,44 @@ func validateName(kind, name string) error {
 }
 
 func validateUsername(name string) error { return validateName("username", name) }
+
+// validateField rejects values that would corrupt /etc/passwd or inject extra
+// fields/records when written via useradd/usermod. Every free-form account field
+// (Comment/HomeDir/Shell, and group references) must contain no control
+// character (NUL, newline, CR, …) and none of the separators in `reject` — ':'
+// is the passwd field separator; ',' is the -G group-list separator. An empty
+// value is the "unchanged"/"default" sentinel and is allowed.
+func validateField(kind, val, reject string) error {
+	for _, r := range val {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("invalid %s: must not contain control characters", kind)
+		}
+		if strings.ContainsRune(reject, r) {
+			return fmt.Errorf("invalid %s: must not contain %q", kind, r)
+		}
+	}
+	return nil
+}
+
+// validateAccountFields validates the free-form fields shared by Create/Modify.
+// reject for a passwd field is ":"; group references also reject ",".
+func validateAccountFields(comment, homeDir, shell, primaryGroup string, groups []string) error {
+	if err := validateField("comment", comment, ":"); err != nil {
+		return err
+	}
+	if err := validateField("home directory", homeDir, ":"); err != nil {
+		return err
+	}
+	if err := validateField("shell", shell, ":"); err != nil {
+		return err
+	}
+	if err := validateField("primary group", primaryGroup, ":,"); err != nil {
+		return err
+	}
+	for _, g := range groups {
+		if err := validateField("supplementary group", g, ":,"); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Third SDK behaviour/security fix (user half of the validation pass).

- **Negative UID/GID**: Create/GroupCreate silently dropped them (`> 0` guard) → now rejected (0 stays auto-assign).
- **Field injection**: Comment/HomeDir/Shell unvalidated into /etc/passwd. `validateAccountFields` rejects control chars + `:` (and `,` for group refs) — closes GECOS/passwd-record injection (newline in Comment) and `-G` list injection (comma). Legit GECOS commas still pass.
- **LockedKnown**: `Get` left `Locked=false` on a failed/unauthorized shadow read (unknown looked unlocked). Added `Info.LockedKnown`, true only on a successful shadow read.

TDD with rejection coverage (every invalid request asserts zero Runner calls), extended the two shadow tests for LockedKnown, red-checked; 99.7% coverage, whole-SDK build clean, local cr clean. Closes #172.