### PR TITLE
fix(notify): NotifyAll/NotifyUsers return aggregated errors instead of swallowing

### DIFF
--- a/go/sys/notify/notify.go
+++ b/go/sys/notify/notify.go
@@ -1,7 +1,9 @@
 // Package notify sends system-wide notifications to logged-in users through an
 // injected exec.Runner. It uses wall for terminal sessions and notify-send for
-// graphical sessions. All operations are best-effort — errors are logged but
-// never returned, so notifications never block the calling action.
+// graphical sessions. Methods return an aggregated error of every delivery that
+// ran and failed; an absent capability (no notify-send, no D-Bus socket, no
+// sessions) is a graceful skip, not an error. The SDK surfaces failures; the
+// caller decides whether to ignore them (notifications need not block an action).
 //
 //	r, _ := exec.NewRunner(exec.Sudo)
 //	n, _ := notify.New(r)
@@ -10,6 +12,7 @@ package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -35,15 +38,19 @@ type session struct {
 	typ  string // "tty", "x11", "wayland", "mir"
 }
 
-// Manager sends notifications to logged-in users. All methods are best-effort
-// (failures are logged, never returned).
+// Manager sends notifications to logged-in users. Methods return an aggregated
+// error of deliveries that ran and failed; an absent capability is a graceful
+// skip (nil).
 type Manager interface {
 	// NotifyAll notifies every logged-in user: a wall broadcast to terminal
-	// sessions and a desktop notification to graphical ones.
-	NotifyAll(ctx context.Context, title, message string)
+	// sessions and a desktop notification to graphical ones. It returns an
+	// aggregated error of every attempt that ran and failed; an absent capability
+	// (no notify-send, no D-Bus socket, no sessions) is a graceful skip, not an
+	// error. The SDK surfaces failures; the caller decides whether to ignore them.
+	NotifyAll(ctx context.Context, title, message string) error
 	// NotifyUsers notifies the named users only (wall still broadcasts, since it
-	// has no per-user target).
-	NotifyUsers(ctx context.Context, usernames []string, title, message string)
+	// has no per-user target). Error semantics match NotifyAll.
+	NotifyUsers(ctx context.Context, usernames []string, title, message string) error
 }
 
 // New returns a Manager driven by runner. A nil runner is rejected.
@@ -58,55 +65,77 @@ type notifier struct {
 	r exec.Runner
 }
 
-func (n *notifier) NotifyAll(ctx context.Context, title, message string) {
-	n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
-	n.sendDesktopNotifications(ctx, title, message, nil)
+func (n *notifier) NotifyAll(ctx context.Context, title, message string) error {
+	return errors.Join(
+		n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message)),
+		n.sendDesktopNotifications(ctx, title, message, nil),
+	)
 }
 
-func (n *notifier) NotifyUsers(ctx context.Context, usernames []string, title, message string) {
-	n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message))
+func (n *notifier) NotifyUsers(ctx context.Context, usernames []string, title, message string) error {
 	filter := make(map[string]bool, len(usernames))
 	for _, u := range usernames {
 		filter[u] = true
 	}
-	n.sendDesktopNotifications(ctx, title, message, filter)
+	return errors.Join(
+		n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message)),
+		n.sendDesktopNotifications(ctx, title, message, filter),
+	)
 }
 
