### PR TITLE
test(terminal,notify): real PTY+setresuid and real wall container tests (WS5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,6 +285,16 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/catrust/
+          # Real PTY + setresuid privilege drop (creates an unprivileged user).
+          - label: sys/terminal (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/terminal/
+          # Real `wall` broadcast.
+          - label: sys/notify (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/notify/
     steps:
       - uses: actions/checkout@v5
         with:

--- a/sys/notify/notify_container_test.go
+++ b/sys/notify/notify_container_test.go
@@ -1,0 +1,41 @@
+//go:build container
+
+// Container-based real-execution test for the wall broadcast. The fake-runner
+// unit tests assert the `wall` argv and stdin; this runs the REAL wall binary so
+// an argv/stdin-handling change (or a wall that rejects our invocation) is caught.
+// notify-send is intentionally not exercised (no D-Bus/graphical session in CI —
+// the SDK skips it gracefully). Needs root-ish; self-skips when wall is absent.
+package notify
+
+import (
+	"context"
+	osexec "os/exec"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func TestNotifyAll_RealWall_Container(t *testing.T) {
+	if _, err := osexec.LookPath("wall"); err != nil {
+		t.Skip("wall not on PATH")
+	}
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// wall broadcasts to all terminals; with no logged-in terminals it still
+	// succeeds (writes nowhere). A non-nil error means the real wall rejected our
+	// argv/stdin — exactly the drift we want to catch. notify-send is skipped by
+	// the SDK when no D-Bus session exists, so NotifyAll must return nil here.
+	if err := m.NotifyAll(ctx, "PM Container Test", "hello from the container test"); err != nil {
+		t.Fatalf("NotifyAll via real wall returned error: %v", err)
+	}
+}

--- a/sys/terminal/terminal_container_test.go
+++ b/sys/terminal/terminal_container_test.go
@@ -1,0 +1,74 @@
+//go:build container
+
+// Container-based real-execution test for the PTY terminal. The fake/unit tests
+// can't exercise the real fork + setresuid + PTY allocation; this creates a real
+// unprivileged user, opens a real login shell as that user, and proves — via the
+// shell's own `id -un` over the PTY — that the privilege drop took effect. This
+// is the path the audit flagged as never exercised (setresuid to a *different*
+// user). Needs root (to create the user and switch to it). Self-skips when
+// useradd is unavailable.
+package terminal
+
+import (
+	"bytes"
+	"context"
+	osexec "os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenRunsShellAsTargetUser_Container(t *testing.T) {
+	if _, err := osexec.LookPath("useradd"); err != nil {
+		t.Skip("useradd not on PATH")
+	}
+	const u = "pmttytest"
+	_ = osexec.Command("userdel", "-r", u).Run() // best-effort clean slate
+	if out, err := osexec.Command("useradd", "-m", "-s", "/bin/bash", u).CombinedOutput(); err != nil {
+		t.Skipf("cannot create test user (need root?): %v\n%s", err, out)
+	}
+	t.Cleanup(func() { _ = osexec.Command("userdel", "-r", u).Run() })
+
+	m, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	sess, err := m.Open(ctx, SessionConfig{User: u})
+	if err != nil {
+		t.Fatalf("Open as %q: %v", u, err)
+	}
+	defer sess.Close()
+
+	// Ask the shell who it is, then exit so the PTY reaches EOF.
+	if _, err := sess.Write([]byte("id -un\nexit\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, rerr := sess.Read(b)
+			if n > 0 {
+				buf.Write(b[:n])
+			}
+			if rerr != nil {
+				return // EOF when the login shell exits
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("timed out reading PTY output; got so far:\n%s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), u) {
+		t.Errorf("shell did not run as %q (its `id -un` is absent from PTY output):\n%s", u, buf.String())
+	}
+}


### PR DESCRIPTION
Closes #199. Batch ③ — both confirmed correct.

- **sys/terminal**: real user + real login shell over a real PTY; `id -un` proves the **setresuid privilege drop** to a *different* user (audit-flagged, previously unexercised).
- **sys/notify**: `NotifyAll` via real `wall`.

Verified both cells under Docker — green. `race -short`, `vet`, `gofmt` clean.