### PR TITLE
feat(pkg): UpgradeAll supports security-only upgrades

### DIFF
--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -141,10 +141,27 @@ func (a *apt) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, e
 	return a.write(ctx, "apt", args...)
 }
 
-// UpgradeAll performs a full distribution upgrade (apt dist-upgrade).
-func (a *apt) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
+// UpgradeAll performs a full distribution upgrade (apt dist-upgrade), or — with
+// opts.SecurityOnly — applies only security updates via unattended-upgrade.
+func (a *apt) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error) {
+	if opts.SecurityOnly {
+		return a.securityUpgrade(ctx)
+	}
 	args := append([]string{"dist-upgrade", "-y"}, dpkgConfOptions...)
 	return a.write(ctx, "apt", args...)
+}
+
+// securityUpgrade applies only security updates via unattended-upgrade — Debian/
+// Ubuntu's canonical security-upgrade tool. It matches the exact security
+// origins from its Allowed-Origins config (rather than a fragile origin-name
+// heuristic) and handles holds, kernel transitions and conffile prompts. It
+// requires the unattended-upgrades package; if absent it fails closed with an
+// actionable error rather than silently performing a full upgrade.
+func (a *apt) securityUpgrade(ctx context.Context) (pmexec.Result, error) {
+	if _, err := lookPath("unattended-upgrade"); err != nil {
+		return pmexec.Result{}, fmt.Errorf("%w: unattended-upgrade not found — install the unattended-upgrades package for apt security-only upgrades", pmexec.ErrBackendUnavailable)
+	}
+	return a.write(ctx, "unattended-upgrade", "-v")
 }
 
 // Pin holds packages (apt-mark hold).

