### PR TITLE
test(inventory,catrust): real-tool container tests + unique CI cell names (WS4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,31 +246,45 @@ jobs:
   # stage + a `container`-tagged test file; the tests self-skip when their baked
   # precondition is absent, so no other wiring changes.
   container-tests:
-    name: Container Tests (${{ matrix.distro }}/${{ matrix.state }})
+    name: Container Tests (${{ matrix.label }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - distro: debian
+          - label: pkg/repair (debian/state-locked-apt)
+            distro: debian
             state: state-locked-apt
             path: ./sdk/pkg/
           # LUKS Manager against real cryptsetup. No bad-state needed (each test
           # formats its own LUKS2 container on a /dev/shm file), so it runs on
           # the clean `base` stage. --shm-size gives /dev/shm headroom for the
           # 64 MiB container files.
-          - distro: debian
+          - label: sys/encryption (debian/base)
+            distro: debian
             state: base
             path: ./sdk/sys/encryption/
           # nftables round-trip + iproute2 read path. Run on the clean `base`
           # stage; the tests load real kernel netfilter / interface state in the
           # container's own network namespace (CAP_NET_ADMIN, added below).
-          - distro: debian
+          - label: sys/firewall (debian/base)
+            distro: debian
             state: base
             path: ./sdk/sys/firewall/
-          - distro: debian
+          - label: sys/netconfig (debian/base)
+            distro: debian
             state: base
             path: ./sdk/sys/netconfig/
+          # /proc + os-release + lsblk + ip parsers against the real container.
+          - label: sys/inventory (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/inventory/
+          # update-ca-certificates round-trip into the real system trust bundle.
+          - label: sys/catrust (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/catrust/
     steps:
       - uses: actions/checkout@v5
         with:

--- a/sys/catrust/catrust_container_test.go
+++ b/sys/catrust/catrust_container_test.go
@@ -1,0 +1,132 @@
+//go:build container
+
+// Container-based real-execution test for the CA trust-store flow. The fake-
+// runner unit tests assert the emitted update-ca-certificates argv and the file
+// written to the anchors dir; this runs the REAL update-ca-certificates and then
+// proves the installed CA actually appears in (and is removed from) the system
+// trust bundle — the security-relevant round-trip, since a trusted CA can MITM
+// any TLS connection. Anti-rot guard: a future update-ca-certificates that
+// changes its bundle path or behaviour is caught here.
+//
+// Debian/CaCertificates backend only (the test image). Self-skips when
+// update-ca-certificates is absent.
+package catrust
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// debianBundle is where update-ca-certificates concatenates every trusted CA.
+const debianBundle = "/etc/ssl/certs/ca-certificates.crt"
+
+// selfSignedCA returns a PEM-encoded self-signed CA certificate with the given
+// CommonName, valid 2000-2100 (spans now without using the wall clock).
+func selfSignedCA(t *testing.T, cn string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// bundleHasCN parses the real system CA bundle and reports whether any cert in
+// it has the given CommonName.
+func bundleHasCN(t *testing.T, cn string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(debianBundle)
+	if err != nil {
+		t.Fatalf("read system bundle %s: %v", debianBundle, err)
+	}
+	for block, rest := pem.Decode(raw); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+		if c.Subject.CommonName == cn {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInstallRemove_RealTrustStore_Container(t *testing.T) {
+	if _, err := osexec.LookPath("update-ca-certificates"); err != nil {
+		t.Skip("update-ca-certificates not on PATH")
+	}
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(CaCertificates, r)
+	if err != nil {
+		t.Fatalf("New(CaCertificates): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const name = "pm-container-test-ca"
+	const cn = "pm container test root"
+	pemBytes := selfSignedCA(t, cn)
+
+	t.Cleanup(func() { _ = m.Remove(context.Background(), name) })
+
+	// Install → the CA must actually appear in the real system bundle.
+	if err := m.Install(ctx, name, pemBytes); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !bundleHasCN(t, cn) {
+		t.Fatalf("after Install, CA %q is NOT in the real system bundle %s — not actually trusted", cn, debianBundle)
+	}
+	anchors, err := m.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, a := range anchors {
+		if a.Name == name {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("List does not report the installed anchor %q: %+v", name, anchors)
+	}
+
+	// Remove → the CA must be gone from the real bundle (distrust took effect).
+	if err := m.Remove(ctx, name); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if bundleHasCN(t, cn) {
+		t.Errorf("after Remove, CA %q is STILL in the real system bundle %s — distrust failed", cn, debianBundle)
+	}
+}

--- a/sys/inventory/inventory_container_test.go
+++ b/sys/inventory/inventory_container_test.go
@@ -1,0 +1,119 @@
+//go:build container
+
+// Container-based real-execution tests for the inventory parsers. The fake-runner
+// unit tests feed captured /proc, os-release, lsblk and `ip -j` output; these run
+// the parsers against the REAL files and tools inside the container, so a kernel
+// /proc format change, an os-release field change, or an iproute2/lsblk JSON
+// shape change is caught here. Anti-rot guard. Self-skips nothing — /proc and
+// /etc/os-release always exist; tool-backed methods need their binary (present
+// in the test image).
+package inventory
+
+import (
+	"context"
+	osexec "os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func realCollector(t *testing.T) Collector {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	c, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func invCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestSystem_ParsesRealProc_Container pins the /proc/cpuinfo + /proc/meminfo +
+// uname parse against the real kernel.
+func TestSystem_ParsesRealProc_Container(t *testing.T) {
+	info, err := realCollector(t).System(invCtx(t))
+	if err != nil {
+		t.Fatalf("System: %v", err)
+	}
+	if info.Hostname == "" {
+		t.Error("Hostname empty")
+	}
+	if info.CPUModel == "" {
+		t.Error("CPUModel empty (parsed from /proc/cpuinfo)")
+	}
+	if info.CPUCores < 1 {
+		t.Errorf("CPUCores = %d, want >= 1", info.CPUCores)
+	}
+	if info.MemoryTotalMB <= 0 {
+		t.Errorf("MemoryTotalMB = %d, want > 0 (parsed from /proc/meminfo)", info.MemoryTotalMB)
+	}
+	out, err := osexec.Command("uname", "-r").Output()
+	if err != nil {
+		t.Fatalf("uname -r: %v", err)
+	}
+	if want := strings.TrimSpace(string(out)); info.KernelVersion != want {
+		t.Errorf("KernelVersion = %q, want %q (real `uname -r`)", info.KernelVersion, want)
+	}
+}
+
+// TestOS_ParsesRealOSRelease_Container pins the /etc/os-release parse against the
+// real (debian) file.
+func TestOS_ParsesRealOSRelease_Container(t *testing.T) {
+	os, err := realCollector(t).OS()
+	if err != nil {
+		t.Fatalf("OS: %v", err)
+	}
+	if os.ID != "debian" {
+		t.Errorf("OS.ID = %q, want %q (the container distro)", os.ID, "debian")
+	}
+	if os.Name == "" || os.VersionID == "" {
+		t.Errorf("OS Name/VersionID empty: %+v", os)
+	}
+	if os.Arch != runtime.GOARCH {
+		t.Errorf("OS.Arch = %q, want %q", os.Arch, runtime.GOARCH)
+	}
+}
+
+// TestDisks_ParsesRealLsblk_Container pins the `lsblk --json` parse: it must
+// decode real lsblk output without error.
+func TestDisks_ParsesRealLsblk_Container(t *testing.T) {
+	if _, err := osexec.LookPath("lsblk"); err != nil {
+		t.Skip("lsblk not on PATH")
+	}
+	if _, err := realCollector(t).Disks(invCtx(t)); err != nil {
+		t.Fatalf("Disks (real `lsblk --json` parse): %v", err)
+	}
+}
+
+// TestNetworkInterfaces_ParsesRealIpJSON_Container pins the `ip -j addr` parse:
+// loopback must be discovered.
+func TestNetworkInterfaces_ParsesRealIpJSON_Container(t *testing.T) {
+	if _, err := osexec.LookPath("ip"); err != nil {
+		t.Skip("iproute2 `ip` not on PATH")
+	}
+	ifaces, err := realCollector(t).NetworkInterfaces(invCtx(t))
+	if err != nil {
+		t.Fatalf("NetworkInterfaces (real `ip -j addr` parse): %v", err)
+	}
+	found := false
+	for _, i := range ifaces {
+		if i.Name == "lo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("loopback 'lo' not found in parsed interfaces: %+v", ifaces)
+	}
+}


### PR DESCRIPTION
Closes #197. Batch ② — both confirmed correct against real tools.

- **sys/inventory**: `System`/`OS`/`Disks`/`NetworkInterfaces` parsers against real /proc, /etc/os-release, `lsblk --json`, `ip -j addr`.
- **sys/catrust**: `Install → List → Remove` with real `update-ca-certificates`, asserting the CA actually appears in / disappears from the system trust bundle `/etc/ssl/certs/ca-certificates.crt` (security round-trip).
- **CI**: unique `label` per container-tests matrix cell (distinct check names).

Verified both container cells under Docker — green. `race -short`, `vet`, `gofmt` clean.