### PR TITLE
test(osquery): real osqueryi coverage — fixes ListTables parser bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -296,6 +296,13 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/notify/
+          # Real `osqueryi --json` queries + the sensitive-table deny-list
+          # against the actual binary (pinned osquery .deb in the with-osquery
+          # stage).
+          - label: sys/osquery (debian/with-osquery)
+            distro: debian
+            state: with-osquery
+            path: ./sdk/sys/osquery/
     steps:
       - uses: actions/checkout@v5
         with:

--- a/sys/osquery/osquery.go
+++ b/sys/osquery/osquery.go
@@ -161,14 +161,19 @@ func (c *client) ListTables(ctx context.Context) ([]string, error) {
 	var tables []string
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		// Skip empty lines and header lines
-		if line == "" || strings.HasPrefix(line, "=>") || strings.HasPrefix(line, "+") {
+		if line == "" {
 			continue
 		}
-		// Remove leading "=>" if present
-		line = strings.TrimPrefix(line, "=> ")
-		if line != "" {
-			tables = append(tables, line)
+		// osqueryi `.tables` prints one table per line as "=> <name>" (with
+		// leading indentation, already trimmed above). The "=> " lines ARE the
+		// data; strip the marker and keep the name. Any line without the marker
+		// is decoration/noise and is ignored.
+		name, ok := strings.CutPrefix(line, "=>")
+		if !ok {
+			continue
+		}
+		if name = strings.TrimSpace(name); name != "" {
+			tables = append(tables, name)
 		}
 	}
 	return tables, nil

--- a/sys/osquery/osquery_container_test.go
+++ b/sys/osquery/osquery_container_test.go
@@ -1,0 +1,174 @@
+//go:build container
+
+// Container-based real-execution tests for the osquery Querier. The fake-runner
+// unit tests feed captured osqueryi JSON; these run real `osqueryi --json`
+// queries inside the container against the installed binary, so an osquery
+// output-format change (the []map[string]string JSON shape, the `.tables`
+// listing) is caught here. They also prove the security-critical sensitive-table
+// deny-list against the REAL binary: the table path refuses every deny-listed
+// table before exec, while the CA-signed RawSql escape hatch is intentionally
+// NOT gated and runs the same table.
+//
+// Runs in the container-tests lane (root), so the Runner is Direct: Escalate is
+// a no-op wrapper and osqueryi runs as the already-root process — the same shape
+// production drives when the agent is root.
+package osquery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func realQuerier(t *testing.T) Querier {
+	t.Helper()
+	r, err := exec.NewRunner(exec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	q, err := New(r)
+	if err != nil {
+		// In the with-osquery stage the binary is present (asserted at build
+		// time); anywhere else this capability is simply not exercisable.
+		t.Skipf("osquery not installed here: %v", err)
+	}
+	return q
+}
+
+func osqCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestQueryTable_OSVersion_Container runs a real `SELECT * FROM os_version` and
+// pins the JSON round-trip: osqueryi must return exactly one row whose `name`
+// column is populated. A change to osqueryi's --json shape breaks the
+// []map[string]string parse and fails here.
+func TestQueryTable_OSVersion_Container(t *testing.T) {
+	rows, err := realQuerier(t).QueryTable(osqCtx(t), "os_version")
+	if err != nil {
+		t.Fatalf("QueryTable(os_version): %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("os_version returned %d rows, want 1", len(rows))
+	}
+	if name := rows[0].Data["name"]; name == "" {
+		t.Errorf("os_version row missing/empty `name` column: %+v", rows[0].Data)
+	}
+}
+
+// TestIsInstalled_Container: the live re-probe must see the binary baked into the
+// image.
+func TestIsInstalled_Container(t *testing.T) {
+	if !realQuerier(t).IsInstalled(osqCtx(t)) {
+		t.Error("IsInstalled = false, but osqueryi is installed in this image")
+	}
+}
+
+// TestListTables_Container pins the `.tables` meta-command parse: the real
+// listing must decode into a non-empty slice that includes well-known core
+// tables. A format change to osqueryi's `.tables` output is caught here.
+func TestListTables_Container(t *testing.T) {
+	tables, err := realQuerier(t).ListTables(osqCtx(t))
+	if err != nil {
+		t.Fatalf("ListTables: %v", err)
+	}
+	if len(tables) == 0 {
+		t.Fatal("ListTables returned no tables from real osqueryi `.tables`")
+	}
+	for _, want := range []string{"os_version", "processes"} {
+		if !containsTable(tables, want) {
+			t.Errorf("ListTables missing core table %q; got %d tables", want, len(tables))
+		}
+	}
+}
+
+// TestDenyList_RefusedBeforeExec_Container is SELF-DISCOVERING: it iterates the
+// real sensitiveTables map (not a hardcoded copy), so a table added to the
+// deny-list is automatically covered. Each must be refused by BOTH the
+// QueryTable and Query table paths — and the refusal must be the policy error
+// ("not permitted"), distinguishable from a query-execution failure, proving the
+// gate fires BEFORE the binary is ever invoked.
+func TestDenyList_RefusedBeforeExec_Container(t *testing.T) {
+	q := realQuerier(t)
+	ctx := osqCtx(t)
+	if len(sensitiveTables) == 0 {
+		t.Fatal("sensitiveTables is empty — deny-list coverage would be vacuous")
+	}
+	for table := range sensitiveTables {
+		// QueryTable path: a Go error carrying the policy phrase.
+		_, err := q.QueryTable(ctx, table)
+		if err == nil {
+			t.Errorf("QueryTable(%q): expected refusal, got nil error", table)
+		} else if !strings.Contains(err.Error(), "not permitted") {
+			t.Errorf("QueryTable(%q): want a 'not permitted' refusal, got %v", table, err)
+		}
+		// Query path: refusal folded into the result, never executed.
+		res, err := q.Query(ctx, &pb.OSQuery{Table: table})
+		if err != nil {
+			t.Errorf("Query(%q): unexpected Go error: %v", table, err)
+		}
+		if res.GetSuccess() {
+			t.Errorf("Query(%q): expected Success=false (refused), got success", table)
+		}
+		if !strings.Contains(res.GetError(), "not permitted") {
+			t.Errorf("Query(%q): want a 'not permitted' refusal, got %q", table, res.GetError())
+		}
+	}
+}
+
+// TestRawSqlEscapeHatch_Container proves the documented asymmetry against the
+// real binary: the CA-signed RawSql path is NOT gated by the deny-list, so the
+// very same table the table path refuses (`shadow`) is queryable via RawSql. A
+// `count(*)` keeps password-hash material out of the test output while still
+// proving the query ran and returned structured rows.
+func TestRawSqlEscapeHatch_Container(t *testing.T) {
+	res, err := realQuerier(t).Query(osqCtx(t), &pb.OSQuery{
+		RawSql: "SELECT count(*) AS n FROM shadow",
+	})
+	if err != nil {
+		t.Fatalf("Query(RawSql shadow count): unexpected Go error: %v", err)
+	}
+	if !res.GetSuccess() {
+		t.Fatalf("RawSql against deny-listed `shadow` should bypass the gate and run; got error %q", res.GetError())
+	}
+	if len(res.GetRows()) != 1 {
+		t.Fatalf("count(*) returned %d rows, want 1", len(res.GetRows()))
+	}
+	if _, ok := res.GetRows()[0].Data["n"]; !ok {
+		t.Errorf("RawSql count row missing `n` column: %+v", res.GetRows()[0].Data)
+	}
+}
+
+// TestInvalidTableName_Container: a non-identifier table name is rejected on
+// shape (before exec) by both table paths against the real binary.
+func TestInvalidTableName_Container(t *testing.T) {
+	q := realQuerier(t)
+	ctx := osqCtx(t)
+	const bad = "os_version; DROP TABLE x"
+	if _, err := q.QueryTable(ctx, bad); err == nil || !strings.Contains(err.Error(), "invalid table name") {
+		t.Errorf("QueryTable(%q): want 'invalid table name', got %v", bad, err)
+	}
+	res, err := q.Query(ctx, &pb.OSQuery{Table: bad})
+	if err != nil {
+		t.Errorf("Query(%q): unexpected Go error: %v", bad, err)
+	}
+	if res.GetSuccess() || !strings.Contains(res.GetError(), "invalid table name") {
+		t.Errorf("Query(%q): want refused with 'invalid table name', got success=%v err=%q", bad, res.GetSuccess(), res.GetError())
+	}
+}
+
+func containsTable(tables []string, want string) bool {
+	for _, tbl := range tables {
+		if tbl == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sys/osquery/osquery_coverage_test.go
+++ b/sys/osquery/osquery_coverage_test.go
@@ -12,22 +12,31 @@ import (
 
 func TestListTables(t *testing.T) {
 	r := exectest.New(exec.Direct)
-	// Bare table names are kept; "=>"-prefixed lines, "+" header noise, and
-	// blanks are skipped.
-	r.Push(exec.Result{Stdout: "os_version\nuptime\n+ ignore me\n\n=> skip me\nsystem_info\n"}, nil)
+	// REAL `osqueryi .tables` format: one table per line as "  => <name>"
+	// (leading whitespace + "=> " prefix). The "=> " lines ARE the data — they
+	// are the table names, not noise to skip. Blank lines are ignored. This
+	// mirrors the captured real output the sys/osquery container test asserts
+	// live; an earlier fake fed bare names + treated "=>" lines as skippable,
+	// which inverted the contract and hid that the parser dropped every real
+	// table.
+	r.Push(exec.Result{Stdout: "  => os_version\n  => uptime\n\n  => system_info\n"}, nil)
 	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
 	tables, err := c.ListTables(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := map[string]bool{"os_version": true, "uptime": true, "system_info": true}
-	if len(tables) != 3 {
-		t.Fatalf("tables = %v, want 3 entries", tables)
+	if len(tables) != len(want) {
+		t.Fatalf("tables = %v, want %d entries", tables, len(want))
 	}
 	for _, tb := range tables {
 		if !want[tb] {
 			t.Errorf("unexpected table %q", tb)
 		}
+		delete(want, tb)
+	}
+	if len(want) != 0 {
+		t.Errorf("parser dropped tables: %v", want)
 	}
 	// `.tables` is a dot-command — passed bare, not via --json.
 	if argv := strings.Join(r.Calls()[0].Args, " "); argv != ".tables" {

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -51,3 +51,34 @@ RUN touch /var/lib/dpkg/lock \
           /var/cache/apt/archives/lock \
     && test -f /var/lib/dpkg/lock \
        || (echo "PRECONDITION FAILED: /var/lib/dpkg/lock not created" && exit 1)
+
+# with-osquery: the real osqueryi binary, installed from the upstream release
+# .deb (pinned for reproducibility — add a row with a different version to test
+# drift across osquery releases). osquery is NOT in the Debian archive, so it
+# gets its own stage instead of bloating `base` and every base-stage cell with
+# the ~30 MB binary + its build-time apt deps. The build-time `osqueryi
+# --version` asserts the binary is installed and runnable, so a bad URL / moved
+# install path fails the BUILD, not the container test (which would otherwise
+# New() -> ErrNotInstalled and skip).
+FROM base AS with-osquery
+# Pin the version AND its SHA-256 together — bump both in lockstep (the checksum
+# is version-specific, so a version bump without a matching checksum fails the
+# build, which is the intended fail-closed behaviour). osquery publishes no
+# checksums/signature asset, so this is pin-on-first-use over TLS-authenticated
+# github.com: it makes the build reproducible and tamper-evident — if the
+# release URL's content ever changes, `sha256sum -c` fails the build.
+ARG OSQUERY_VERSION=5.23.0
+ARG OSQUERY_SHA256=8938e83d71c6e668f24648b4fb612581db30f95cd31bf76a86c3ba4a6680a7dc
+RUN arch="$(dpkg --print-architecture)" \
+    && if [ "$arch" != "amd64" ]; then \
+         echo "with-osquery only pins an amd64 .deb; build arch is $arch" && exit 1; \
+       fi \
+    && apt-get update && apt-get install -y --no-install-recommends curl \
+    && curl -fsSL --max-time 300 -o /tmp/osquery.deb \
+       "https://github.com/osquery/osquery/releases/download/${OSQUERY_VERSION}/osquery_${OSQUERY_VERSION}-1.linux_amd64.deb" \
+    && echo "${OSQUERY_SHA256}  /tmp/osquery.deb" | sha256sum -c - \
+    && apt-get install -y --no-install-recommends /tmp/osquery.deb \
+    && rm -f /tmp/osquery.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && osqueryi --version \
+       || (echo "PRECONDITION FAILED: osqueryi not installed/runnable" && exit 1)


### PR DESCRIPTION
## What

Adds container-based real-execution coverage for `sys/osquery` (FakeRunner-only until now) and, in writing it, **fixes a real production bug the fake had masked**.

## The bug — ListTables dropped every real table

`osqueryi .tables` prints one table per line as `  => <name>`. The parser `TrimSpace`d each line to `=> <name>` and then `continue`d on `HasPrefix(line, "=>")` — skipping exactly the data lines. The `TrimPrefix(line, "=> ")` below it was dead code. So `ListTables` **always returned an empty slice against a real binary**.

The unit test hid it: it fed bare names and asserted `=>` lines were *skipped*, encoding the inverted contract (derived from the broken code, not the tool). Fixed red-green — the unit test now feeds the real `.tables` format and asserts no table is dropped (red against the old parser, green after).

## Real-system coverage (container lane, root → Direct)

- `Dockerfile.debian`: `with-osquery` stage — pinned osquery 5.23.0 `.deb` with a **SHA-256 pin** (pin-on-first-use over TLS github.com; fail-closed) and a build-time `osqueryi --version` precondition guard.
- `osquery_container_test.go` (`//go:build container`): real `QueryTable(os_version)` JSON round-trip; `ListTables` contains core tables; the sensitive-table **deny-list is self-discovering** over the real `sensitiveTables` map and refused before exec on both table paths; the CA-signed **RawSql escape hatch runs the same denied table** (`SELECT count(*) FROM shadow`) — proving the documented asymmetry against the real binary; invalid table name rejected on shape.
- `test.yml`: matrix row `sys/osquery (debian/with-osquery)`.

Verified locally: all 6 container tests green; checksum guard confirmed fail-closed (wrong SHA fails the build).

Closes #211