### PR TITLE
fix(firewall): decode saddr/daddr in List + firewall/netconfig container tests (WS3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,15 @@ jobs:
           - distro: debian
             state: base
             path: ./sdk/sys/encryption/
+          # nftables round-trip + iproute2 read path. Run on the clean `base`
+          # stage; the tests load real kernel netfilter / interface state in the
+          # container's own network namespace (CAP_NET_ADMIN, added below).
+          - distro: debian
+            state: base
+            path: ./sdk/sys/firewall/
+          - distro: debian
+            state: base
+            path: ./sdk/sys/netconfig/
     steps:
       - uses: actions/checkout@v5
         with:
@@ -274,9 +283,12 @@ jobs:
             --target ${{ matrix.state }} \
             -t pm-sdk-container .
 
+      # --cap-add NET_ADMIN: the firewall/netconfig tests load real netfilter and
+      # interface state in the container's own network namespace. It is harmless
+      # for the other cells. --shm-size gives /dev/shm headroom for the LUKS cell.
       - name: Run container tests
         run: |
-          docker run --rm --shm-size=512m pm-sdk-container \
+          docker run --rm --shm-size=512m --cap-add NET_ADMIN pm-sdk-container \
             go test -tags=container -count=1 -v ${{ matrix.path }} -run Container
 
   test-apt:

--- a/sys/firewall/nftables.go
+++ b/sys/firewall/nftables.go
@@ -337,12 +337,42 @@ func applyExprToRule(expr []json.RawMessage, out *Rule) {
 			} `json:"match"`
 		}
 		if err := json.Unmarshal(e, &match); err == nil && match.Match != nil {
-			if pl := match.Match.Left.Payload; pl != nil && pl.Field == "dport" {
-				out.Protocol = Protocol(pl.Protocol)
-				var port int
-				_ = json.Unmarshal(match.Match.Right, &port)
-				out.Port = port
+			if pl := match.Match.Left.Payload; pl != nil {
+				switch pl.Field {
+				case "dport":
+					out.Protocol = Protocol(pl.Protocol)
+					var port int
+					_ = json.Unmarshal(match.Match.Right, &port)
+					out.Port = port
+				case "saddr":
+					out.Source = nftDecodeAddr(match.Match.Right)
+				case "daddr":
+					out.Dest = nftDecodeAddr(match.Match.Right)
+				}
 			}
 		}
 	}
+}
+
+// nftDecodeAddr renders an nft match right-hand side back to the SDK's
+// address/CIDR string. nft emits a bare address as a JSON string
+// ("10.0.0.1") and a network as {"prefix":{"addr":"10.0.0.0","len":24}}.
+// Without this, List dropped a rule's Source/Dest (returned ""), so a rule
+// that filters on an address round-tripped as "any" — a real fidelity bug the
+// fake-runner tests missed and the real-nft container round-trip caught.
+func nftDecodeAddr(raw json.RawMessage) string {
+	var bare string
+	if err := json.Unmarshal(raw, &bare); err == nil {
+		return bare
+	}
+	var p struct {
+		Prefix *struct {
+			Addr string `json:"addr"`
+			Len  int    `json:"len"`
+		} `json:"prefix"`
+	}
+	if err := json.Unmarshal(raw, &p); err == nil && p.Prefix != nil {
+		return fmt.Sprintf("%s/%d", p.Prefix.Addr, p.Prefix.Len)
+	}
+	return ""
 }

