### PR TITLE
ci: real pacman + zypper coverage (the 100%-fake package managers) (WS6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,16 +398,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Leap ships an older Go; GOTOOLCHAIN=auto (default) fetches the go.mod
-      # toolchain (go 1.25.11) on first `go` invocation.
       - name: Install Go + refresh zypper
         run: |
           zypper --non-interactive --gpg-auto-import-keys refresh
           zypper --non-interactive install go git tar gzip
 
+      # Leap's `go` package pins GOTOOLCHAIN=local and ships go 1.25.10, one
+      # patch below the go.mod requirement (1.25.11). GOTOOLCHAIN=auto lets the
+      # first `go` invocation fetch the exact toolchain the module declares.
       - name: Run integration tests
         run: go test -v ./...
         working-directory: pkg
+        env:
+          GOTOOLCHAIN: auto
 
   coverage-report:
     name: Coverage Report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,6 +370,45 @@ jobs:
           name: coverage-dnf
           path: pkg/coverage-dnf.out
 
+  # pacman/zypper are the two package managers with zero real-tool coverage
+  # before this. The pkg integration tests (TestIntegration_Pacman/_Zypper)
+  # auto-detect the backend and run read-only ops (List / IsInstalled / Search)
+  # against the REAL binary, so an output-format / exit-code change across distro
+  # or tool versions is caught.
+  test-pacman:
+    name: Integration Tests (pacman)
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Go + sync pacman db
+        run: pacman -Sy --noconfirm go git
+
+      - name: Run integration tests
+        run: go test -v ./...
+        working-directory: pkg
+
+  test-zypper:
+    name: Integration Tests (zypper)
+    runs-on: ubuntu-latest
+    container:
+      image: opensuse/leap:latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Leap ships an older Go; GOTOOLCHAIN=auto (default) fetches the go.mod
+      # toolchain (go 1.25.11) on first `go` invocation.
+      - name: Install Go + refresh zypper
+        run: |
+          zypper --non-interactive --gpg-auto-import-keys refresh
+          zypper --non-interactive install go git tar gzip
+
+      - name: Run integration tests
+        run: go test -v ./...
+        working-directory: pkg
+
   coverage-report:
     name: Coverage Report
     needs: [test-apt, test-dnf]


### PR DESCRIPTION
Closes #201. The audit's headline gap closed: pacman + zypper now run against the **real** binaries in CI.

`TestIntegration_Pacman`/`_Zypper` already existed (auto-detect backend, read-only List/IsInstalled/Search) but never ran — no Arch/openSUSE host. Adds `test-pacman` (archlinux:latest) + `test-zypper` (opensuse/leap:latest) jobs, modeled on `test-dnf`.

**Verified locally under Docker:** both pass — pacman (go 1.26.4) and zypper (go 1.25.11 via GOTOOLCHAIN auto on Leap). Parsers correct against the real tools. CI-only change (no Go edits). flatpak deferred (needs a flathub remote).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing infrastructure with additional Linux distribution coverage for Go package tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->