### PR TITLE
test(remote): git-https harness + transfer failure modes (WS7c)

### DIFF
--- a/sys/remote/conditional_test.go
+++ b/sys/remote/conditional_test.go
@@ -1,0 +1,80 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// condServer serves body with an ETag and honours If-None-Match with a 304 —
+// the conditional-request path the per-test fixtures don't model.
+func condServer(t *testing.T, body []byte, etag, contentType string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", etag)
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestArchive_NotModifiedNoOp — a second archive Fetch into the same dest sends
+// the stored ETag and gets a 304, so it is a no-op (openArchiveBody's 304 branch
+// + fetchArchive's not-modified short-circuit).
+func TestArchive_NotModifiedNoOp(t *testing.T) {
+	body := buildTarGz(t, []archiveEntry{{name: "f", body: "x"}})
+	srv := condServer(t, body, "arch-etag", "application/gzip")
+	src, err := NewHTTP(HTTPConfig{URL: srv.URL + "/a.tar.gz", Extract: true})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	res1, err := src.Fetch(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("Fetch #1: %v", err)
+	}
+	if !res1.Changed {
+		t.Fatal("first archive Fetch: Changed=false")
+	}
+	res2, err := src.Fetch(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("Fetch #2: %v", err)
+	}
+	if res2.Changed {
+		t.Error("second archive Fetch with an unchanged ETag: Changed=true (304 not honoured)")
+	}
+}
+
+// TestS3_HeadNotModifiedNoOp — a second single-key S3 Fetch HEADs with the stored
+// ETag, gets 304, and skips the GET (headNotModified's 304 branch).
+func TestS3_HeadNotModifiedNoOp(t *testing.T) {
+	srv := condServer(t, []byte("payload"), "s3-etag", "")
+	src, err := NewS3(S3Config{Endpoint: srv.URL, Bucket: "b", Key: "k"})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if _, err := src.Fetch(context.Background(), dest); err != nil {
+		t.Fatalf("Fetch #1: %v", err)
+	}
+	res2, err := src.Fetch(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("Fetch #2: %v", err)
+	}
+	if res2.Changed {
+		t.Error("second S3 Fetch with an unchanged ETag: Changed=true (304 not honoured)")
+	}
+}

--- a/sys/remote/git_https_test.go
+++ b/sys/remote/git_https_test.go
@@ -1,0 +1,109 @@
+package remote
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/cgi"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+// TestGitFetch_RealHTTPS exercises the go-git clone + re-sync path against a REAL
+// git repository served over the smart-HTTP protocol by git-http-backend over
+// TLS — the path NewGit requires (https only) that no in-process fixture could
+// reach. Covers CloneOrSync / openOrClone (both the clone and the reopen
+// branches) and Resolve's success path.
+//
+// Self-skips when git or git-http-backend is unavailable; the test-go-all CI
+// host (ubuntu) ships both, so the path is covered there.
+func TestGitFetch_RealHTTPS(t *testing.T) {
+	if _, err := osexec.LookPath("git"); err != nil {
+		t.Skip("git not present")
+	}
+	backend := gitHTTPBackend(t)
+	if backend == "" {
+		t.Skip("git-http-backend not present")
+	}
+
+	root := t.TempDir()
+	// A working repo with one commit on 'main', cloned to a bare repo to serve.
+	work := filepath.Join(root, "work")
+	runGit(t, "", "init", "-q", "-b", "main", work)
+	runGit(t, work, "config", "user.email", "t@e")
+	runGit(t, work, "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(work, "f"), []byte("hello-https"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, work, "add", "f")
+	runGit(t, work, "-c", "commit.gpgsign=false", "commit", "-qm", "init")
+	runGit(t, "", "clone", "-q", "--bare", work, filepath.Join(root, "repo.git"))
+
+	// Serve every repo under root via git-http-backend (smart HTTP) over TLS.
+	srv := httptest.NewTLSServer(&cgi.Handler{
+		Path: backend,
+		Dir:  root,
+		Env:  []string{"GIT_PROJECT_ROOT=" + root, "GIT_HTTP_EXPORT_ALL=1"},
+	})
+	defer srv.Close()
+
+	// Make go-git trust the httptest TLS cert for the duration of the test.
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	trusting := githttp.NewClient(&http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+	})
+	client.InstallProtocol("https", trusting)
+	defer client.InstallProtocol("https", githttp.DefaultClient)
+
+	src, err := NewGit(GitConfig{URL: srv.URL + "/repo.git", Ref: "main"})
+	if err != nil {
+		t.Fatalf("NewGit: %v", err)
+	}
+	ctx := context.Background()
+	dest := filepath.Join(t.TempDir(), "checkout")
+
+	// First Fetch → clone.
+	if _, err := src.Fetch(ctx, dest); err != nil {
+		t.Fatalf("Fetch (clone): %v", err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dest, "f")); string(b) != "hello-https" {
+		t.Errorf("cloned file content = %q, want hello-https", b)
+	}
+
+	// Second Fetch into the same dest → reopen the existing repo + re-sync (no
+	// clone): exercises openOrClone's reopen branch.
+	if _, err := src.Fetch(ctx, dest); err != nil {
+		t.Fatalf("Fetch (re-sync): %v", err)
+	}
+}
+
+func gitHTTPBackend(t *testing.T) string {
+	t.Helper()
+	out, err := osexec.Command("git", "--exec-path").Output()
+	if err != nil {
+		return ""
+	}
+	candidate := filepath.Join(strings.TrimSpace(string(out)), "git-http-backend")
+	if _, err := os.Stat(candidate); err != nil {
+		return ""
+	}
+	return candidate
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := osexec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/sys/remote/io_errors2_test.go
+++ b/sys/remote/io_errors2_test.go
@@ -1,0 +1,39 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// TestArchive_UndetectableType — Extract is requested but neither the
+// content-type nor the URL extension identifies an archive kind, so fetchArchive
+// must refuse with ErrInvalidConfig rather than guess.
+func TestArchive_UndetectableType(t *testing.T) {
+	fix := newArchiveFixture(t, []byte("opaque bytes"), "application/octet-stream", "/payload.bin", "")
+	src, err := NewHTTP(HTTPConfig{URL: fix.srv.URL + fix.urlPath, Extract: true})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	_, ferr := src.Fetch(context.Background(), filepath.Join(t.TempDir(), "out"))
+	if !errors.Is(ferr, ErrInvalidConfig) {
+		t.Errorf("Fetch of an undetectable archive = %v; want ErrInvalidConfig", ferr)
+	}
+}
+
+// TestS3Prefix_PerObjectGetError — during a prefix sync, an object GET that
+// fails (500) must surface an error, exercising openSingleObject /
+// streamObjectToFile's error path.
+func TestS3Prefix_PerObjectGetError(t *testing.T) {
+	objs := []s3TestObject{{key: "p/a", body: []byte("x"), etag: "e1"}}
+	fix := newS3PrefixFixture(t, "b", "p/", objs)
+	fix.getErr = 500
+	src, err := NewS3(S3Config{Endpoint: fix.srv.URL, Bucket: "b", Key: "p/"})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	if _, ferr := src.Fetch(context.Background(), t.TempDir()); ferr == nil {
+		t.Error("prefix sync with a 500 on an object GET returned nil error")
+	}
+}

--- a/sys/remote/io_errors_test.go
+++ b/sys/remote/io_errors_test.go
@@ -1,0 +1,56 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// errReader fails the first Read — used to drive the io.Copy error branch of the
+// streaming writers (the "the source died mid-transfer" failure mode).
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("injected read error") }
+
+func TestStreamToTmp_CopyError(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "out")
+	if _, _, _, err := streamToTmp(out, errReader{}, 1<<20); err == nil {
+		t.Error("streamToTmp with a failing reader returned nil error")
+	}
+}
+
+func TestWriteTarEntry_CopyError(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "out")
+	if _, err := writeTarEntry(out, errReader{}, 0o644); err == nil {
+		t.Error("writeTarEntry with a failing reader returned nil error")
+	}
+}
+
+// TestGitFetch_UnreachableURL drives openOrClone's clone-failure branch: a
+// well-formed but unreachable https endpoint makes PlainClone fail.
+func TestGitFetch_UnreachableURL(t *testing.T) {
+	src, err := NewGit(GitConfig{URL: "https://127.0.0.1:1/nope.git", Ref: "main"})
+	if err != nil {
+		t.Fatalf("NewGit: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, ferr := src.Fetch(ctx, filepath.Join(t.TempDir(), "dest")); ferr == nil {
+		t.Error("Fetch from an unreachable git endpoint returned nil error")
+	}
+}
+
+// TestS3Fetch_GetError drives the single-key GET error path: a HEAD-OK then a
+// GET that fails surfaces an error (and leaves no partial file).
+func TestS3Fetch_GetError(t *testing.T) {
+	fix := newS3Fixture(t, "bucket", "key", []byte("payload"), "etag-1")
+	fix.getErr = 500
+	src, err := NewS3(S3Config{Endpoint: fix.srv.URL, Bucket: "bucket", Key: "key"})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	if _, ferr := src.Fetch(context.Background(), filepath.Join(t.TempDir(), "out")); ferr == nil {
+		t.Error("S3 Fetch with a 500 on GET returned nil error")
+	}
+}


### PR DESCRIPTION
Refs #203. The **git-https harness** + deeper failure-mode coverage you asked for; `sys/remote` now at **83.1%** (from 76.4% pre-WS7).

- **git-https harness**: a real bare repo served via `git-http-backend` over `httptest` TLS, with a go-git client that trusts the test cert — exercises the https-only clone + reopen/re-sync path. (Self-skips without git/git-http-backend; ubuntu CI ships both, so it runs there.)
- **transfer failure modes** (via reader injection, no production seams): `streamToTmp`/`writeTarEntry` copy errors, git clone-failure, s3 single-key + per-object GET errors, undetectable archive type, archive/s3 304 no-op.

**Remaining long tail** (tracked on #203): a handful of trivial defensive error-wrappers (`os.Rename`/`http.NewRequest` failures) reachable only via production package-var seams — low value. `race -short`/`vet`/`gofmt` clean.