--- a/sys/firewall/nftables_container_test.go
+++ b/sys/firewall/nftables_container_test.go
@@ -1,0 +1,131 @@
+//go:build container
+
+// Container-based real-execution tests for the nftables backend. The fake-runner
+// unit tests assert the emitted nft argv/ruleset; these load rules into the REAL
+// nft binary and the kernel netfilter state (in the container's own network
+// namespace), then read them back with `nft -j list` and the SDK's own JSON
+// parser. This is an anti-rot guard: a future nft version that changes its JSON
+// shape, its address normalisation, or its acceptance of a rule fails loudly
+// here instead of silently in production.
+//
+// Needs CAP_NET_ADMIN (nft writes kernel state). Self-skips when nft is absent.
+package firewall
+
+import (
+	"context"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+const fwCtxTimeout = 30 * time.Second
+
+func requireNft(t *testing.T) {
+	t.Helper()
+	if _, err := osexec.LookPath("nft"); err != nil {
+		t.Skip("nft not on PATH")
+	}
+}
+
+func nftMgr(t *testing.T, ns string) Manager {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct) // container runs as root
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(Nftables, ns, r)
+	if err != nil {
+		t.Fatalf("New(Nftables, %q): %v", ns, err)
+	}
+	return m
+}
+
+func findRule(rules []Rule, id string) (Rule, bool) {
+	for _, r := range rules {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return Rule{}, false
+}
+
+// TestNftablesApplyListRemove_Container pins the full ApplyRule → List →
+// RemoveRule round-trip against real nft, including idempotency.
+func TestNftablesApplyListRemove_Container(t *testing.T) {
+	requireNft(t)
+	m := nftMgr(t, "pmrt")
+	ctx, cancel := context.WithTimeout(context.Background(), fwCtxTimeout)
+	defer cancel()
+
+	rule := Rule{ID: "allow_ssh", Allow: true, Protocol: ProtocolTCP, Port: 22, Source: "10.0.0.0/24"}
+	if err := m.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
+	}
+
+	rules, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List after Apply: %v", err)
+	}
+	got, ok := findRule(rules, "allow_ssh")
+	if !ok {
+		t.Fatalf("applied rule not found in List; got %+v", rules)
+	}
+	if got.Allow != rule.Allow || got.Protocol != rule.Protocol || got.Port != rule.Port || got.Source != rule.Source {
+		t.Errorf("round-trip mismatch:\n applied = %+v\n listed  = %+v", rule, got)
+	}
+
+	// Idempotent: applying the same rule again must not duplicate it.
+	if err := m.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule (2nd): %v", err)
+	}
+	rules, err = m.List(ctx)
+	if err != nil {
+		t.Fatalf("List after 2nd Apply: %v", err)
+	}
+	if n := len(rules); n != 1 {
+		t.Errorf("after re-applying the same rule, List = %d rules, want 1: %+v", n, rules)
+	}
+
+	// Remove → gone.
+	if err := m.RemoveRule(ctx, "allow_ssh"); err != nil {
+		t.Fatalf("RemoveRule: %v", err)
+	}
+	rules, err = m.List(ctx)
+	if err != nil {
+		t.Fatalf("List after Remove: %v", err)
+	}
+	if _, ok := findRule(rules, "allow_ssh"); ok {
+		t.Errorf("rule still present after RemoveRule: %+v", rules)
+	}
+}
+
+// TestNftablesV4MappedIPv6_Container documents the real-nft behaviour for a
+// v4-mapped IPv6 source (::ffff:10.0.0.1) — the audit suspected real nft rejects
+// it (atomic batch rollback → rule silently never applies). Against real nft we
+// assert the honest contract: ApplyRule must either reject it up front OR apply
+// it AND have it survive a List round-trip — it must NOT silently disappear
+// (accepted by ApplyRule but absent from List), which would be the dangerous
+// "rule thought-applied but not enforced" state.
+func TestNftablesV4MappedIPv6_Container(t *testing.T) {
+	requireNft(t)
+	m := nftMgr(t, "pmv4m")
+	ctx, cancel := context.WithTimeout(context.Background(), fwCtxTimeout)
+	defer cancel()
+
+	rule := Rule{ID: "v4mapped", Allow: false, Source: "::ffff:10.0.0.1"}
+	err := m.ApplyRule(ctx, rule)
+	if err != nil {
+		// Rejecting a v4-mapped source up front is an acceptable, safe outcome.
+		t.Logf("ApplyRule(::ffff:10.0.0.1) rejected up front: %v (acceptable)", err)
+		return
+	}
+	rules, lerr := m.List(ctx)
+	if lerr != nil {
+		t.Fatalf("List: %v", lerr)
+	}
+	if _, ok := findRule(rules, "v4mapped"); !ok {
+		t.Fatalf("ApplyRule accepted ::ffff:10.0.0.1 but the rule is ABSENT from List — silently-unapplied rule (false sense of protection); ApplyRule should have failed instead")
+	}
+}

