### PR TITLE
test(dns): exercise Resolved backend Apply against real systemd-resolved

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
               /usr/local/go/bin/go test \
               -v -tags=integration -count=1 -timeout=10m \
               ./sdk/sys/exec/ ./sdk/sys/fs/ ./sdk/sys/user/ ./sdk/sys/service/ \
-              ./sdk/sys/timesync/ ./sdk/sys/log/
+              ./sdk/sys/timesync/ ./sdk/sys/log/ ./sdk/sys/dns/
 
       - name: Cleanup
         if: always()

--- a/sys/dns/integration_test.go
+++ b/sys/dns/integration_test.go
@@ -4,59 +4,212 @@ package dns_test
 
 import (
 	"context"
-	"os/exec"
+	"os"
+	osexec "os/exec"
+	"slices"
 	"testing"
 
 	"github.com/manchtools/power-manage-sdk/sys/dns"
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
-// These are READ-ONLY integration checks: they never call Apply (which would
-// rewrite the host's real DNS). They assert Detect reflects the host and that
-// the Resolved/NetworkManager Get path parses real resolver files without error.
+// systemdRunning reports whether systemd is PID 1 (so resolvectl/systemctl can
+// reach the running systemd-resolved). /run/systemd/system exists exactly then.
+func systemdRunning() bool {
+	_, err := os.Stat("/run/systemd/system")
+	return err == nil
+}
 
+// resolvedActive reports whether systemd-resolved is the live resolver: its
+// generated uplink resolv.conf exists and resolvectl is on PATH. Under the
+// test-sys systemd container both hold (the unit is enabled in the image), so
+// the Apply round-trip below is a HARD assertion there; elsewhere it skips.
+func resolvedActive() bool {
+	if _, err := osexec.LookPath("resolvectl"); err != nil {
+		return false
+	}
+	_, err := os.Stat("/run/systemd/resolve/resolv.conf")
+	return err == nil
+}
+
+// TestDetect_Integration: Detect must only ever return implemented backends, and
+// under the test-sys container (resolvectl installed) it must report Resolved.
 func TestDetect_Integration(t *testing.T) {
-	for _, b := range dns.Detect(context.Background()) {
+	backends := dns.Detect(context.Background())
+	for _, b := range backends {
 		if b != dns.Resolved && b != dns.NetworkManager {
 			t.Errorf("Detect returned an unexpected backend %v", b)
 		}
 	}
+	if _, err := osexec.LookPath("resolvectl"); err == nil {
+		if !slices.Contains(backends, dns.Resolved) {
+			t.Errorf("resolvectl on PATH but Detect did not report Resolved: %v", backends)
+		}
+	}
 }
 
+// TestResolvedGet_Integration reads the real systemd-resolved resolv.conf and
+// asserts it parses into a well-formed State. Under the systemd container this
+// MUST succeed (the unit is enabled); elsewhere it skips.
 func TestResolvedGet_Integration(t *testing.T) {
-	if _, err := exec.LookPath("resolvectl"); err != nil {
-		t.Skip("resolvectl not present; Resolved backend not exercisable here")
+	if !resolvedActive() {
+		t.Skip("systemd-resolved not active here; Resolved Get not exercisable")
 	}
-	r, err := pmexec.NewRunner(pmexec.Direct)
+	m := newResolved(t)
+	if _, err := m.Get(context.Background()); err != nil {
+		t.Fatalf("Get against real systemd-resolved resolv.conf: %v", err)
+	}
+}
+
+// TestResolvedApply_Global_Integration is the high-value drift guard: it drives
+// the real global Apply path end-to-end — render the managed resolved.conf.d
+// drop-in, write it through escalated fs ops, `systemctl restart systemd-resolved`
+// — then reads back the regenerated /run/systemd/resolve/resolv.conf and asserts
+// the applied nameservers and search domain round-trip through real resolved.
+//
+// This pins two contracts at once against the live tool: (1) the drop-in format
+// the SDK emits is still accepted by systemd-resolved, and (2) resolved's
+// generated resolv.conf is still the shape parseResolvConf reads. A format change
+// in either direction fails here.
+func TestResolvedApply_Global_Integration(t *testing.T) {
+	if !systemdRunning() || !resolvedActive() {
+		t.Skip("requires a live systemd + systemd-resolved (test-sys container)")
+	}
+	m := newResolved(t)
+	ctx := context.Background()
+
+	// TEST-NET-1 (RFC 5737) / documentation-range (RFC 3849) addresses: valid IP
+	// literals that are guaranteed not to be real resolvers, so a leftover can
+	// never silently exfiltrate or hijack lookups.
+	const wantV4 = "192.0.2.53"
+	const wantV6 = "2001:db8::53"
+	const wantDomain = "corp.example"
+
+	// Restore baseline: remove the managed drop-in and restart resolved so the
+	// container's DNS is not left pinned at the dead TEST-NET resolver for any
+	// later test sharing this container.
+	t.Cleanup(func() { restoreResolved(t) })
+
+	if err := m.Apply(ctx, dns.Config{
+		Nameservers:   []string{wantV4, wantV6},
+		SearchDomains: []string{wantDomain},
+	}); err != nil {
+		t.Fatalf("Apply(global) against real systemd-resolved: %v", err)
+	}
+
+	st, err := m.Get(ctx)
 	if err != nil {
-		t.Fatalf("NewRunner: %v", err)
+		t.Fatalf("Get after Apply: %v", err)
+	}
+	if !slices.Contains(st.Nameservers, wantV4) {
+		t.Errorf("applied nameserver %q not reflected in resolv.conf; got %v", wantV4, st.Nameservers)
+	}
+	if !slices.Contains(st.Nameservers, wantV6) {
+		t.Errorf("applied nameserver %q not reflected in resolv.conf; got %v", wantV6, st.Nameservers)
+	}
+	if !slices.Contains(st.SearchDomains, wantDomain) {
+		t.Errorf("applied search domain %q not reflected in resolv.conf; got %v", wantDomain, st.SearchDomains)
+	}
+}
+
+// TestResolvedApply_PerLink_Integration drives the runtime per-link path
+// (`resolvectl dns <iface> -- <ns>`) against a real interface. resolved tracks
+// every kernel link, so on a normal container eth0 is configurable; where the
+// link is not resolvable by resolved (minimal/edge netns) the tool rejects it
+// and we skip — the global path above is the load-bearing assertion.
+func TestResolvedApply_PerLink_Integration(t *testing.T) {
+	if !systemdRunning() || !resolvedActive() {
+		t.Skip("requires a live systemd + systemd-resolved (test-sys container)")
+	}
+	iface := firstRealLink(t)
+	if iface == "" {
+		t.Skip("no non-loopback link to scope per-link DNS to")
+	}
+	m := newResolved(t)
+	// resolvectl dns sets a RUNTIME per-link resolver; revert it so the link is
+	// not left pointing at the dead TEST-NET address for the rest of the run.
+	t.Cleanup(func() { revertLink(t, iface) })
+	err := m.Apply(context.Background(), dns.Config{
+		Nameservers: []string{"192.0.2.53"},
+		Interface:   iface,
+	})
+	if err != nil {
+		// resolved declined to scope DNS to this link (link not managed in this
+		// netns); informative, not a drift failure.
+		t.Skipf("per-link resolvectl dns %s not applicable here: %v", iface, err)
+	}
+	t.Logf("per-link Apply on %s accepted by real resolvectl", iface)
+}
+
+func newResolved(t *testing.T) dns.Manager {
+	t.Helper()
+	// Sudo (not Direct): the test runs as the unprivileged power-manage user, so
+	// Apply's escalated mutations (mkdir/tee/chmod the root-owned drop-in,
+	// `systemctl restart`, `resolvectl`) must go through `sudo -n`. This exercises
+	// the exact escalation seam production uses (where the agent runs as root and
+	// Direct is a no-op wrapper) — the capability code is escalation-agnostic.
+	r, err := pmexec.NewRunner(pmexec.Sudo)
+	if err != nil {
+		t.Fatalf("NewRunner(Sudo): %v", err)
 	}
 	m, err := dns.New(dns.Resolved, r)
 	if err != nil {
 		t.Fatalf("New(Resolved): %v", err)
 	}
-	st, err := m.Get(context.Background())
-	if err != nil {
-		t.Skipf("no systemd-resolved resolv.conf to read on this host: %v", err)
-	}
-	// A successful read must parse into a well-formed State (no panic; the parse
-	// already ran). Nameservers may legitimately be empty on a minimal host.
-	_ = st
+	return m
 }
 
-func TestNMGet_Integration(t *testing.T) {
-	if _, err := exec.LookPath("nmcli"); err != nil {
-		t.Skip("nmcli not present; NetworkManager backend not exercisable here")
-	}
-	r, err := pmexec.NewRunner(pmexec.Direct)
+// restoreResolved removes the managed drop-in and restarts resolved, returning
+// the container to its baseline resolver config. Best-effort: failures here are
+// logged, not fatal, so they never mask the test's own verdict.
+func restoreResolved(t *testing.T) {
+	t.Helper()
+	r, err := pmexec.NewRunner(pmexec.Sudo)
 	if err != nil {
-		t.Fatalf("NewRunner: %v", err)
+		t.Logf("restore: NewRunner: %v", err)
+		return
 	}
-	m, err := dns.New(dns.NetworkManager, r)
+	ctx := context.Background()
+	if _, err := r.Run(ctx, pmexec.Command{
+		Name: "rm", Args: []string{"-f", "/etc/systemd/resolved.conf.d/10-power-manage.conf"}, Escalate: true,
+	}); err != nil {
+		t.Logf("restore: rm drop-in: %v", err)
+	}
+	if _, err := r.Run(ctx, pmexec.Command{
+		Name: "systemctl", Args: []string{"restart", "systemd-resolved"}, Escalate: true,
+	}); err != nil {
+		t.Logf("restore: restart resolved: %v", err)
+	}
+}
+
+// revertLink clears any runtime per-link resolver configuration on iface,
+// returning it to baseline. Best-effort: logged, never fatal.
+func revertLink(t *testing.T, iface string) {
+	t.Helper()
+	r, err := pmexec.NewRunner(pmexec.Sudo)
 	if err != nil {
-		t.Fatalf("New(NetworkManager): %v", err)
+		t.Logf("revert: NewRunner: %v", err)
+		return
 	}
-	if _, err := m.Get(context.Background()); err != nil {
-		t.Skipf("no /etc/resolv.conf to read on this host: %v", err)
+	if _, err := r.Run(context.Background(), pmexec.Command{
+		Name: "resolvectl", Args: []string{"revert", iface}, Escalate: true,
+	}); err != nil {
+		t.Logf("revert: resolvectl revert %s: %v", iface, err)
 	}
+}
+
+// firstRealLink returns the first non-loopback interface name from
+// /sys/class/net, or "" when only lo is present.
+func firstRealLink(t *testing.T) string {
+	t.Helper()
+	entries, err := os.ReadDir("/sys/class/net")
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if name := e.Name(); name != "lo" {
+			return name
+		}
+	}
+	return ""
 }

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -5,11 +5,21 @@ RUN apt-get update && apt-get install -y \
     openssh-server \
     systemd \
     systemd-sysv \
+    systemd-resolved \
     procps \
     locales \
     && sed -i 's/^# *ja_JP.UTF-8 UTF-8/ja_JP.UTF-8 UTF-8/; s/^# *zh_CN.UTF-8 UTF-8/zh_CN.UTF-8 UTF-8/' /etc/locale.gen \
     && locale-gen \
     && rm -rf /var/lib/apt/lists/*
+
+# Enable systemd-resolved so the sys/dns Resolved-backend integration test can
+# exercise the real Apply round-trip: write the managed resolved.conf.d drop-in,
+# restart the service, and read back the generated /run/systemd/resolve/resolv.conf.
+# `systemctl enable` works offline at build time (it only creates the wants/
+# symlinks); the unit actually starts when systemd boots as PID 1. Installing the
+# package also puts `resolvectl` on PATH, so dns.Detect reports the Resolved
+# backend in-container.
+RUN systemctl enable systemd-resolved
 
 # Non-English locales so the integration suite runs under a foreign locale (see
 # run-tests.sh / CI). Standing guard against locale-fragile parsing of tool
@@ -87,6 +97,8 @@ power-manage ALL=(root) NOPASSWD: /bin/sh *\n\
 power-manage ALL=(root) NOPASSWD: /usr/bin/sh *\n\
 power-manage ALL=(root) NOPASSWD: /usr/bin/test *\n\
 power-manage ALL=(root) NOPASSWD: /bin/test *\n\
+power-manage ALL=(root) NOPASSWD: /usr/bin/resolvectl *\n\
+power-manage ALL=(root) NOPASSWD: /bin/resolvectl *\n\
 ' > /etc/sudoers.d/power-manage && \
     chmod 0440 /etc/sudoers.d/power-manage && \
     visudo -c -f /etc/sudoers.d/power-manage


### PR DESCRIPTION
## What

Makes the `sys/dns` integration tests assertive against a **live systemd-resolved**, exercising the Resolved-backend mutation path (`Apply`) end-to-end — previously the tests were read-only (Detect + Get, skip-or-pass).

The high-value untested surface was the global `Apply` round-trip: render the managed `/etc/systemd/resolved.conf.d/10-power-manage.conf` drop-in → write it through escalated fs ops → `systemctl restart systemd-resolved` → the regenerated `/run/systemd/resolve/resolv.conf` must parse back with the applied config.

## How — reuses the existing systemd container (no purpose-built image)

- **`Dockerfile.integration`**: install + enable `systemd-resolved` (also puts `resolvectl` on PATH so `dns.Detect` reports Resolved in-container); allow `resolvectl` in the `power-manage` sudoers for the per-link path.
- **`integration_test.go`**:
  - `TestResolvedApply_Global_Integration` — the drift guard: applies TEST-NET-1/doc-range nameservers + a search domain, restarts resolved, asserts they round-trip through the regenerated resolv.conf. Self-restoring via `t.Cleanup` (rm drop-in + restart).
  - `TestResolvedApply_PerLink_Integration` — `resolvectl dns <iface>` against a real link, best-effort (skips if resolved won't scope the link), with a `resolvectl revert` cleanup.
  - `TestDetect/ResolvedGet` — hardened to assert (not just skip) under the systemd container.
  - Uses the **Sudo** runner: the test runs as the unprivileged `power-manage` user, so escalation goes through `sudo -n` — the exact seam production drives (where the agent is root and Direct is a no-op wrapper).
- **`test.yml`**: wire `./sys/dns/` into the `test-sys` integration job.

## Why it's a real assertion

A fresh container's baseline resolv.conf contains zero occurrences of `192.0.2.53`; the test only passes because `Apply` genuinely drove real resolved state. Verified locally in the systemd PID 1 container (full `test-sys` suite green, container left fully restored).

Pins that the drop-in format the SDK emits is still accepted by systemd-resolved and that resolved's generated resolv.conf is still the shape `parseResolvConf` reads — drift fails here.

Closes #209