-// sendWall broadcasts a message to all terminal sessions via wall (stdin).
-func (n *notifier) sendWall(ctx context.Context, message string) {
+// sendWall broadcasts a message to all terminal sessions via wall (stdin). A
+// failed broadcast (runner error or non-zero exit) is returned, not swallowed.
+func (n *notifier) sendWall(ctx context.Context, message string) error {
 	res, err := n.r.Run(ctx, exec.Command{
 		Name:     "wall",
 		Stdin:    strings.NewReader(message),
 		Escalate: true,
 	})
-	if err != nil || res.ExitCode != 0 {
-		slog.Warn("wall notification failed", "error", err, "stderr", res.Stderr)
+	if err != nil {
+		return fmt.Errorf("wall notification: %w", err)
 	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("wall notification failed: exit %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
 }
 
 // sendDesktopNotifications discovers graphical sessions and sends notify-send to
-// each. With a non-nil userFilter only matching usernames are notified.
-func (n *notifier) sendDesktopNotifications(ctx context.Context, title, message string, userFilter map[string]bool) {
+// each. With a non-nil userFilter only matching usernames are notified. It
+// returns the aggregated errors of deliveries that ran and failed; an absent
+// notify-send is a graceful skip (nil), not a failure.
+func (n *notifier) sendDesktopNotifications(ctx context.Context, title, message string, userFilter map[string]bool) error {
 	if _, err := lookPath("notify-send"); err != nil {
 		slog.Warn("notify-send not available, skipping desktop notifications")
-		return
+		return nil
 	}
-	sessions := n.listGraphicalSessions(ctx)
+	sessions, err := n.listGraphicalSessions(ctx)
+	if err != nil {
+		return err
+	}
 	slog.Info("discovered graphical sessions for desktop notification", "count", len(sessions))
+	var errs []error
 	for _, s := range sessions {
 		if userFilter != nil && !userFilter[s.user] {
 			continue
 		}
-		n.sendDesktopNotification(ctx, s, title, message)
+		if e := n.sendDesktopNotification(ctx, s, title, message); e != nil {
+			errs = append(errs, e)
+		}
 	}
+	return errors.Join(errs...)
 }
 
-// listGraphicalSessions returns all active graphical login sessions.
-func (n *notifier) listGraphicalSessions(ctx context.Context) []session {
+// listGraphicalSessions returns all active graphical login sessions. A failed
+// enumeration is an error (we couldn't determine who to notify); a single
+// session whose details can't be read is skipped (best-effort per session).
+func (n *notifier) listGraphicalSessions(ctx context.Context) ([]session, error) {
 	res, err := n.r.Run(ctx, exec.Command{Name: "loginctl", Args: []string{"list-sessions", "--no-legend"}, Escalate: true})
-	if err != nil || res.ExitCode != 0 {
-		slog.Warn("failed to list sessions", "error", err, "stderr", res.Stderr)
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("list sessions: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return nil, fmt.Errorf("list sessions failed: exit %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
 
 	var sessions []session
@@ -128,7 +157,7 @@ func (n *notifier) listGraphicalSessions(ctx context.Context) []session {
 		}
 		sessions = append(sessions, s)
 	}
-	return sessions
+	return sessions, nil
 }
 
 // parseLoginctlListSessions extracts session IDs from `loginctl list-sessions
@@ -181,11 +210,12 @@ func parseLoginctlShowSession(sessionID, stdout string) (session, bool) {
 // session, running notify-send as the target user (via runuser) with the user's
 // D-Bus session address. Each argument is passed separately to avoid shell
 // injection.
-func (n *notifier) sendDesktopNotification(ctx context.Context, s session, title, message string) {
+func (n *notifier) sendDesktopNotification(ctx context.Context, s session, title, message string) error {
 	socketPath := fmt.Sprintf("/run/user/%d/bus", s.uid)
 	if _, err := statSocket(socketPath); err != nil {
+		// No D-Bus session bus for this user — nothing to deliver to; graceful skip.
 		slog.Warn("DBUS socket not found, skipping desktop notification", "user", s.user, "path", socketPath)
-		return
+		return nil
 	}
 	dbusAddr := "unix:path=" + socketPath
 
@@ -199,8 +229,11 @@ func (n *notifier) sendDesktopNotification(ctx context.Context, s session, title
 		},
 		Escalate: true,
 	})
-	if err != nil || res.ExitCode != 0 {
-		slog.Warn("desktop notification failed",
-			"user", s.user, "session", s.id, "type", s.typ, "error", err, "stderr", res.Stderr)
+	if err != nil {
+		return fmt.Errorf("desktop notification to %s: %w", s.user, err)
 	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("desktop notification to %s failed: exit %d: %s", s.user, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
 }

--- a/go/sys/notify/notify_errors_test.go
+++ b/go/sys/notify/notify_errors_test.go
@@ -1,0 +1,134 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/go/sys/exec"
+	"github.com/manchtools/power-manage/sdk/go/sys/exec/exectest"
+)
+
+// seamNotifySendAbsent isolates the wall path: notify-send is "not installed",
+// so the desktop branch is a graceful skip and only the wall result matters.
+func seamNotifySendAbsent(t *testing.T) {
+	t.Helper()
+	ol, os_ := lookPath, statSocket
+	t.Cleanup(func() { lookPath, statSocket = ol, os_ })
+	lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	statSocket = func(string) (os.FileInfo, error) { return nil, errors.New("no socket") }
+}
+
+func TestNotifyAll_ReturnsErrorOnWallFailure(t *testing.T) {
+	seamNotifySendAbsent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{ExitCode: 1, Stderr: "wall: permission denied"}, nil)
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err == nil {
+		t.Error("NotifyAll = nil when wall failed; the failure must be surfaced, not swallowed")
+	}
+}
+
+func TestNotifyUsers_ReturnsErrorOnWallFailure(t *testing.T) {
+	seamNotifySendAbsent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, errors.New("runner down")) // wall: runner error
+	if err := mgr(t, r).NotifyUsers(context.Background(), []string{"alice"}, "T", "m"); err == nil {
+		t.Error("NotifyUsers = nil when wall failed")
+	}
+}
+
+// notify-send absent (a headless host) is a graceful skip, not a failure: a
+// successful wall returns nil.
+func TestNotifyAll_NilOnSuccessNoDesktopTool(t *testing.T) {
+	seamNotifySendAbsent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil) // wall ok
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err != nil {
+		t.Errorf("NotifyAll = %v, want nil (wall ok, notify-send absent is a graceful skip)", err)
+	}
+}
+
+// A notify-send delivery that runs and fails IS surfaced (aggregated).
+func TestNotifyAll_AggregatesDesktopDeliveryFailure(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                              // wall ok
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -"}, nil)               // list-sessions
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show c1
+	r.Push(exec.Result{ExitCode: 1, Stderr: "notify-send failed"}, nil)     // env notify-send alice → fail
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err == nil {
+		t.Error("NotifyAll = nil when a desktop notification delivery failed")
+	}
+}
+
+// Full success (wall + every desktop delivery) returns nil.
+func TestNotifyAll_NilOnFullSuccess(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                              // wall
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -"}, nil)               // list-sessions
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show c1
+	r.Push(exec.Result{}, nil)                                              // env notify-send alice ok
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err != nil {
+		t.Errorf("NotifyAll = %v, want nil on full success", err)
+	}
+}
+
+// Failing to enumerate sessions (loginctl) is surfaced — we couldn't determine
+// who to notify on the desktop.
+func TestNotifyAll_ErrorWhenSessionListFails(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                     // wall ok
+	r.Push(exec.Result{ExitCode: 1, Stderr: "loginctl down"}, nil) // list-sessions fails
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err == nil {
+		t.Error("NotifyAll = nil when session enumeration failed")
+	}
+}
+
+// A user with no D-Bus session socket is a graceful skip, not an error (nothing
+// to deliver to).
+func TestNotifyAll_MissingDBusSocketIsGracefulSkip(t *testing.T) {
+	ol, os_ := lookPath, statSocket
+	t.Cleanup(func() { lookPath, statSocket = ol, os_ })
+	lookPath = func(string) (string, error) { return "/usr/bin/notify-send", nil }
+	statSocket = func(string) (os.FileInfo, error) { return nil, errors.New("no socket") }
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                              // wall ok
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -"}, nil)               // list-sessions
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show c1
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err != nil {
+		t.Errorf("NotifyAll = %v, want nil (missing D-Bus socket is a graceful skip)", err)
+	}
+	// No env/notify-send call was made (socket missing → skipped before delivery).
+	for _, c := range r.Calls() {
+		if c.Name == "env" {
+			t.Error("notify-send ran despite a missing D-Bus socket")
+		}
+	}
+}
+
+// A Runner error (not just a non-zero exit) on session listing is surfaced.
+func TestNotifyAll_ErrorWhenSessionListRunnerErrors(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                       // wall ok
+	r.Push(exec.Result{}, errors.New("runner down")) // list-sessions: runner error
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err == nil {
+		t.Error("NotifyAll = nil when the session-list runner errored")
+	}
+}
+
+// A Runner error on a desktop delivery is surfaced (aggregated).
+func TestNotifyAll_ErrorWhenDeliveryRunnerErrors(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	r.Push(exec.Result{}, nil)                                              // wall ok
+	r.Push(exec.Result{Stdout: "c1 1000 alice seat0 -"}, nil)               // list-sessions
+	r.Push(exec.Result{Stdout: "Type=wayland\nName=alice\nUser=1000"}, nil) // show c1
+	r.Push(exec.Result{}, errors.New("runner down"))                        // env notify-send: runner error
+	if err := mgr(t, r).NotifyAll(context.Background(), "T", "m"); err == nil {
+		t.Error("NotifyAll = nil when a desktop delivery runner errored")
+	}
+}


### PR DESCRIPTION
fix D (notify). The methods returned nothing — failed wall/notify-send was only logged. They now return `errors.Join` of every delivery that ran and failed; an absent capability (no notify-send / no D-Bus socket / no sessions) stays a graceful skip (nil). The SDK surfaces failures, the caller decides.

`sendWall`/`sendDesktopNotification` return errors; `listGraphicalSessions` returns `(sessions, error)`. Package + Manager docs corrected.

Authored **test-first** (compile-RED → nil-stub behavioral-RED → implement → GREEN); 100% coverage across runner-error / non-zero-exit / graceful-skip branches; whole-SDK build + race sweep green; local cr clean. Closes #178.