### PR TITLE
fix(pkg): Upgrade is a no-op on empty input; add explicit UpgradeAll

### DIFF
--- a/go/pkg/apt.go
+++ b/go/pkg/apt.go
@@ -132,11 +132,16 @@ func (a *apt) Upgrade(ctx context.Context, packages ...string) error {
 		return err
 	}
 	if len(packages) == 0 {
-		args := append([]string{"dist-upgrade", "-y"}, dpkgConfOptions...)
-		return a.write(ctx, "apt", args...)
+		return nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	args := append([]string{"install", "-y", "--only-upgrade"}, dpkgConfOptions...)
 	args = append(args, packages...)
+	return a.write(ctx, "apt", args...)
+}
+
+// UpgradeAll performs a full distribution upgrade (apt dist-upgrade).
+func (a *apt) UpgradeAll(ctx context.Context) error {
+	args := append([]string{"dist-upgrade", "-y"}, dpkgConfOptions...)
 	return a.write(ctx, "apt", args...)
 }
 

--- a/go/pkg/apt_test.go
+++ b/go/pkg/apt_test.go
@@ -191,14 +191,23 @@ func TestApt_Update(t *testing.T) {
 
 func TestApt_Upgrade(t *testing.T) {
 	ctx := context.Background()
-	t.Run("all -> dist-upgrade", func(t *testing.T) {
+	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx); err != nil {
+		if err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.HasPrefix(a, "apt dist-upgrade -y") {
 			t.Errorf("argv = %q, want dist-upgrade", a)
+		}
+	})
+	t.Run("empty Upgrade is a no-op (not a full upgrade)", func(t *testing.T) {
+		m, f := aptM(t)
+		if err := m.Upgrade(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Upgrade ran %d commands, want 0", len(f.Calls()))
 		}
 	})
 	t.Run("specific -> only-upgrade", func(t *testing.T) {

--- a/go/pkg/dnf.go
+++ b/go/pkg/dnf.go
@@ -122,9 +122,14 @@ func (d *dnf) Upgrade(ctx context.Context, packages ...string) error {
 		return err
 	}
 	if len(packages) == 0 {
-		return d.write(ctx, "upgrade", "-y")
+		return nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return d.write(ctx, append([]string{"upgrade", "-y"}, packages...)...)
+}
+
+// UpgradeAll performs a full system upgrade (dnf upgrade).
+func (d *dnf) UpgradeAll(ctx context.Context) error {
+	return d.write(ctx, "upgrade", "-y")
 }
 
 // ensureVersionLock installs the versionlock plugin if its subcommand is absent.

--- a/go/pkg/dnf_test.go
+++ b/go/pkg/dnf_test.go
@@ -190,14 +190,23 @@ func TestDnf_Update(t *testing.T) {
 
 func TestDnf_Upgrade(t *testing.T) {
 	ctx := context.Background()
-	t.Run("all", func(t *testing.T) {
+	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx); err != nil {
+		if err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "dnf upgrade -y" {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		}
+	})
+	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
+		m, f := dnfM(t)
+		if err := m.Upgrade(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Upgrade ran %d commands, want 0", len(f.Calls()))
 		}
 	})
 	t.Run("specific", func(t *testing.T) {

--- a/go/pkg/flatpak.go
+++ b/go/pkg/flatpak.go
@@ -100,8 +100,16 @@ func (f *flatpak) Upgrade(ctx context.Context, packages ...string) error {
 	if err := ValidatePackageNames(packages); err != nil {
 		return err
 	}
+	if len(packages) == 0 {
+		return nil // empty is a no-op; UpgradeAll updates everything (flatpak update with no refs)
+	}
 	args := append([]string{"update", "-y", "--noninteractive", f.scope()}, packages...)
 	return f.write(ctx, args...)
+}
+
+// UpgradeAll updates every installed app/runtime (flatpak update with no refs).
+func (f *flatpak) UpgradeAll(ctx context.Context) error {
+	return f.write(ctx, "update", "-y", "--noninteractive", f.scope())
 }
 
 // Autoremove removes unused runtimes/extensions (flatpak uninstall --unused).

--- a/go/pkg/flatpak_test.go
+++ b/go/pkg/flatpak_test.go
@@ -157,14 +157,23 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
 		}
 	})
-	t.Run("upgrade all", func(t *testing.T) {
+	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx); err != nil {
+		if err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak update -y --noninteractive --system" {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		}
+	})
+	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
+		m, f := flatpakM(t)
+		if err := m.Upgrade(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Upgrade ran %d commands, want 0", len(f.Calls()))
 		}
 	})
 	t.Run("upgrade specific", func(t *testing.T) {

--- a/go/pkg/pacman.go
+++ b/go/pkg/pacman.go
@@ -103,9 +103,14 @@ func (p *pacman) Upgrade(ctx context.Context, packages ...string) error {
 		return err
 	}
 	if len(packages) == 0 {
-		return p.write(ctx, "-Syu", "--noconfirm")
+		return nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return p.write(ctx, append([]string{"-S", "--noconfirm"}, packages...)...)
+}
+
+// UpgradeAll performs a full system upgrade (pacman -Syu).
+func (p *pacman) UpgradeAll(ctx context.Context) error {
+	return p.write(ctx, "-Syu", "--noconfirm")
 }
 
 // Autoremove removes orphaned packages (installed as deps, no longer required).

--- a/go/pkg/pacman_test.go
+++ b/go/pkg/pacman_test.go
@@ -157,14 +157,23 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
 		}
 	})
