### PR TITLE
feat(pkg): Manager mutations return command output (exec.Result)

### DIFF
--- a/docs/02-concepts/01-architecture.md
+++ b/docs/02-concepts/01-architecture.md
@@ -35,7 +35,10 @@ m, err := pkg.New(pkg.Apt, r)
 if err != nil {
     return err
 }
-err = m.Install(ctx, pkg.InstallOptions{}, "vim", "git")
+// Mutations return the command output (exec.Result: exit code, stdout, stderr)
+// so the caller can surface what the package manager actually did.
+res, err := m.Install(ctx, pkg.InstallOptions{}, "vim", "git")
+_ = res
 ```
 
 ## Why it's shaped this way

--- a/go/pkg/apt.go
+++ b/go/pkg/apt.go
@@ -53,16 +53,18 @@ func (a *apt) hasApt() bool { return a.aptCommand() == "apt" }
 
 // write runs a privileged apt-family command and maps a non-zero exit to an
 // *exec.CommandError. "apt"/"apt-get" are resolved to the preferred binary;
-// other commands (dpkg, apt-mark) run as named.
-func (a *apt) write(ctx context.Context, cmd string, args ...string) error {
+// other commands (dpkg, apt-mark) run as named. The command's Result (stdout,
+// stderr, exit code) is returned on both the success and non-zero-exit paths;
+// only an unrunnable command yields the zero Result.
+func (a *apt) write(ctx context.Context, cmd string, args ...string) (pmexec.Result, error) {
 	if cmd == "apt" || cmd == "apt-get" {
 		cmd = a.aptCommand()
 	}
 	res, err := runPriv(ctx, a.r, true, aptWriteEnv, cmd, args...)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	return asCommandError(cmd, res)
+	return res, asCommandError(cmd, res)
 }
 
 // Version returns the apt version string.
@@ -79,18 +81,18 @@ func (a *apt) Version(ctx context.Context) (string, error) {
 }
 
 // Install installs packages, using --fix-broken to resolve dependency issues.
-func (a *apt) Install(ctx context.Context, opts InstallOptions, packages ...string) error {
+func (a *apt) Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if err := ValidatePackageVersion(opts.Version); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if opts.Version != "" && len(packages) != 1 {
-		return fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
+		return pmexec.Result{}, fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	args := []string{"install", "-y", "--fix-broken"}
 	if opts.AllowDowngrade {
@@ -105,12 +107,12 @@ func (a *apt) Install(ctx context.Context, opts InstallOptions, packages ...stri
 }
 
 // Remove removes packages; opts.Purge deletes configuration files too.
-func (a *apt) Remove(ctx context.Context, opts RemoveOptions, packages ...string) error {
+func (a *apt) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	verb := "remove"
 	if opts.Purge {
@@ -121,18 +123,18 @@ func (a *apt) Remove(ctx context.Context, opts RemoveOptions, packages ...string
 }
 
 // Update refreshes the package index.
-func (a *apt) Update(ctx context.Context) error {
+func (a *apt) Update(ctx context.Context) (pmexec.Result, error) {
 	return a.write(ctx, "apt", "update")
 }
 
 // Upgrade upgrades the named packages; with no names it runs a full
 // dist-upgrade (which can add/remove packages to satisfy held-back deps).
-func (a *apt) Upgrade(ctx context.Context, packages ...string) error {
+func (a *apt) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil // empty is a no-op; UpgradeAll does a full upgrade
+		return pmexec.Result{}, nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	args := append([]string{"install", "-y", "--only-upgrade"}, dpkgConfOptions...)
 	args = append(args, packages...)
@@ -140,41 +142,43 @@ func (a *apt) Upgrade(ctx context.Context, packages ...string) error {
 }
 
 // UpgradeAll performs a full distribution upgrade (apt dist-upgrade).
-func (a *apt) UpgradeAll(ctx context.Context) error {
+func (a *apt) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
 	args := append([]string{"dist-upgrade", "-y"}, dpkgConfOptions...)
 	return a.write(ctx, "apt", args...)
 }
 
 // Pin holds packages (apt-mark hold).
-func (a *apt) Pin(ctx context.Context, packages ...string) error {
+func (a *apt) Pin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return a.write(ctx, "apt-mark", append([]string{"hold"}, packages...)...)
 }
 
 // Unpin releases held packages (apt-mark unhold).
-func (a *apt) Unpin(ctx context.Context, packages ...string) error {
+func (a *apt) Unpin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return a.write(ctx, "apt-mark", append([]string{"unhold"}, packages...)...)
 }
 
 // Autoremove removes packages installed only as now-unneeded dependencies.
-func (a *apt) Autoremove(ctx context.Context) error {
+func (a *apt) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	return a.write(ctx, "apt", "autoremove", "-y")
 }
 
 // Repair clears stale dpkg/apt locks, reconfigures interrupted packages, fixes
-// broken dependencies, and refreshes the index.
-func (a *apt) Repair(ctx context.Context) error {
+// broken dependencies, and refreshes the index. The returned Result is that of
+// the final `apt update` step (or the step that failed hard); best-effort steps
+// whose failures are swallowed do not change the returned Result.
+func (a *apt) Repair(ctx context.Context) (pmexec.Result, error) {
 	for _, lf := range []string{
 		"/var/lib/dpkg/lock",
 		"/var/lib/dpkg/lock-frontend",
@@ -182,27 +186,29 @@ func (a *apt) Repair(ctx context.Context) error {
 		"/var/cache/apt/archives/lock",
 	} {
 		if err := removeStaleLock(ctx, a.r, lf); err != nil {
-			return err
+			return pmexec.Result{}, err
 		}
 	}
 
 	fixArgs := append([]string{"--fix-broken", "install", "-y"}, dpkgConfOptions...)
 	steps := []struct {
 		what string
-		run  func() error
+		run  func() (pmexec.Result, error)
 	}{
-		{"dpkg --configure -a", func() error { return a.write(ctx, "dpkg", "--configure", "-a") }},
-		{"apt --fix-broken install", func() error { return a.write(ctx, "apt", fixArgs...) }},
+		{"dpkg --configure -a", func() (pmexec.Result, error) { return a.write(ctx, "dpkg", "--configure", "-a") }},
+		{"apt --fix-broken install", func() (pmexec.Result, error) { return a.write(ctx, "apt", fixArgs...) }},
 	}
 	for _, s := range steps {
-		if err := bestEffortStep(ctx, s.what, s.run()); err != nil {
-			return err
+		res, err := s.run()
+		if err := bestEffortStep(ctx, s.what, err); err != nil {
+			return res, err
 		}
 	}
-	if err := a.write(ctx, "apt", "update"); err != nil {
-		return repairErr(ctx, "apt update failed", err)
+	res, err := a.write(ctx, "apt", "update")
+	if err != nil {
+		return res, repairErr(ctx, "apt update failed", err)
 	}
-	return nil
+	return res, nil
 }
 
 // Search searches package names. It always uses `apt-cache search`, which emits

--- a/go/pkg/apt_test.go
+++ b/go/pkg/apt_test.go
@@ -50,7 +50,7 @@ func TestApt_AptGetFallback(t *testing.T) {
 	stubLookPath(t) // neither apt nor apt-get on PATH -> resolves to apt-get
 	m, f := mustNew(t, Apt)
 	ok(f, "")
-	if err := m.Update(context.Background()); err != nil {
+	if _, err := m.Update(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if c := f.Calls()[0]; c.Name != "apt-get" {
@@ -63,7 +63,7 @@ func TestApt_Install(t *testing.T) {
 	t.Run("multiple packages, latest", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -77,7 +77,7 @@ func TestApt_Install(t *testing.T) {
 	t.Run("pinned version", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "2:8.2.3995-1ubuntu2"}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "2:8.2.3995-1ubuntu2"}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "vim=2:8.2.3995-1ubuntu2") {
@@ -87,7 +87,7 @@ func TestApt_Install(t *testing.T) {
 	t.Run("allow downgrade", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "--allow-downgrades") {
@@ -96,7 +96,7 @@ func TestApt_Install(t *testing.T) {
 	})
 	t.Run("empty is a no-op", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Install(ctx, InstallOptions{}); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -105,7 +105,7 @@ func TestApt_Install(t *testing.T) {
 	})
 	t.Run("bad name rejected before exec", func(t *testing.T) {
 		m, f := aptM(t)
-		err := m.Install(ctx, InstallOptions{}, "vim;rm -rf /")
+		_, err := m.Install(ctx, InstallOptions{}, "vim;rm -rf /")
 		if err == nil || !strings.Contains(err.Error(), "invalid package name") {
 			t.Fatalf("err = %v, want validation rejection", err)
 		}
@@ -115,7 +115,7 @@ func TestApt_Install(t *testing.T) {
 	})
 	t.Run("bad version rejected before exec", func(t *testing.T) {
 		m, f := aptM(t)
-		err := m.Install(ctx, InstallOptions{Version: "1.0;evil"}, "vim")
+		_, err := m.Install(ctx, InstallOptions{Version: "1.0;evil"}, "vim")
 		if err == nil || !strings.Contains(err.Error(), "version") {
 			t.Fatalf("err = %v, want version rejection", err)
 		}
@@ -125,7 +125,7 @@ func TestApt_Install(t *testing.T) {
 	})
 	t.Run("version with multiple packages rejected", func(t *testing.T) {
 		m, f := aptM(t)
-		err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git")
+		_, err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git")
 		if err == nil || !strings.Contains(err.Error(), "exactly one package") {
 			t.Fatalf("err = %v, want one-package rejection", err)
 		}
@@ -135,7 +135,7 @@ func TestApt_Install(t *testing.T) {
 	})
 	t.Run("version with zero packages rejected", func(t *testing.T) {
 		m, _ := aptM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1.0"}); err == nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0"}); err == nil {
 			t.Fatal("version with no package must be rejected")
 		}
 	})
@@ -146,7 +146,7 @@ func TestApt_Remove(t *testing.T) {
 	t.Run("remove", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "apt remove -y vim" {
@@ -156,7 +156,7 @@ func TestApt_Remove(t *testing.T) {
 	t.Run("purge", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "apt purge -y vim" {
@@ -165,13 +165,13 @@ func TestApt_Remove(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Remove(ctx, RemoveOptions{}, "--force"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "--force"); err == nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d, want rejection", err, len(f.Calls()))
 		}
 	})
@@ -180,7 +180,7 @@ func TestApt_Remove(t *testing.T) {
 func TestApt_Update(t *testing.T) {
 	m, f := aptM(t)
 	ok(f, "")
-	if err := m.Update(context.Background()); err != nil {
+	if _, err := m.Update(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	c := f.Calls()[0]
@@ -194,7 +194,7 @@ func TestApt_Upgrade(t *testing.T) {
 	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.HasPrefix(a, "apt dist-upgrade -y") {
@@ -203,7 +203,7 @@ func TestApt_Upgrade(t *testing.T) {
 	})
 	t.Run("empty Upgrade is a no-op (not a full upgrade)", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Upgrade(ctx); err != nil {
+		if _, err := m.Upgrade(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -213,7 +213,7 @@ func TestApt_Upgrade(t *testing.T) {
 	t.Run("specific -> only-upgrade", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx, "vim"); err != nil {
+		if _, err := m.Upgrade(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		a := argv(f.Calls()[0])
@@ -223,7 +223,7 @@ func TestApt_Upgrade(t *testing.T) {
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Upgrade(ctx, "vim|sh"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Upgrade(ctx, "vim|sh"); err == nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
@@ -234,7 +234,7 @@ func TestApt_PinUnpin(t *testing.T) {
 	t.Run("pin", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Pin(ctx, "vim"); err != nil {
+		if _, err := m.Pin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if c := f.Calls()[0]; argv(c) != "apt-mark hold vim" || !c.Escalate {
@@ -244,7 +244,7 @@ func TestApt_PinUnpin(t *testing.T) {
 	t.Run("unpin", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if err := m.Unpin(ctx, "vim"); err != nil {
+		if _, err := m.Unpin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "apt-mark unhold vim" {
@@ -253,25 +253,25 @@ func TestApt_PinUnpin(t *testing.T) {
 	})
 	t.Run("pin empty no-op", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("unpin empty no-op", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("pin bad name", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Pin(ctx, "a b"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "a b"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection, no exec")
 		}
 	})
 	t.Run("unpin bad name", func(t *testing.T) {
 		m, f := aptM(t)
-		if err := m.Unpin(ctx, "a b"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx, "a b"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection, no exec")
 		}
 	})
@@ -280,7 +280,7 @@ func TestApt_PinUnpin(t *testing.T) {
 func TestApt_Autoremove(t *testing.T) {
 	m, f := aptM(t)
 	ok(f, "")
-	if err := m.Autoremove(context.Background()); err != nil {
+	if _, err := m.Autoremove(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if c := f.Calls()[0]; argv(c) != "apt autoremove -y" || !c.Escalate {
@@ -291,7 +291,7 @@ func TestApt_Autoremove(t *testing.T) {
 func TestApt_WriteFailure(t *testing.T) {
 	m, f := aptM(t)
 	f.Push(pmexec.Result{ExitCode: 100, Stderr: "E: Unable to locate package ghost"}, nil)
-	err := m.Install(context.Background(), InstallOptions{}, "ghost")
+	_, err := m.Install(context.Background(), InstallOptions{}, "ghost")
 	var ce *pmexec.CommandError
 	if !errors.As(err, &ce) || ce.ExitCode != 100 {
 		t.Fatalf("err = %v, want CommandError(exit 100)", err)
@@ -304,7 +304,7 @@ func TestApt_WriteFailure(t *testing.T) {
 func TestApt_WriteExecError(t *testing.T) {
 	m, f := aptM(t)
 	f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
-	if err := m.Update(context.Background()); !errors.Is(err, pmexec.ErrEscalationDenied) {
+	if _, err := m.Update(context.Background()); !errors.Is(err, pmexec.ErrEscalationDenied) {
 		t.Fatalf("err = %v, want ErrEscalationDenied", err)
 	}
 }
@@ -318,7 +318,7 @@ func TestApt_Repair(t *testing.T) {
 		ok(f, "") // dpkg --configure -a
 		ok(f, "") // apt --fix-broken install
 		ok(f, "") // apt update
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
 		var got []string
@@ -336,7 +336,7 @@ func TestApt_Repair(t *testing.T) {
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "dpkg busy"}, nil)     // configure fails (warn)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "still broken"}, nil)  // fix-broken fails (warn)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "update failed"}, nil) // update fails (returned)
-		err := m.Repair(ctx)
+		_, err := m.Repair(ctx)
 		if err == nil || !strings.Contains(err.Error(), "apt update failed") {
 			t.Fatalf("err = %v, want apt update failure", err)
 		}
@@ -347,7 +347,7 @@ func TestApt_Repair(t *testing.T) {
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		m, f := mustNew(t, Apt)
-		if err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
+		if _, err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
 			t.Fatalf("err = %v, want context.Canceled", err)
 		}
 		if len(f.Calls()) != 0 {
@@ -368,7 +368,7 @@ func TestApt_Repair(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := m.Repair(ctx2); !errors.Is(err, context.Canceled) {
+		if _, err := m.Repair(ctx2); !errors.Is(err, context.Canceled) {
 			t.Fatalf("err = %v, want context.Canceled", err)
 		}
 	})

--- a/go/pkg/dnf.go
+++ b/go/pkg/dnf.go
@@ -35,13 +35,15 @@ func parseNEVRAName(nevra string) string {
 
 func (d *dnf) Backend() Backend { return Dnf }
 
-// write runs a privileged dnf command and maps a non-zero exit to an error.
-func (d *dnf) write(ctx context.Context, args ...string) error {
+// write runs a privileged dnf command and maps a non-zero exit to an error,
+// returning the command Result (stdout/stderr/exit) on both the success and
+// non-zero-exit paths.
+func (d *dnf) write(ctx context.Context, args ...string) (pmexec.Result, error) {
 	res, err := runPriv(ctx, d.r, true, nil, "dnf", args...)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	return asCommandError("dnf", res)
+	return res, asCommandError("dnf", res)
 }
 
 // Version returns the dnf version string.
@@ -56,18 +58,18 @@ func (d *dnf) Version(ctx context.Context) (string, error) {
 // Install installs packages. opts.Version pins a single package (dnf name-version
 // form); opts.AllowDowngrade adds --allowerasing and, on failure, retries an
 // explicit `dnf downgrade`.
-func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...string) error {
+func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if err := ValidatePackageVersion(opts.Version); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if opts.Version != "" && len(packages) != 1 {
-		return fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
+		return pmexec.Result{}, fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	args := []string{"install", "-y"}
 	if opts.AllowDowngrade {
@@ -81,7 +83,7 @@ func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...stri
 		args = append(args, packages...)
 	}
 
-	err := d.write(ctx, args...)
+	res, err := d.write(ctx, args...)
 	// Only retry as an explicit downgrade when dnf itself rejected the install
 	// (a non-zero exit). An exec/escalation/context failure must not trigger a
 	// second escalated command.
@@ -89,46 +91,46 @@ func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...stri
 	if errors.As(err, &ce) && opts.AllowDowngrade && opts.Version != "" {
 		return d.write(ctx, "downgrade", "-y", pkgSpec)
 	}
-	return err
+	return res, err
 }
 
 // Remove removes packages. dnf has no purge concept, so opts.Purge is a no-op.
-func (d *dnf) Remove(ctx context.Context, _ RemoveOptions, packages ...string) error {
+func (d *dnf) Remove(ctx context.Context, _ RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return d.write(ctx, append([]string{"remove", "-y"}, packages...)...)
 }
 
 // Update refreshes metadata via `dnf check-update` (exit 100 = updates available
 // is a success, not an error).
-func (d *dnf) Update(ctx context.Context) error {
+func (d *dnf) Update(ctx context.Context) (pmexec.Result, error) {
 	res, err := runPriv(ctx, d.r, true, nil, "dnf", "check-update")
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if res.ExitCode == 0 || res.ExitCode == 100 {
-		return nil
+		return res, nil
 	}
-	return asCommandError("dnf", res)
+	return res, asCommandError("dnf", res)
 }
 
 // Upgrade upgrades the named packages, or all packages with no names.
-func (d *dnf) Upgrade(ctx context.Context, packages ...string) error {
+func (d *dnf) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil // empty is a no-op; UpgradeAll does a full upgrade
+		return pmexec.Result{}, nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return d.write(ctx, append([]string{"upgrade", "-y"}, packages...)...)
 }
 
 // UpgradeAll performs a full system upgrade (dnf upgrade).
-func (d *dnf) UpgradeAll(ctx context.Context) error {
+func (d *dnf) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
 	return d.write(ctx, "upgrade", "-y")
 }
 
@@ -141,60 +143,71 @@ func (d *dnf) ensureVersionLock(ctx context.Context) error {
 	if ok {
 		return nil // plugin already present
 	}
-	return d.write(ctx, "install", "-y", "python3-dnf-plugin-versionlock")
+	_, err = d.write(ctx, "install", "-y", "python3-dnf-plugin-versionlock")
+	return err
 }
 
 // Pin holds packages back (dnf versionlock add), installing the plugin if needed.
-func (d *dnf) Pin(ctx context.Context, packages ...string) error {
+func (d *dnf) Pin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	if err := d.ensureVersionLock(ctx); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	return d.write(ctx, append([]string{"versionlock", "add"}, packages...)...)
 }
 
 // Unpin releases held packages (dnf versionlock delete).
-func (d *dnf) Unpin(ctx context.Context, packages ...string) error {
+func (d *dnf) Unpin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	if err := d.ensureVersionLock(ctx); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	return d.write(ctx, append([]string{"versionlock", "delete"}, packages...)...)
 }
 
 // Autoremove removes packages installed only as now-unneeded dependencies.
-func (d *dnf) Autoremove(ctx context.Context) error {
+func (d *dnf) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	return d.write(ctx, "autoremove", "-y")
 }
 
 // Repair re-runs the last transaction, drops duplicate packages, and verifies
 // the rpm database. Every step is best-effort (logged, not fatal) except a
-// context cancellation, which short-circuits.
-func (d *dnf) Repair(ctx context.Context) error {
+// context cancellation, which short-circuits. The returned Result is that of the
+// last step run (or the step that cancelled).
+func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 	steps := []struct {
 		what string
-		run  func() error
+		run  func() (pmexec.Result, error)
 	}{
-		{"dnf history redo last", func() error { return d.write(ctx, "history", "redo", "last", "-y") }},
-		{"dnf remove --duplicates", func() error { return d.write(ctx, "remove", "--duplicates", "-y") }},
-		{"rpm --verifydb", func() error { _, err := readOut(ctx, d.r, "rpm", "--verifydb"); return err }},
+		{"dnf history redo last", func() (pmexec.Result, error) { return d.write(ctx, "history", "redo", "last", "-y") }},
+		{"dnf remove --duplicates", func() (pmexec.Result, error) { return d.write(ctx, "remove", "--duplicates", "-y") }},
+		{"rpm --verifydb", func() (pmexec.Result, error) {
+			res, err := runRead(ctx, d.r, "rpm", "--verifydb")
+			if err != nil {
+				return res, err
+			}
+			return res, asCommandError("rpm", res)
+		}},
 	}
+	var last pmexec.Result
 	for _, s := range steps {
-		if err := bestEffortStep(ctx, s.what, s.run()); err != nil {
-			return err
+		res, err := s.run()
+		last = res
+		if err := bestEffortStep(ctx, s.what, err); err != nil {
+			return res, err
 		}
 	}
-	return nil
+	return last, nil
 }
 
 // Search searches package names/summaries (exit 1 = no matches).

--- a/go/pkg/dnf_test.go
+++ b/go/pkg/dnf_test.go
@@ -41,7 +41,7 @@ func TestDnf_Install(t *testing.T) {
 	t.Run("multiple latest", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -52,7 +52,7 @@ func TestDnf_Install(t *testing.T) {
 	t.Run("pinned version uses name-version", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "8.2.3"}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "8.2.3"}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "vim-8.2.3") {
@@ -63,7 +63,7 @@ func TestDnf_Install(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "newer already installed"}, nil) // install fails
 		ok(f, "")                                                                  // downgrade succeeds
-		if err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
 			t.Fatalf("downgrade retry should succeed, got %v", err)
 		}
 		calls := f.Calls()
@@ -80,7 +80,7 @@ func TestDnf_Install(t *testing.T) {
 	t.Run("downgrade NOT retried after a runner/exec failure", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // install fails to even run
-		err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim")
+		_, err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim")
 		if !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v, want the original escalation error", err)
 		}
@@ -91,7 +91,7 @@ func TestDnf_Install(t *testing.T) {
 	t.Run("install failure without downgrade is returned", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "no package"}, nil)
-		err := m.Install(ctx, InstallOptions{}, "ghost")
+		_, err := m.Install(ctx, InstallOptions{}, "ghost")
 		var ce *pmexec.CommandError
 		if !errors.As(err, &ce) || ce.ExitCode != 1 {
 			t.Fatalf("err=%v want CommandError", err)
@@ -102,25 +102,25 @@ func TestDnf_Install(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection, no exec")
 		}
 	})
 	t.Run("bad version", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want version rejection, no exec")
 		}
 	})
 	t.Run("version with multiple packages rejected", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want one-package rejection")
 		}
 	})
@@ -131,7 +131,7 @@ func TestDnf_Remove(t *testing.T) {
 	t.Run("remove (purge ignored)", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "dnf remove -y vim" {
@@ -140,13 +140,13 @@ func TestDnf_Remove(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -157,7 +157,7 @@ func TestDnf_Update(t *testing.T) {
 	t.Run("exit 0 is success", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 0}, nil)
-		if err := m.Update(ctx); err != nil {
+		if _, err := m.Update(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if c := f.Calls()[0]; argv(c) != "dnf check-update" || !c.Escalate {
@@ -167,7 +167,7 @@ func TestDnf_Update(t *testing.T) {
 	t.Run("exit 100 (updates available) is success", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 100}, nil)
-		if err := m.Update(ctx); err != nil {
+		if _, err := m.Update(ctx); err != nil {
 			t.Fatalf("exit 100 must be success, got %v", err)
 		}
 	})
@@ -175,14 +175,14 @@ func TestDnf_Update(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 5, Stderr: "metadata error"}, nil)
 		var ce *pmexec.CommandError
-		if err := m.Update(ctx); !errors.As(err, &ce) || ce.ExitCode != 5 {
+		if _, err := m.Update(ctx); !errors.As(err, &ce) || ce.ExitCode != 5 {
 			t.Fatalf("err=%v want CommandError(5)", err)
 		}
 	})
 	t.Run("exec error", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{}, errors.New("boom"))
-		if err := m.Update(ctx); err == nil {
+		if _, err := m.Update(ctx); err == nil {
 			t.Fatal("want error")
 		}
 	})
@@ -193,7 +193,7 @@ func TestDnf_Upgrade(t *testing.T) {
 	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "dnf upgrade -y" {
@@ -202,7 +202,7 @@ func TestDnf_Upgrade(t *testing.T) {
 	})
 	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Upgrade(ctx); err != nil {
+		if _, err := m.Upgrade(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -212,7 +212,7 @@ func TestDnf_Upgrade(t *testing.T) {
 	t.Run("specific", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx, "vim"); err != nil {
+		if _, err := m.Upgrade(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "dnf upgrade -y vim" {
@@ -221,7 +221,7 @@ func TestDnf_Upgrade(t *testing.T) {
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -234,7 +234,7 @@ func TestDnf_PinUnpin(t *testing.T) {
 		f.Push(pmexec.Result{ExitCode: 1}, nil) // versionlock --help: plugin absent
 		ok(f, "")                               // install plugin
 		ok(f, "")                               // versionlock add
-		if err := m.Pin(ctx, "vim"); err != nil {
+		if _, err := m.Pin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		calls := f.Calls()
@@ -252,7 +252,7 @@ func TestDnf_PinUnpin(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 0}, nil) // versionlock --help ok
 		ok(f, "")                               // versionlock add
-		if err := m.Pin(ctx, "vim"); err != nil {
+		if _, err := m.Pin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 2 {
@@ -263,7 +263,7 @@ func TestDnf_PinUnpin(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 0}, nil) // help ok
 		ok(f, "")                               // versionlock delete
-		if err := m.Unpin(ctx, "vim"); err != nil {
+		if _, err := m.Unpin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[1]) != "dnf versionlock delete vim" {
@@ -274,14 +274,14 @@ func TestDnf_PinUnpin(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 1}, nil)                      // help: absent
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "no plugin"}, nil) // install fails
-		if err := m.Pin(ctx, "vim"); err == nil {
+		if _, err := m.Pin(ctx, "vim"); err == nil {
 			t.Fatal("want plugin-install failure")
 		}
 	})
 	t.Run("probe runner failure does not trigger a plugin install", func(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // versionlock --help can't run
-		if err := m.Pin(ctx, "vim"); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		if _, err := m.Pin(ctx, "vim"); !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v, want the probe's runner error", err)
 		}
 		if len(f.Calls()) != 1 {
@@ -292,31 +292,31 @@ func TestDnf_PinUnpin(t *testing.T) {
 		m, f := dnfM(t)
 		f.Push(pmexec.Result{ExitCode: 1}, nil)                      // help: absent
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "no plugin"}, nil) // install fails
-		if err := m.Unpin(ctx, "vim"); err == nil {
+		if _, err := m.Unpin(ctx, "vim"); err == nil {
 			t.Fatal("want plugin-install failure")
 		}
 	})
 	t.Run("pin empty no-op", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("unpin empty no-op", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("pin bad name", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("unpin bad name", func(t *testing.T) {
 		m, f := dnfM(t)
-		if err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -325,7 +325,7 @@ func TestDnf_PinUnpin(t *testing.T) {
 func TestDnf_Autoremove(t *testing.T) {
 	m, f := dnfM(t)
 	ok(f, "")
-	if err := m.Autoremove(context.Background()); err != nil {
+	if _, err := m.Autoremove(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if c := f.Calls()[0]; argv(c) != "dnf autoremove -y" || !c.Escalate {
@@ -340,7 +340,7 @@ func TestDnf_Repair(t *testing.T) {
 		ok(f, "") // history redo
 		ok(f, "") // remove --duplicates
 		ok(f, "") // rpm --verifydb
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 3 {
@@ -352,7 +352,7 @@ func TestDnf_Repair(t *testing.T) {
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "x"}, nil)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "y"}, nil)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "z"}, nil)
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatalf("best-effort repair must not fail, got %v", err)
 		}
 	})
@@ -360,8 +360,17 @@ func TestDnf_Repair(t *testing.T) {
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		m, _ := dnfM(t)
-		if err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
+		if _, err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
 			t.Fatalf("err=%v want context.Canceled", err)
+		}
+	})
+	t.Run("rpm --verifydb runner error is swallowed (best-effort)", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")                                       // history redo
+		ok(f, "")                                       // remove --duplicates
+		f.Push(pmexec.Result{}, errors.New("rpm gone")) // rpm --verifydb: runner error, not just non-zero exit
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatalf("a non-cancellation verifydb runner error must be swallowed, got %v", err)
 		}
 	})
 }

--- a/go/pkg/flatpak.go
+++ b/go/pkg/flatpak.go
@@ -34,13 +34,14 @@ func (f *flatpak) scope() string {
 }
 
 // write runs a privileged flatpak command. It escalates only in system scope;
-// --user operations run unprivileged.
-func (f *flatpak) write(ctx context.Context, args ...string) error {
+// --user operations run unprivileged. The command Result is returned on both
+// the success and non-zero-exit paths.
+func (f *flatpak) write(ctx context.Context, args ...string) (pmexec.Result, error) {
 	res, err := runPriv(ctx, f.r, f.system, nil, "flatpak", args...)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	return asCommandError("flatpak", res)
+	return res, asCommandError("flatpak", res)
 }
 
 // Version returns the flatpak version string ("Flatpak 1.14.4").
@@ -59,27 +60,27 @@ func (f *flatpak) Version(ctx context.Context) (string, error) {
 // Install installs application bundles. Flatpak does not support traditional
 // version pinning, so opts.Version is validated but ignored (use commits/refs
 // for exact version control). All named bundles are installed at latest.
-func (f *flatpak) Install(ctx context.Context, opts InstallOptions, packages ...string) error {
+func (f *flatpak) Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if err := ValidatePackageVersion(opts.Version); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	args := append([]string{"install", "-y", "--noninteractive", f.scope()}, packages...)
 	return f.write(ctx, args...)
 }
 
 // Remove uninstalls bundles; opts.Purge also deletes per-app data (--delete-data).
-func (f *flatpak) Remove(ctx context.Context, opts RemoveOptions, packages ...string) error {
+func (f *flatpak) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	args := []string{"uninstall", "-y", "--noninteractive"}
 	if opts.Purge {
@@ -91,38 +92,39 @@ func (f *flatpak) Remove(ctx context.Context, opts RemoveOptions, packages ...st
 }
 
 // Update refreshes appstream metadata for the configured remotes.
-func (f *flatpak) Update(ctx context.Context) error {
+func (f *flatpak) Update(ctx context.Context) (pmexec.Result, error) {
 	return f.write(ctx, "update", "--appstream", "-y", "--noninteractive", f.scope())
 }
 
 // Upgrade updates the named bundles, or all installed bundles with no names.
-func (f *flatpak) Upgrade(ctx context.Context, packages ...string) error {
+func (f *flatpak) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil // empty is a no-op; UpgradeAll updates everything (flatpak update with no refs)
+		return pmexec.Result{}, nil // empty is a no-op; UpgradeAll updates everything (flatpak update with no refs)
 	}
 	args := append([]string{"update", "-y", "--noninteractive", f.scope()}, packages...)
 	return f.write(ctx, args...)
 }
 
 // UpgradeAll updates every installed app/runtime (flatpak update with no refs).
-func (f *flatpak) UpgradeAll(ctx context.Context) error {
+func (f *flatpak) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
 	return f.write(ctx, "update", "-y", "--noninteractive", f.scope())
 }
 
 // Autoremove removes unused runtimes/extensions (flatpak uninstall --unused).
-func (f *flatpak) Autoremove(ctx context.Context) error {
+func (f *flatpak) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	return f.write(ctx, "uninstall", "--unused", "-y", "--noninteractive", f.scope())
 }
 
 // Repair runs `flatpak repair`, restoring a consistent installation state.
-func (f *flatpak) Repair(ctx context.Context) error {
-	if err := f.write(ctx, "repair", f.scope()); err != nil {
-		return repairErr(ctx, "flatpak repair failed", err)
+func (f *flatpak) Repair(ctx context.Context) (pmexec.Result, error) {
+	res, err := f.write(ctx, "repair", f.scope())
+	if err != nil {
+		return res, repairErr(ctx, "flatpak repair failed", err)
 	}
-	return nil
+	return res, nil
 }
 
 // Search searches configured remotes (exit 1 = no matches).
@@ -383,32 +385,39 @@ func (f *flatpak) HasUpdates(ctx context.Context, securityOnly bool) (bool, erro
 }
 
 // Pin masks bundles so they are held back from updates. Best-effort across the
-// set: every bundle is attempted and the last error (if any) is returned.
-func (f *flatpak) Pin(ctx context.Context, packages ...string) error {
+// set: every bundle is attempted and the last error (if any) is returned, along
+// with the last command's Result.
+func (f *flatpak) Pin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
+	var last pmexec.Result
 	var lastErr error
 	for _, name := range packages {
-		if err := f.write(ctx, "mask", name, f.scope()); err != nil {
+		res, err := f.write(ctx, "mask", name, f.scope())
+		last = res
+		if err != nil {
 			lastErr = err
 		}
 	}
-	return lastErr
+	return last, lastErr
 }
 
 // Unpin removes the mask so bundles update again.
-func (f *flatpak) Unpin(ctx context.Context, packages ...string) error {
+func (f *flatpak) Unpin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
+	var last pmexec.Result
 	var lastErr error
 	for _, name := range packages {
-		if err := f.write(ctx, "mask", "--remove", name, f.scope()); err != nil {
+		res, err := f.write(ctx, "mask", "--remove", name, f.scope())
+		last = res
+		if err != nil {
 			lastErr = err
 		}
 	}
-	return lastErr
+	return last, lastErr
 }
 
 // ListPinned lists masked bundles.
@@ -488,7 +497,10 @@ func (f *flatpak) AddRemote(ctx context.Context, name, url string) error {
 	if err := ValidateRepoBaseURL(url); err != nil {
 		return err
 	}
-	return f.write(ctx, "remote-add", "--if-not-exists", name, url, f.scope())
+	// Remote management is configuration, not a package transaction, so it keeps
+	// the error-only contract; the command output is not surfaced as an action.
+	_, err := f.write(ctx, "remote-add", "--if-not-exists", name, url, f.scope())
+	return err
 }
 
 // RemoveRemote deletes a flatpak remote.
@@ -496,7 +508,8 @@ func (f *flatpak) RemoveRemote(ctx context.Context, name string) error {
 	if err := ValidateRemoteName(name); err != nil {
 		return err
 	}
-	return f.write(ctx, "remote-delete", "--force", name, f.scope())
+	_, err := f.write(ctx, "remote-delete", "--force", name, f.scope())
+	return err
 }
 
 // ListRemotes returns the configured flatpak remote names.

--- a/go/pkg/flatpak_test.go
+++ b/go/pkg/flatpak_test.go
@@ -58,7 +58,7 @@ func TestFlatpak_Install(t *testing.T) {
 	t.Run("system scope, escalated", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "org.vim.Vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -71,7 +71,7 @@ func TestFlatpak_Install(t *testing.T) {
 		ok(f, "")
 		// flatpak cannot pin a version, but multiple packages with a version are
 		// allowed here (version is ignored, not one-package-enforced).
-		if err := m.Install(ctx, InstallOptions{Version: "1.0"}, "org.vim.Vim", "org.gnu.emacs"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0"}, "org.vim.Vim", "org.gnu.emacs"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); strings.Contains(a, "1.0") {
@@ -81,7 +81,7 @@ func TestFlatpak_Install(t *testing.T) {
 	t.Run("user scope is unprivileged", func(t *testing.T) {
 		m, f := flatpakM(t, WithUserScope())
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "org.vim.Vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -91,19 +91,19 @@ func TestFlatpak_Install(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Install(ctx, InstallOptions{}, "org.vim.Vim;rm"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}, "org.vim.Vim;rm"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("bad version", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1;0"}, "org.vim.Vim"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1;0"}, "org.vim.Vim"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -114,7 +114,7 @@ func TestFlatpak_Remove(t *testing.T) {
 	t.Run("remove", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{}, "org.vim.Vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak uninstall -y --noninteractive --system org.vim.Vim" {
@@ -124,7 +124,7 @@ func TestFlatpak_Remove(t *testing.T) {
 	t.Run("purge adds --delete-data", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{Purge: true}, "org.vim.Vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{Purge: true}, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "--delete-data") {
@@ -133,13 +133,13 @@ func TestFlatpak_Remove(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -150,7 +150,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	t.Run("update --appstream", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Update(ctx); err != nil {
+		if _, err := m.Update(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak update --appstream -y --noninteractive --system" {
@@ -160,7 +160,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak update -y --noninteractive --system" {
@@ -169,7 +169,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Upgrade(ctx); err != nil {
+		if _, err := m.Upgrade(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -179,7 +179,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	t.Run("upgrade specific", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx, "org.vim.Vim"); err != nil {
+		if _, err := m.Upgrade(ctx, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		if !strings.HasSuffix(argv(f.Calls()[0]), "--system org.vim.Vim") {
@@ -188,14 +188,14 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("upgrade bad name", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Upgrade(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Upgrade(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("write exec error surfaced", func(t *testing.T) {
 		m, f := flatpakM(t)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
-		if err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		if _, err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -204,7 +204,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 func TestFlatpak_Autoremove(t *testing.T) {
 	m, f := flatpakM(t)
 	ok(f, "")
-	if err := m.Autoremove(context.Background()); err != nil {
+	if _, err := m.Autoremove(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if a := argv(f.Calls()[0]); a != "flatpak uninstall --unused -y --noninteractive --system" {
@@ -217,7 +217,7 @@ func TestFlatpak_Repair(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak repair --system" {
@@ -227,7 +227,7 @@ func TestFlatpak_Repair(t *testing.T) {
 	t.Run("failure returned", func(t *testing.T) {
 		m, f := flatpakM(t)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "repair failed"}, nil)
-		if err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "flatpak repair failed") {
+		if _, err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "flatpak repair failed") {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -546,7 +546,7 @@ func TestFlatpak_PinUnpin(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "") // mask org.vim.Vim
 		ok(f, "") // mask org.gnu.emacs
-		if err := m.Pin(ctx, "org.vim.Vim", "org.gnu.emacs"); err != nil {
+		if _, err := m.Pin(ctx, "org.vim.Vim", "org.gnu.emacs"); err != nil {
 			t.Fatal(err)
 		}
 		calls := f.Calls()
@@ -557,7 +557,7 @@ func TestFlatpak_PinUnpin(t *testing.T) {
 	t.Run("unpin removes the mask", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if err := m.Unpin(ctx, "org.vim.Vim"); err != nil {
+		if _, err := m.Unpin(ctx, "org.vim.Vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak mask --remove org.vim.Vim --system" {
@@ -568,7 +568,7 @@ func TestFlatpak_PinUnpin(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")                                            // first unmask ok
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "x"}, nil) // second unmask fails
-		if err := m.Unpin(ctx, "org.a.A", "org.b.B"); err == nil {
+		if _, err := m.Unpin(ctx, "org.a.A", "org.b.B"); err == nil {
 			t.Fatal("want last error")
 		}
 		if len(f.Calls()) != 2 {
@@ -579,7 +579,7 @@ func TestFlatpak_PinUnpin(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")                                            // first mask ok
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "x"}, nil) // second mask fails
-		err := m.Pin(ctx, "org.a.A", "org.b.B")
+		_, err := m.Pin(ctx, "org.a.A", "org.b.B")
 		if err == nil {
 			t.Fatal("want last error")
 		}
@@ -589,13 +589,13 @@ func TestFlatpak_PinUnpin(t *testing.T) {
 	})
 	t.Run("pin bad name", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Pin(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("unpin bad name", func(t *testing.T) {
 		m, f := flatpakM(t)
-		if err := m.Unpin(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx, "a;b"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})

--- a/go/pkg/pacman.go
+++ b/go/pkg/pacman.go
@@ -24,12 +24,12 @@ var _ Manager = (*pacman)(nil)
 
 func (p *pacman) Backend() Backend { return Pacman }
 
-func (p *pacman) write(ctx context.Context, args ...string) error {
+func (p *pacman) write(ctx context.Context, args ...string) (pmexec.Result, error) {
 	res, err := runPriv(ctx, p.r, true, nil, "pacman", args...)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	return asCommandError("pacman", res)
+	return res, asCommandError("pacman", res)
 }
 
 // Version returns the pacman version string (parsed from " Pacman v6.0.2 - …").
@@ -53,18 +53,18 @@ func (p *pacman) Version(ctx context.Context) (string, error) {
 // Install installs packages. With opts.Version it targets a single package via
 // the name=version form (pacman can only satisfy this if the version is in a
 // configured repo); opts.AllowDowngrade adds `--overwrite '*'`.
-func (p *pacman) Install(ctx context.Context, opts InstallOptions, packages ...string) error {
+func (p *pacman) Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if err := ValidatePackageVersion(opts.Version); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if opts.Version != "" && len(packages) != 1 {
-		return fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
+		return pmexec.Result{}, fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	if opts.Version == "" {
 		return p.write(ctx, append([]string{"-S", "--noconfirm", "--needed"}, packages...)...)
@@ -78,12 +78,12 @@ func (p *pacman) Install(ctx context.Context, opts InstallOptions, packages ...s
 }
 
 // Remove removes packages; opts.Purge uses -Rns (with deps + config files).
-func (p *pacman) Remove(ctx context.Context, opts RemoveOptions, packages ...string) error {
+func (p *pacman) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	flag := "-R"
 	if opts.Purge {
@@ -93,37 +93,37 @@ func (p *pacman) Remove(ctx context.Context, opts RemoveOptions, packages ...str
 }
 
 // Update syncs the package databases (-Sy).
-func (p *pacman) Update(ctx context.Context) error {
+func (p *pacman) Update(ctx context.Context) (pmexec.Result, error) {
 	return p.write(ctx, "-Sy", "--noconfirm")
 }
 
 // Upgrade upgrades the named packages, or the whole system (-Syu) with no names.
-func (p *pacman) Upgrade(ctx context.Context, packages ...string) error {
+func (p *pacman) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil // empty is a no-op; UpgradeAll does a full upgrade
+		return pmexec.Result{}, nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return p.write(ctx, append([]string{"-S", "--noconfirm"}, packages...)...)
 }
 
 // UpgradeAll performs a full system upgrade (pacman -Syu).
-func (p *pacman) UpgradeAll(ctx context.Context) error {
+func (p *pacman) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
 	return p.write(ctx, "-Syu", "--noconfirm")
 }
 
 // Autoremove removes orphaned packages (installed as deps, no longer required).
-func (p *pacman) Autoremove(ctx context.Context) error {
+func (p *pacman) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	res, err := runRead(ctx, p.r, "pacman", "-Qtdq")
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if res.ExitCode == 1 {
-		return nil // no orphans
+		return pmexec.Result{}, nil // no orphans
 	}
 	if res.ExitCode != 0 {
-		return asCommandError("pacman", res)
+		return res, asCommandError("pacman", res)
 	}
 	var orphans []string
 	for _, line := range strings.Split(res.Stdout, "\n") {
@@ -132,20 +132,21 @@ func (p *pacman) Autoremove(ctx context.Context) error {
 		}
 	}
 	if len(orphans) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return p.write(ctx, append([]string{"-Rns", "--noconfirm"}, orphans...)...)
 }
 
 // Repair clears a stale db lock and force-refreshes all databases.
-func (p *pacman) Repair(ctx context.Context) error {
+func (p *pacman) Repair(ctx context.Context) (pmexec.Result, error) {
 	if err := removeStaleLock(ctx, p.r, "/var/lib/pacman/db.lck"); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	if err := p.write(ctx, "-Syy", "--noconfirm"); err != nil {
-		return repairErr(ctx, "pacman -Syy failed", err)
+	res, err := p.write(ctx, "-Syy", "--noconfirm")
+	if err != nil {
+		return res, repairErr(ctx, "pacman -Syy failed", err)
 	}
-	return nil
+	return res, nil
 }
 
 // Search searches packages (-Ss; exit 1 = no matches).
@@ -404,26 +405,28 @@ func (p *pacman) HasUpdates(ctx context.Context, securityOnly bool) (bool, error
 	return strings.TrimSpace(res.Stdout) != "", nil
 }
 
-// Pin holds packages by adding them to IgnorePkg in /etc/pacman.conf.
-func (p *pacman) Pin(ctx context.Context, packages ...string) error {
+// Pin holds packages by adding them to IgnorePkg in /etc/pacman.conf. Pinning is
+// a config-file edit, not a package transaction, so it has no command output to
+// surface — the returned Result is the zero Result.
+func (p *pacman) Pin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	// Second, stricter gate: IgnorePkg values land in pacman.conf, so reject any
 	// name that could inject a config directive even though ValidatePackageNames
 	// already passed.
 	for _, name := range packages {
 		if !validPacmanPkgName.MatchString(name) {
-			return fmt.Errorf("invalid package name %q: must match [a-zA-Z0-9][a-zA-Z0-9._+-]*", name)
+			return pmexec.Result{}, fmt.Errorf("invalid package name %q: must match [a-zA-Z0-9][a-zA-Z0-9._+-]*", name)
 		}
 	}
 
 	conf, err := p.readConf(ctx)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	ignored := getIgnoredPackages(conf)
 	for _, name := range packages {
@@ -431,20 +434,21 @@ func (p *pacman) Pin(ctx context.Context, packages ...string) error {
 			ignored = append(ignored, name)
 		}
 	}
-	return p.writeIgnorePkg(ctx, conf, ignored)
+	return pmexec.Result{}, p.writeIgnorePkg(ctx, conf, ignored)
 }
 
-// Unpin releases packages by removing them from IgnorePkg.
-func (p *pacman) Unpin(ctx context.Context, packages ...string) error {
+// Unpin releases packages by removing them from IgnorePkg. Like Pin, this is a
+// config-file edit with no command output (zero Result).
+func (p *pacman) Unpin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	conf, err := p.readConf(ctx)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	var kept []string
 	for _, name := range getIgnoredPackages(conf) {
@@ -452,7 +456,7 @@ func (p *pacman) Unpin(ctx context.Context, packages ...string) error {
 			kept = append(kept, name)
 		}
 	}
-	return p.writeIgnorePkg(ctx, conf, kept)
+	return pmexec.Result{}, p.writeIgnorePkg(ctx, conf, kept)
 }
 
 // ListPinned lists IgnorePkg-held packages.

--- a/go/pkg/pacman_test.go
+++ b/go/pkg/pacman_test.go
@@ -50,7 +50,7 @@ func TestPacman_Install(t *testing.T) {
 	t.Run("latest with --needed", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -61,7 +61,7 @@ func TestPacman_Install(t *testing.T) {
 	t.Run("pinned version (no --needed)", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "9.0-1"}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "9.0-1"}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		a := argv(f.Calls()[0])
@@ -72,7 +72,7 @@ func TestPacman_Install(t *testing.T) {
 	t.Run("allow downgrade does not force-overwrite", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		a := argv(f.Calls()[0])
@@ -85,25 +85,25 @@ func TestPacman_Install(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("bad version", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("version with multiple packages rejected", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want one-package rejection")
 		}
 	})
@@ -114,7 +114,7 @@ func TestPacman_Remove(t *testing.T) {
 	t.Run("remove (-R)", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -R --noconfirm vim" {
@@ -124,7 +124,7 @@ func TestPacman_Remove(t *testing.T) {
 	t.Run("purge (-Rns)", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Rns --noconfirm vim" {
@@ -133,13 +133,13 @@ func TestPacman_Remove(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -150,7 +150,7 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	t.Run("update -Sy", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Update(ctx); err != nil {
+		if _, err := m.Update(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Sy --noconfirm" {
@@ -160,7 +160,7 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll -Syu", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Syu --noconfirm" {
@@ -169,7 +169,7 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Upgrade(ctx); err != nil {
+		if _, err := m.Upgrade(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -179,7 +179,7 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	t.Run("upgrade specific", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx, "vim"); err != nil {
+		if _, err := m.Upgrade(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -S --noconfirm vim" {
@@ -188,14 +188,14 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("upgrade bad name", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("write exec error surfaced", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
-		if err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		if _, err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v want ErrEscalationDenied", err)
 		}
 	})
@@ -207,7 +207,7 @@ func TestPacman_Autoremove(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "orphan1\norphan2\n") // -Qtdq
 		ok(f, "")                   // -Rns
-		if err := m.Autoremove(ctx); err != nil {
+		if _, err := m.Autoremove(ctx); err != nil {
 			t.Fatal(err)
 		}
 		calls := f.Calls()
@@ -218,7 +218,7 @@ func TestPacman_Autoremove(t *testing.T) {
 	t.Run("no orphans (exit 1)", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{ExitCode: 1}, nil)
-		if err := m.Autoremove(ctx); err != nil {
+		if _, err := m.Autoremove(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 1 {
@@ -228,7 +228,7 @@ func TestPacman_Autoremove(t *testing.T) {
 	t.Run("blank query output is a no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "  \n\n") // exit 0 but only blank lines
-		if err := m.Autoremove(ctx); err != nil {
+		if _, err := m.Autoremove(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 1 {
@@ -238,14 +238,14 @@ func TestPacman_Autoremove(t *testing.T) {
 	t.Run("query failure surfaced", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{ExitCode: 2, Stderr: "db error"}, nil)
-		if err := m.Autoremove(ctx); err == nil {
+		if _, err := m.Autoremove(ctx); err == nil {
 			t.Fatal("want error")
 		}
 	})
 	t.Run("query exec error", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{}, errors.New("boom"))
-		if err := m.Autoremove(ctx); err == nil {
+		if _, err := m.Autoremove(ctx); err == nil {
 			t.Fatal("want error")
 		}
 	})
@@ -257,7 +257,7 @@ func TestPacman_Repair(t *testing.T) {
 		stubStatFile(t, nil) // db.lck absent
 		m, f := pacmanM(t)
 		ok(f, "") // -Syy
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Syy --noconfirm" {
@@ -268,7 +268,7 @@ func TestPacman_Repair(t *testing.T) {
 		stubStatFile(t, nil)
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "sync failed"}, nil)
-		if err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "pacman -Syy failed") {
+		if _, err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "pacman -Syy failed") {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -277,7 +277,7 @@ func TestPacman_Repair(t *testing.T) {
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		m, f := pacmanM(t)
-		if err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
+		if _, err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
 			t.Fatalf("err=%v", err)
 		}
 		if len(f.Calls()) != 0 {
@@ -644,7 +644,7 @@ func TestPacman_Pin(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, samplePacmanConf) // readConf
 		ok(f, "")               // tee
-		if err := m.Pin(ctx, "vim"); err != nil {
+		if _, err := m.Pin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		tee := f.Calls()[1]
@@ -660,7 +660,7 @@ func TestPacman_Pin(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, samplePacmanConf) // linux already ignored
 		ok(f, "")
-		if err := m.Pin(ctx, "linux"); err != nil {
+		if _, err := m.Pin(ctx, "linux"); err != nil {
 			t.Fatal(err)
 		}
 		body := readAll(t, f.Calls()[1])
@@ -671,26 +671,26 @@ func TestPacman_Pin(t *testing.T) {
 	t.Run("config-injection name rejected by stricter gate", func(t *testing.T) {
 		m, f := pacmanM(t)
 		// passes ValidatePackageName (':' allowed) but fails validPacmanPkgName
-		if err := m.Pin(ctx, "vim:amd64"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "vim:amd64"); err == nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d, want stricter-gate rejection with no exec", err, len(f.Calls()))
 		}
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("readConf failure surfaced", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{}, errors.New("cat failed"))
-		if err := m.Pin(ctx, "vim"); err == nil || !strings.Contains(err.Error(), "pacman.conf") {
+		if _, err := m.Pin(ctx, "vim"); err == nil || !strings.Contains(err.Error(), "pacman.conf") {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -698,7 +698,7 @@ func TestPacman_Pin(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, samplePacmanConf)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "permission denied"}, nil)
-		if err := m.Pin(ctx, "vim"); err == nil {
+		if _, err := m.Pin(ctx, "vim"); err == nil {
 			t.Fatal("want tee failure")
 		}
 	})
@@ -706,7 +706,7 @@ func TestPacman_Pin(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, samplePacmanConf)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
-		if err := m.Pin(ctx, "vim"); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		if _, err := m.Pin(ctx, "vim"); !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v want ErrEscalationDenied", err)
 		}
 	})
@@ -718,7 +718,7 @@ func TestPacman_Unpin(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "[options]\nIgnorePkg = linux vim\n") // readConf
 		ok(f, "")                                   // tee
-		if err := m.Unpin(ctx, "vim"); err != nil {
+		if _, err := m.Unpin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		body := readAll(t, f.Calls()[1])
@@ -728,20 +728,20 @@ func TestPacman_Unpin(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := pacmanM(t)
-		if err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("readConf failure surfaced", func(t *testing.T) {
 		m, f := pacmanM(t)
 		f.Push(pmexec.Result{}, errors.New("cat failed"))
-		if err := m.Unpin(ctx, "vim"); err == nil {
+		if _, err := m.Unpin(ctx, "vim"); err == nil {
 			t.Fatal("want error")
 		}
 	})

--- a/go/pkg/pkg.go
+++ b/go/pkg/pkg.go
@@ -72,8 +72,14 @@ func (b Backend) String() string {
 
 // Manager is the uniform package-manager surface. Every method takes a context
 // so the caller controls timeout/cancellation. Query methods return typed
-// results; mutating methods return error only — a non-zero exit becomes an
-// *exec.CommandError carrying the exit code and stderr.
+// results; mutating methods return the command's output (an exec.Result carrying
+// exit code, stdout and stderr) so callers can surface what the package manager
+// actually did, plus an error — a non-zero exit becomes an *exec.CommandError
+// carrying the exit code and stderr while the Result still carries the full
+// stdout/stderr. The Result is populated on both the success and non-zero-exit
+// paths; it is the zero Result only when the command could not be run at all
+// (the error is then a plain runner error) or when the call is a validated
+// no-op (e.g. an empty package list).
 type Manager interface {
 	// Backend reports which package-manager backend this Manager drives.
 	Backend() Backend
@@ -111,30 +117,31 @@ type Manager interface {
 	// Install installs the named packages. opts.Version pins a single package
 	// (exactly one name required when set); opts.AllowDowngrade permits a lower
 	// version than installed.
-	Install(ctx context.Context, opts InstallOptions, packages ...string) error
+	Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error)
 	// Remove removes the named packages. opts.Purge also deletes configuration
 	// where the backend distinguishes it (apt/pacman/flatpak); elsewhere Purge
 	// is equivalent to a plain remove.
-	Remove(ctx context.Context, opts RemoveOptions, packages ...string) error
+	Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error)
 	// Update refreshes the package metadata/database.
-	Update(ctx context.Context) error
+	Update(ctx context.Context) (pmexec.Result, error)
 	// Upgrade upgrades the named packages. With NO names it is a no-op (not a
 	// full upgrade) — an accidentally-empty list must never upgrade the whole
 	// system. Use UpgradeAll for that.
-	Upgrade(ctx context.Context, packages ...string) error
+	Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error)
 	// UpgradeAll performs a full system upgrade (apt dist-upgrade / dnf upgrade /
 	// pacman -Syu / zypper dist-upgrade / flatpak update).
-	UpgradeAll(ctx context.Context) error
+	UpgradeAll(ctx context.Context) (pmexec.Result, error)
 	// Pin holds the named packages back from upgrades.
-	Pin(ctx context.Context, packages ...string) error
+	Pin(ctx context.Context, packages ...string) (pmexec.Result, error)
 	// Unpin releases the named packages so they upgrade again.
-	Unpin(ctx context.Context, packages ...string) error
+	Unpin(ctx context.Context, packages ...string) (pmexec.Result, error)
 	// Repair attempts to fix a wedged package-manager state (stale locks,
-	// interrupted transactions, broken dependencies).
-	Repair(ctx context.Context) error
+	// interrupted transactions, broken dependencies). It runs several recovery
+	// commands; the returned Result is that of the final (or first failing) step.
+	Repair(ctx context.Context) (pmexec.Result, error)
 	// Autoremove removes packages installed only as now-unneeded dependencies.
-	// It is a no-op (returns nil) on backends with no native equivalent.
-	Autoremove(ctx context.Context) error
+	// It is a no-op (zero Result, nil error) on backends with no native equivalent.
+	Autoremove(ctx context.Context) (pmexec.Result, error)
 }
 
 // FlatpakManager is the Manager returned by New(Flatpak, …); it adds remote

--- a/go/pkg/pkg_test.go
+++ b/go/pkg/pkg_test.go
@@ -54,6 +54,51 @@ func mustNew(t *testing.T, b Backend, opts ...Option) (Manager, *exectest.FakeRu
 // ok scripts the next runner call as a clean success with the given stdout.
 func ok(f *exectest.FakeRunner, stdout string) { f.Push(pmexec.Result{Stdout: stdout}, nil) }
 
+// TestMutationsReturnCommandOutput pins the contract that a Manager mutation
+// returns the package manager's command output (exec.Result), not just an error
+// — operators need to see what an install/remove/update actually did. On a clean
+// exit the Result carries stdout; on a non-zero exit it carries stdout + stderr
+// + exit code AND a typed *exec.CommandError. Driven by the agent migration:
+// the agent maps this Result into the pb.CommandOutput it returns to control.
+func TestMutationsReturnCommandOutput(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("install surfaces stdout on success", func(t *testing.T) {
+		m, f := mustNew(t, Apt)
+		f.Push(pmexec.Result{Stdout: "Setting up vim ...\n", ExitCode: 0}, nil)
+		res, err := m.Install(ctx, InstallOptions{}, "vim")
+		if err != nil {
+			t.Fatalf("Install err = %v", err)
+		}
+		if res.Stdout != "Setting up vim ...\n" {
+			t.Errorf("Result.Stdout = %q, want the command stdout", res.Stdout)
+		}
+		if res.ExitCode != 0 {
+			t.Errorf("Result.ExitCode = %d, want 0", res.ExitCode)
+		}
+	})
+
+	t.Run("install surfaces stdout+stderr+exit AND CommandError on failure", func(t *testing.T) {
+		m, f := mustNew(t, Apt)
+		f.Push(pmexec.Result{
+			Stdout:   "Reading package lists...\n",
+			Stderr:   "E: Unable to locate package vim\n",
+			ExitCode: 100,
+		}, nil)
+		res, err := m.Install(ctx, InstallOptions{}, "vim")
+		if err == nil {
+			t.Fatal("Install err = nil, want a non-zero-exit error")
+		}
+		var ce *pmexec.CommandError
+		if !errors.As(err, &ce) {
+			t.Fatalf("err = %v, want *exec.CommandError", err)
+		}
+		if res.ExitCode != 100 || res.Stdout != "Reading package lists...\n" || res.Stderr != "E: Unable to locate package vim\n" {
+			t.Errorf("Result = %+v, want stdout+stderr+exit preserved", res)
+		}
+	})
+}
+
 // --- New -------------------------------------------------------------------
 
 func TestNew_AllBackends(t *testing.T) {
@@ -111,7 +156,7 @@ func TestNew_FlatpakScopeOption(t *testing.T) {
 	t.Run("default is system + escalated", func(t *testing.T) {
 		m, f := mustNew(t, Flatpak)
 		ok(f, "")
-		if err := m.Update(context.Background()); err != nil {
+		if _, err := m.Update(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -125,7 +170,7 @@ func TestNew_FlatpakScopeOption(t *testing.T) {
 	t.Run("WithUserScope is user + unescalated", func(t *testing.T) {
 		m, f := mustNew(t, Flatpak, WithUserScope())
 		ok(f, "")
-		if err := m.Update(context.Background()); err != nil {
+		if _, err := m.Update(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -144,7 +189,7 @@ func TestNew_UserScopeIgnoredByNativeBackends(t *testing.T) {
 	m, f := mustNew(t, Apt, WithUserScope())
 	stubLookPath(t, "apt")
 	ok(f, "")
-	if err := m.Update(context.Background()); err != nil {
+	if _, err := m.Update(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if c := f.Calls()[0]; !c.Escalate {

--- a/go/pkg/zypper.go
+++ b/go/pkg/zypper.go
@@ -32,12 +32,12 @@ func isZypperInfoExit(code int) bool {
 
 func (z *zypper) Backend() Backend { return Zypper }
 
-func (z *zypper) write(ctx context.Context, args ...string) error {
+func (z *zypper) write(ctx context.Context, args ...string) (pmexec.Result, error) {
 	res, err := runPriv(ctx, z.r, true, nil, "zypper", args...)
 	if err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	return asCommandError("zypper", res)
+	return res, asCommandError("zypper", res)
 }
 
 // Version returns the zypper version string.
@@ -55,18 +55,18 @@ func (z *zypper) Version(ctx context.Context) (string, error) {
 
 // Install installs packages. opts.Version pins a single package (name=version);
 // opts.AllowDowngrade adds --oldpackage.
-func (z *zypper) Install(ctx context.Context, opts InstallOptions, packages ...string) error {
+func (z *zypper) Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if err := ValidatePackageVersion(opts.Version); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if opts.Version != "" && len(packages) != 1 {
-		return fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
+		return pmexec.Result{}, fmt.Errorf("pkg: InstallOptions.Version requires exactly one package, got %d", len(packages))
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	args := []string{"--non-interactive", "install"}
 	if opts.AllowDowngrade {
@@ -82,53 +82,54 @@ func (z *zypper) Install(ctx context.Context, opts InstallOptions, packages ...s
 
 // Remove removes packages. zypper does not distinguish purge from remove, so
 // opts.Purge is a no-op.
-func (z *zypper) Remove(ctx context.Context, _ RemoveOptions, packages ...string) error {
+func (z *zypper) Remove(ctx context.Context, _ RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return z.write(ctx, append([]string{"--non-interactive", "remove"}, packages...)...)
 }
 
 // Update refreshes the repositories.
-func (z *zypper) Update(ctx context.Context) error {
+func (z *zypper) Update(ctx context.Context) (pmexec.Result, error) {
 	return z.write(ctx, "--non-interactive", "refresh")
 }
 
 // Upgrade upgrades the named packages, or runs a full dist-upgrade with no names.
-func (z *zypper) Upgrade(ctx context.Context, packages ...string) error {
+func (z *zypper) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil // empty is a no-op; UpgradeAll does a full upgrade
+		return pmexec.Result{}, nil // empty is a no-op; UpgradeAll does a full upgrade
 	}
 	return z.write(ctx, append([]string{"--non-interactive", "update"}, packages...)...)
 }
 
 // UpgradeAll performs a full distribution upgrade (zypper dist-upgrade).
-func (z *zypper) UpgradeAll(ctx context.Context) error {
+func (z *zypper) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
 	return z.write(ctx, "--non-interactive", "dist-upgrade")
 }
 
 // Autoremove is a no-op: zypper has no single-shot unneeded-package removal
 // matching apt/dnf autoremove semantics.
-func (z *zypper) Autoremove(ctx context.Context) error {
+func (z *zypper) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	slog.Debug("zypper has no native autoremove; skipping")
-	return nil
+	return pmexec.Result{}, nil
 }
 
 // Repair clears a stale zypp lock and refreshes the repositories.
-func (z *zypper) Repair(ctx context.Context) error {
+func (z *zypper) Repair(ctx context.Context) (pmexec.Result, error) {
 	if err := removeStaleLock(ctx, z.r, "/run/zypp.pid"); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
-	if err := z.write(ctx, "--non-interactive", "refresh"); err != nil {
-		return repairErr(ctx, "zypper refresh failed", err)
+	res, err := z.write(ctx, "--non-interactive", "refresh")
+	if err != nil {
+		return res, repairErr(ctx, "zypper refresh failed", err)
 	}
-	return nil
+	return res, nil
 }
 
 // Search searches packages (exit 104 = no matches).
@@ -428,23 +429,23 @@ func (z *zypper) HasUpdates(ctx context.Context, securityOnly bool) (bool, error
 }
 
 // Pin holds packages back (zypper addlock).
-func (z *zypper) Pin(ctx context.Context, packages ...string) error {
+func (z *zypper) Pin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return z.write(ctx, append([]string{"--non-interactive", "addlock"}, packages...)...)
 }
 
 // Unpin releases held packages (zypper removelock).
-func (z *zypper) Unpin(ctx context.Context, packages ...string) error {
+func (z *zypper) Unpin(ctx context.Context, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
-		return err
+		return pmexec.Result{}, err
 	}
 	if len(packages) == 0 {
-		return nil
+		return pmexec.Result{}, nil
 	}
 	return z.write(ctx, append([]string{"--non-interactive", "removelock"}, packages...)...)
 }

--- a/go/pkg/zypper_test.go
+++ b/go/pkg/zypper_test.go
@@ -48,7 +48,7 @@ func TestZypper_Install(t *testing.T) {
 	t.Run("latest", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{}, "vim", "git"); err != nil {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
@@ -59,7 +59,7 @@ func TestZypper_Install(t *testing.T) {
 	t.Run("pinned version", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "9.0-1"}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "9.0-1"}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "vim=9.0-1") {
@@ -69,7 +69,7 @@ func TestZypper_Install(t *testing.T) {
 	t.Run("allow downgrade adds --oldpackage", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0", AllowDowngrade: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.Contains(a, "--oldpackage") {
@@ -78,25 +78,25 @@ func TestZypper_Install(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{}, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("bad version", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1;0"}, "vim"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("version with multiple packages rejected", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Install(ctx, InstallOptions{Version: "1.0"}, "vim", "git"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want one-package rejection")
 		}
 	})
@@ -107,7 +107,7 @@ func TestZypper_Remove(t *testing.T) {
 	t.Run("remove (purge ignored)", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
+		if _, err := m.Remove(ctx, RemoveOptions{Purge: true}, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive remove vim" {
@@ -116,13 +116,13 @@ func TestZypper_Remove(t *testing.T) {
 	})
 	t.Run("empty no-op", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("bad name", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Remove(ctx, RemoveOptions{}, "--x"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
@@ -133,7 +133,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	t.Run("update refresh", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Update(ctx); err != nil {
+		if _, err := m.Update(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive refresh" {
@@ -143,7 +143,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive dist-upgrade" {
@@ -152,7 +152,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("empty Upgrade is a no-op", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Upgrade(ctx); err != nil {
+		if _, err := m.Upgrade(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if len(f.Calls()) != 0 {
@@ -162,7 +162,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	t.Run("upgrade specific -> update", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Upgrade(ctx, "vim"); err != nil {
+		if _, err := m.Upgrade(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive update vim" {
@@ -171,14 +171,14 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	})
 	t.Run("upgrade bad name", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Upgrade(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("write exec error surfaced", func(t *testing.T) {
 		m, f := zypperM(t)
 		f.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
-		if err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		if _, err := m.Update(ctx); !errors.Is(err, pmexec.ErrEscalationDenied) {
 			t.Fatalf("err=%v want ErrEscalationDenied", err)
 		}
 	})
@@ -186,7 +186,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 
 func TestZypper_Autoremove(t *testing.T) {
 	m, f := zypperM(t)
-	if err := m.Autoremove(context.Background()); err != nil {
+	if _, err := m.Autoremove(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if len(f.Calls()) != 0 {
@@ -200,7 +200,7 @@ func TestZypper_Repair(t *testing.T) {
 		stubStatFile(t, nil)
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Repair(ctx); err != nil {
+		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive refresh" {
@@ -211,7 +211,7 @@ func TestZypper_Repair(t *testing.T) {
 		stubStatFile(t, nil)
 		m, f := zypperM(t)
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "refresh failed"}, nil)
-		if err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "zypper refresh failed") {
+		if _, err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "zypper refresh failed") {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -220,7 +220,7 @@ func TestZypper_Repair(t *testing.T) {
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		m, _ := zypperM(t)
-		if err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
+		if _, err := m.Repair(cctx); !errors.Is(err, context.Canceled) {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -564,7 +564,7 @@ func TestZypper_PinUnpin(t *testing.T) {
 	t.Run("pin addlock", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Pin(ctx, "vim"); err != nil {
+		if _, err := m.Pin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if c := f.Calls()[0]; argv(c) != "zypper --non-interactive addlock vim" || !c.Escalate {
@@ -574,7 +574,7 @@ func TestZypper_PinUnpin(t *testing.T) {
 	t.Run("unpin removelock", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if err := m.Unpin(ctx, "vim"); err != nil {
+		if _, err := m.Unpin(ctx, "vim"); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive removelock vim" {
@@ -583,25 +583,25 @@ func TestZypper_PinUnpin(t *testing.T) {
 	})
 	t.Run("pin empty no-op", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("unpin empty no-op", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx); err != nil || len(f.Calls()) != 0 {
 			t.Fatalf("err=%v calls=%d", err, len(f.Calls()))
 		}
 	})
 	t.Run("pin bad name", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Pin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})
 	t.Run("unpin bad name", func(t *testing.T) {
 		m, f := zypperM(t)
-		if err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
+		if _, err := m.Unpin(ctx, "v;m"); err == nil || len(f.Calls()) != 0 {
 			t.Fatal("want rejection")
 		}
 	})


### PR DESCRIPTION
Closes #182

The 9 `Manager` mutations now return `(exec.Result, error)` across all backends so callers can surface what a package action actually did. The `Result` carries exit code + stdout + stderr on **both** the success and non-zero-exit paths; a non-zero exit still returns a typed `*exec.CommandError`. The zero `Result` is returned only for a validated no-op (empty list) or an unrunnable command.

**Why:** `asCommandError` preserved exit code + stderr but discarded **stdout**, and success returned no output at all. The agent's package-action executor maps this into the `pb.CommandOutput` it returns to the control server — operators need to see the install/remove/update output. (Driven by the agent migration: usage drives the API.)

`FlatpakManager.AddRemote/RemoveRemote` keep `error`-only — remote management is configuration, not a surfaced package transaction.

### Tests (test-first)
- New `TestMutationsReturnCommandOutput` pins stdout on success + stdout/stderr/exit + `*CommandError` on failure (red-checked: fails when propagation is removed).
- 158 existing mutation call-sites adapted to the two-value return.
- Added a dnf.Repair verifydb runner-error case → 100% statement coverage retained.
- Full `-race` gate, docref, and the architecture doc example updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Package manager operations (install, remove, update, upgrade, autoremove, repair, and more) now return execution results with exit codes and command output (stdout/stderr) in addition to error information, providing detailed feedback for all package management interactions.

* **Documentation**
  * Updated documentation examples demonstrating how to capture and use the new execution result values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->