### PR TITLE
test(log): seed a real journal entry, assert Query{Grep} filters it — fixes 2 Query bugs

### DIFF
--- a/sys/log/backends_test.go
+++ b/sys/log/backends_test.go
@@ -86,6 +86,62 @@ func TestJournald_QueryRunError(t *testing.T) {
 	}
 }
 
+// journalctl prints status MARKERS wrapped in "-- ... --" on stdout (e.g.
+// "-- Boot <id> --", "-- No entries --", "-- Reboot --"). These are NOT log
+// entries and must not be returned as if they were — in the default short
+// output every real entry begins with a timestamp, so a "-- ... --" line is
+// always a marker.
+func TestJournald_QueryDropsStatusMarkers(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "-- Boot a1b2c3d4 --\n" +
+		"Jun 20 10:59:41 host app[1]: real one\n" +
+		"-- Reboot --\n" +
+		"Jun 20 10:59:42 host app[2]: -- not a marker, real two\n"}, nil)
+	s, _ := New(Journald, r)
+	got, err := s.Query(context.Background(), Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"Jun 20 10:59:41 host app[1]: real one",
+		"Jun 20 10:59:42 host app[2]: -- not a marker, real two",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("Query kept the wrong lines:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestJournald_QueryNoMatchReturnsEmpty(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "-- No entries --\n"}, nil)
+	s, _ := New(Journald, r)
+	got, err := s.Query(context.Background(), Query{Grep: "nope"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a no-match query must return zero entries, got %v", got)
+	}
+}
+
+// journalctl --grep exits 1 (grep-like) when nothing matches, writing only
+// "-- No entries --" to stdout and NOTHING to stderr. That is an empty result,
+// not a failure — a filter matching nothing must return [], not an error, so a
+// caller can tell "no logs matched" from "journalctl broke" (a real fault writes
+// a diagnostic to stderr; see TestJournald_QueryRunError).
+func TestJournald_QueryGrepNoMatchExit1IsEmpty(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{ExitCode: 1, Stdout: "-- No entries --\n", Stderr: ""}, nil)
+	s, _ := New(Journald, r)
+	got, err := s.Query(context.Background(), Query{Grep: "nope"})
+	if err != nil {
+		t.Fatalf("no-match (exit 1, empty stderr) must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("no-match must return zero entries, got %v", got)
+	}
+}
+
 // withSyslogFixture points syslogPaths + statFile at a fake existing file.
 func withSyslogFixture(t *testing.T, exists bool) {
 	t.Helper()

--- a/sys/log/integration_test.go
+++ b/sys/log/integration_test.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 	syslog "github.com/manchtools/power-manage-sdk/sys/log"
@@ -15,6 +18,19 @@ import (
 func systemdRunning() bool {
 	_, err := os.Stat("/run/systemd/system")
 	return err == nil
+}
+
+func newJournald(t *testing.T) syslog.Source {
+	t.Helper()
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	s, err := syslog.New(syslog.Journald, r)
+	if err != nil {
+		t.Fatalf("New(Journald): %v", err)
+	}
+	return s
 }
 
 // READ-ONLY: Detect + a small real Query against journald. Under a real systemd
@@ -30,14 +46,7 @@ func TestQuery_Integration(t *testing.T) {
 	if _, err := exec.LookPath("journalctl"); err != nil {
 		t.Skip("journalctl not present")
 	}
-	r, err := pmexec.NewRunner(pmexec.Direct)
-	if err != nil {
-		t.Fatalf("NewRunner: %v", err)
-	}
-	s, err := syslog.New(syslog.Journald, r)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	s := newJournald(t)
 	lines, err := s.Query(context.Background(), syslog.Query{Lines: 5})
 	if systemdRunning() {
 		if err != nil {
@@ -51,5 +60,76 @@ func TestQuery_Integration(t *testing.T) {
 	}
 	if err != nil {
 		t.Skipf("journalctl read unusable here (no privilege/journal): %v", err)
+	}
+}
+
+// TestQuery_GrepSeed_Integration is the FILTER drift guard: it seeds a uniquely
+// tagged entry into the real journal (`logger`), then drives the SDK's
+// Query{Grep} (real `journalctl --grep`) and asserts that exact entry comes
+// back. Unlike TestQuery_Integration (which only checks the journal is
+// non-empty), this proves the --grep filter path returns the matching content —
+// a change to journalctl's --grep semantics or output framing is caught here.
+func TestQuery_GrepSeed_Integration(t *testing.T) {
+	if !systemdRunning() {
+		t.Skip("no live systemd journal to seed (needs the test-sys container)")
+	}
+	if _, err := exec.LookPath("logger"); err != nil {
+		t.Skip("logger not present; cannot seed a journal entry")
+	}
+
+	// Unique per process so a re-run never matches a stale entry; PID needs no
+	// clock/random and is stable within one container run.
+	marker := "PM-LOG-SEED-" + strconv.Itoa(os.Getpid())
+	if out, err := exec.Command("logger", "-t", "pm-sdk-test", marker).CombinedOutput(); err != nil {
+		t.Skipf("cannot seed journal via logger: %v\n%s", err, out)
+	}
+
+	s := newJournald(t)
+	ctx := context.Background()
+
+	// journald ingests /dev/log asynchronously; poll briefly for the entry to
+	// land rather than asserting on the first read. (time.Sleep is fine in a
+	// test — the clock seam is production-only.)
+	var lines []string
+	var lastErr error
+	for i := 0; i < 20; i++ {
+		var err error
+		lines, err = s.Query(ctx, syslog.Query{Grep: marker, Lines: 50})
+		if err != nil {
+			lastErr, lines = err, nil
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if len(lines) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(lines) == 0 {
+		if lastErr != nil {
+			t.Fatalf("Query{Grep} against real journalctl: %v", lastErr)
+		}
+		t.Fatalf("seeded marker %q never returned by Query{Grep} — real journalctl --grep filter drifted?", marker)
+	}
+
+	// Filter proof: EVERY returned line is the seeded entry (the unique marker),
+	// so --grep genuinely EXCLUDED the rest of the journal rather than no-op'ing
+	// and returning everything.
+	for _, ln := range lines {
+		if !strings.Contains(ln, marker) {
+			t.Errorf("Query{Grep:%q} returned a non-matching line %q — --grep is not filtering", marker, ln)
+		}
+	}
+
+	// Exclusion proof: a marker that was never logged returns ZERO entries — and
+	// the SDK drops journalctl's "-- No entries --" status marker (not a real
+	// entry) rather than surfacing it as one.
+	absent := "PM-LOG-ABSENT-" + strconv.Itoa(os.Getpid())
+	ghost, err := s.Query(ctx, syslog.Query{Grep: absent, Lines: 50})
+	if err != nil {
+		t.Fatalf("Query{Grep:absent}: %v", err)
+	}
+	if len(ghost) != 0 {
+		t.Errorf("Query{Grep:%q} for an unlogged marker returned %d line(s) — --grep not excluding or status marker leaked: %v", absent, len(ghost), ghost)
 	}
 }

--- a/sys/log/journald.go
+++ b/sys/log/journald.go
@@ -36,11 +36,43 @@ func (s *journaldSource) Query(ctx context.Context, q Query) ([]string, error) {
 	if q.Grep != "" {
 		args = append(args, "--grep", q.Grep)
 	}
-	out, err := runEscalated(ctx, s.r, nil, "journalctl", args...)
+	res, err := s.r.Run(ctx, exec.Command{Name: "journalctl", Args: args, Escalate: true})
 	if err != nil {
 		return nil, err
 	}
-	return splitLines(out), nil
+	if res.ExitCode != 0 {
+		// journalctl --grep exits 1 (grep-like) when it matches NOTHING — an empty
+		// result, not a failure. A genuine fault writes a diagnostic to stderr,
+		// whereas a no-match leaves stderr empty (only "-- No entries --" on
+		// stdout). Treat that exact shape — a Grep query, exit 1, empty stderr — as
+		// the empty result so a caller can tell "no logs matched" from "journalctl
+		// broke"; anything else (other exit codes, any stderr, no Grep) stays an
+		// error, fail-closed.
+		if q.Grep != "" && res.ExitCode == 1 && strings.TrimSpace(res.Stderr) == "" {
+			return []string{}, nil
+		}
+		return nil, &exec.CommandError{Name: "journalctl", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return dropStatusMarkers(splitLines(res.Stdout)), nil
+}
+
+// dropStatusMarkers removes journalctl's status MARKERS — the "-- ... --"
+// wrapped lines it prints on stdout that are NOT log entries: "-- No entries --"
+// (a non-matching query), "-- Boot <id> --" / "-- Reboot --" boot delimiters,
+// and "-- Logs begin at ..., end at ... --". In the default short output every
+// real entry begins with a timestamp, so a line wrapped in "-- ... --" is always
+// a marker. Returns a non-nil empty slice when every line was a marker, matching
+// splitLines' contract.
+func dropStatusMarkers(lines []string) []string {
+	kept := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "-- ") && strings.HasSuffix(t, " --") {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+	return kept
 }
 
 // splitLines splits captured stdout into lines, dropping a single trailing


### PR DESCRIPTION
## What

Strengthens the `sys/log` integration test from a weak "journal is non-empty" check into a real **filter round-trip**, and fixes the two Query-fidelity bugs writing that test surfaced.

## Real test (preseed-known-state)

`logger` a unique per-PID marker → `Query{Grep:marker}` must return that exact entry, **every** returned line must contain it (proving `--grep` excluded the rest, not no-op'd), and an unlogged marker must return **zero** entries.

## Two bugs the fake never exercised

1. **journalctl status markers leaked as log entries.** `-- No entries --`, `-- Boot <id> --`, `-- Reboot --` are printed on stdout and `splitLines` passed them through. Added journald-only `dropStatusMarkers` (in short output every real entry starts with a timestamp, so a `-- ... --` line is always a marker).
2. **A filter matching nothing returned an ERROR.** `journalctl --grep` exits 1 (grep-like) on no-match; the SDK mapped exit≠0 → error, so `Query{Grep:<nomatch>}` failed instead of returning empty — a caller couldn't tell "no logs matched" from "journalctl broke". journald Query now treats the exact no-match shape (Grep set, exit 1, **empty stderr**) as an empty result; anything else (other exit codes, any stderr, no Grep) stays an error, fail-closed.

Both pinned red→green by unit tests (real journalctl-shaped fixtures) + the container integration round-trip against live journald.

Closes #215