--- a/sys/firewall/nftables_parse_golden_test.go
+++ b/sys/firewall/nftables_parse_golden_test.go
@@ -1,0 +1,56 @@
+package firewall
+
+import "testing"
+
+// Golden parse tests using REAL `nft -j list` rule objects captured from nft
+// 1.0.6. They pin the saddr/daddr decode that the emit-only fakes missed and
+// the real-nft container round-trip (TestNftablesApplyListRemove_Container)
+// caught: List used to drop a rule's Source/Dest (returned ""), so a rule that
+// filtered on an address round-tripped as "any". These run in the normal suite
+// (no Docker), so the regression is caught fast.
+func TestNftParseRules_DecodesSourceDest(t *testing.T) {
+	cases := []struct {
+		name       string
+		json       string
+		wantSource string
+		wantDest   string
+	}{
+		{
+			name:       "source CIDR (prefix form)",
+			json:       `{"nftables":[{"rule":{"comment":"r1","expr":[{"match":{"op":"==","left":{"payload":{"protocol":"ip","field":"saddr"}},"right":{"prefix":{"addr":"10.0.0.0","len":24}}}},{"drop":null}]}}]}`,
+			wantSource: "10.0.0.0/24",
+		},
+		{
+			name:       "source bare address (string form)",
+			json:       `{"nftables":[{"rule":{"comment":"r2","expr":[{"match":{"op":"==","left":{"payload":{"protocol":"ip","field":"saddr"}},"right":"10.0.0.1"}},{"drop":null}]}}]}`,
+			wantSource: "10.0.0.1",
+		},
+		{
+			name:     "dest CIDR",
+			json:     `{"nftables":[{"rule":{"comment":"r3","expr":[{"match":{"op":"==","left":{"payload":{"protocol":"ip","field":"daddr"}},"right":{"prefix":{"addr":"192.168.0.0","len":16}}}},{"accept":null}]}}]}`,
+			wantDest: "192.168.0.0/16",
+		},
+		{
+			name:       "ipv6 source CIDR",
+			json:       `{"nftables":[{"rule":{"comment":"r4","expr":[{"match":{"op":"==","left":{"payload":{"protocol":"ip6","field":"saddr"}},"right":{"prefix":{"addr":"2001:db8::","len":32}}}},{"drop":null}]}}]}`,
+			wantSource: "2001:db8::/32",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, err := nftParseRules([]byte(tc.json))
+			if err != nil {
+				t.Fatalf("nftParseRules: %v", err)
+			}
+			if len(rules) != 1 {
+				t.Fatalf("got %d rules, want 1", len(rules))
+			}
+			if rules[0].Source != tc.wantSource {
+				t.Errorf("Source = %q, want %q", rules[0].Source, tc.wantSource)
+			}
+			if rules[0].Dest != tc.wantDest {
+				t.Errorf("Dest = %q, want %q", rules[0].Dest, tc.wantDest)
+			}
+		})
+	}
+}

--- a/sys/netconfig/ip_container_test.go
+++ b/sys/netconfig/ip_container_test.go
@@ -1,0 +1,61 @@
+//go:build container
+
+// Container-based real-execution test for the iproute2 read path. Get parses
+// `ip -j addr/route show dev <name>` (JSON). The fake-runner unit tests feed a
+// captured JSON blob; this runs the REAL `ip` binary against a real interface in
+// the container's network namespace, so a future iproute2 that changes its `-j`
+// JSON shape is caught here. Anti-rot guard. Needs CAP_NET_ADMIN (to add the
+// test address). Self-skips when `ip` is absent.
+package netconfig
+
+import (
+	"context"
+	osexec "os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func TestGet_ParsesRealIpJSON_Container(t *testing.T) {
+	if _, err := osexec.LookPath("ip"); err != nil {
+		t.Skip("iproute2 `ip` not on PATH")
+	}
+
+	const testAddr = "192.0.2.5"
+	// Add a deterministic test address to loopback (always present, no module
+	// dependency) and clean it up.
+	if out, err := osexec.Command("ip", "addr", "add", testAddr+"/32", "dev", "lo").CombinedOutput(); err != nil {
+		t.Skipf("cannot add test address (need CAP_NET_ADMIN?): %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = osexec.Command("ip", "addr", "del", testAddr+"/32", "dev", "lo").Run()
+	})
+
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(SystemdNetworkd, r) // Get is backend-independent (just runs `ip`); no daemon needed
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg, err := m.Get(ctx, "lo")
+	if err != nil {
+		t.Fatalf("Get(lo): %v", err)
+	}
+	found := false
+	for _, a := range cfg.Addresses {
+		if strings.HasPrefix(a, testAddr) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Get(lo).Addresses = %v; want one starting %q (real `ip -j addr` parse drifted?)", cfg.Addresses, testAddr)
+	}
+}

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -17,14 +17,18 @@
 # test/Dockerfile.integration so both images move together.
 FROM golang:1.26-bookworm AS base
 
