### PR TITLE
test(remote): security-branch unit coverage, 76->80% (WS7)

### DIFF
--- a/sys/remote/remote_coverage_test.go
+++ b/sys/remote/remote_coverage_test.go
@@ -1,0 +1,206 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- detectArchiveKind: full content-type + extension matrix ---
+
+func TestDetectArchiveKind_Matrix(t *testing.T) {
+	cases := []struct {
+		ct, url string
+		want    archiveKind
+	}{
+		{"application/gzip", "", archiveTarGz},
+		{"application/x-gzip", "", archiveTarGz},
+		{"application/x-tar+gzip", "", archiveTarGz},
+		{"application/x-tgz", "", archiveTarGz},
+		{"APPLICATION/GZIP", "", archiveTarGz}, // case-insensitive
+		{"application/zip", "", archiveZip},
+		{"application/x-zip", "", archiveZip},
+		{"application/x-zip-compressed", "", archiveZip},
+		{"application/x-xz", "", archiveTarXz},
+		{"application/x-tar+xz", "", archiveTarXz},
+		// content-type unknown → fall through to URL extension
+		{"", "https://h/f.tar.gz", archiveTarGz},
+		{"", "https://h/f.tgz", archiveTarGz},
+		{"", "https://h/f.zip", archiveZip},
+		{"", "https://h/f.tar.xz", archiveTarXz},
+		{"", "https://h/f.txz", archiveTarXz},
+		{"", "https://h/f.tar.gz?sig=abc#frag", archiveTarGz}, // query/fragment stripped
+		{"application/octet-stream", "https://h/f.zip", archiveZip},
+		{"", "https://h/f.bin", archiveUnknown},
+		{"text/plain", "https://h/nope", archiveUnknown},
+	}
+	for _, c := range cases {
+		if got := detectArchiveKind(c.ct, c.url); got != c.want {
+			t.Errorf("detectArchiveKind(%q,%q) = %v, want %v", c.ct, c.url, got, c.want)
+		}
+	}
+}
+
+// --- safeJoinDest: zip/tar-slip and malformed entry refusal ---
+
+func TestSafeJoinDest_RefusesEscape(t *testing.T) {
+	staging := t.TempDir()
+	bad := []string{
+		"",                 // empty
+		".",                // dot
+		"/",                // root
+		"/etc/passwd",      // absolute
+		"../escape",        // parent traversal
+		"a/../../escape",   // traversal after a component
+		"../../etc/passwd", // deep traversal
+		"sub/../../escape", // traversal mid-path
+		"foo\x00bar",       // NUL
+		"./",               // dot + slash → normalises empty
+	}
+	for _, e := range bad {
+		if _, err := safeJoinDest(staging, e); !errors.Is(err, ErrUnsafeDestination) {
+			t.Errorf("safeJoinDest(%q) err = %v; want ErrUnsafeDestination", e, err)
+		}
+	}
+	// Legitimate local entries are accepted and stay under staging.
+	for _, e := range []string{"file", "sub/file", "a/b/c/file", "dir/"} {
+		full, err := safeJoinDest(staging, e)
+		if err != nil {
+			t.Errorf("safeJoinDest(%q) unexpected err: %v", e, err)
+			continue
+		}
+		if !strings.HasPrefix(full, staging) {
+			t.Errorf("safeJoinDest(%q) = %q escaped staging %q", e, full, staging)
+		}
+	}
+}
+
+// --- digest: sha256File / sha256Tree happy + error paths ---
+
+func TestSha256File(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	if err := os.WriteFile(p, []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Known sha256("abc")
+	const want = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	got, err := sha256File(p)
+	if err != nil {
+		t.Fatalf("sha256File: %v", err)
+	}
+	if got != want {
+		t.Errorf("sha256File = %q, want %q", got, want)
+	}
+	// Error: nonexistent file (open failure).
+	if _, err := sha256File(filepath.Join(dir, "missing")); err == nil {
+		t.Error("sha256File(missing) returned nil error")
+	}
+}
+
+func TestSha256Tree(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "b"), []byte("2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h1, err := sha256Tree(dir)
+	if err != nil {
+		t.Fatalf("sha256Tree: %v", err)
+	}
+	if h1 == "" {
+		t.Error("sha256Tree returned empty hash")
+	}
+	// Deterministic: same tree → same digest.
+	if h2, _ := sha256Tree(dir); h2 != h1 {
+		t.Errorf("sha256Tree not deterministic: %q vs %q", h1, h2)
+	}
+	// A content change flips the digest.
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if h3, _ := sha256Tree(dir); h3 == h1 {
+		t.Error("sha256Tree digest unchanged after a file edit")
+	}
+	// Error: nonexistent root.
+	if _, err := sha256Tree(filepath.Join(dir, "no-such-dir")); err == nil {
+		t.Error("sha256Tree(missing) returned nil error")
+	}
+}
+
+// --- 0% functions: Source.String() and Source.Wipe() for git + s3 ---
+
+func TestGitSource_StringAndWipe(t *testing.T) {
+	src, err := NewGit(GitConfig{URL: "https://example.test/repo.git", Ref: "main"})
+	if err != nil {
+		t.Fatalf("NewGit: %v", err)
+	}
+	if s := src.String(); !strings.Contains(s, "example.test") {
+		t.Errorf("String() = %q, want it to mention the URL host", s)
+	}
+	// Wipe of an unmanaged/unrecorded path must be refused.
+	if err := src.Wipe(context.Background(), "/etc/cron.d/x"); !errors.Is(err, ErrUnsafeDestination) {
+		t.Errorf("Wipe(unmanaged) err = %v; want ErrUnsafeDestination", err)
+	}
+}
+
+func TestS3Source_StringAndWipe(t *testing.T) {
+	src, err := NewS3(S3Config{Endpoint: "https://s3.example.test", Bucket: "b", Key: "k"})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	if s := src.String(); !strings.Contains(s, "b") || !strings.Contains(s, "k") {
+		t.Errorf("String() = %q, want bucket/key", s)
+	}
+	if err := src.Wipe(context.Background(), "/usr/bin/x"); !errors.Is(err, ErrUnsafeDestination) {
+		t.Errorf("Wipe(unmanaged) err = %v; want ErrUnsafeDestination", err)
+	}
+}
+
+// --- validation rejection branches ---
+
+func TestNewGit_RejectsConfig(t *testing.T) {
+	bad := []GitConfig{
+		{URL: ""},                        // empty url
+		{URL: "http://h/r.git"},          // non-https scheme
+		{URL: "ftp://h/r.git"},           // unsupported scheme
+		{URL: "https://user:pw@h/r.git"}, // userinfo
+		{URL: "https:///r.git"},          // no host
+		{URL: "https://h/r.git", Ref: "bad ref with space"}, // bad ref charset
+		{URL: "https://h/r.git", Ref: "ref;rm -rf"},         // shell metachar in ref
+	}
+	for _, c := range bad {
+		if _, err := NewGit(c); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("NewGit(%+v) err = %v; want ErrInvalidConfig", c, err)
+		}
+	}
+}
+
+func TestNewS3_RejectsConfig(t *testing.T) {
+	bad := []S3Config{
+		{Endpoint: "", Bucket: "b", Key: "k"},                                // empty endpoint
+		{Endpoint: "https://h\x01", Bucket: "b", Key: "k"},                   // control char
+		{Endpoint: "not-absolute", Bucket: "b", Key: "k"},                    // not absolute
+		{Endpoint: "ftp://h", Bucket: "b", Key: "k"},                         // bad scheme
+		{Endpoint: "https://u:p@h", Bucket: "b", Key: "k"},                   // userinfo
+		{Endpoint: "https://", Bucket: "b", Key: "k"},                        // no host
+		{Endpoint: "https://h", Bucket: "", Key: "k"},                        // empty bucket
+		{Endpoint: "https://h", Bucket: strings.Repeat("a", 64), Key: "k"},   // bucket too long
+		{Endpoint: "https://h", Bucket: "b", Key: ""},                        // empty key
+		{Endpoint: "https://h", Bucket: "b", Key: strings.Repeat("a", 1025)}, // key too long
+	}
+	for _, c := range bad {
+		if _, err := NewS3(c); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("NewS3(endpoint=%q bucket=%q keyLen=%d) err = %v; want ErrInvalidConfig",
+				c.Endpoint, c.Bucket, len(c.Key), err)
+		}
+	}
+}

