### PR TITLE
test(remote): failure-mode coverage (git helpers, archive + write errors) (WS7b)

### DIFF
--- a/sys/remote/http_archive_errors_test.go
+++ b/sys/remote/http_archive_errors_test.go
@@ -1,0 +1,115 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fetchArchiveTo builds an Extract HTTP source over a fixture serving body with
+// contentType, fetches into a fresh dest, and returns the error.
+func fetchArchiveTo(t *testing.T, body []byte, contentType, urlPath string) error {
+	t.Helper()
+	fix := newArchiveFixture(t, body, contentType, urlPath, "")
+	src, err := NewHTTP(HTTPConfig{URL: fix.srv.URL + fix.urlPath, Extract: true})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	_, ferr := src.Fetch(context.Background(), dest)
+	return ferr
+}
+
+// TestArchive_CorruptBodies — a body that isn't a valid gzip/zip must surface a
+// decode error, never a partially-populated dest.
+func TestArchive_CorruptBodies(t *testing.T) {
+	if err := fetchArchiveTo(t, []byte("this is not gzip"), "application/gzip", "/x.tar.gz"); err == nil {
+		t.Error("corrupt gzip body returned nil error")
+	}
+	if err := fetchArchiveTo(t, []byte("this is not a zip"), "application/zip", "/x.zip"); err == nil {
+		t.Error("corrupt zip body returned nil error")
+	}
+}
+
+// TestArchive_FileDirConflict — a tar that declares a regular file "a" and then
+// an entry "a/b" forces a real mkdir/create failure (the parent "a" is a file),
+// exercising the extractor's mid-extract I/O error path. Belt-and-braces: a
+// malformed archive must fail cleanly, not panic or half-write.
+func TestArchive_FileDirConflict(t *testing.T) {
+	body := buildTarGz(t, []archiveEntry{
+		{name: "a", body: "i am a file"},
+		{name: "a/b", body: "cannot live under a file"},
+	})
+	if err := fetchArchiveTo(t, body, "application/gzip", "/x.tar.gz"); err == nil {
+		t.Error("tar with a file/dir path conflict returned nil error")
+	}
+}
+
+// TestArchive_Non2xx — openArchiveBody must turn a non-2xx into an error.
+func TestArchive_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	src, err := NewHTTP(HTTPConfig{URL: srv.URL + "/x.tar.gz", Extract: true})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	if _, ferr := src.Fetch(context.Background(), filepath.Join(t.TempDir(), "out")); ferr == nil {
+		t.Error("archive Fetch on a 502 returned nil error")
+	}
+}
+
+// TestChownNoFollow_ErrorBranches walks every inode-type branch of chownNoFollow.
+// Run as non-root, chown(0,0) fails with EPERM on each, which still executes the
+// directory / regular-file / symlink / missing-target code paths (belt-and-
+// braces: the privileged path must fail closed, not silently no-op).
+func TestChownNoFollow_ErrorBranches(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chown(0,0) succeeds, so the error branches don't trigger")
+	}
+	dir := t.TempDir()
+
+	regular := filepath.Join(dir, "file")
+	if err := os.WriteFile(regular, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(dir, "d")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(regular, link); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, target := range map[string]string{
+		"regular-file": regular,
+		"directory":    subdir,
+		"symlink":      link,
+		"missing":      filepath.Join(dir, "nope"),
+	} {
+		if err := chownNoFollow(target, 0, 0); err == nil {
+			t.Errorf("chownNoFollow(%s) = nil; want a permission/refusal error as non-root", name)
+		}
+	}
+}
+
+// TestApplyMode_OwnerPath — applyMode with an owner reaches ResolveOwnership +
+// chownNoFollow; as non-root the chown fails, exercising the owner branch.
+func TestApplyMode_OwnerPath(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chown succeeds")
+	}
+	f := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyMode(f, "", "root", ""); err == nil {
+		t.Error("applyMode(owner=root) as non-root returned nil; want an ownership error")
+	}
+}

