### PR TITLE
test(encryption): real-cryptsetup container tests for the LUKS Manager (WS2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,6 +255,13 @@ jobs:
           - distro: debian
             state: state-locked-apt
             path: ./sdk/pkg/
+          # LUKS Manager against real cryptsetup. No bad-state needed (each test
+          # formats its own LUKS2 container on a /dev/shm file), so it runs on
+          # the clean `base` stage. --shm-size gives /dev/shm headroom for the
+          # 64 MiB container files.
+          - distro: debian
+            state: base
+            path: ./sdk/sys/encryption/
     steps:
       - uses: actions/checkout@v5
         with:
@@ -269,7 +276,7 @@ jobs:
 
       - name: Run container tests
         run: |
-          docker run --rm pm-sdk-container \
+          docker run --rm --shm-size=512m pm-sdk-container \
             go test -tags=container -count=1 -v ${{ matrix.path }} -run Container
 
   test-apt:

--- a/sys/encryption/encryption_test.go
+++ b/sys/encryption/encryption_test.go
@@ -133,20 +133,12 @@ func TestIsEncrypted(t *testing.T) {
 			t.Errorf("command = %+v, want escalated `cryptsetup isLuks /dev/sda2`", c)
 		}
 	})
-	t.Run("not luks (exit 1)", func(t *testing.T) {
-		r := &recordingRunner{}
-		r.push(exec.Result{ExitCode: 1}, nil)
-		if ok, err := mgr(t, r).IsEncrypted(context.Background(), "/dev/sda2"); err != nil || ok {
-			t.Errorf("IsEncrypted = (%v,%v), want (false,nil)", ok, err)
-		}
-	})
-	t.Run("error (exit 4)", func(t *testing.T) {
-		r := &recordingRunner{}
-		r.push(exec.Result{ExitCode: 4}, nil)
-		if _, err := mgr(t, r).IsEncrypted(context.Background(), "/dev/sda2"); err == nil {
-			t.Error("IsEncrypted(exit 4) returned nil error")
-		}
-	})
+	// The exit-code → result mapping (exit 1 → not-LUKS, exit 4 → error) is no
+	// longer asserted here against a FABRICATED exit code: TestIsEncrypted_Container
+	// (build tag `container`) now proves it against REAL cryptsetup, which is the
+	// only thing that establishes a real LUKS / non-LUKS / missing device actually
+	// yields exit 0 / 1 / 4. This subtest keeps only the argv-shape pin (above) and
+	// the path-validation pin (below) — both unobservable through real cryptsetup.
 	t.Run("invalid device path rejected before runner", func(t *testing.T) {
 		r := &recordingRunner{}
 		if _, err := mgr(t, r).IsEncrypted(context.Background(), "-rf"); err == nil {

--- a/sys/encryption/luks_container_test.go
+++ b/sys/encryption/luks_container_test.go
@@ -1,0 +1,183 @@
+//go:build container
+
+// Container-based real-execution tests for the LUKS Manager. The fake-runner
+// unit tests feed cryptsetup's exit codes and output; these run the Manager
+// against the REAL cryptsetup binary on a REAL LUKS2 container, so the exit-code
+// mapping (incl. the P0.4 "not-LUKS vs error" distinction) and the slot
+// lifecycle are verified, not assumed.
+//
+// No privileged container / loop device is required: cryptsetup does every
+// HEADER operation (luksFormat / isLuks / luksAddKey / luksRemoveKey /
+// luksKillSlot / open --test-passphrase) directly on a file, and a file under
+// /dev/shm satisfies the Manager's validateDevicePath (/dev/ prefix) while being
+// an ordinary writable tmpfs path inside the container. (Activation / lsblk
+// detection DO need a real block device and are out of scope here.)
+//
+// Tests self-skip when cryptsetup is absent, so `go test -tags=container` is
+// correct against any image.
+package encryption
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+const containerCtxTimeout = 60 * time.Second
+
+func requireCryptsetup(t *testing.T) {
+	t.Helper()
+	if _, err := osexec.LookPath("cryptsetup"); err != nil {
+		t.Skip("cryptsetup not on PATH")
+	}
+}
+
+// directMgr builds a LUKS Manager on the Direct backend (the container runs as
+// root, so cryptsetup needs no escalation wrapper).
+func directMgr(t *testing.T) Manager {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	return mgr(t, r) // mgr (encryption_test.go) = New(LUKS, r)
+}
+
+// newDevFile creates an empty `size`-byte file under /dev/shm (a tmpfs path that
+// passes validateDevicePath's /dev/ requirement) and registers its cleanup.
+func newDevFile(t *testing.T, size int64) string {
+	t.Helper()
+	f, err := os.CreateTemp("/dev/shm", "pm-test-luks-*.img")
+	if err != nil {
+		t.Fatalf("create /dev/shm device file (need --shm-size headroom?): %v", err)
+	}
+	name := f.Name()
+	if err := f.Truncate(size); err != nil {
+		f.Close()
+		os.Remove(name)
+		t.Fatalf("truncate device file: %v", err)
+	}
+	f.Close()
+	t.Cleanup(func() { os.Remove(name) })
+	return name
+}
+
+// formatLUKS creates a LUKS2 container at a /dev/shm path keyed by passphrase,
+// using raw cryptsetup (this is test SETUP, not the code under test). 64 MiB
+// leaves room for the ~16 MiB LUKS2 keyslot area plus a little data.
+func formatLUKS(t *testing.T, passphrase string) string {
+	t.Helper()
+	dev := newDevFile(t, 64<<20)
+	kf, err := os.CreateTemp(t.TempDir(), "fmt.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kf.WriteString(passphrase); err != nil {
+		t.Fatal(err)
+	}
+	kf.Close()
+	cmd := osexec.Command("cryptsetup", "luksFormat", dev, "--key-file", kf.Name(), "--batch-mode")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("setup: cryptsetup luksFormat failed: %v\n%s", err, out)
+	}
+	return dev
+}
+
+// TestIsEncrypted_Container pins the exit-code mapping against real cryptsetup:
+// a LUKS2 container is encrypted, a zeroed file is not, and a NONEXISTENT device
+// is an ERROR — never (false, nil). The last case is the P0.4 anti-fail-open
+// pin: real cryptsetup returns exit 4 (access denied) for a missing device, and
+// IsEncrypted must NOT report that as "plaintext".
+func TestIsEncrypted_Container(t *testing.T) {
+	requireCryptsetup(t)
+	m := directMgr(t)
+	ctx, cancel := context.WithTimeout(context.Background(), containerCtxTimeout)
+	defer cancel()
+
+	if enc, err := m.IsEncrypted(ctx, formatLUKS(t, "fmt-pass")); err != nil || !enc {
+		t.Errorf("IsEncrypted(real LUKS) = (%v, %v); want (true, nil)", enc, err)
+	}
+	if enc, err := m.IsEncrypted(ctx, newDevFile(t, 16<<20)); err != nil || enc {
+		t.Errorf("IsEncrypted(zeros) = (%v, %v); want (false, nil)", enc, err)
+	}
+	if enc, err := m.IsEncrypted(ctx, "/dev/pm-nonexistent-xyz"); err == nil || enc {
+		t.Errorf("IsEncrypted(nonexistent) = (%v, %v); want (false, error) — must not fail-open to plaintext", enc, err)
+	}
+}
+
+// TestVerifyPassphrase_Container pins that a correct passphrase verifies, a
+// WRONG one returns (false, nil) — NOT an error (real cryptsetup exit 2) — and a
+// missing device is an error.
+func TestVerifyPassphrase_Container(t *testing.T) {
+	requireCryptsetup(t)
+	m := directMgr(t)
+	ctx, cancel := context.WithTimeout(context.Background(), containerCtxTimeout)
+	defer cancel()
+	dev := formatLUKS(t, "right-pass")
+
+	if ok, err := m.VerifyPassphrase(ctx, dev, mustSecret(t, "right-pass")); err != nil || !ok {
+		t.Errorf("VerifyPassphrase(correct) = (%v, %v); want (true, nil)", ok, err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, mustSecret(t, "wrong-pass")); err != nil || ok {
+		t.Errorf("VerifyPassphrase(wrong) = (%v, %v); want (false, nil) — a wrong passphrase is not an error", ok, err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, "/dev/pm-nonexistent-xyz", mustSecret(t, "x")); err == nil || ok {
+		t.Errorf("VerifyPassphrase(nonexistent) = (%v, %v); want (false, error)", ok, err)
+	}
+}
+
+// TestKeySlotLifecycle_Container exercises AddKey → RemoveKey end-to-end against
+// real cryptsetup: a second key added (authenticated by the first) verifies,
+// then after removal stops verifying while the original still works.
+func TestKeySlotLifecycle_Container(t *testing.T) {
+	requireCryptsetup(t)
+	m := directMgr(t)
+	ctx, cancel := context.WithTimeout(context.Background(), containerCtxTimeout)
+	defer cancel()
+	dev := formatLUKS(t, "key-one")
+	k1, k2 := mustSecret(t, "key-one"), mustSecret(t, "key-two")
+
+	if err := m.AddKey(ctx, dev, k1, k2, AddKeyOptions{}); err != nil {
+		t.Fatalf("AddKey(k2 authed by k1): %v", err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, k2); err != nil || !ok {
+		t.Fatalf("after AddKey, VerifyPassphrase(k2) = (%v, %v); want true", ok, err)
+	}
+	if err := m.RemoveKey(ctx, dev, k2); err != nil {
+		t.Fatalf("RemoveKey(k2): %v", err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, k2); err != nil || ok {
+		t.Errorf("after RemoveKey, VerifyPassphrase(k2) = (%v, %v); want false", ok, err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, k1); err != nil || !ok {
+		t.Errorf("VerifyPassphrase(k1, untouched) = (%v, %v); want true", ok, err)
+	}
+}
+
+// TestKillSlot_Container pins KillSlot against real cryptsetup: a key added to
+// slot 1 stops verifying after that slot is killed, while slot 0 is unaffected.
+func TestKillSlot_Container(t *testing.T) {
+	requireCryptsetup(t)
+	m := directMgr(t)
+	ctx, cancel := context.WithTimeout(context.Background(), containerCtxTimeout)
+	defer cancel()
+	dev := formatLUKS(t, "slot-zero") // occupies slot 0
+	k0, k1 := mustSecret(t, "slot-zero"), mustSecret(t, "slot-one")
+
+	if err := m.AddKey(ctx, dev, k0, k1, AddKeyOptions{Slot: ptr(1)}); err != nil {
+		t.Fatalf("AddKey(slot 1): %v", err)
+	}
+	if err := m.KillSlot(ctx, dev, 1, k0); err != nil {
+		t.Fatalf("KillSlot(1, authed by k0): %v", err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, k1); err != nil || ok {
+		t.Errorf("after KillSlot(1), VerifyPassphrase(k1) = (%v, %v); want false", ok, err)
+	}
+	if ok, err := m.VerifyPassphrase(ctx, dev, k0); err != nil || !ok {
+		t.Errorf("VerifyPassphrase(k0, untouched) = (%v, %v); want true", ok, err)
+	}
+}

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -18,10 +18,13 @@
 FROM golang:1.26-bookworm AS base
 
 # psmisc provides `fuser`, the read-side lock probe in pkg/repair.go's
-# removeStaleLock; ca-certificates for `apt update` during Repair.
+# removeStaleLock; ca-certificates for `apt update` during Repair;
+# cryptsetup-bin provides `cryptsetup` for the sys/encryption LUKS tests
+# (header-only ops on a /dev/shm file — no loop device / privilege needed).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     psmisc \
     ca-certificates \
+    cryptsetup-bin \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -34,5 +34,7 @@ echo "==> Building ${DISTRO}:${STATE} test image..."
     "$ROOT"
 
 echo "==> Running container tests (${TEST_PATH}) inside ${STATE}..."
-"$ENGINE" run --rm "${IMAGE}" \
+# --shm-size gives /dev/shm headroom for tests that stage container files there
+# (e.g. the LUKS Manager's 64 MiB LUKS2 containers).
+"$ENGINE" run --rm --shm-size=512m "${IMAGE}" \
     go test -tags=container -count=1 -v "${TEST_PATH}" -run Container


### PR DESCRIPTION
Closes #193. Second container-only migration on the WS1 foundation — the LUKS Manager against the **real `cryptsetup`** binary.

## Outcome: confirms correctness, pins it, no new bug
The audit's **P0.4** (`IsEncrypted` exit-1 fail-open) **does not reproduce** against real cryptsetup 2.6.1. The empirical exit codes:

| case | `isLuks` exit | mapped to |
|---|---|---|
| real LUKS2 | 0 | `true` |
| non-LUKS (zeros) | 1 | `false` |
| **missing / unreadable** | **4** | `default` → **error** |

The audit assumed exit-1 conflated "not-LUKS" with "unreadable" — but cryptsetup uses a *distinct* code (4) for access-denied, which the code already turns into an error. So the code is correct; the container test now **pins** the real exit-code behaviour so it can't regress (e.g. a future cryptsetup version, or a refactor of the `switch`).

## No privileged container / loop device
cryptsetup does every **header** op directly on a file, and a `/dev/shm` path satisfies `validateDevicePath` (the `/dev/` prefix) while being writable tmpfs inside the container. (Activation / lsblk detection need a real block device and are out of scope.)

## Coverage (all green locally against real cryptsetup, ~73s)
- `IsEncrypted` — real→true, zeros→false, **missing→error** (anti-fail-open).
- `VerifyPassphrase` — correct→true, **wrong→`(false,nil)`** not an error (real exit 2), missing→error.
- AddKey→RemoveKey lifecycle; KillSlot (slot 1 killed, slot 0 intact).

## Migration
- `cryptsetup-bin` added to `test/Dockerfile.debian` base; `container-tests` CI matrix gains a `debian/base` row for `sys/encryption` (with `--shm-size`).
- Removed the two purely-behavioural fake `IsEncrypted` subtests (fabricated exit 1 / exit 4) — now proven against real cryptsetup. Kept the argv-shape, path-validation, and **secret-not-in-argv** hygiene fakes (unobservable through real cryptsetup).

## Verification
- Built + ran the encryption container tests end-to-end under Docker — green.
- `go test -race -short ./...`, `go vet ./...` (incl. `-tags=container`), `gofmt -l` clean.
- Local CodeRabbit CLI session was unavailable (auth); relying on PR CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for encryption functionality, including LUKS container creation, passphrase verification, and key slot management.
  * Enhanced test infrastructure with increased shared memory allocation and cryptsetup tool support to enable real container-based testing scenarios.
  * Streamlined unit tests by consolidating mock exit-code tests into dedicated container integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->