### PR TITLE
feat(test): container-based real-execution test foundation (WS1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,39 @@ jobs:
         if: always()
         run: docker rm -f pm-sdk-test 2>/dev/null || true
 
+  # Container-based real-execution tests (`//go:build container`). Each cell
+  # builds one immutable bad-state image stage (the precondition is asserted at
+  # BUILD time) and runs the container-tagged tests INSIDE it, against the real
+  # tool binaries. Adding a distro or a state is a new matrix row + a Dockerfile
+  # stage + a `container`-tagged test file; the tests self-skip when their baked
+  # precondition is absent, so no other wiring changes.
+  container-tests:
+    name: Container Tests (${{ matrix.distro }}/${{ matrix.state }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: debian
+            state: state-locked-apt
+            path: ./sdk/pkg/
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: sdk
+
+      - name: Build ${{ matrix.distro }}/${{ matrix.state }} image
+        run: |
+          docker build \
+            -f sdk/test/Dockerfile.${{ matrix.distro }} \
+            --target ${{ matrix.state }} \
+            -t pm-sdk-container .
+
+      - name: Run container tests
+        run: |
+          docker run --rm pm-sdk-container \
+            go test -tags=container -count=1 -v ${{ matrix.path }} -run Container
+
   test-apt:
     name: Integration Tests (apt)
     runs-on: ubuntu-latest

--- a/pkg/repair_container_test.go
+++ b/pkg/repair_container_test.go
@@ -1,0 +1,101 @@
+//go:build container
+
+// Container-based real-execution tests for the package-manager stale-lock
+// repair path. Unlike the fake-runner unit tests (which feed fabricated fuser
+// exit codes), these run INSIDE a container against the REAL fuser binary and a
+// REAL lock file on the container filesystem — so a shell-quoting change, a
+// fuser behaviour difference, or a wrong lock path is caught, not assumed.
+//
+// The test process runs in the container, so os.Stat (the statFile seam) and
+// the Runner-driven fuser/rm hit the SAME filesystem. A host-side proxy Runner
+// would break this: removeStaleLock's os.Stat would probe the host while fuser
+// probed the container.
+//
+// Each test owns its precondition: it self-skips when the expected container
+// state (a baked stale lock) is absent, so `go test -tags=container ./pkg/`
+// against any image is correct.
+package pkg
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+const containerDpkgLock = "/var/lib/dpkg/lock"
+
+func containerRunner(t *testing.T) pmexec.Runner {
+	t.Helper()
+	// The container runs the test as root (matching the production agent:
+	// systemd User=root), so the Direct backend runs commands without a
+	// privilege wrapper.
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	return r
+}
+
+// TestRepair_RemovesStaleLock_Container pins the success path against a REAL
+// fuser: a lock file that NO process holds open is removed.
+func TestRepair_RemovesStaleLock_Container(t *testing.T) {
+	if _, err := os.Stat(containerDpkgLock); os.IsNotExist(err) {
+		t.Skip("precondition absent: not a state-locked-apt container")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := removeStaleLock(ctx, containerRunner(t), containerDpkgLock); err != nil {
+		t.Fatalf("removeStaleLock on an unheld lock returned error: %v", err)
+	}
+	if _, err := os.Stat(containerDpkgLock); !os.IsNotExist(err) {
+		t.Fatalf("stale (unheld) lock was not removed; stat err = %v", err)
+	}
+}
+
+// TestRepair_KeepsHeldLock_Container pins the safety-critical REJECTION path
+// against a REAL fuser: a lock a process is actively holding open MUST NOT be
+// removed (fuser reports it in use → removeStaleLock leaves it).
+//
+// It is a two-phase check so it cannot pass for the wrong reason: a broken or
+// missing fuser would ALSO leave the lock (removeStaleLock returns nil on a
+// probe error), which looks identical to "correctly kept". So we assert
+// held→KEPT, then release the fd and assert released→REMOVED. Only a fuser that
+// genuinely discriminates a held fd from an unheld one passes both.
+func TestRepair_KeepsHeldLock_Container(t *testing.T) {
+	dir := t.TempDir()
+	lock := dir + "/held.lock"
+	f, err := os.OpenFile(lock, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("create held lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	r := containerRunner(t)
+
+	// Phase 1: the fd is held → fuser sees this process → lock must remain.
+	if err := removeStaleLock(ctx, r, lock); err != nil {
+		t.Fatalf("removeStaleLock(held) returned error: %v", err)
+	}
+	if _, err := os.Stat(lock); err != nil {
+		t.Fatalf("a HELD lock was removed (or stat failed): %v — never delete a live lock", err)
+	}
+
+	// Phase 2: release the fd → fuser sees no holder → lock must now be removed.
+	// If fuser were broken, this would still leave the lock and fail here,
+	// proving phase 1 wasn't a false positive.
+	if err := f.Close(); err != nil {
+		t.Fatalf("close held lock fd: %v", err)
+	}
+	if err := removeStaleLock(ctx, r, lock); err != nil {
+		t.Fatalf("removeStaleLock(released) returned error: %v", err)
+	}
+	if _, err := os.Stat(lock); !os.IsNotExist(err) {
+		t.Fatalf("released lock not removed; stat err = %v — fuser did not discriminate held vs unheld", err)
+	}
+}

--- a/pkg/repair_test.go
+++ b/pkg/repair_test.go
@@ -42,34 +42,17 @@ func TestRemoveStaleLock_FileAbsent(t *testing.T) {
 	}
 }
 
-func TestRemoveStaleLock_InUse(t *testing.T) {
-	stubStatFile(t, nil, "/lock")
-	f := newFake()
-	f.Push(pmexec.Result{ExitCode: 0}, nil) // fuser: a process holds it
-	if err := removeStaleLock(context.Background(), f, "/lock"); err != nil {
-		t.Fatal(err)
-	}
-	if n := len(f.Calls()); n != 1 {
-		t.Fatalf("in-use lock must probe but not remove, ran %d", n)
-	}
-}
-
-func TestRemoveStaleLock_StaleRemoved(t *testing.T) {
-	stubStatFile(t, nil, "/lock")
-	f := newFake()
-	f.Push(pmexec.Result{ExitCode: 1}, nil) // fuser: nobody holds it (stale)
-	f.Push(pmexec.Result{ExitCode: 0}, nil) // rm -f
-	if err := removeStaleLock(context.Background(), f, "/lock"); err != nil {
-		t.Fatal(err)
-	}
-	calls := f.Calls()
-	if len(calls) != 2 {
-		t.Fatalf("stale lock must probe then remove, ran %d", len(calls))
-	}
-	if argv(calls[1]) != "rm -f /lock" || !calls[1].Escalate {
-		t.Errorf("removal call = %q (escalate=%v), want escalated rm -f", argv(calls[1]), calls[1].Escalate)
-	}
-}
+// NOTE: the in-use ("fuser reports a holder → keep") and stale-removed
+// ("fuser reports no holder → escalated rm") behaviours were previously
+// asserted here by FEEDING the FakeRunner a fabricated fuser exit code — i.e.
+// the test scripted the exact tool behaviour it then "verified", proving only
+// that the Go branch on a hand-chosen exit code works, never that real fuser
+// emits that code for a real held/unheld fd. Those two cases now run against
+// the REAL fuser binary on a REAL lock file in pkg/repair_container_test.go
+// (build tag `container`), so they are removed here as the first step of the
+// container-only migration. The fake-runner tests BELOW are kept: they cover
+// error/edge LOGIC (inconclusive probe, exec failure, stat error, context
+// cancellation) that is about the Go code path, not fabricated tool behaviour.
 
 func TestRemoveStaleLock_InconclusiveProbeKeepsLock(t *testing.T) {
 	stubStatFile(t, nil, "/lock")

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -1,0 +1,46 @@
+# Container-based real-execution test image for the SDK (Debian/apt family).
+#
+# Tests run INSIDE the container (`go test -tags=container`), so the SDK's
+# direct os.* filesystem access and its Runner-driven exec hit the SAME
+# filesystem — the only model that is faithful for capabilities (like
+# pkg/repair) that mix os.Stat with real tool exec.
+#
+# Multi-stage: `base` installs the toolchain + tool surface once; each
+# `state-*` stage bakes one known system state and asserts its precondition at
+# BUILD time (a mis-built state fails the BUILD, not the test). The test then
+# self-skips when its precondition is absent, so adding a state is a new stage +
+# a new test file — no CI wiring change.
+
+# The toolchain (1.26) is newer than the module's `go` directive (1.25.11, the
+# SDK's go.mod version mirrored into go.work below); a newer toolchain building
+# an older go-directive module is standard Go behaviour. Matches the pinning in
+# test/Dockerfile.integration so both images move together.
+FROM golang:1.26-bookworm AS base
+
+# psmisc provides `fuser`, the read-side lock probe in pkg/repair.go's
+# removeStaleLock; ca-certificates for `apt update` during Repair.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    psmisc \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Copy only the SDK module and pin it into a minimal workspace (standalone
+# resolution; mirrors test/Dockerfile.integration).
+COPY sdk/ ./sdk/
+RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN cd sdk && go mod download
+
+# --- bad-state stages -------------------------------------------------------
+
+# state-locked-apt: a STALE (unheld) set of apt/dpkg lock files. The build-time
+# `test -f` asserts the precondition exists, so a future base change that moves
+# the lock paths fails the build instead of silently skipping the test.
+FROM base AS state-locked-apt
+RUN touch /var/lib/dpkg/lock \
+          /var/lib/dpkg/lock-frontend \
+          /var/lib/apt/lists/lock \
+          /var/cache/apt/archives/lock \
+    && test -f /var/lib/dpkg/lock \
+       || (echo "PRECONDITION FAILED: /var/lib/dpkg/lock not created" && exit 1)

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Runs the SDK's container-tagged real-execution tests.
+#
+# Usage:
+#   ./sdk/test/run-container-tests.sh [distro] [state] [go-test-path]
+#
+# Defaults: debian / state-locked-apt / ./sdk/pkg/
+#
+# The tests run INSIDE the container (go test -tags=container), so the SDK's
+# direct os.* filesystem access and its Runner-driven exec hit the same
+# filesystem. Each test owns its precondition and self-skips when the baked
+# state is absent, so running this against any stage is correct.
+#
+# Works with docker or podman (set CONTAINER_ENGINE).
+
+set -euo pipefail
+
+ENGINE="${CONTAINER_ENGINE:-docker}"
+DISTRO="${1:-debian}"
+STATE="${2:-state-locked-apt}"
+TEST_PATH="${3:-./sdk/pkg/}"
+IMAGE="pm-sdk-container-${DISTRO}-${STATE}"
+
+# Build context is the repo root (parent of sdk/), matching the existing
+# integration CI: the Dockerfile does `COPY sdk/ ./sdk/`.
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "==> Building ${DISTRO}:${STATE} test image..."
+"$ENGINE" build \
+    -f "sdk/test/Dockerfile.${DISTRO}" \
+    --target "${STATE}" \
+    -t "${IMAGE}" \
+    "$ROOT"
+
+echo "==> Running container tests (${TEST_PATH}) inside ${STATE}..."
+"$ENGINE" run --rm "${IMAGE}" \
+    go test -tags=container -count=1 -v "${TEST_PATH}" -run Container


### PR DESCRIPTION
Closes #191. Establishes the **stable, extensible foundation** for testing the SDK against REAL tool binaries — the audit's headline gap is that ~100% statement coverage is *FakeRunner* coverage (only 4 of ~33 packages ever touch a real binary).

## Design finding: tests-in-container, not a host-side testcontainers-go proxy
The audit floated "tests on host + a `containerRunner` proxy satisfying `exec.Runner`". **Building it surfaced that this is broken for the SDK**: capabilities like `pkg/repair` mix *direct* `os.*` filesystem access with Runner-driven exec — `removeStaleLock` calls `os.Stat(path)` in-process **and** runs `fuser`/`rm` via the Runner. A host-side proxy would `os.Stat` the **host** while `fuser` probed the **container** → divergence → green-for-the-wrong-reason.

The faithful model is **tests-in-container** (the test process runs inside, so `os.Stat` and the Runner share one filesystem). This also matches the existing `container-test-strategy.md` proposal (its `os.Stat` self-skip only works in-container) and the agent's Dockerfile model. So for the SDK the agent-style approach is correct; testcontainers-go's host-proxy model is **not** a better fit here. *(Open to revisiting for pure-exec capabilities, but the foundation should be uniform.)*

## What's here
- **`test/Dockerfile.debian`** — multi-stage: `base` installs the tool surface once; `state-locked-apt` bakes a stale apt/dpkg lock and **asserts the precondition at BUILD time** (`RUN test -f ...`), so a mis-built state fails the build, not the test.
- **`pkg/repair_container_test.go`** (`//go:build container`) — the stale-lock path against **real `fuser`**: unheld→removed, plus a **two-phase** held→kept / released→removed that cannot pass if fuser is broken/missing. Each test **owns its precondition** and self-skips when the baked state is absent.
- **`test/run-container-tests.sh`** + a **`container-tests` CI matrix job**. Adding a distro or a state = a matrix row + a Dockerfile stage + a `container`-tagged test file; no other wiring.
- **First container-only migration**: delete the two fake repair tests that fed the FakeRunner a fabricated fuser exit code and then "verified" it (the circular case). Error/edge-LOGIC fakes are kept.

## Verification
- Built and ran both container tests **end-to-end under Docker locally — green**.
- `go test -race -short ./...`, `go vet ./...`, `gofmt -l`, container-tagged `go vet` all clean.
- Normal `go test ./...` (no tag) is unaffected — the container file is excluded without the build tag.

## How to extend (the recipe)
- **Add a state**: new `state-*` stage in the Dockerfile (with a `RUN test` guard) + a `//go:build container` test that self-skips on its precondition.
- **Add a distro**: `test/Dockerfile.<distro>` + a matrix row.