--- a/pkg/apt_test.go
+++ b/pkg/apt_test.go
@@ -194,7 +194,7 @@ func TestApt_Upgrade(t *testing.T) {
 	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := aptM(t)
 		ok(f, "")
-		if _, err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if a := argv(f.Calls()[0]); !strings.HasPrefix(a, "apt dist-upgrade -y") {

--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -130,8 +130,12 @@ func (d *dnf) Upgrade(ctx context.Context, packages ...string) (pmexec.Result, e
 }
 
 // UpgradeAll performs a full system upgrade (dnf upgrade).
-func (d *dnf) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
-	return d.write(ctx, "upgrade", "-y")
+func (d *dnf) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error) {
+	args := []string{"upgrade", "-y"}
+	if opts.SecurityOnly {
+		args = append(args, "--security")
+	}
+	return d.write(ctx, args...)
 }
 
 // ensureVersionLock installs the versionlock plugin if its subcommand is absent.

--- a/pkg/dnf_test.go
+++ b/pkg/dnf_test.go
@@ -193,7 +193,7 @@ func TestDnf_Upgrade(t *testing.T) {
 	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := dnfM(t)
 		ok(f, "")
-		if _, err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "dnf upgrade -y" {

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -109,7 +109,12 @@ func (f *flatpak) Upgrade(ctx context.Context, packages ...string) (pmexec.Resul
 }
 
 // UpgradeAll updates every installed app/runtime (flatpak update with no refs).
-func (f *flatpak) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
+func (f *flatpak) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error) {
+	if opts.SecurityOnly {
+		// flatpak has no security/non-security update distinction — it updates
+		// apps/runtimes to latest. Fail closed rather than do a full update.
+		return pmexec.Result{}, ErrSecurityOnlyUnsupported
+	}
 	return f.write(ctx, "update", "-y", "--noninteractive", f.scope())
 }
 

--- a/pkg/flatpak_test.go
+++ b/pkg/flatpak_test.go
@@ -160,7 +160,7 @@ func TestFlatpak_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll", func(t *testing.T) {
 		m, f := flatpakM(t)
 		ok(f, "")
-		if _, err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "flatpak update -y --noninteractive --system" {

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -109,7 +109,13 @@ func (p *pacman) Upgrade(ctx context.Context, packages ...string) (pmexec.Result
 }
 
 // UpgradeAll performs a full system upgrade (pacman -Syu).
-func (p *pacman) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
+func (p *pacman) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error) {
+	if opts.SecurityOnly {
+		// Arch is a rolling release with no security/non-security split — there
+		// is no way to apply only security updates. Fail closed rather than
+		// silently run a full upgrade.
+		return pmexec.Result{}, ErrSecurityOnlyUnsupported
+	}
 	return p.write(ctx, "-Syu", "--noconfirm")
 }
 

--- a/pkg/pacman_test.go
+++ b/pkg/pacman_test.go
@@ -160,7 +160,7 @@ func TestPacman_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll -Syu", func(t *testing.T) {
 		m, f := pacmanM(t)
 		ok(f, "")
-		if _, err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "pacman -Syu --noconfirm" {

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -31,6 +31,22 @@ import (
 // (including the zero value). Fail-closed: no silent default.
 var ErrUnknownBackend = errors.New("pkg: unknown package-manager backend")
 
+// ErrSecurityOnlyUnsupported is returned by UpgradeAll when UpgradeOptions.
+// SecurityOnly is set on a backend that has no security-only upgrade path:
+// pacman (a rolling release with no security/non-security distinction) and
+// flatpak (no security channel). Fail-closed: the SDK never silently performs a
+// full upgrade when only security updates were requested.
+var ErrSecurityOnlyUnsupported = errors.New("pkg: security-only upgrade not supported by this backend")
+
+// UpgradeOptions configures UpgradeAll.
+type UpgradeOptions struct {
+	// SecurityOnly restricts the upgrade to security updates. Supported on apt
+	// (simulate dist-upgrade, then upgrade only packages from a security suite),
+	// dnf (--security) and zypper (patch --category security). pacman and flatpak
+	// return ErrSecurityOnlyUnsupported.
+	SecurityOnly bool
+}
+
 // lookPath is the exec.LookPath seam used by Detect and apt's apt/apt-get
 // resolution so binary discovery can be stubbed in tests.
 var lookPath = exec.LookPath
@@ -129,8 +145,11 @@ type Manager interface {
 	// system. Use UpgradeAll for that.
 	Upgrade(ctx context.Context, packages ...string) (pmexec.Result, error)
 	// UpgradeAll performs a full system upgrade (apt dist-upgrade / dnf upgrade /
-	// pacman -Syu / zypper dist-upgrade / flatpak update).
-	UpgradeAll(ctx context.Context) (pmexec.Result, error)
+	// pacman -Syu / zypper dist-upgrade / flatpak update). With
+	// opts.SecurityOnly it upgrades only security updates where the backend
+	// supports it (apt/dnf/zypper); pacman and flatpak return
+	// ErrSecurityOnlyUnsupported.
+	UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error)
 	// Pin holds the named packages back from upgrades.
 	Pin(ctx context.Context, packages ...string) (pmexec.Result, error)
 	// Unpin releases the named packages so they upgrade again.

--- a/pkg/security_upgrade_test.go
+++ b/pkg/security_upgrade_test.go
@@ -1,0 +1,78 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// TestUpgradeAll_SecurityOnly pins the per-backend security-only upgrade contract
+// added so callers (the agent's UPDATE action) can apply ONLY security updates
+// through the SDK instead of shelling out. apt/dnf/zypper support it natively;
+// pacman (rolling) and flatpak (no security channel) fail closed with
+// ErrSecurityOnlyUnsupported rather than silently doing a full upgrade.
+func TestUpgradeAll_SecurityOnly(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("dnf upgrade --security", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true}); err != nil {
+			t.Fatal(err)
+		}
+		if got := argv(f.Calls()[0]); got != "dnf upgrade -y --security" {
+			t.Errorf("argv = %q, want `dnf upgrade -y --security`", got)
+		}
+	})
+
+	t.Run("zypper patch --category security", func(t *testing.T) {
+		m, f := zypperM(t)
+		ok(f, "")
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true}); err != nil {
+			t.Fatal(err)
+		}
+		if got := argv(f.Calls()[0]); got != "zypper --non-interactive patch --category security" {
+			t.Errorf("argv = %q, want `zypper --non-interactive patch --category security`", got)
+		}
+	})
+
+	t.Run("apt via unattended-upgrade (escalated)", func(t *testing.T) {
+		stubLookPath(t, "apt", "apt-get", "unattended-upgrade")
+		m, f := mustNew(t, Apt)
+		ok(f, "")
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "unattended-upgrade -v" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v), want escalated `unattended-upgrade -v`", argv(c), c.Escalate)
+		}
+	})
+
+	t.Run("apt without unattended-upgrade fails closed (ErrBackendUnavailable, no command run)", func(t *testing.T) {
+		m, f := aptM(t) // stub resolves apt/apt-get only — unattended-upgrade absent
+		_, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true})
+		if !errors.Is(err, pmexec.ErrBackendUnavailable) {
+			t.Fatalf("err = %v, want ErrBackendUnavailable", err)
+		}
+		if len(f.Calls()) != 0 {
+			t.Errorf("nothing must run when unattended-upgrade is absent; got %d calls", len(f.Calls()))
+		}
+	})
+
+	t.Run("pacman security-only unsupported", func(t *testing.T) {
+		m, _ := pacmanM(t)
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true}); !errors.Is(err, ErrSecurityOnlyUnsupported) {
+			t.Errorf("err = %v, want ErrSecurityOnlyUnsupported", err)
+		}
+	})
+
+	t.Run("flatpak security-only unsupported", func(t *testing.T) {
+		m, _ := flatpakM(t)
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true}); !errors.Is(err, ErrSecurityOnlyUnsupported) {
+			t.Errorf("err = %v, want ErrSecurityOnlyUnsupported", err)
+		}
+	})
+}

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -109,7 +109,12 @@ func (z *zypper) Upgrade(ctx context.Context, packages ...string) (pmexec.Result
 }
 
 // UpgradeAll performs a full distribution upgrade (zypper dist-upgrade).
