### PR TITLE
fix(network): reject control chars in profile fields + validate connection names

### DIFF
--- a/go/sys/exec/secret.go
+++ b/go/sys/exec/secret.go
@@ -55,3 +55,11 @@ func (s Secret) Reveal() string { return s.v }
 
 // IsZero reports whether the secret is empty.
 func (s Secret) IsZero() bool { return s.v == "" }
+
+// HasNewline reports whether the secret contains a newline or carriage return —
+// without exposing the plaintext (it returns only a bool, so it is not a Reveal
+// sink). A NewSecret value never does; a NewMultilineSecret one may, and such a
+// value must not be interpolated into a line-oriented sink (a tool's stdin
+// record, or an nmcli keyfile `psk=` line). Callers validate with this instead
+// of revealing the secret to inspect it.
+func (s Secret) HasNewline() bool { return strings.ContainsAny(s.v, "\n\r") }

--- a/go/sys/exec/secret_test.go
+++ b/go/sys/exec/secret_test.go
@@ -114,3 +114,24 @@ func TestSecret_RedactsWhenNestedInStruct(t *testing.T) {
 		t.Fatalf("nested Secret not redacted: %q", out)
 	}
 }
+
+// HasNewline reports a newline/CR without revealing the plaintext — the safe
+// predicate validators use for line-oriented sinks (keyfile psk=, stdin records).
+func TestSecret_HasNewline(t *testing.T) {
+	clean, err := NewSecret("Hunter2-no-newlines")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clean.HasNewline() {
+		t.Error("a clean secret reported a newline")
+	}
+	if NewMultilineSecret("a\nb").HasNewline() != true {
+		t.Error("a \\n multiline secret must report HasNewline")
+	}
+	if NewMultilineSecret("a\rb").HasNewline() != true {
+		t.Error("a \\r multiline secret must report HasNewline")
+	}
+	if (Secret{}).HasNewline() {
+		t.Error("the zero secret has no newline")
+	}
+}