--- a/sys/remote/remote_internal_test.go
+++ b/sys/remote/remote_internal_test.go
@@ -1,0 +1,112 @@
+package remote
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// --- matchRef: branch/tag/annotated-tag matching ---
+
+func TestMatchRef(t *testing.T) {
+	h := func(s string) plumbing.Hash { return plumbing.NewHash(s) }
+	hMain := h("1111111111111111111111111111111111111111")
+	hTag := h("2222222222222222222222222222222222222222")
+	hAnnot := h("3333333333333333333333333333333333333333")
+	refs := []*plumbing.Reference{
+		plumbing.NewHashReference("refs/heads/main", hMain),
+		plumbing.NewHashReference("refs/tags/v1", hTag),
+		plumbing.NewHashReference("refs/tags/v2^{}", hAnnot), // dereferenced annotated tag
+	}
+	cases := []struct {
+		ref     string
+		want    plumbing.Hash
+		wantHit bool
+	}{
+		{"main", hMain, true}, // branch
+		{"v1", hTag, true},    // lightweight tag
+		{"v2", hAnnot, true},  // annotated tag via ^{} fallback
+		{"nonexistent", plumbing.ZeroHash, false},
+	}
+	for _, c := range cases {
+		got, ok := matchRef(refs, c.ref)
+		if ok != c.wantHit || got != c.want {
+			t.Errorf("matchRef(%q) = (%v,%v), want (%v,%v)", c.ref, got, ok, c.want, c.wantHit)
+		}
+	}
+}
+
+// --- countTreeFiles: counts files, skips .git ---
+
+func TestCountTreeFiles(t *testing.T) {
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dest, "a"), []byte("123"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dest, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "sub", "b"), []byte("45"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// .git contents must be skipped.
+	if err := os.MkdirAll(filepath.Join(dest, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, ".git", "HEAD"), []byte("ref: x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	n, bytes, err := countTreeFiles(dest)
+	if err != nil {
+		t.Fatalf("countTreeFiles: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("file count = %d, want 2 (.git skipped)", n)
+	}
+	if bytes != 5 {
+		t.Errorf("total bytes = %d, want 5 (3 + 2)", bytes)
+	}
+}
+
+// --- relPathForKey: S3-key → relative path with traversal refusal ---
+
+func TestRelPathForKey(t *testing.T) {
+	// Valid: key under prefix maps to the relative tail.
+	if rel, err := relPathForKey("p/", "p/sub/file"); err != nil || rel != "sub/file" {
+		t.Errorf("relPathForKey valid = (%q,%v), want (sub/file, nil)", rel, err)
+	}
+	bad := []struct {
+		prefix, key string
+		sentinel    error
+	}{
+		{"p/", "other/file", ErrInvalidConfig},      // key not under prefix
+		{"p/", "p/", ErrInvalidConfig},              // key == prefix (no tail)
+		{"p/", "p/a\x00b", ErrUnsafeDestination},    // NUL
+		{"p/", "p/../escape", ErrUnsafeDestination}, // traversal component
+		{"p/", "p/sub/../../escape", ErrUnsafeDestination},
+	}
+	for _, c := range bad {
+		if _, err := relPathForKey(c.prefix, c.key); !errors.Is(err, c.sentinel) {
+			t.Errorf("relPathForKey(%q,%q) err = %v; want %v", c.prefix, c.key, err, c.sentinel)
+		}
+	}
+}
+
+// --- assertWithinDest: post-join containment check ---
+
+func TestAssertWithinDest(t *testing.T) {
+	dest := t.TempDir()
+	if err := assertWithinDest(dest, filepath.Join(dest, "sub", "file")); err != nil {
+		t.Errorf("assertWithinDest(inside) = %v, want nil", err)
+	}
+	if err := assertWithinDest(dest, dest); err != nil {
+		t.Errorf("assertWithinDest(dest itself) = %v, want nil", err)
+	}
+	if err := assertWithinDest(dest, filepath.Dir(dest)+"/escape"); !errors.Is(err, ErrUnsafeDestination) {
+		t.Errorf("assertWithinDest(outside) = %v, want ErrUnsafeDestination", err)
+	}
+}

--- a/sys/remote/remote_transfer_test.go
+++ b/sys/remote/remote_transfer_test.go
@@ -1,0 +1,95 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- applyMode: no-op, valid mode, invalid mode ---
+
+func TestApplyMode(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "x")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No-op when nothing is requested.
+	if err := applyMode(f, "", "", ""); err != nil {
+		t.Errorf("applyMode(no-op) = %v, want nil", err)
+	}
+	// A valid octal mode is applied.
+	if err := applyMode(f, "0640", "", ""); err != nil {
+		t.Fatalf("applyMode(0640): %v", err)
+	}
+	if info, _ := os.Stat(f); info.Mode().Perm() != 0o640 {
+		t.Errorf("perm = %o, want 0640", info.Mode().Perm())
+	}
+	// An invalid mode string is rejected.
+	if err := applyMode(f, "not-octal", "", ""); err == nil {
+		t.Error("applyMode(invalid mode) = nil, want error")
+	}
+}
+
+// --- http Fetch: a non-2xx response is an error, not a silent empty file ---
+
+func TestHTTPFetch_Non2xx_Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	src, err := NewHTTP(HTTPConfig{URL: srv.URL + "/f"})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if _, err := src.Fetch(context.Background(), dest); err == nil {
+		t.Error("Fetch on a 503 returned nil error")
+	}
+	if _, statErr := os.Stat(dest); statErr == nil {
+		t.Error("Fetch on a 503 left a destination file behind")
+	}
+}
+
+// --- s3 Fetch error contract: 403 → ErrInvalidConfig (bucket-policy hint, from
+// the HEAD), other non-2xx → a plain error (from the GET). Both must surface,
+// never a silent empty file. ---
+
+func TestS3Fetch_ErrorStatuses(t *testing.T) {
+	cases := []struct {
+		code        int
+		wantInvalid bool // expect ErrInvalidConfig specifically
+	}{
+		{http.StatusForbidden, true}, // 403 → bucket-policy hint
+		{http.StatusNotFound, false}, // 404 → plain status error
+		{http.StatusInternalServerError, false},
+	}
+	for _, c := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(c.code)
+		}))
+		src, err := NewS3(S3Config{Endpoint: srv.URL, Bucket: "b", Key: "k"})
+		if err != nil {
+			srv.Close()
+			t.Fatalf("NewS3: %v", err)
+		}
+		dest := filepath.Join(t.TempDir(), "out")
+		_, ferr := src.Fetch(context.Background(), dest)
+		srv.Close()
+		if ferr == nil {
+			t.Errorf("S3 Fetch on %d returned nil error", c.code)
+			continue
+		}
+		if c.wantInvalid && !errors.Is(ferr, ErrInvalidConfig) {
+			t.Errorf("S3 Fetch on %d: err = %v, want ErrInvalidConfig", c.code, ferr)
+		}
+		if _, statErr := os.Stat(dest); statErr == nil {
+			t.Errorf("S3 Fetch on %d left a destination file behind", c.code)
+		}
+	}
+}


### PR DESCRIPTION
Refs #203. First pass of the `sys/remote` unit-coverage completion — concentrated on the **security-critical** branches.

Covered to ~completion: zip-slip/path-traversal guards (`safeJoinDest`, `relPathForKey`, `assertWithinDest`), `detectArchiveKind` matrix, digest happy+error, every `NewGit`/`NewS3` rejection branch, the two 0% functions (`String`/`Wipe`), `matchRef`, `applyMode` (incl. invalid-mode), http non-2xx, s3 403-vs-404/500.

**Honest residual** (follow-up): archive-extractor I/O-error branches (need a failure-injection seam), `chownNoFollow` owner path (root), and the go-git clone/fetch path (needs a git-http harness). `vet`/`race`/`gofmt` clean, no regressions.