### PR TITLE
fix(reboot): Schedule takes ScheduleOptions; IsRequired surfaces genuine run errors

### DIFF
--- a/go/sys/reboot/reboot.go
+++ b/go/sys/reboot/reboot.go
@@ -6,7 +6,9 @@
 //
 //	r, _ := exec.NewRunner(exec.Sudo)
 //	rb, _ := reboot.New(r)
-//	if need, _ := rb.IsRequired(ctx); need { _ = rb.Schedule(ctx, "+5", "patching") }
+//	if need, _ := rb.IsRequired(ctx); need {
+//		_ = rb.Schedule(ctx, reboot.ScheduleOptions{Delay: "+5", Message: "patching"})
+//	}
 //
 // Status: SDK-resident, single-consumer today (the agent's reboot-required +
 // scheduled-reboot pipeline). Sits in the SDK because the planned server-side
@@ -33,16 +35,32 @@ var statFunc = os.Stat
 
 // Manager detects and schedules system reboots.
 type Manager interface {
-	// IsRequired reports whether the system needs a reboot after updates. It is
-	// best-effort: an unsupported host or a detection failure yields (false, nil);
-	// the returned error is reserved for a genuinely unexpected condition the
-	// caller may want to surface (e.g. a non-ENOENT stat error on the marker).
+	// IsRequired reports whether the system needs a reboot after updates. An
+	// unsupported host (no marker file and no needs-restarting binary) yields
+	// (false, nil) — absence of detection is not a failure. A genuinely
+	// unexpected condition IS surfaced as an error: a non-ENOENT stat error on
+	// the marker, or a needs-restarting run failure that isn't "tool absent"
+	// (e.g. a cancelled/timed-out context).
 	IsRequired(ctx context.Context) (bool, error)
-	// Schedule schedules a reboot via shutdown -r. An empty delay defaults to
-	// "+1"; a non-empty message is broadcast to logged-in users.
-	Schedule(ctx context.Context, delay, message string) error
+	// Schedule schedules a reboot via shutdown -r using opts. An empty
+	// opts.Delay defaults to "+1"; a non-empty opts.Message is broadcast to
+	// logged-in users.
+	Schedule(ctx context.Context, opts ScheduleOptions) error
 	// Cancel cancels a pending scheduled reboot (shutdown -c).
 	Cancel(ctx context.Context) error
+}
+
+// ScheduleOptions configures a scheduled reboot. Fields are named so callers
+// can't transpose the (delay, message) pair, and so future knobs (e.g. a
+// kexec fast-reboot) can be added without breaking the signature.
+type ScheduleOptions struct {
+	// Delay is the shutdown(8) TIME spec (e.g. "+5", "now", "23:00"). Empty
+	// defaults to "+1" (one minute), matching shutdown's own grace default
+	// intent while never rebooting instantly by accident.
+	Delay string
+	// Message, when non-empty, is the wall message broadcast to logged-in
+	// users by shutdown.
+	Message string
 }
 
 // New returns a Manager driven by runner. A nil runner is rejected.
