### PR TITLE
test(timesync,log): activate against real systemd (WS8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,7 +233,8 @@ jobs:
             runuser -u power-manage -- env LANG=ja_JP.UTF-8 LC_ALL=ja_JP.UTF-8 \
               /usr/local/go/bin/go test \
               -v -tags=integration -count=1 -timeout=10m \
-              ./sdk/sys/exec/ ./sdk/sys/fs/ ./sdk/sys/user/ ./sdk/sys/service/
+              ./sdk/sys/exec/ ./sdk/sys/fs/ ./sdk/sys/user/ ./sdk/sys/service/ \
+              ./sdk/sys/timesync/ ./sdk/sys/log/
 
       - name: Cleanup
         if: always()

--- a/sys/log/integration_test.go
+++ b/sys/log/integration_test.go
@@ -4,6 +4,7 @@ package log_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -11,8 +12,15 @@ import (
 	syslog "github.com/manchtools/power-manage-sdk/sys/log"
 )
 
-// READ-ONLY: Detect + a small real Query against journald if present. Skips when
-// the tool/privilege is unavailable (common in unprivileged CI).
+func systemdRunning() bool {
+	_, err := os.Stat("/run/systemd/system")
+	return err == nil
+}
+
+// READ-ONLY: Detect + a small real Query against journald. Under a real systemd
+// (the test-sys container, where power-manage is in the systemd-journal group)
+// the Query MUST succeed and return real journal lines — the drift guard against
+// a journalctl output change. Elsewhere it skips gracefully.
 func TestQuery_Integration(t *testing.T) {
 	for _, b := range syslog.Detect(context.Background()) {
 		if b != syslog.Journald && b != syslog.Syslog {
@@ -30,7 +38,18 @@ func TestQuery_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := s.Query(context.Background(), syslog.Query{Lines: 5}); err != nil {
+	lines, err := s.Query(context.Background(), syslog.Query{Lines: 5})
+	if systemdRunning() {
+		if err != nil {
+			t.Fatalf("journalctl Query under systemd: %v", err)
+		}
+		if len(lines) == 0 {
+			t.Fatal("journalctl returned no lines under systemd (journal-group access missing, or empty journal)")
+		}
+		t.Logf("journalctl returned %d line(s)", len(lines))
+		return
+	}
+	if err != nil {
 		t.Skipf("journalctl read unusable here (no privilege/journal): %v", err)
 	}
 }

--- a/sys/timesync/integration_test.go
+++ b/sys/timesync/integration_test.go
@@ -4,14 +4,24 @@ package timesync_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 	"github.com/manchtools/power-manage-sdk/sys/timesync"
 )
 
+// systemdRunning reports whether systemd is PID 1 (so timedatectl can reach
+// timedated). /run/systemd/system exists exactly then.
+func systemdRunning() bool {
+	_, err := os.Stat("/run/systemd/system")
+	return err == nil
+}
+
 // READ-ONLY: Detect + a real Status read from whichever backend is present.
-// `timedatectl show` and `chronyc tracking` are both unprivileged.
+// `timedatectl show` and `chronyc tracking` are both unprivileged. Under a real
+// systemd (the test-sys container) the Timedatectl read MUST succeed and parse —
+// that is the drift guard against a `timedatectl show` output-format change.
 func TestStatus_Integration(t *testing.T) {
 	backends := timesync.Detect(context.Background())
 	if len(backends) == 0 {
@@ -26,8 +36,17 @@ func TestStatus_Integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("New(%v): %v", b, err)
 		}
-		if _, err := m.Status(context.Background()); err != nil {
-			// chronyc present but daemon not running, etc. — informative, not fatal.
+		status, err := m.Status(context.Background())
+		switch {
+		case b == timesync.Timedatectl && systemdRunning():
+			// Hard assertion: real timedatectl under systemd must parse cleanly.
+			if err != nil {
+				t.Fatalf("Timedatectl Status under systemd: %v", err)
+			}
+			t.Logf("Timedatectl Status = %+v", status)
+		case err != nil:
+			// e.g. chronyc present but chronyd not running, or no systemd —
+			// informative, not fatal.
 			t.Logf("Status(%v): %v", b, err)
 		}
 	}

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -17,10 +17,13 @@ RUN apt-get update && apt-get install -y \
 # LC_ALL=C (via Command.CLocale) fails here. ja_JP/zh_CN translate the strings
 # the SDK parses (e.g. cat's "No such file or directory").
 
-# Create power-manage user (matches production setup)
+# Create power-manage user (matches production setup). Add it to systemd-journal
+# so the sys/log integration test can read the real system journal via journalctl
+# (a non-member only sees its own, empty, user journal).
 RUN useradd --system --no-create-home --shell /usr/sbin/nologin power-manage && \
     mkdir -p /home/power-manage && \
-    chown power-manage:power-manage /home/power-manage
+    chown power-manage:power-manage /home/power-manage && \
+    usermod -aG systemd-journal power-manage
 
 # sshd host keys (needed for systemd tests that reference ssh.service)
 RUN ssh-keygen -A


### PR DESCRIPTION
Closes #207. Activates the dormant systemd-cluster integration tests + makes them assert, in the existing systemd-PID1 container.

- **sys/timesync**: real `timedatectl show` must parse cleanly (gated on /run/systemd/system).
- **sys/log**: `journalctl` must return real journal lines — added `power-manage` to the `systemd-journal` group in Dockerfile.integration.
- Wired `./sys/timesync/` + `./sys/log/` into the test-sys job (power-manage, ja_JP locale).

Verified locally in the systemd container: timedatectl parses, journalctl returns 5 lines. **dns deferred** (resolvectl/systemd-resolved not in the image). Normal suite unaffected (tests are `//go:build integration`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Expanded CI integration test coverage to include log and time synchronization modules
* Enhanced integration tests with systemd detection to handle both systemd-enabled and non-systemd environments
* Improved conditional test assertions and error handling based on system configuration

## Chores
* Updated Docker integration test environment configuration to add test user to systemd-journal group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->