--- a/go/sys/network/keyfile_injection_test.go
+++ b/go/sys/network/keyfile_injection_test.go
@@ -1,0 +1,90 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+)
+
+// TestValidateProfile_RejectsControlChars: Name/SSID/PSK are rendered into the
+// .nmconnection keyfile (id=/ssid=/psk=); a control character (notably a
+// newline) would inject extra INI lines or sections. validateProfile must reject
+// them; legitimate values must pass.
+func TestValidateProfile_RejectsControlChars(t *testing.T) {
+	ok := mustSecret(t, "Hunter2-Corp-PSK-distinctive")
+	valid := Profile{Name: "pm-wifi-1", SSID: "CorpNet", AuthType: AuthPSK, PSK: ok}
+	if err := validateProfile(valid); err != nil {
+		t.Fatalf("a clean PSK profile was rejected: %v", err)
+	}
+
+	bad := map[string]Profile{
+		"newline in name":      {Name: "pm\n[connection]\nid=evil", SSID: "Corp", AuthType: AuthPSK, PSK: ok},
+		"leading dash in name": {Name: "-x", SSID: "Corp", AuthType: AuthPSK, PSK: ok},
+		"empty name":           {Name: "", SSID: "Corp", AuthType: AuthPSK, PSK: ok},
+		"newline in ssid":      {Name: "pm-wifi-1", SSID: "Corp\nhidden=true", AuthType: AuthPSK, PSK: ok},
+		"NUL in ssid":          {Name: "pm-wifi-1", SSID: "Corp\x00", AuthType: AuthPSK, PSK: ok},
+		// A normal NewSecret PSK can't hold a newline, but a NewMultilineSecret one
+		// can — and its own doc forbids using it for a keyfile psk= line. The
+		// profile validator is what enforces that, so test it via that constructor.
+		"newline in psk":      {Name: "pm-wifi-1", SSID: "Corp", AuthType: AuthPSK, PSK: exec.NewMultilineSecret("pass\n[wifi-security]\nkey-mgmt=none")},
+		"newline in identity": {Name: "pm-wifi-1", SSID: "Corp", AuthType: AuthEAPTLS, Identity: "user\nx"},
+	}
+	for name, p := range bad {
+		t.Run(name, func(t *testing.T) {
+			if err := validateProfile(p); err == nil {
+				t.Errorf("validateProfile accepted an injectable profile (%s)", name)
+			}
+		})
+	}
+}
+
+// TestApply_RejectsInjectionBeforeAnyCommand: Apply validates the profile first,
+// so an injectable field is refused before any nmcli runs or keyfile is written.
+func TestApply_RejectsInjectionBeforeAnyCommand(t *testing.T) {
+	r := &recordingRunner{}
+	_, err := mgr(t, r).Apply(context.Background(), Profile{
+		Name: "pm\nid=evil", SSID: "Corp", AuthType: AuthPSK, PSK: mustSecret(t, "Hunter2xxxxxxx"),
+	})
+	if err == nil {
+		t.Fatal("Apply accepted a newline-injected name")
+	}
+	if n := len(r.calls); n != 0 {
+		t.Errorf("Apply ran %d commands; an injectable profile must be refused first", n)
+	}
+}
+
+func TestConnectionNameMethods_RejectInvalidName(t *testing.T) {
+	for _, name := range []string{"-x", "a\nb", "", "x\x00y"} {
+		t.Run(name, func(t *testing.T) {
+			r := &recordingRunner{}
+			m := mgr(t, r)
+			if _, err := m.ConnectionExists(context.Background(), name); err == nil {
+				t.Errorf("ConnectionExists(%q) = nil err, want a validation error", name)
+			}
+			if _, err := m.Settings(context.Background(), name); err == nil {
+				t.Errorf("Settings(%q) = nil err, want a validation error", name)
+			}
+			if err := m.Delete(context.Background(), name, DeleteOptions{}); err == nil {
+				t.Errorf("Delete(%q) = nil err, want a validation error", name)
+			}
+			if n := len(r.calls); n != 0 {
+				t.Errorf("an invalid name reached nmcli (%d calls)", n)
+			}
+		})
+	}
+}
+
+// A legitimate connection name (including one with embedded spaces, which nmcli
+// permits) must be accepted by the name validator.
+func TestValidateConnName_AllowsLegitNames(t *testing.T) {
+	for _, name := range []string{"pm-wifi-01", "Corp Net", "home_5GHz"} {
+		if err := validateConnName(name); err != nil {
+			t.Errorf("validateConnName(%q) = %v, want nil", name, err)
+		}
+	}
+	if !strings.Contains(validateConnName("").Error(), "required") {
+		t.Error("empty name should report 'required'")
+	}
+}