--- a/sys/remote/vc_gogit_inprocess_test.go
+++ b/sys/remote/vc_gogit_inprocess_test.go
@@ -1,0 +1,121 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// initRepoWithCommit creates a real git repo at dir with one committed file and
+// returns the repo, its worktree, and the commit hash. Pure in-process go-git —
+// no network, no git binary.
+func initRepoWithCommit(t *testing.T, dir string) (*gogit.Repository, *gogit.Worktree, plumbing.Hash) {
+	t.Helper()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tracked"), []byte("t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("tracked"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	h, err := wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@e", When: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return repo, wt, h
+}
+
+func TestResolveTargetHash(t *testing.T) {
+	dir := t.TempDir()
+	repo, _, h := initRepoWithCommit(t, dir)
+
+	branch, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if _, err := repo.CreateTag("v1", h, nil); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+
+	// Branch name (refs/heads/<branch>).
+	if got, err := resolveTargetHash(repo, branch.Name().Short()); err != nil || got != h {
+		t.Errorf("resolveTargetHash(branch) = (%v,%v), want (%v,nil)", got, err, h)
+	}
+	// Tag name (refs/tags/v1).
+	if got, err := resolveTargetHash(repo, "v1"); err != nil || got != h {
+		t.Errorf("resolveTargetHash(tag) = (%v,%v), want (%v,nil)", got, err, h)
+	}
+	// Raw SHA fallback.
+	if got, err := resolveTargetHash(repo, h.String()); err != nil || got != h {
+		t.Errorf("resolveTargetHash(sha) = (%v,%v), want (%v,nil)", got, err, h)
+	}
+	// Not found → ErrInvalidConfig.
+	if _, err := resolveTargetHash(repo, "no-such-ref"); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("resolveTargetHash(missing) err = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestSnapshotRestoreUntracked(t *testing.T) {
+	dir := t.TempDir()
+	_, wt, _ := initRepoWithCommit(t, dir)
+
+	// Two untracked files (one nested).
+	if err := os.WriteFile(filepath.Join(dir, "u1"), []byte("keep1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "u2"), []byte("keep2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := snapshotUntracked(dir, wt)
+	if err != nil {
+		t.Fatalf("snapshotUntracked: %v", err)
+	}
+	if len(snap) < 2 {
+		t.Fatalf("snapshot captured %d untracked files, want >= 2", len(snap))
+	}
+
+	// Simulate a checkout blowing them away, then restore.
+	_ = os.Remove(filepath.Join(dir, "u1"))
+	_ = os.RemoveAll(filepath.Join(dir, "sub"))
+	if err := restoreUntracked(dir, snap); err != nil {
+		t.Fatalf("restoreUntracked: %v", err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dir, "u1")); string(b) != "keep1" {
+		t.Errorf("u1 not restored: %q", b)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dir, "sub", "u2")); string(b) != "keep2" {
+		t.Errorf("sub/u2 not restored: %q", b)
+	}
+}
+
+// TestResolve_LsRemoteError covers the Resolve error path: an unreachable
+// endpoint makes the in-memory ls-remote fail. (The success path needs a live
+// git remote — covered by the container/integration tier, not here.)
+func TestResolve_LsRemoteError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := goGitBackend{}.Resolve(ctx, GitConfig{URL: "https://127.0.0.1:1/nope.git", Ref: "main"})
+	if err == nil {
+		t.Error("Resolve against an unreachable endpoint returned nil error")
+	}
+}

--- a/sys/remote/write_errors_test.go
+++ b/sys/remote/write_errors_test.go
@@ -1,0 +1,74 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A read-only destination directory forces the create/mkdir/rename failure
+// branches of the streaming writers without instrumenting production code — the
+// "belt and braces" failure modes: a write that can't land must surface an
+// error, never silently succeed or leave a partial file. Skipped as root (which
+// bypasses the permission bits).
+
+func TestHTTPFetch_WriteIntoReadOnlyDir_Errors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	ro := t.TempDir()
+	if err := os.Chmod(ro, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ro, 0o700) })
+
+	fix := newHTTPFixture(t, []byte("payload"), "etag-1")
+	src, err := NewHTTP(HTTPConfig{URL: fix.srv.URL})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	// dest under a subdir that can't be created (parent is read-only).
+	if _, ferr := src.Fetch(context.Background(), filepath.Join(ro, "sub", "out")); ferr == nil {
+		t.Error("Fetch into a read-only dir returned nil error")
+	}
+}
+
+func TestS3Fetch_WriteIntoReadOnlyDir_Errors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	ro := t.TempDir()
+	if err := os.Chmod(ro, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ro, 0o700) })
+
+	fix := newS3Fixture(t, "bucket", "key", []byte("payload"), "etag-1")
+	src, err := NewS3(S3Config{Endpoint: fix.srv.URL, Bucket: "bucket", Key: "key"})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	if _, ferr := src.Fetch(context.Background(), filepath.Join(ro, "sub", "out")); ferr == nil {
+		t.Error("S3 Fetch into a read-only dir returned nil error")
+	}
+}
+
+// TestRestoreUntracked_WriteError — restoring an untracked snapshot into a
+// read-only tree must fail (the file would otherwise be silently lost on a
+// checkout).
+func TestRestoreUntracked_WriteError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	ro := t.TempDir()
+	if err := os.Chmod(ro, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ro, 0o700) })
+
+	snap := []untrackedFile{{relPath: "sub/u", body: []byte("x"), mode: 0o600}}
+	if err := restoreUntracked(ro, snap); err == nil {
+		t.Error("restoreUntracked into a read-only dir returned nil error")
+	}
+}


### PR DESCRIPTION
Refs #203. Belt-and-braces continuation of `sys/remote` coverage: **81.5%** (from 76.4% pre-WS7), covering the failure modes forceable without production seams or a git server.

- **git helpers in-process** (go-git `PlainInit`, no network): `resolveTargetHash`, `snapshotUntracked`/`restoreUntracked`, `Resolve` error path.
- **archive failure modes**: corrupt gzip/zip, a tar file/dir path conflict (mid-extract mkdir failure), `openArchiveBody` non-2xx.
- **chownNoFollow** every inode branch + `applyMode` owner path.
- **streaming write failures**: http/s3 Fetch + `restoreUntracked` into a read-only dest must error, never half-write.

**Honest residual** (follow-up on #203): git clone/fetch over HTTPS (needs a git-https harness) + a few deep I/O lines that need production package-var seams. `race -short`/`vet`/`gofmt` clean.