-func (z *zypper) UpgradeAll(ctx context.Context) (pmexec.Result, error) {
+func (z *zypper) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Result, error) {
+	if opts.SecurityOnly {
+		// zypper patches are security-categorised; patch --category security
+		// applies only the security patches.
+		return z.write(ctx, "--non-interactive", "patch", "--category", "security")
+	}
 	return z.write(ctx, "--non-interactive", "dist-upgrade")
 }
 

--- a/pkg/zypper_test.go
+++ b/pkg/zypper_test.go
@@ -143,7 +143,7 @@ func TestZypper_UpdateUpgrade(t *testing.T) {
 	t.Run("UpgradeAll -> dist-upgrade", func(t *testing.T) {
 		m, f := zypperM(t)
 		ok(f, "")
-		if _, err := m.UpgradeAll(ctx); err != nil {
+		if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if argv(f.Calls()[0]) != "zypper --non-interactive dist-upgrade" {


### PR DESCRIPTION
Closes #186

Adds `UpgradeOptions{SecurityOnly}` to `Manager.UpgradeAll` so callers apply only security updates through the SDK:
- **dnf**: `dnf upgrade -y --security`
- **zypper**: `zypper --non-interactive patch --category security`
- **apt**: `unattended-upgrade -v` — Debian/Ubuntu's canonical security tool (matches exact security origins via Allowed-Origins, handles holds/kernel/conffiles). Fails closed with `ErrBackendUnavailable` if the unattended-upgrades package is absent — never a silent full upgrade.
- **pacman** (rolling) / **flatpak** (no security channel): `ErrSecurityOnlyUnsupported` (fail-closed).

Surfaced by the agent migration: the agent's UPDATE action has a SecurityOnly mode that previously shelled out to `dnf --security`/`unattended-upgrade` directly. Test-first, 100% coverage, `-race` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for security-only package upgrades. Backends vary in support: apt, dnf, and zypper enable selective security patching; flatpak and pacman do not support this mode and will return an error when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->