@@ -59,8 +77,8 @@ type rebooter struct {
 
 // IsRequired checks the Debian/Ubuntu marker file, then falls back to
 // `needs-restarting -r` (Fedora/RHEL; exit 1 = reboot needed) run unprivileged
-// through the Runner. A binary that isn't installed, or any execution failure, is
-// treated as "not required" — this is a hint, not an authority.
+// through the Runner. A binary that isn't installed is treated as "not required"
+// (no detection available, not a failure); a genuine run failure is surfaced.
 func (rb *rebooter) IsRequired(ctx context.Context) (bool, error) {
 	if _, err := statFunc(rebootRequiredPath); err == nil {
 		return true, nil
@@ -72,22 +90,30 @@ func (rb *rebooter) IsRequired(ctx context.Context) (bool, error) {
 
 	res, err := rb.r.Run(ctx, exec.Command{Name: "needs-restarting", Args: []string{"-r"}})
 	if err != nil {
-		// needs-restarting absent or unrunnable → no detection available here.
-		slog.Debug("needs-restarting -r could not run", "error", err)
-		return false, nil
+		if errors.Is(err, exec.ErrBackendUnavailable) {
+			// needs-restarting isn't installed → no detection available on this
+			// host. That's expected on non-RHEL systems, not a failure.
+			slog.Debug("needs-restarting not available, skipping reboot probe", "error", err)
+			return false, nil
+		}
+		// Any other failure (e.g. context cancelled/timed out) is genuinely
+		// unexpected: we were asked and couldn't answer. Surface it rather than
+		// silently reporting "no reboot needed".
+		return false, fmt.Errorf("run needs-restarting: %w", err)
 	}
 	// Exit 1 = a reboot is needed; 0 = not; anything else = indeterminate.
 	return res.ExitCode == 1, nil
 }
 
 // Schedule schedules a system reboot via shutdown -r (escalated).
-func (rb *rebooter) Schedule(ctx context.Context, delay, message string) error {
+func (rb *rebooter) Schedule(ctx context.Context, opts ScheduleOptions) error {
+	delay := opts.Delay
 	if delay == "" {
 		delay = "+1"
 	}
 	args := []string{"-r", delay}
-	if message != "" {
-		args = append(args, message)
+	if opts.Message != "" {
+		args = append(args, opts.Message)
 	}
 	return rb.shutdown(ctx, "schedule reboot", args...)
 }

--- a/go/sys/reboot/reboot_test.go
+++ b/go/sys/reboot/reboot_test.go
@@ -3,6 +3,7 @@ package reboot
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -59,23 +60,43 @@ func TestIsRequired_MarkerStatError(t *testing.T) {
 func TestIsRequired_NeedsRestarting(t *testing.T) {
 	withStat(t, func(string) (os.FileInfo, error) { return nil, os.ErrNotExist })
 	cases := []struct {
-		name   string
-		res    exec.Result
-		runErr error
-		want   bool
+		name    string
+		res     exec.Result
+		runErr  error
+		want    bool
+		wantErr bool
 	}{
-		{"reboot needed (exit 1)", exec.Result{ExitCode: 1}, nil, true},
-		{"no reboot (exit 0)", exec.Result{ExitCode: 0}, nil, false},
-		{"indeterminate (exit 2)", exec.Result{ExitCode: 2}, nil, false},
-		{"not installed (run error)", exec.Result{}, errors.New("exec: needs-restarting not found"), false},
+		{"reboot needed (exit 1)", exec.Result{ExitCode: 1}, nil, true, false},
+		{"no reboot (exit 0)", exec.Result{ExitCode: 0}, nil, false, false},
+		{"indeterminate (exit 2)", exec.Result{ExitCode: 2}, nil, false, false},
+		// Tool absent (the exec layer wraps ErrBackendUnavailable for a missing
+		// binary) → no detection available here, a graceful (false, nil).
+		{
+			"not installed (ErrBackendUnavailable)",
+			exec.Result{},
+			fmt.Errorf("%w: command not found: needs-restarting", exec.ErrBackendUnavailable),
+			false, false,
+		},
+		// A genuine run failure (NOT a missing tool) must surface — we were asked
+		// and couldn't answer for an unexpected reason; swallowing it as
+		// "no reboot needed" hides the failure from the caller.
+		{
+			"genuine run error surfaces",
+			exec.Result{},
+			context.DeadlineExceeded,
+			false, true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			r := exectest.New(exec.Direct)
 			r.Push(c.res, c.runErr)
 			need, err := mgr(t, r).IsRequired(context.Background())
-			if err != nil || need != c.want {
-				t.Fatalf("IsRequired = (%v,%v), want (%v,nil)", need, err, c.want)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("IsRequired error = %v, wantErr = %v", err, c.wantErr)
+			}
+			if need != c.want {
+				t.Fatalf("IsRequired need = %v, want %v", need, c.want)
 			}
 			cmd := r.Calls()[0]
 			if cmd.Name != "needs-restarting" || cmd.Escalate || strings.Join(cmd.Args, " ") != "-r" {
@@ -86,9 +107,22 @@ func TestIsRequired_NeedsRestarting(t *testing.T) {
 }
 
 func TestSchedule(t *testing.T) {
+	t.Run("zero options: default delay, no message, escalated", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		cmd := r.Calls()[0]
+		if cmd.Name != "shutdown" || !cmd.Escalate {
+			t.Fatalf("command = %+v, want escalated shutdown", cmd)
+		}
+		if strings.Join(cmd.Args, " ") != "-r +1" {
+			t.Errorf("argv = %q, want `-r +1`", strings.Join(cmd.Args, " "))
+		}
+	})
 	t.Run("default delay + message, escalated", func(t *testing.T) {
 		r := exectest.New(exec.Sudo)
-		if err := mgr(t, r).Schedule(context.Background(), "", "patching now"); err != nil {
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Message: "patching now"}); err != nil {
 			t.Fatal(err)
 		}
 		cmd := r.Calls()[0]
@@ -101,24 +135,33 @@ func TestSchedule(t *testing.T) {
 	})
 	t.Run("explicit delay, no message", func(t *testing.T) {
 		r := exectest.New(exec.Sudo)
-		if err := mgr(t, r).Schedule(context.Background(), "+5", ""); err != nil {
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Delay: "+5"}); err != nil {
 			t.Fatal(err)
 		}
 		if got := strings.Join(r.Calls()[0].Args, " "); got != "-r +5" {
 			t.Errorf("argv = %q, want `-r +5`", got)
 		}
 	})
+	t.Run("explicit delay + message", func(t *testing.T) {
+		r := exectest.New(exec.Sudo)
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Delay: "+5", Message: "patching"}); err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Join(r.Calls()[0].Args, " "); got != "-r +5 patching" {
+			t.Errorf("argv = %q, want `-r +5 patching`", got)
+		}
+	})
 	t.Run("non-zero exit is an error", func(t *testing.T) {
 		r := exectest.New(exec.Sudo)
 		r.Push(exec.Result{ExitCode: 1, Stderr: "Failed to schedule"}, nil)
-		if err := mgr(t, r).Schedule(context.Background(), "+1", ""); err == nil {
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Delay: "+1"}); err == nil {
 			t.Error("Schedule swallowed a non-zero exit")
 		}
 	})
 	t.Run("exec failure is an error", func(t *testing.T) {
 		r := exectest.New(exec.Sudo)
 		r.Push(exec.Result{}, errors.New("sudo: a password is required"))
-		if err := mgr(t, r).Schedule(context.Background(), "+1", ""); err == nil {
+		if err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Delay: "+1"}); err == nil {
 			t.Error("Schedule swallowed an exec failure")
 		}
 	})


### PR DESCRIPTION
Closes #180

## Schedule: `(delay, message string)` → `ScheduleOptions{Delay, Message}`
Two adjacent string params are trivially transposable with no compiler help. A named options struct (matching `pkg.InstallOptions`/`RemoveOptions`) removes the footgun and leaves room for future knobs without breaking the signature. Behaviour unchanged: empty `Delay` → `+1`, non-empty `Message` appended, escalated `shutdown -r`.

## IsRequired: stop swallowing genuine `needs-restarting` run failures
Previously **every** runner error → `(false, nil)`. Now a missing binary (`errors.Is(err, exec.ErrBackendUnavailable)`) stays a graceful `(false, nil)` ("no detection available"), but any other failure — e.g. a cancelled/timed-out context — is surfaced. Mirrors the notify (#178) error-discipline fix; doc comments aligned with the new behaviour.

## Tests (test-first)
- `TestSchedule` rewritten onto `ScheduleOptions` (zero opts, message-only, delay-only, delay+message, non-zero-exit, exec-failure).
- `TestIsRequired_NeedsRestarting` table gains a `wantErr` column; the "not installed" case now uses the real `ErrBackendUnavailable` shape, and a new `genuine run error surfaces` case pins the fix (was RED against the old swallow).
- 100% statement coverage, `-race` clean.