### PR TITLE
fix: 3 confirmed security bugs from the NIS2 coverage audit (WS0)

### DIFF
--- a/client.go
+++ b/client.go
@@ -1340,11 +1340,15 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		c.deliverPending(msg)
 
 	case *pm.ServerMessage_RequestInventory:
+		if p.RequestInventory == nil {
+			c.logger.Warn("dropping RequestInventory with nil payload", "message_id", msg.Id)
+			return nil
+		}
+		if err := c.validateInbound(p.RequestInventory); err != nil {
+			c.logger.Warn("dropping invalid RequestInventory", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if invHandler, ok := handler.(InventoryHandler); ok {
-			if p.RequestInventory == nil {
-				c.logger.Warn("dropping RequestInventory with nil payload", "message_id", msg.Id)
-				return nil
-			}
 			req := p.RequestInventory
 			// Bound concurrency: drop (don't queue) when already at
 			// capacity so a flood cannot spawn unbounded osquery forks.
@@ -1375,6 +1379,10 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 			c.logger.Warn("dropping LogQuery with nil payload", "message_id", msg.Id)
 			return nil
 		}
+		if err := c.validateInbound(p.LogQuery); err != nil {
+			c.logger.Warn("dropping invalid LogQuery", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if lqHandler, ok := handler.(LogQueryHandler); ok {
 			result, err := lqHandler.OnLogQuery(ctx, p.LogQuery)
 			if err != nil {
@@ -1388,15 +1396,22 @@ func (c *Client) dispatchServerMessage(ctx context.Context, msg *pm.ServerMessag
 		}
 
 	case *pm.ServerMessage_RevokeLuksDeviceKey:
+		if p.RevokeLuksDeviceKey == nil {
+			// A compromised/buggy gateway could deliver a nil payload;
+			// dropping it avoids a nil dereference and is harmless (a
+			// real revocation always carries action_id + signature).
+			c.logger.Warn("dropping RevokeLuksDeviceKey with nil payload", "message_id", msg.Id)
+			return nil
+		}
+		// Defence-in-depth before the irreversible LUKS slot-7 wipe: reject a
+		// malformed action_id at the SDK boundary (the handler still verifies
+		// the CA signature that binds it).
+		if err := c.validateInbound(p.RevokeLuksDeviceKey); err != nil {
+			c.logger.Warn("dropping invalid RevokeLuksDeviceKey", "message_id", msg.Id, "error", err)
+			return nil
+		}
 		if luksHandler, ok := handler.(LuksHandler); ok {
 			req := p.RevokeLuksDeviceKey
-			if req == nil {
-				// A compromised/buggy gateway could deliver a nil payload;
-				// dropping it avoids a nil dereference and is harmless (a
-				// real revocation always carries action_id + signature).
-				c.logger.Warn("dropping RevokeLuksDeviceKey with nil payload", "message_id", msg.Id)
-				return nil
-			}
 			actionID := req.ActionId
 			// Run in goroutine: the handler calls GetLuksKey which sends
 			// a request on the stream and waits for a response. Processing

--- a/client_inbound_validation_test.go
+++ b/client_inbound_validation_test.go
@@ -1,0 +1,339 @@
+package sdk
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// recordingHandler implements StreamHandler plus every optional command
+// interface (Inventory/LogQuery/Luks), counting how often each command
+// callback is invoked. Used to prove that a malformed inbound command is
+// dropped by validateInbound BEFORE it reaches the handler, and — as a
+// guard against a vacuous pass — that a well-formed one still gets through.
+type recordingHandler struct {
+	inventoryCalls int32
+	logQueryCalls  int32
+	luksCalls      int32
+}
+
+func (h *recordingHandler) OnWelcome(context.Context, *pm.Welcome) error { return nil }
+func (h *recordingHandler) OnAction(context.Context, []byte, []byte) (*pm.ActionResult, error) {
+	return nil, nil
+}
+func (h *recordingHandler) OnQuery(context.Context, *pm.OSQuery) (*pm.OSQueryResult, error) {
+	return nil, nil
+}
+func (h *recordingHandler) OnError(context.Context, *pm.Error) error { return nil }
+func (h *recordingHandler) CollectInventory(context.Context) *pm.DeviceInventory {
+	return nil
+}
+func (h *recordingHandler) OnRequestInventory(context.Context, *pm.RequestInventory) *pm.DeviceInventory {
+	atomic.AddInt32(&h.inventoryCalls, 1)
+	return nil
+}
+func (h *recordingHandler) OnLogQuery(context.Context, *pm.LogQuery) (*pm.LogQueryResult, error) {
+	atomic.AddInt32(&h.logQueryCalls, 1)
+	return nil, nil
+}
+func (h *recordingHandler) OnRevokeLuksDeviceKey(context.Context, *pm.RevokeLuksDeviceKey) (bool, string) {
+	atomic.AddInt32(&h.luksCalls, 1)
+	return false, ""
+}
+
+// validULID is a syntactically valid ULID; badULID fails the
+// `validate:"required,ulid"` rule the three command payloads carry on their
+// query_id / action_id field.
+const (
+	validULID = "01HQ0000000000000000000000"
+	badULID   = "not-a-ulid"
+)
+
+// TestDispatch_RejectsInvalidInboundCommands pins the WS0 P0.3 fix: the
+// RequestInventory, LogQuery and RevokeLuksDeviceKey dispatch branches must run
+// validateInbound — exactly like Action/Query/Terminal* — so a compromised
+// relay cannot push a malformed-but-non-nil command past the SDK boundary into
+// a handler. The RevokeLuksDeviceKey case matters most: it drives the
+// irreversible LUKS slot-7 wipe.
+//
+// Each subtest asserts BOTH directions: a non-ULID id NEVER reaches the handler
+// (the rejection — the point of the test), and a valid ULID DOES (so the test
+// can't pass vacuously because the handler interface went unsatisfied).
+func TestDispatch_RejectsInvalidInboundCommands(t *testing.T) {
+	mkInventory := func(id string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RequestInventory{
+			RequestInventory: &pm.RequestInventory{QueryId: id}}}
+	}
+	mkLogQuery := func(id string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_LogQuery{
+			LogQuery: &pm.LogQuery{QueryId: id}}}
+	}
+	mkLuks := func(id string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
+			RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: id}}}
+	}
+
+	cases := []struct {
+		name  string
+		build func(id string) *pm.ServerMessage
+		count func(*recordingHandler) int32
+	}{
+		{"RequestInventory", mkInventory, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.inventoryCalls) }},
+		{"LogQuery", mkLogQuery, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.logQueryCalls) }},
+		{"RevokeLuksDeviceKey", mkLuks, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.luksCalls) }},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"/invalid_id_never_reaches_handler", func(t *testing.T) {
+			c := NewClient("https://gw.invalid", WithAuth(validULID, ""))
+			h := &recordingHandler{}
+			if err := c.dispatchServerMessage(context.Background(), tc.build(badULID), h); err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			// RequestInventory and RevokeLuksDeviceKey run the handler on a
+			// spawned goroutine; settle so an unguarded dispatch would have
+			// invoked it before we assert zero.
+			settle()
+			if got := tc.count(h); got != 0 {
+				t.Fatalf("%s: a non-ULID id reached the handler %d time(s); validateInbound must drop it at the boundary", tc.name, got)
+			}
+		})
+
+		t.Run(tc.name+"/valid_id_reaches_handler", func(t *testing.T) {
+			c := NewClient("https://gw.invalid", WithAuth(validULID, ""))
+			h := &recordingHandler{}
+			if err := c.dispatchServerMessage(context.Background(), tc.build(validULID), h); err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			waitForCond(t, func() bool { return tc.count(h) == 1 })
+		})
+	}
+}
+
+// settle waits a short, fixed period for a dispatch-spawned goroutine to have
+// run, so a "handler must NOT be called" assertion is not racing the spawn.
+func settle() { time.Sleep(150 * time.Millisecond) }
+
+// TestDispatchValidatesEveryInboundCommand is the self-discovering regression
+// guard for P0.3: it walks EVERY ServerMessage oneof arm whose payload carries
+// `validate` gotags and asserts that dispatchServerMessage runs validateInbound
+// for it — so a newly-added command RPC cannot silently skip validation again.
+//
+// Exemptions are by intrinsic KIND, not a name list:
+//   - response arms whose case delivers to a pending caller (deliverPending) —
+//     validated at the request site, not at dispatch; and
+//   - connection-lifecycle arms (OnWelcome / OnError) — these carry no
+//     operator-issued command parameters that drive privileged device work.
+//
+// The set is discovered from the proto descriptor + the dispatch AST, with a
+// matches-zero guard and a guard that every discovered arm is actually handled
+// by a dispatch case, so descriptor/registry drift can't pass the check
+// vacuously.
+func TestDispatchValidatesEveryInboundCommand(t *testing.T) {
+	// 1. Discover, from the descriptor, the ServerMessage oneof arms whose Go
+	//    payload type carries validate gotags.
+	md := (&pm.ServerMessage{}).ProtoReflect().Descriptor()
+	oneof := md.Oneofs().ByName("payload")
+	if oneof == nil {
+		t.Fatal("ServerMessage has no 'payload' oneof — descriptor drift")
+	}
+	validatable := map[string]bool{} // wrapper Go type name -> has validate gotags
+	for i := 0; i < oneof.Fields().Len(); i++ {
+		fd := oneof.Fields().Get(i)
+		if fd.Message() == nil {
+			continue // scalar oneof arm (none today)
+		}
+		gt := messageGoType(fd.Message().FullName())
+		if gt == nil {
+			t.Fatalf("cannot resolve Go type for %s (registry drift)", fd.Message().FullName())
+		}
+		if typeHasValidateTag(gt, map[reflect.Type]bool{}) {
+			validatable["ServerMessage_"+goCamel(string(fd.Name()))] = true
+		}
+	}
+	if len(validatable) == 0 {
+		t.Fatal("matches-zero guard: discovered zero validatable ServerMessage oneof arms — descriptor/registry drift?")
+	}
+
+	// 2. Classify each dispatch case from the AST.
+	cases := parseDispatchCases(t)
+
+	commandArms := 0
+	for wrapper := range validatable {
+		info, handled := cases[wrapper]
+		if !handled {
+			t.Errorf("oneof arm %q carries validate gotags but has no dispatchServerMessage case — unhandled inbound (drift)", wrapper)
+			continue
+		}
+		if info.deliversPending || info.lifecycle {
+			continue // exempt by kind (response / lifecycle)
+		}
+		commandArms++
+		if !info.validates {
+			t.Errorf("dispatchServerMessage case %q drives a command handler but does NOT call validateInbound — inbound-validation gap (WS0 P0.3)", wrapper)
+		}
+	}
+	if commandArms == 0 {
+		t.Fatal("matches-zero guard: classified zero command arms requiring validateInbound — AST classifier drift?")
+	}
+}
+
+// dispatchCaseInfo records what an AST dispatch case does, for kind-based
+// classification.
+type dispatchCaseInfo struct {
+	validates       bool // calls c.validateInbound(...)
+	deliversPending bool // calls c.deliverPending(...) — request-response arm
+	lifecycle       bool // calls handler.OnWelcome / handler.OnError — lifecycle arm
+}
+
+// parseDispatchCases parses client.go, locates dispatchServerMessage's type
+// switch, and returns per-arm (ServerMessage_X wrapper name) classification.
+func parseDispatchCases(t *testing.T) map[string]dispatchCaseInfo {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "client.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse client.go: %v", err)
+	}
+
+	out := map[string]dispatchCaseInfo{}
+	var fn *ast.FuncDecl
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "dispatchServerMessage" {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("dispatchServerMessage not found in client.go — refactor without updating the parity guard?")
+	}
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		cc, ok := n.(*ast.CaseClause)
+		if !ok {
+			return true
+		}
+		// Collect the ServerMessage_X wrapper names this case matches.
+		var wrappers []string
+		for _, expr := range cc.List {
+			star, ok := expr.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			sel, ok := star.X.(*ast.SelectorExpr)
+			if !ok {
+				continue
+			}
+			if strings.HasPrefix(sel.Sel.Name, "ServerMessage_") {
+				wrappers = append(wrappers, sel.Sel.Name)
+			}
+		}
+		if len(wrappers) == 0 {
+			return true
+		}
+		// Scan the case body for the classifying calls.
+		var info dispatchCaseInfo
+		for _, stmt := range cc.Body {
+			ast.Inspect(stmt, func(m ast.Node) bool {
+				call, ok := m.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "validateInbound":
+					info.validates = true
+				case "deliverPending":
+					info.deliversPending = true
+				case "OnWelcome", "OnError":
+					info.lifecycle = true
+				}
+				return true
+			})
+		}
+		for _, w := range wrappers {
+			out[w] = info
+		}
+		return true
+	})
+	return out
+}
+
+// messageGoType resolves a proto message full name to its generated Go pointer
+// type via the global type registry.
+func messageGoType(name protoreflect.FullName) reflect.Type {
+	mt, err := protoregistry.GlobalTypes.FindMessageByName(name)
+	if err != nil {
+		return nil
+	}
+	return reflect.TypeOf(mt.New().Interface())
+}
+
+// typeHasValidateTag reports whether t (or any nested message type reachable
+// from it) declares a non-empty `validate` struct tag. seen guards against
+// recursive proto types; pass a fresh map per top-level query.
+func typeHasValidateTag(t reflect.Type, seen map[reflect.Type]bool) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct || seen[t] {
+		return false
+	}
+	seen[t] = true
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported (state, sizeCache, unknownFields)
+		}
+		if v, ok := f.Tag.Lookup("validate"); ok && v != "" {
+			return true
+		}
+		ft := f.Type
+		for ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		switch ft.Kind() {
+		case reflect.Struct:
+			if typeHasValidateTag(ft, seen) {
+				return true
+			}
+		case reflect.Slice:
+			et := ft.Elem()
+			for et.Kind() == reflect.Ptr {
+				et = et.Elem()
+			}
+			if et.Kind() == reflect.Struct && typeHasValidateTag(et, seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// goCamel converts a proto field name (snake_case) to the Go camel-case used in
+// the generated oneof wrapper type name (matches protoc-gen-go for the
+// digit-free field names of ServerMessage).
+func goCamel(snake string) string {
+	parts := strings.Split(snake, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}

--- a/sys/encryption/luks.go
+++ b/sys/encryption/luks.go
@@ -30,6 +30,14 @@ const (
 // ErrInvalidKeySlot is returned for a slot index outside [LuksMinKeySlot, LuksMaxKeySlot].
 var ErrInvalidKeySlot = errors.New("invalid LUKS keyslot")
 
+// ErrEmptyKeyMaterial is returned by a mutating LUKS/TPM operation given an
+// empty passphrase/key. It is refused before any cryptsetup/cryptenroll exec:
+// an empty NEW key would enroll a slot that unlocks with no passphrase, and an
+// empty AUTHENTICATING key for a mutating op is never a legitimate request.
+// (VerifyPassphrase is intentionally exempt — probing an empty passphrase is a
+// legitimate read-only query.)
+var ErrEmptyKeyMaterial = errors.New("encryption: empty key material not permitted")
+
 func validateKeySlot(slot int) error {
 	if slot < LuksMinKeySlot || slot > LuksMaxKeySlot {
 		return fmt.Errorf("%w: slot %d outside valid range %d..%d", ErrInvalidKeySlot, slot, LuksMinKeySlot, LuksMaxKeySlot)
@@ -68,6 +76,15 @@ func (l *luks) AddKey(ctx context.Context, dev string, existing, newKey exec.Sec
 			return err
 		}
 	}
+	// Refuse before any cryptsetup exec: an empty NEW key would enroll a slot
+	// that unlocks with no passphrase; an empty authenticating key is never a
+	// legitimate add request.
+	if newKey.IsZero() {
+		return fmt.Errorf("%w: refusing to add an empty new key (would create an empty-passphrase unlock slot)", ErrEmptyKeyMaterial)
+	}
+	if existing.IsZero() {
+		return fmt.Errorf("%w: empty authenticating passphrase", ErrEmptyKeyMaterial)
+	}
 	existingFile, err := writeKeyFile(existing)
 	if err != nil {
 		return err
@@ -94,6 +111,9 @@ func (l *luks) RemoveKey(ctx context.Context, dev string, key exec.Secret) error
 	if err := validateDevicePath(dev); err != nil {
 		return err
 	}
+	if key.IsZero() {
+		return fmt.Errorf("%w: empty passphrase", ErrEmptyKeyMaterial)
+	}
 	keyFile, err := writeKeyFile(key)
 	if err != nil {
 		return err
@@ -110,6 +130,9 @@ func (l *luks) KillSlot(ctx context.Context, dev string, slot int, existing exec
 	}
 	if err := validateKeySlot(slot); err != nil {
 		return err
+	}
+	if existing.IsZero() {
+		return fmt.Errorf("%w: empty authenticating passphrase", ErrEmptyKeyMaterial)
 	}
 	keyFile, err := writeKeyFile(existing)
 	if err != nil {
@@ -222,7 +245,11 @@ var (
 	createKeyFile = func(dir string) (keyFileHandle, error) { return os.CreateTemp(dir, "key-*") }
 	removeFile    = os.Remove
 	openKeyFile   = func(path string) (scrubFile, error) {
-		return os.OpenFile(path, os.O_WRONLY|syscall.O_NOFOLLOW, 0)
+		// O_NOFOLLOW refuses a symlink swap; O_NONBLOCK refuses to BLOCK on a
+		// FIFO swap (O_WRONLY on a readerless FIFO hangs forever otherwise — a
+		// FIFO is not a symlink, so O_NOFOLLOW alone does not help). A regular
+		// file ignores O_NONBLOCK.
+		return os.OpenFile(path, os.O_WRONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
 	}
 )
 
@@ -268,7 +295,12 @@ func cleanupKeyFile(path string) {
 		}
 		return
 	}
-	if info, err := f.Stat(); err == nil && info.Size() > 0 {
+	if info, err := f.Stat(); err == nil && !info.Mode().IsRegular() {
+		// A non-regular fd (FIFO with a reader, device node) must never be
+		// written to — zeroing it would push bytes into a pipe/device, not
+		// scrub a file. Refuse the scrub; the unlink below still proceeds.
+		slog.Warn("luks: refusing to scrub a non-regular key file (possible TOCTOU swap)", "path", path, "mode", info.Mode().String())
+	} else if err == nil && info.Size() > 0 {
 		zeros := make([]byte, info.Size())
 		if _, werr := f.WriteAt(zeros, 0); werr != nil {
 			slog.Warn("luks: scrubbing key file before unlink failed; passphrase bytes may persist", "path", path, "error", werr)

--- a/sys/encryption/luks_security_test.go
+++ b/sys/encryption/luks_security_test.go
@@ -1,0 +1,160 @@
+package encryption
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// --- P0.5: cleanupKeyFile must never block, and never scrub a non-regular file ---
+
+// TestCleanupKeyFile_DoesNotHangOnFIFO pins the live FIFO-hang bug: if the
+// key-file path is replaced by a FIFO between write and cleanup (a TOCTOU swap
+// in /dev/shm), opening it O_WRONLY without O_NONBLOCK blocks forever waiting
+// for a reader — the passphrase file is never scrubbed and the LUKS op wedges.
+// O_NOFOLLOW does NOT help (a FIFO is not a symlink). Uses the REAL openKeyFile.
+func TestCleanupKeyFile_DoesNotHangOnFIFO(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "key-fifo")
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported on this platform: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); cleanupKeyFile(p) }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cleanupKeyFile blocked on a FIFO key-file path — openKeyFile must set O_NONBLOCK so a TOCTOU FIFO swap cannot wedge the scrub")
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("cleanupKeyFile must still unlink the FIFO; stat err = %v", err)
+	}
+}
+
+// pipeScrub is a scrubFile whose Stat reports a non-regular (named pipe) mode
+// and records whether WriteAt was called.
+type pipeScrub struct{ wrote bool }
+
+func (p *pipeScrub) Stat() (os.FileInfo, error)             { return pipeInfo{}, nil }
+func (p *pipeScrub) WriteAt(b []byte, _ int64) (int, error) { p.wrote = true; return len(b), nil }
+func (p *pipeScrub) Close() error                           { return nil }
+
+type pipeInfo struct{}
+
+func (pipeInfo) Name() string       { return "fifo" }
+func (pipeInfo) Size() int64        { return 16 }
+func (pipeInfo) Mode() fs.FileMode  { return fs.ModeNamedPipe | 0o600 }
+func (pipeInfo) ModTime() time.Time { return time.Time{} }
+func (pipeInfo) IsDir() bool        { return false }
+func (pipeInfo) Sys() any           { return nil }
+
+// TestCleanupKeyFile_RefusesToScrubNonRegular — defence-in-depth for the case
+// where the open DOES succeed on a non-regular target (a FIFO that has a reader,
+// or a device node): cleanupKeyFile must refuse to WriteAt zeros to it (which
+// would write into a pipe/device) and still unlink the path.
+func TestCleanupKeyFile_RefusesToScrubNonRegular(t *testing.T) {
+	defer swapKeyFileSeams(t)()
+	f := &pipeScrub{}
+	openKeyFile = func(string) (scrubFile, error) { return f, nil }
+	removed := false
+	removeFile = func(string) error { removed = true; return nil }
+
+	cleanupKeyFile("/dev/shm/pm-luks/key-x")
+
+	if f.wrote {
+		t.Error("cleanupKeyFile wrote zeros to a non-regular (FIFO/device) file; it must refuse non-regular scrub targets")
+	}
+	if !removed {
+		t.Error("cleanupKeyFile must still unlink a non-regular path")
+	}
+}
+
+// --- P0.6: mutating LUKS/TPM ops must reject an empty passphrase BEFORE exec ---
+
+// emptySecret is a valid, empty Secret (NewSecret permits empty).
+func emptySecret(t *testing.T) exec.Secret {
+	t.Helper()
+	s, err := exec.NewSecret("")
+	if err != nil {
+		t.Fatalf("NewSecret(\"\"): %v", err)
+	}
+	if !s.IsZero() {
+		t.Fatal("expected NewSecret(\"\") to be zero/empty")
+	}
+	return s
+}
+
+// TestAddKey_RejectsEmptyNewKey is the security-critical case: adding an EMPTY
+// new key would enroll a LUKS slot that unlocks with no passphrase. It must be
+// refused before cryptsetup runs.
+func TestAddKey_RejectsEmptyNewKey(t *testing.T) {
+	r := &recordingRunner{}
+	m := mgr(t, r)
+	err := m.AddKey(context.Background(), "/dev/sda1", mustSecret(t, "current"), emptySecret(t), AddKeyOptions{})
+	if !errors.Is(err, ErrEmptyKeyMaterial) {
+		t.Fatalf("AddKey(emptyNewKey) err = %v; want ErrEmptyKeyMaterial (would create an empty-passphrase slot)", err)
+	}
+	if n := len(r.calls); n != 0 {
+		t.Fatalf("AddKey(emptyNewKey) ran cryptsetup %d time(s); it must reject BEFORE exec", n)
+	}
+}
+
+// TestMutatingOps_RejectEmptyAuth — an empty authenticating passphrase for a
+// mutating operation is never a legitimate request and must be refused before
+// any cryptsetup/cryptenroll exec. (VerifyPassphrase is deliberately excluded:
+// probing an empty passphrase is a legitimate read-only query.)
+func TestMutatingOps_RejectEmptyAuth(t *testing.T) {
+	ctx := context.Background()
+	dev := "/dev/sda1"
+
+	// Each op takes the SUBTEST's *testing.T so a t.Skip (no TPM hardware)
+	// skips only that subtest, not the parent — the closures must not capture
+	// the outer t.
+	ops := map[string]func(t *testing.T, m Manager) error{
+		"AddKey/existing": func(t *testing.T, m Manager) error {
+			return m.AddKey(ctx, dev, emptySecret(t), mustSecret(t, "new"), AddKeyOptions{})
+		},
+		"RemoveKey": func(t *testing.T, m Manager) error {
+			return m.RemoveKey(ctx, dev, emptySecret(t))
+		},
+		"KillSlot": func(t *testing.T, m Manager) error {
+			return m.KillSlot(ctx, dev, 1, emptySecret(t))
+		},
+		"TPM.Enroll": func(t *testing.T, m Manager) error {
+			tpm, ok := m.TPM()
+			if !ok {
+				t.Skip("LUKS backend reports no TPM support")
+			}
+			return tpm.Enroll(ctx, dev, emptySecret(t))
+		},
+		"TPM.Wipe": func(t *testing.T, m Manager) error {
+			tpm, ok := m.TPM()
+			if !ok {
+				t.Skip("LUKS backend reports no TPM support")
+			}
+			return tpm.Wipe(ctx, dev, emptySecret(t))
+		},
+	}
+
+	for name, op := range ops {
+		t.Run(name, func(t *testing.T) {
+			r := &recordingRunner{}
+			m := mgr(t, r)
+			if err := op(t, m); !errors.Is(err, ErrEmptyKeyMaterial) {
+				t.Fatalf("%s(emptyAuth) err = %v; want ErrEmptyKeyMaterial", name, err)
+			}
+			if n := len(r.calls); n != 0 {
+				t.Fatalf("%s(emptyAuth) ran the tool %d time(s); it must reject BEFORE exec", name, n)
+			}
+		})
+	}
+}

--- a/sys/encryption/tpm.go
+++ b/sys/encryption/tpm.go
@@ -50,6 +50,11 @@ func (t *tpmEnroller) Wipe(ctx context.Context, dev string, existing exec.Secret
 // run executes an escalated systemd-cryptenroll command with the passphrase on
 // stdin. Reveal() here is the single sanctioned TPM-stdin sink.
 func (t *tpmEnroller) run(ctx context.Context, op string, args []string, key exec.Secret) error {
+	// Both Enroll and Wipe authenticate with the existing passphrase; an empty
+	// one is never a legitimate request, so refuse before any cryptenroll exec.
+	if key.IsZero() {
+		return fmt.Errorf("%w: empty authenticating passphrase", ErrEmptyKeyMaterial)
+	}
 	res, err := t.r.Run(ctx, exec.Command{
 		Name:     "systemd-cryptenroll",
 		Args:     args,

--- a/sys/remote/doc.go
+++ b/sys/remote/doc.go
@@ -69,12 +69,16 @@
 //
 // # Safety
 //
-// Every destination flows through sys/fs.ResolveAndValidatePath plus
-// the sys/fs.IsProtectedPath check. Wipe additionally requires the
-// path to live under one of the managed roots (/var/lib/power-manage/,
-// /etc/power-manage/) OR to have been seen by a successful Fetch
-// (RecordDest); a hostile actor with action-creation rights can't
-// instruct an agent to rm-rf /etc by guessing a clever URL.
+// Every destination flows through sys/fs.ResolveAndValidatePath plus a
+// deny-by-default subtree check (sys/fs.IsUnderProtectedPrefix): any path at
+// or under a protected system root — /etc/cron.d/x, /usr/bin/x,
+// /home/<u>/.ssh/x, /var/lib/x — is refused at ANY depth, not just the exact
+// top-level dir. The only exemptions are the agent-owned managed roots
+// (/var/lib/power-manage/, /etc/power-manage/). Wipe additionally requires the
+// path to live under one of those managed roots OR to have been seen by a
+// successful Fetch (RecordDest), and refuses a protected subtree even if it
+// was somehow recorded; a hostile actor with action-creation rights can't
+// instruct an agent to write or rm-rf /etc/cron.d by guessing a clever URL.
 //
 // Archive extraction (HTTP Extract=true) refuses entries that contain
 // "..", absolute paths, escape symlinks, NUL bytes, or anything that

--- a/sys/remote/paths.go
+++ b/sys/remote/paths.go
@@ -14,9 +14,11 @@ import (
 // Path-safety helpers shared by every Source. Two layers:
 //
 //   - validateDestination — used by Fetch. Refuses relative paths,
-//     `/` and the empty string, sys/fs.IsProtectedPath matches, and any
-//     symlink-rewritten destination (parent chain OR final component)
-//     that lands on a protected path.
+//     `/` and the empty string, any path at or under a protected system
+//     subtree (sys/fs.IsUnderProtectedPrefix — deny-by-default at ANY depth,
+//     not just an exact top-level match), and any symlink-rewritten
+//     destination (parent chain OR final component) that lands on one. The
+//     agent-owned managed roots are the sole exemption.
 //   - canWipe — used by Wipe. Strict allow-list on top of the
 //     destination check: `/var/lib/power-manage/...`,
 //     `/etc/power-manage/...`, or any path previously seen by a
@@ -41,6 +43,26 @@ var wipeAllowedRoots = []string{
 	"/etc/power-manage/",
 }
 
+// isManagedRoot reports whether clean is at or under one of the agent-owned
+// managed roots. These live UNDER protected system prefixes (/etc/power-manage
+// is under /etc, /var/lib/power-manage under /var/lib), so the deny-by-default
+// subtree check would otherwise refuse the agent's own state dirs. The match is
+// lexical with a trailing-slash boundary (so a hostile sibling like
+// /etc/power-manage-evil is NOT mistaken for the managed root) — see the file
+// header for why agent-owned roots are intentionally not symlink-resolved.
+func isManagedRoot(clean string) bool {
+	for _, root := range wipeAllowedRoots {
+		// Normalise to a trailing-slash boundary regardless of how the entry is
+		// written, so a hostile sibling (/etc/power-manage-evil) can never be
+		// mistaken for the managed root /etc/power-manage.
+		root = strings.TrimSuffix(root, "/") + "/"
+		if strings.HasPrefix(clean+"/", root) {
+			return true
+		}
+	}
+	return false
+}
+
 var (
 	recordedDestsMu sync.RWMutex
 	recordedDests   = make(map[string]struct{})
@@ -61,8 +83,20 @@ func validateDestination(path string) error {
 	if clean == "/" {
 		return fmt.Errorf("%w: %s resolves to /", ErrUnsafeDestination, path)
 	}
-	if sysfs.IsProtectedPath(clean) {
-		return fmt.Errorf("%w: %s is a protected system path", ErrUnsafeDestination, path)
+	// Agent-owned managed roots are accepted lexically and early — before the
+	// deny-by-default subtree check (which would refuse them, as they live
+	// under /etc and /var/lib) and before symlink resolution (which can hit
+	// permission-denied on a root-owned managed dir). See the file header.
+	if isManagedRoot(clean) {
+		return nil
+	}
+	// Deny-by-default: refuse any destination at or under a protected system
+	// subtree at ANY depth (sys/fs.IsUnderProtectedPrefix), not just the exact
+	// top-level dir. The old exact-match IsProtectedPath accepted /etc/cron.d/x,
+	// /usr/bin/sshd, /home/<u>/.ssh/... — writing remote content there is root
+	// code-exec / privesc, which doc.go promises is impossible.
+	if sysfs.IsUnderProtectedPrefix(clean) {
+		return fmt.Errorf("%w: %s is under a protected system path", ErrUnsafeDestination, path)
 	}
 
 	// Resolve symlinks in the parent chain so a tampered intermediate
@@ -71,7 +105,7 @@ func validateDestination(path string) error {
 	// caution rather than write through an opaque ACL.
 	if resolved, err := sysfs.ResolveAndValidatePath(trim); err != nil {
 		return fmt.Errorf("%w: %s: %v", ErrUnsafeDestination, path, err)
-	} else if sysfs.IsProtectedPath(resolved) {
+	} else if sysfs.IsUnderProtectedPrefix(resolved) {
 		return fmt.Errorf("%w: %s resolves to protected path %s", ErrUnsafeDestination, path, resolved)
 	}
 
@@ -80,7 +114,7 @@ func validateDestination(path string) error {
 	// above. Lstat + EvalSymlinks closes that gap for the case where the
 	// leaf already exists.
 	if fi, lerr := os.Lstat(trim); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
-		if target, terr := filepath.EvalSymlinks(trim); terr == nil && sysfs.IsProtectedPath(target) {
+		if target, terr := filepath.EvalSymlinks(trim); terr == nil && sysfs.IsUnderProtectedPrefix(target) {
 			return fmt.Errorf("%w: %s is a symlink to protected path %s", ErrUnsafeDestination, path, target)
 		}
 	}
@@ -103,17 +137,19 @@ func canWipe(path string) error {
 	if clean == "/" {
 		return fmt.Errorf("%w: %s resolves to /", ErrUnsafeDestination, path)
 	}
-	if sysfs.IsProtectedPath(clean) {
-		return fmt.Errorf("%w: %s is a protected system path", ErrUnsafeDestination, path)
+	// Managed roots are agent-owned; accept them lexically and skip resolution
+	// so the check doesn't fail on hosts where those dirs are owned by another
+	// uid (e.g. a dev machine post-install).
+	if isManagedRoot(clean) {
+		return nil
 	}
-
-	// Lexical allow-list — managed roots are agent-owned; skip resolution
-	// so the check doesn't fail on hosts where those dirs are owned by
-	// another uid (e.g. a dev machine post-install).
-	for _, root := range wipeAllowedRoots {
-		if strings.HasPrefix(clean+"/", root) {
-			return nil
-		}
+	// Deny-by-default subtree refusal comes BEFORE the recorded-set check, so a
+	// recorded protected path can never jailbreak the guard: a Fetch→RecordDest
+	// →Wipe round-trip cannot rm -rf /etc/cron.d/x even if it were somehow
+	// recorded (the WS0 fail-open: old exact-match IsProtectedPath let subpaths
+	// through here and at the recorded check below).
+	if sysfs.IsUnderProtectedPrefix(clean) {
+		return fmt.Errorf("%w: %s is under a protected system path", ErrUnsafeDestination, path)
 	}
 
 	// Outside the managed roots — require resolution AND prior recording.
@@ -127,7 +163,7 @@ func canWipe(path string) error {
 		return nil
 	}
 	if resolved, err := sysfs.ResolveAndValidatePath(trim); err == nil {
-		if sysfs.IsProtectedPath(resolved) {
+		if sysfs.IsUnderProtectedPrefix(resolved) {
 			return fmt.Errorf("%w: %s resolves to protected path %s", ErrUnsafeDestination, path, resolved)
 		}
 		recordedDestsMu.RLock()

--- a/sys/remote/paths_test.go
+++ b/sys/remote/paths_test.go
@@ -144,14 +144,128 @@ func TestCanWipe_RecordDestRoundTrip(t *testing.T) {
 // jailbreak for the protected-path check. If someone manages to feed a
 // protected path through Fetch (which validateDestination already rejects)
 // and then call Wipe, canWipe must STILL refuse.
+//
+// The set covers BOTH exact protected roots (/etc, /var) AND protected
+// *subpaths* (/etc/cron.d/x, ...). The subpath cases are the security point:
+// the old exact-match IsProtectedPath let a recorded /etc/cron.d/x slip the
+// guard, so a Fetch→RecordDest→Wipe round-trip could rm -rf a privilege
+// vector. canWipe must refuse a protected subtree at ANY depth, recorded or
+// not.
 func TestCanWipe_RefusesProtectedEvenIfRecorded(t *testing.T) {
-	for _, p := range []string{"/etc", "/var"} {
+	cases := append([]string{"/etc", "/var"}, protectedSubpaths...)
+	for _, p := range cases {
 		t.Run("dest="+p, func(t *testing.T) {
 			RecordDest(p)
 			t.Cleanup(func() { forgetDest(p) })
 			err := canWipe(p)
 			if err == nil || !strings.Contains(err.Error(), "unsafe") {
 				t.Fatalf("canWipe(%q) = %v; want unsafe rejection", p, err)
+			}
+		})
+	}
+}
+
+// protectedSubpaths are real-world privilege-escalation / data-destruction
+// targets that live ONE OR MORE levels under a protected system root. The set
+// is derived from the design intent encoded in sys/fs.protectedPrefixRoots
+// (deny-by-default subtree), NOT from the artifact under test (IsProtectedPath,
+// whose exact-match semantics are exactly the bug). Writing or wiping any of
+// these via the remote ingester is a root code-exec / privesc vector, which
+// sys/remote/doc.go promises is impossible.
+var protectedSubpaths = []string{
+	"/etc/cron.d/evil",                     // root cron job → code exec
+	"/etc/sudoers.d/evil",                  // grant NOPASSWD → privesc
+	"/etc/systemd/system/evil.service",     // unit drop-in → code exec
+	"/usr/bin/sshd",                        // overwrite a system binary
+	"/usr/lib/systemd/system/sshd.service", // hijack a service
+	"/bin/ls",                              // overwrite a core binary
+	"/sbin/init",                           // overwrite PID1
+	"/lib/x86_64-linux-gnu/libc.so.6",      // overwrite libc
+	"/boot/grub/grub.cfg",                  // bootloader tamper
+	"/home/alice/.ssh/authorized_keys",     // add an SSH key → account takeover
+	"/home/alice/.bashrc",                  // shell-init code exec
+	"/root/.bashrc",                        // root shell-init code exec
+	"/var/lib/postgresql/data",             // destroy persistent DB state
+	"/proc/sysrq-trigger",                  // kernel control
+	"/sys/kernel/uevent_helper",            // kernel-invoked binary
+}
+
+// TestValidateDestination_RejectsProtectedSubpaths pins the fail-open fix:
+// Fetch must refuse to write attacker-controlled remote content to any path
+// under a protected system subtree. Derived from intent (protectedPrefixRoots),
+// these were ACCEPTED by the old exact-match IsProtectedPath.
+func TestValidateDestination_RejectsProtectedSubpaths(t *testing.T) {
+	for _, p := range protectedSubpaths {
+		t.Run("dest="+p, func(t *testing.T) {
+			if err := validateDestination(p); !errors.Is(err, ErrUnsafeDestination) {
+				t.Fatalf("validateDestination(%q) = %v; want errors.Is(..., ErrUnsafeDestination)", p, err)
+			}
+		})
+	}
+}
+
+// TestCanWipe_RejectsProtectedSubpaths — the Wipe-side mirror: ABSENT/wipe of
+// a protected subtree must be refused even before the recorded-set check.
+func TestCanWipe_RejectsProtectedSubpaths(t *testing.T) {
+	for _, p := range protectedSubpaths {
+		t.Run("dest="+p, func(t *testing.T) {
+			if err := canWipe(p); !errors.Is(err, ErrUnsafeDestination) {
+				t.Fatalf("canWipe(%q) = %v; want errors.Is(..., ErrUnsafeDestination)", p, err)
+			}
+		})
+	}
+}
+
+// TestValidateDestination_StillAcceptsManagedRootsUnderProtectedPrefix is the
+// regression guard for the carve-out: the agent's own managed roots live UNDER
+// protected prefixes (/etc/power-manage is under /etc, /var/lib/power-manage is
+// under /var/lib), so the deny-by-default subtree check must explicitly exempt
+// them or the agent can no longer manage its own state. Pins the boundary so a
+// future tightening of the deny set can't silently break legitimate writes.
+func TestValidateDestination_StillAcceptsManagedRootsUnderProtectedPrefix(t *testing.T) {
+	for _, p := range []string{
+		"/etc/power-manage",
+		"/etc/power-manage/sub/file",
+		"/var/lib/power-manage",
+		"/var/lib/power-manage/sub/dir/file",
+	} {
+		t.Run("dest="+p, func(t *testing.T) {
+			if err := validateDestination(p); err != nil {
+				t.Fatalf("validateDestination(%q) unexpected err: %v", p, err)
+			}
+		})
+	}
+}
+
+// TestIsManagedRoot_BoundaryRobustToMissingTrailingSlash pins that the
+// sibling-prefix boundary does NOT depend on wipeAllowedRoots entries being
+// written with a trailing slash: even a no-slash entry must refuse a hostile
+// sibling (/etc/power-manage-evil) while still matching real managed subpaths.
+func TestIsManagedRoot_BoundaryRobustToMissingTrailingSlash(t *testing.T) {
+	orig := wipeAllowedRoots
+	t.Cleanup(func() { wipeAllowedRoots = orig })
+	wipeAllowedRoots = []string{"/etc/power-manage"} // intentionally no trailing slash
+
+	if isManagedRoot("/etc/power-manage-evil") {
+		t.Error("isManagedRoot matched a hostile sibling /etc/power-manage-evil; boundary must not depend on a trailing slash")
+	}
+	if !isManagedRoot("/etc/power-manage") {
+		t.Error("isManagedRoot must match the exact managed root")
+	}
+	if !isManagedRoot("/etc/power-manage/x") {
+		t.Error("isManagedRoot must match a real managed subpath")
+	}
+}
+
+// TestCanWipe_RejectsManagedRootSiblingPrefix — the carve-out must use a
+// trailing-slash boundary so a hostile sibling like /etc/power-manage-evil is
+// NOT mistaken for the managed root /etc/power-manage and is refused as a
+// protected /etc subtree.
+func TestCanWipe_RejectsManagedRootSiblingPrefix(t *testing.T) {
+	for _, p := range []string{"/etc/power-manage-evil/x", "/var/lib/power-manage-evil"} {
+		t.Run("dest="+p, func(t *testing.T) {
+			if err := canWipe(p); !errors.Is(err, ErrUnsafeDestination) {
+				t.Fatalf("canWipe(%q) = %v; want errors.Is(..., ErrUnsafeDestination)", p, err)
 			}
 		})
 	}

--- a/sys/remote/remote.go
+++ b/sys/remote/remote.go
@@ -12,10 +12,11 @@
 // per agent run and the choice is per call, not per startup.
 //
 // Safety surface: every destination is run through
-// sys/fs.ResolveAndValidatePath and the IsProtectedPath check before any
-// filesystem mutation, archive entries are guarded against ../, absolute
-// paths, and escape-symlinks, and HTTP fetches are size-capped to defeat
-// zip-bomb-style inputs.
+// sys/fs.ResolveAndValidatePath and a deny-by-default protected-subtree check
+// (sys/fs.IsUnderProtectedPrefix, exempting only the agent-owned managed roots)
+// before any filesystem mutation, archive entries are guarded against ../,
+// absolute paths, and escape-symlinks, and HTTP fetches are size-capped to
+// defeat zip-bomb-style inputs.
 package remote
 
 import (


### PR DESCRIPTION
Closes #189. Three live, code-verified security bugs from the NIS2 test-coverage audit, each fixed **red-first** (a failing test pinning the intended behaviour, then the fix). All confirmed against the actual code, not just the audit.

## P0.1 / P0.2 — `sys/remote` protected-subtree fail-open (critical)
`validateDestination` (Fetch) and `canWipe` (Wipe) used exact-match `sys/fs.IsProtectedPath`, which only flags canonical top-level dirs. A remote Fetch/Wipe was therefore **accepted** for protected *subpaths* — `/etc/cron.d/x`, `/usr/bin/sshd`, `/home/<u>/.ssh/authorized_keys`, `/var/lib/<db>`, `/boot/grub/grub.cfg` — root code-exec / privesc / data-destruction that `doc.go` promises is impossible.

- Switch both guards to the deny-by-default subtree predicate `sys/fs.IsUnderProtectedPrefix`.
- Early lexical carve-out for the agent-owned managed roots (`/etc/power-manage`, `/var/lib/power-manage`), normalised to a trailing-slash boundary so `/etc/power-manage-evil` can't impersonate the root.
- In `canWipe` the subtree refusal runs **before** the recorded-set check, closing the `RecordDest` jailbreak.
- Tests derive the protected set from intent (`protectedPrefixRoots`), not from the buggy predicate.

## P0.3 — `client.go` asymmetric inbound validation (critical)
`RequestInventory`, `LogQuery` and `RevokeLuksDeviceKey` dispatch branches skipped the `validateInbound` gate that `Action`/`Query`/`Terminal*` run; a non-ULID id reached the handler. Worst case: `RevokeLuksDeviceKey` (irreversible LUKS slot-7 wipe).

- Add `validateInbound` to all three branches.
- **Self-discovering parity guard** walks every `ServerMessage` oneof arm with validate gotags and asserts dispatch validates it — exempting response (`deliverPending`) and lifecycle (`OnWelcome`/`OnError`) arms *by kind*, with a matches-zero guard — so a new command RPC can't silently skip validation again.

## P0.5 / P0.6 — `sys/encryption` key-file FIFO hang + empty-key acceptance (critical/high)
- `cleanupKeyFile` could **hang forever** if the `/dev/shm` key path was swapped for a FIFO (`O_WRONLY|O_NOFOLLOW` without `O_NONBLOCK`; `O_NOFOLLOW` doesn't stop a FIFO). Add `O_NONBLOCK` + refuse to scrub a non-regular fd.
- Mutating ops accepted an **empty passphrase** — an empty *new* key in `AddKey` would enroll an empty-passphrase unlock slot. Add `ErrEmptyKeyMaterial`, rejected before any cryptsetup/cryptenroll exec, for `AddKey`/`RemoveKey`/`KillSlot`/TPM `Enroll`+`Wipe`. Read-only `VerifyPassphrase`/`DetectVolumeByKey` stay exempt.

## Verification
- Every fix is red→green (failing test confirmed first).
- `go test -race -short ./...`, `go vet ./...`, `staticcheck ./...`, `gofmt -l` all clean locally.
- Local CodeRabbit review run pre-push; both findings (subtest skip isolation; managed-root boundary robustness) fixed.

## Carried forward (not this PR)
- **P0.4** `IsEncrypted` exit-1 fail-open needs real `cryptsetup` → WS1/WS3 container harness.
- `http_archive.go` extraction `O_WRONLY` open is a separate WS6 `sys/remote` hardening item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced inbound message validation to reject invalid commands before processing.
  * Strengthened encryption key/passphrase handling by rejecting empty credentials and preventing unauthorized LUKS slot operations.
  * Improved protection against filesystem access to sensitive system directories; managed paths are now properly exempted.
  * Fixed potential hang when cleaning up special files during key management operations.

* **Chores**
  * Updated safety documentation for path handling and destination validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->