-# psmisc provides `fuser`, the read-side lock probe in pkg/repair.go's
-# removeStaleLock; ca-certificates for `apt update` during Repair;
-# cryptsetup-bin provides `cryptsetup` for the sys/encryption LUKS tests
-# (header-only ops on a /dev/shm file — no loop device / privilege needed).
+# Tool surface for the container tests:
+#   psmisc          — `fuser`, the read-side lock probe in pkg/repair.go
+#   ca-certificates — `apt update` during pkg.Repair
+#   cryptsetup-bin  — `cryptsetup` for the sys/encryption LUKS tests
+#   nftables        — `nft` for the sys/firewall round-trip tests (CAP_NET_ADMIN)
+#   iproute2        — `ip` for the sys/netconfig read-path tests (CAP_NET_ADMIN)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     psmisc \
     ca-certificates \
     cryptsetup-bin \
+    nftables \
+    iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -36,5 +36,5 @@ echo "==> Building ${DISTRO}:${STATE} test image..."
 echo "==> Running container tests (${TEST_PATH}) inside ${STATE}..."
 # --shm-size gives /dev/shm headroom for tests that stage container files there
 # (e.g. the LUKS Manager's 64 MiB LUKS2 containers).
-"$ENGINE" run --rm --shm-size=512m "${IMAGE}" \
+"$ENGINE" run --rm --shm-size=512m --cap-add NET_ADMIN "${IMAGE}" \
     go test -tags=container -count=1 -v "${TEST_PATH}" -run Container


### PR DESCRIPTION
Closes #195. Batch ① of the full container migration — and the real-nft round-trip **found and fixed a genuine fidelity bug**.

## 🐛 Bug found by the container test: `nftables.List` dropped Source/Dest
`applyExprToRule` decoded the verdict + `dport` but **never the `saddr`/`daddr` match**, so a rule filtering on an address round-tripped through `List` as `Source:""`/`Dest:""` — i.e. reported as "any". A consumer reconciling/auditing rules would see the wrong scope.

**Why the fakes missed it:** they assert the *emit* path (generated `nft` argv) and the *parse* path **separately**, with hand-authored JSON that never round-trips. `ApplyRule → real nft → List` exposed it on the first run. This is precisely the anti-rot value: the real tool disagreed with the fake's assumptions.

**Fix:** `nftDecodeAddr` decodes both nft forms — bare string (`"10.0.0.1"`) and `{"prefix":{"addr","len"}}` — for v4 and v6.

## Tests
- **`sys/firewall`** (`//go:build container`, CAP_NET_ADMIN): `ApplyRule → List → RemoveRule` round-trip + idempotency against real nft, asserting Source/Protocol/Port/verdict fidelity; a v4-mapped-IPv6 case that fails if a rule is silently accepted-but-unapplied. *(Audit aside: real nft 1.0.6 **accepts** `ip saddr ::ffff:10.0.0.1` — the "rejected → rule never applies" claim doesn't reproduce.)*
- **`sys/netconfig`** (container): `Get` parsing real `ip -j addr` JSON via a test address on `lo`.
- **Golden unit test**: pins the saddr/daddr parse against captured real nft 1.0.6 JSON — regression caught in the normal suite (no Docker).

## Plumbing (anti-rot extensibility)
`nftables` + `iproute2` in `test/Dockerfile.debian` base; two `debian/base` matrix rows; `--cap-add NET_ADMIN` on the run. Adding another distro/tool-version is a matrix row.

## Verification
Built + ran both container cells under Docker — green (the firewall test was **red before the fix**). `go test -race -short ./...`, `vet`, `staticcheck`, `gofmt -l` clean.