--- a/go/sys/network/network.go
+++ b/go/sys/network/network.go
@@ -122,20 +122,35 @@ func New(b Backend, runner exec.Runner, _ ...Option) (Manager, error) {
 // validateProfile checks required fields based on auth type. PSK/ClientKey are
 // Secrets; an empty Secret counts as absent.
 func validateProfile(p Profile) error {
-	if p.Name == "" {
-		return fmt.Errorf("connection name is required")
+	if err := validateConnName(p.Name); err != nil {
+		return err
 	}
 	if p.SSID == "" {
 		return fmt.Errorf("SSID is required")
+	}
+	// Name, SSID and PSK are rendered into the .nmconnection keyfile as
+	// `id=`/`ssid=`/`psk=` lines; a control character (notably a newline) would
+	// inject additional INI lines or sections (config injection).
+	if containsControl(p.SSID) {
+		return fmt.Errorf("invalid SSID: must not contain control characters")
 	}
 	switch p.AuthType {
 	case AuthPSK:
 		if p.PSK.IsZero() {
 			return fmt.Errorf("PSK is required for WPA authentication")
 		}
+		// The PSK is rendered into the keyfile psk= line. A NewSecret PSK can't
+		// hold a newline, but a NewMultilineSecret one can — reject that here
+		// (checked without revealing the plaintext) so it can't split the line.
+		if p.PSK.HasNewline() {
+			return fmt.Errorf("invalid PSK: must not contain a newline or carriage return")
+		}
 	case AuthEAPTLS:
 		if p.Identity == "" {
 			return fmt.Errorf("identity is required for EAP-TLS authentication")
+		}
+		if containsControl(p.Identity) {
+			return fmt.Errorf("invalid identity: must not contain control characters")
 		}
 		if p.CertDir == "" {
 			return fmt.Errorf("cert directory is required for EAP-TLS authentication")
@@ -151,6 +166,34 @@ func validateProfile(p Profile) error {
 		}
 	default:
 		return fmt.Errorf("unknown auth type: %d", p.AuthType)
+	}
+	return nil
+}
+
+// containsControl reports whether s holds any control character (NUL, newline,
+// CR, tab, …) — bytes that would corrupt the line-oriented .nmconnection keyfile
+// or nmcli's terse output.
+func containsControl(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// validateConnName validates a connection name. It is rendered into the keyfile
+// (`id=`) and passed to nmcli as an argument, so it must be non-empty, free of
+// control characters, and not start with '-' (which nmcli would read as a flag).
+func validateConnName(name string) error {
+	if name == "" {
+		return fmt.Errorf("connection name is required")
+	}
+	if containsControl(name) {
+		return fmt.Errorf("invalid connection name: must not contain control characters")
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid connection name %q: must not start with '-'", name)
 	}
 	return nil
 }

--- a/go/sys/network/networkmanager.go
+++ b/go/sys/network/networkmanager.go
@@ -48,6 +48,9 @@ func (m *networkManager) nmcliWrite(ctx context.Context, args ...string) error {
 // that real failures (NetworkManager not running, nmcli missing, ctx cancelled)
 // propagate as errors instead of collapsing into "not found".
 func (m *networkManager) ConnectionExists(ctx context.Context, name string) (bool, error) {
+	if err := validateConnName(name); err != nil {
+		return false, err
+	}
 	out, err := m.nmcliRead(ctx, "-t", "-f", "NAME", "con", "show")
 	if err != nil {
 		return false, fmt.Errorf("list connections: %w", err)
@@ -65,6 +68,9 @@ func (m *networkManager) ConnectionExists(ctx context.Context, name string) (boo
 // Settings retrieves a connection's current settings as a key-value map. Values
 // are unescaped from nmcli terse-mode encoding (\: -> :, \\ -> \).
 func (m *networkManager) Settings(ctx context.Context, name string) (map[string]string, error) {
+	if err := validateConnName(name); err != nil {
+		return nil, err
+	}
 	out, err := m.nmcliRead(ctx, "-t", "-f", "all", "con", "show", name)
 	if err != nil {
 		return nil, fmt.Errorf("get settings for %s: %w", name, err)


### PR DESCRIPTION
Completes fix C (network half). `buildPSKKeyfile` renders Name/SSID/PSK into a `.nmconnection` INI (`id=`/`ssid=`/`psk=`); a newline injects extra INI lines/sections. `validateProfile` now rejects control chars in Name/SSID/PSK/Identity, and `validateConnName` guards the nmcli-arg name (control chars + leading `-`) in ConnectionExists/Settings/Delete.

Notable: the PSK check defends against a `NewMultilineSecret` PSK reaching `psk=` — the exact hazard that constructor's doc warns about (`NewSecret` blocks `\n`, the multiline variant doesn't); tested via that constructor.

TDD with a rejection table + conn-name-method tests (zero nmcli calls on invalid names) + allow-legit cases; red-checked; 100% coverage; whole-SDK build clean; local cr clean. Closes #174.