-	t.Run("upgrade all -Syu", func(t *testing.T) {
+	t.Run("UpgradeAll -Syu", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx); err != nil {
+		if err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Syu --noconfirm" {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		}
+	})
+	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
+		m, f := pacmanM(t)
+		if err := m.Upgrade(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Upgrade ran %d commands, want 0", len(f.Calls()))
 		}
 	})
 	t.Run("upgrade specific", func(t *testing.T) {

--- a/go/pkg/pkg.go
+++ b/go/pkg/pkg.go
@@ -118,9 +118,13 @@ type Manager interface {
 	Remove(ctx context.Context, opts RemoveOptions, packages ...string) error
 	// Update refreshes the package metadata/database.
 	Update(ctx context.Context) error
-	// Upgrade upgrades the named packages; with no names it performs a full
-	// system upgrade (apt dist-upgrade / pacman -Syu / zypper dist-upgrade / …).
+	// Upgrade upgrades the named packages. With NO names it is a no-op (not a
+	// full upgrade) — an accidentally-empty list must never upgrade the whole
+	// system. Use UpgradeAll for that.
 	Upgrade(ctx context.Context, packages ...string) error
+	// UpgradeAll performs a full system upgrade (apt dist-upgrade / dnf upgrade /
+	// pacman -Syu / zypper dist-upgrade / flatpak update).
+	UpgradeAll(ctx context.Context) error
 	// Pin holds the named packages back from upgrades.
 	Pin(ctx context.Context, packages ...string) error
 	// Unpin releases the named packages so they upgrade again.

--- a/go/pkg/zypper.go
+++ b/go/pkg/zypper.go
@@ -103,9 +103,14 @@ func (z *zypper) Upgrade(ctx context.Context, packages ...string) error {
 		return err
 	}
 	if len(packages) == 0 {
-		return z.write(ctx, "--non-interactive", "dist-upgrade")
+		return nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return z.write(ctx, append([]string{"--non-interactive", "update"}, packages...)...)
+}
+
+// UpgradeAll performs a full distribution upgrade (zypper dist-upgrade).
+func (z *zypper) UpgradeAll(ctx context.Context) error {
+	return z.write(ctx, "--non-interactive", "dist-upgrade")
 }
 
 // Autoremove is a no-op: zypper has no single-shot unneeded-package removal

--- a/go/pkg/zypper_test.go
+++ b/go/pkg/zypper_test.go
@@ -140,14 +140,23 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
 		}
 	})
-	t.Run("upgrade all -> dist-upgrade", func(t *testing.T) {
+	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx); err != nil {
+		if err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive dist-upgrade" {
 			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		}
+	})
+	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
+		m, f := zypperM(t)
+		if err := m.Upgrade(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("empty Upgrade ran %d commands, want 0", len(f.Calls()))
 		}
 	})
 	t.Run("upgrade specific -> update", func(t *testing.T) {


### PR DESCRIPTION
fix D (pkg). `Upgrade(ctx)` with no names did a full dist-upgrade on every backend — an empty slice silently upgrading the whole system is a footgun. Empty `Upgrade` is now a no-op; `UpgradeAll(ctx)` is the explicit full upgrade (Manager interface gains it). All 5 backends split accordingly.

pacman.conf `IgnorePkg` writes were already hardened (Pin's stricter name gate + root-only /etc), so unchanged.

Tests updated for no-op + per-backend UpgradeAll; red-checked; 100% coverage; whole-SDK build clean; local cr clean. Closes #176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to explicitly perform full system upgrades across all supported package managers (apt, dnf, flatpak, pacman, zypper).

* **Behavior Changes**
  * Calling the package upgrade function with no packages now results in no operation instead of performing a full system upgrade.

* **Tests**
  * Updated test coverage to verify new and modified upgrade behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->