### PR TITLE
feat(repo): repository-management Manager + real apt/dnf/pacman/zypper tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,6 +309,14 @@ jobs:
             distro: debian
             state: with-clamav
             path: ./sdk/sys/antivirus/
+          # repo Manager apt backend: real `gpg --dearmor` + deb822 .sources
+          # write/idempotency/remove (base + gnupg). The dnf/pacman/zypper repo
+          # cells run in their distro jobs below; each test self-skips when its
+          # backend is absent.
+          - label: sys/repo apt (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/repo/
     steps:
       - uses: actions/checkout@v5
         with:
@@ -384,6 +392,13 @@ jobs:
           name: coverage-dnf
           path: pkg/coverage-dnf.out
 
+      # repo Manager dnf backend: real .repo write/idempotency/remove against the
+      # actual dnf (root container). Run from the module root (pkg/ is the same
+      # module but `./...` there does not reach sys/repo). The apt/pacman/zypper
+      # repo tests self-skip here.
+      - name: Run repo Manager container tests (real dnf)
+        run: go test -tags=container -count=1 -v -run Container ./sys/repo/
+
   # pacman/zypper are the two package managers with zero real-tool coverage
   # before this. The pkg integration tests (TestIntegration_Pacman/_Zypper)
   # auto-detect the backend and run read-only ops (List / IsInstalled / Search)
@@ -404,6 +419,11 @@ jobs:
         run: go test -v ./...
         working-directory: pkg
 
+      # repo Manager pacman backend: real /etc/pacman.conf [section] write/remove
+      # against the actual pacman (root container).
+      - name: Run repo Manager container tests (real pacman)
+        run: go test -tags=container -count=1 -v -run Container ./sys/repo/
+
   test-zypper:
     name: Integration Tests (zypper)
     runs-on: ubuntu-latest
@@ -423,6 +443,13 @@ jobs:
       - name: Run integration tests
         run: go test -v ./...
         working-directory: pkg
+        env:
+          GOTOOLCHAIN: auto
+
+      # repo Manager zypper backend: real `zypper addrepo`/`lr`/`removerepo`
+      # round-trip (root container). GOTOOLCHAIN=auto for Leap's go 1.25.10.
+      - name: Run repo Manager container tests (real zypper)
+        run: go test -tags=container -count=1 -v -run Container ./sys/repo/
         env:
           GOTOOLCHAIN: auto
 

--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -85,6 +85,11 @@ type Manager interface {
 	// (nil, nil) — absence is not an error, matching the "read whatever is
 	// there, empty if nothing" contract callers depend on.
 	ReadFile(ctx context.Context, path string) ([]byte, error)
+	// ReadDir lists the immediate entries of a directory (no recursion). A path
+	// that does not exist yields (nil, nil) — absence is an empty listing, the
+	// same "absent is empty" contract as ReadFile — so a caller enumerating a
+	// managed config directory that has never been created treats it as empty.
+	ReadDir(ctx context.Context, path string) ([]DirEntry, error)
 	// WriteFile writes data to path atomically. When the Runner's backend is
 	// Direct the write is also symlink-safe (fd-anchored); see the package doc.
 	WriteFile(ctx context.Context, path string, data []byte, opts WriteOptions) error

--- a/sys/fs/readdir.go
+++ b/sys/fs/readdir.go
@@ -1,0 +1,92 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// DirEntry is one entry returned by Manager.ReadDir: the bare name (not a full
+// path) and whether it is a directory. It is a minimal, backend-portable view —
+// the escalated (find-based) listing cannot cheaply reproduce the full
+// os.DirEntry / FileInfo surface, and the callers that enumerate a managed
+// config directory need only the name plus is-it-a-directory. A symlink is
+// reported with IsDir=false (its own type, not the target's), so a caller
+// iterating regular files processes it like any other non-directory.
+type DirEntry struct {
+	Name  string
+	IsDir bool
+}
+
+// ReadDir lists path's immediate entries.
+//
+// On the Direct backend (the deployed root agent) it reads the directory
+// directly with os.ReadDir — root can traverse any directory, and this avoids a
+// subprocess. On the escalated (Sudo/Doas) backend it shells `find` through the
+// privilege backend so it can list directories the unprivileged caller cannot
+// traverse, mirroring ReadFile/Exists.
+//
+// A non-existent directory yields (nil, nil): absence is an empty listing, the
+// same contract as ReadFile. Any other failure (permission denied, a non-
+// directory target) is returned as an error — never silently reported as empty.
+func (m *manager) ReadDir(ctx context.Context, path string) ([]DirEntry, error) {
+	if err := ValidatePath(path); err != nil {
+		return nil, err
+	}
+	if m.direct() {
+		return readDirDirect(path)
+	}
+	return m.readDirEscalated(ctx, path)
+}
+
+// readDirDirect is the root path: os.ReadDir, with a missing directory mapped to
+// an empty listing.
+func readDirDirect(path string) ([]DirEntry, error) {
+	osEntries, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	entries := make([]DirEntry, 0, len(osEntries))
+	for _, e := range osEntries {
+		entries = append(entries, DirEntry{Name: e.Name(), IsDir: e.IsDir()})
+	}
+	return entries, nil
+}
+
+// readDirEscalated is the privilege-backend path. It runs
+//
+//	find <path> -maxdepth 1 -mindepth 1 -printf '%y/%f\n'
+//
+// emitting one line per entry as "<type-char>/<basename>". A basename never
+// contains '/', so the first '/' unambiguously separates the single type char
+// from the name. (A pathological filename containing a newline would break the
+// line framing; managed config directories never hold such names, and the
+// Direct/root path — which the deployed agent always takes — handles them
+// correctly via os.ReadDir.)
+func (m *manager) readDirEscalated(ctx context.Context, path string) ([]DirEntry, error) {
+	res, err := m.runPriv(ctx, "find", path, "-maxdepth", "1", "-mindepth", "1", "-printf", `%y/%f\n`)
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		if strings.Contains(res.Stderr, "No such file") {
+			return nil, nil
+		}
+		return nil, cmdError("find", res)
+	}
+	var entries []DirEntry
+	for _, line := range strings.Split(strings.TrimRight(res.Stdout, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		slash := strings.IndexByte(line, '/')
+		if slash <= 0 || slash == len(line)-1 {
+			continue // malformed: no type/name separator or empty name
+		}
+		entries = append(entries, DirEntry{Name: line[slash+1:], IsDir: line[:slash] == "d"})
+	}
+	return entries, nil
+}

--- a/sys/fs/readdir_test.go
+++ b/sys/fs/readdir_test.go
@@ -1,0 +1,161 @@
+package fs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// names renders entries as "name(d|f)" sorted, so assertions are order-stable
+// (os.ReadDir sorts; find does not guarantee order).
+func names(entries []DirEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		kind := "f"
+		if e.IsDir {
+			kind = "d"
+		}
+		out[i] = e.Name + "(" + kind + ")"
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- ReadDir (escalated / find path) --------------------------------------
+
+func TestReadDir_Sudo_ParsesFindOutput(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	// `%y/%f` per line: a single type char, '/', then the basename (a basename
+	// never contains '/', so the first '/' is an unambiguous separator).
+	f.Push(pmexec.Result{Stdout: "f/foo.sources\nd/sub\nl/legacy.list\n"}, nil)
+	m := mustManager(t, f)
+
+	got, err := m.ReadDir(context.Background(), "/etc/apt/sources.list.d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"foo.sources(f)", "legacy.list(f)", "sub(d)"}
+	if strings.Join(names(got), ",") != strings.Join(want, ",") {
+		t.Errorf("entries = %v, want %v", names(got), want)
+	}
+	// A symlink reports type 'l' from find's %y → classified as not-a-dir, so a
+	// caller iterating files (e.g. apt conflict cleanup) processes it.
+	if got := argv(f.Calls()[0]); got != `find /etc/apt/sources.list.d -maxdepth 1 -mindepth 1 -printf %y/%f\n` {
+		t.Errorf("argv = %q", got)
+	}
+	if !f.Calls()[0].Escalate {
+		t.Error("ReadDir must escalate so it can list dirs the caller cannot traverse")
+	}
+}
+
+func TestReadDir_Sudo_EmptyDir(t *testing.T) {
+	f := exectest.New(pmexec.Sudo) // unscripted → exit 0, empty stdout
+	got, err := mustManager(t, f).ReadDir(context.Background(), "/empty")
+	if err != nil || len(got) != 0 {
+		t.Fatalf("ReadDir(empty) = (%v, %v), want (empty, nil)", got, err)
+	}
+}
+
+func TestReadDir_Sudo_MissingDirIsEmptyNoError(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{ExitCode: 1, Stderr: "find: '/x': No such file or directory"}, nil)
+	got, err := mustManager(t, f).ReadDir(context.Background(), "/x")
+	if err != nil || got != nil {
+		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+func TestReadDir_Sudo_OtherErrorIsCommandError(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{ExitCode: 1, Stderr: "find: '/etc/secret': Permission denied"}, nil)
+	if _, err := mustManager(t, f).ReadDir(context.Background(), "/etc/secret"); !errors.As(err, new(*pmexec.CommandError)) {
+		t.Fatalf("err = %v, want *exec.CommandError for a non-absent find failure", err)
+	}
+}
+
+func TestReadDir_Sudo_RunnerErrorPropagates(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{}, pmexec.ErrEscalationUnavailable)
+	if _, err := mustManager(t, f).ReadDir(context.Background(), "/x"); !errors.Is(err, pmexec.ErrEscalationUnavailable) {
+		t.Fatalf("err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+func TestReadDir_Sudo_InvalidPathRejectedBeforeExec(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	if _, err := mustManager(t, f).ReadDir(context.Background(), "-rf"); !errors.Is(err, ErrInvalidPath) {
+		t.Fatalf("err = %v, want ErrInvalidPath", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("a flag-shaped path reached find (%d calls)", n)
+	}
+}
+
+func TestReadDir_Sudo_SkipsMalformedAndBlankLines(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	// A blank line (defensive) and a line with no '/' are skipped, not panicked on.
+	f.Push(pmexec.Result{Stdout: "f/ok.sources\n\nbogusnoslash\nd/d1\n"}, nil)
+	got, err := mustManager(t, f).ReadDir(context.Background(), "/d")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"d1(d)", "ok.sources(f)"}
+	if strings.Join(names(got), ",") != strings.Join(want, ",") {
+		t.Errorf("entries = %v, want %v (malformed/blank lines skipped)", names(got), want)
+	}
+}
+
+// --- ReadDir (Direct / os.ReadDir path) -----------------------------------
+
+func TestReadDir_Direct_ListsRealDir(t *testing.T) {
+	m := directManager(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.repo"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "child"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.ReadDir(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a.repo(f)", "child(d)"}
+	if strings.Join(names(got), ",") != strings.Join(want, ",") {
+		t.Errorf("entries = %v, want %v", names(got), want)
+	}
+}
+
+func TestReadDir_Direct_MissingDirIsEmptyNoError(t *testing.T) {
+	m := directManager(t)
+	got, err := m.ReadDir(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil || got != nil {
+		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, nil)", got, err)
+	}
+}
+
+func TestReadDir_Direct_NotADirIsError(t *testing.T) {
+	m := directManager(t)
+	file := filepath.Join(t.TempDir(), "regular")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Reading a regular file as a directory is a real error (ENOTDIR), not "absent".
+	if _, err := m.ReadDir(context.Background(), file); err == nil {
+		t.Fatal("ReadDir(regular file) err = nil, want a non-directory error")
+	}
+}
+
+func TestReadDir_Direct_InvalidPathRejected(t *testing.T) {
+	m := directManager(t)
+	if _, err := m.ReadDir(context.Background(), "-rf"); !errors.Is(err, ErrInvalidPath) {
+		t.Fatalf("err = %v, want ErrInvalidPath", err)
+	}
+}

--- a/sys/repo/README.md
+++ b/sys/repo/README.md
@@ -1,0 +1,74 @@
+# Repository management SDK
+
+Configure external package-manager repositories (apt, dnf, pacman, zypper)
+through a single `Manager` interface built over an injected `exec.Runner` — no
+global state, fully unit-testable with `exectest.FakeRunner` (no host, no sudo,
+no container).
+
+It owns the per-backend repository file format, GPG public-key import, the
+idempotency comparison, conflict cleanup, and the post-configuration metadata
+refresh, so a consumer never shells out to write a `.sources`/`.repo` file,
+`rpm --import`, or `zypper addrepo` by hand.
+
+## Quick start
+
+```go
+import (
+    "github.com/manchtools/power-manage-sdk/pkg"
+    "github.com/manchtools/power-manage-sdk/sys/exec"
+    "github.com/manchtools/power-manage-sdk/sys/repo"
+)
+
+r, _ := exec.NewRunner(exec.Direct) // the agent runs as root; elsewhere Sudo/Doas
+m, err := repo.New(pkg.Dnf, r)      // pkg.Apt / pkg.Dnf / pkg.Pacman / pkg.Zypper
+if err != nil { /* unsupported backend (flatpak/unknown) or nil runner */ }
+
+out, err := m.Apply(ctx, repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{
+    BaseURL:  "https://packages.example.com/el9",
+    GPGCheck: true,
+    GPGKey:   "https://packages.example.com/RPM-GPG-KEY",
+    Enabled:  true,
+}})
+// out.Changed reports whether on-disk state actually changed (false = no-op).
+// out.Result.Stdout carries a human-readable log of the steps taken.
+
+_, err = m.Remove(ctx, "corp") // idempotent: removing an absent repo is a no-op
+```
+
+Discover which backends exist with `pkg.Detect(ctx)` — repositories belong to a
+package manager, so `repo` has no separate detector. Flatpak has no native-style
+repository (its remotes live on `pkg.FlatpakManager`), so `New` rejects it with
+`ErrUnsupportedBackend`.
+
+## Design notes
+
+- **`New(backend, runner)` then `Apply`/`Remove`/`Validate`.** The backend is
+  fixed at construction; set the matching sub-config on `Repository` (the shape
+  mirrors the control-plane `RepositoryParams` message). `Validate` is exposed
+  separately so a caller can reject a malformed configuration *before* taking any
+  privileged side effect (e.g. remounting a read-only root); `Apply` re-validates
+  internally regardless.
+
+- **Privileged writes go through `fs.Manager`.** On the Direct (root) backend
+  that means the TOCTOU-safe, fd-anchored write path — a hardening upgrade over a
+  raw `cp`/sudo write into a world-traversable config directory.
+
+- **GPG keys are public, not secrets.** apt receives the key material as bytes
+  (`AptConfig.GPGKey`) — the caller downloads it under its own network policy —
+  which the Manager dearmors (`gpg --dearmor`, key on stdin, never argv) into
+  `/etc/apt/keyrings`. dnf/zypper receive a key *reference* (an https URL or
+  absolute path) that the package manager itself resolves via `rpm --import`. No
+  `exec.Secret` is involved.
+
+- **Fail-closed validation.** Every repository name and string field is validated
+  against a tight grammar before it can reach a config file or argv: names are
+  filename/operand-safe, URLs reject control characters (dnf/pacman/zypper also
+  require https; apt is exempt because its trust anchor is the signed `Release`),
+  and GPG key references are restricted to https URLs or absolute paths.
+
+- **Idempotent + change-reporting.** Apply compares against on-disk state and
+  reports `Changed=false` for a no-op (skipping the metadata refresh); Remove
+  reports `Changed=false` when the repository is already absent. Non-fatal steps
+  (key import, index refresh) are surfaced as warnings in the output rather than
+  discarding a repository that was already configured.
+```

--- a/sys/repo/README.md
+++ b/sys/repo/README.md
@@ -14,14 +14,23 @@ refresh, so a consumer never shells out to write a `.sources`/`.repo` file,
 
 ```go
 import (
+    "context"
+    "log"
+
     "github.com/manchtools/power-manage-sdk/pkg"
     "github.com/manchtools/power-manage-sdk/sys/exec"
     "github.com/manchtools/power-manage-sdk/sys/repo"
 )
 
-r, _ := exec.NewRunner(exec.Direct) // the agent runs as root; elsewhere Sudo/Doas
-m, err := repo.New(pkg.Dnf, r)      // pkg.Apt / pkg.Dnf / pkg.Pacman / pkg.Zypper
-if err != nil { /* unsupported backend (flatpak/unknown) or nil runner */ }
+ctx := context.Background()
+r, err := exec.NewRunner(exec.Direct) // the agent runs as root; elsewhere Sudo/Doas
+if err != nil {
+    log.Fatalf("new runner: %v", err)
+}
+m, err := repo.New(pkg.Dnf, r) // pkg.Apt / pkg.Dnf / pkg.Pacman / pkg.Zypper
+if err != nil {
+    log.Fatalf("new repo manager: %v", err) // unsupported backend (flatpak/unknown) or nil runner
+}
 
 out, err := m.Apply(ctx, repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{
     BaseURL:  "https://packages.example.com/el9",

--- a/sys/repo/apt.go
+++ b/sys/repo/apt.go
@@ -1,0 +1,289 @@
+package repo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+const (
+	aptSourcesDir   = "/etc/apt/sources.list.d"
+	aptKeyringDir   = "/etc/apt/keyrings"
+	aptLegacyKeyDir = "/etc/apt/trusted.gpg.d"
+)
+
+func aptRepoFile(name string) string       { return aptSourcesDir + "/" + name + ".sources" }
+func aptLegacyRepoFile(name string) string { return aptSourcesDir + "/" + name + ".list" }
+func aptKeyFile(name string) string        { return aptKeyringDir + "/" + name + ".gpg" }
+func aptLegacyKeyFile(name string) string  { return aptLegacyKeyDir + "/" + name + ".gpg" }
+
+// aptListSignedBy extracts the keyring path from a one-line .list source, e.g.
+// `deb [signed-by=/etc/apt/keyrings/x.gpg] https://…`.
+var aptListSignedBy = regexp.MustCompile(`signed-by=([^\s\]]+)`)
+
+// applyApt writes the modern deb822 source to /etc/apt/sources.list.d/<name>.sources,
+// installs the (dearmored) signing key under /etc/apt/keyrings, removes any
+// conflicting prior configuration of the same URL, and refreshes the index. It is
+// idempotent: an unchanged source + key reports Changed=false and skips the
+// index refresh.
+func (m *manager) applyApt(ctx context.Context, name string, c *AptConfig) (Outcome, error) {
+	repoFile := aptRepoFile(name)
+	keyFile := aptKeyFile(name)
+	var log strings.Builder
+	changed := false
+
+	// Remove any other config that uses the same URL — prevents apt's
+	// "conflicting values set for option Signed-By" on the next update. A scan
+	// failure is surfaced as a warning (in log), never fatal.
+	if m.cleanupConflictingApt(ctx, c.URL, repoFile, keyFile, &log) {
+		changed = true
+	}
+
+	// Clean up legacy single-line .list and trusted.gpg.d key locations.
+	legacyFile := aptLegacyRepoFile(name)
+	if exists, eerr := m.fsm.Exists(ctx, legacyFile); eerr != nil {
+		return Outcome{}, fmt.Errorf("check legacy repo file: %w", eerr)
+	} else if exists {
+		fmt.Fprintf(&log, "removing legacy repository file: %s\n", legacyFile)
+		if rerr := m.fsm.Remove(ctx, legacyFile); rerr != nil {
+			fmt.Fprintf(&log, "warning: failed to remove legacy repo file: %v\n", rerr)
+		}
+		changed = true
+	}
+	legacyKeyFile := aptLegacyKeyFile(name)
+	if exists, eerr := m.fsm.Exists(ctx, legacyKeyFile); eerr != nil {
+		return Outcome{}, fmt.Errorf("check legacy GPG key: %w", eerr)
+	} else if exists {
+		fmt.Fprintf(&log, "removing legacy GPG key: %s\n", legacyKeyFile)
+		if rerr := m.fsm.Remove(ctx, legacyKeyFile); rerr != nil {
+			fmt.Fprintf(&log, "warning: failed to remove legacy GPG key: %v\n", rerr)
+		}
+		changed = true
+	}
+
+	// Ensure the keyrings directory exists before writing into it.
+	if err := m.fsm.Mkdir(ctx, aptKeyringDir, fs.MkdirOptions{Mode: 0o755, Recursive: true}); err != nil {
+		return Outcome{}, fmt.Errorf("create keyrings directory: %w", err)
+	}
+
+	// Import the signing key (idempotent; updates only when content differs).
+	if len(c.GPGKey) > 0 {
+		keyUpdated, kerr := m.updateAptKey(ctx, keyFile, c.GPGKey, &log)
+		if kerr != nil {
+			return Outcome{
+				Result:  fsResultErr(log.String(), kerr),
+				Changed: false,
+			}, kerr
+		}
+		if keyUpdated {
+			log.WriteString("GPG key updated\n")
+			changed = true
+		} else {
+			log.WriteString("GPG key unchanged\n")
+		}
+	}
+
+	desired := buildAptSources(name, c, keyFile)
+
+	existingBytes, err := m.fsm.ReadFile(ctx, repoFile)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("read existing repo file: %w", err)
+	}
+	existing := string(existingBytes)
+	if existing == desired && !changed {
+		fmt.Fprintf(&log, "repository already up to date: %s\n", name)
+		return out(log.String(), false), nil
+	}
+	if existing != desired {
+		if err := m.fsm.WriteFile(ctx, repoFile, []byte(desired), fs.WriteOptions{Mode: 0o644}); err != nil {
+			return Outcome{}, fmt.Errorf("write repo file: %w", err)
+		}
+		fmt.Fprintf(&log, "configured repository: %s\n", name)
+		changed = true
+	}
+
+	// Refresh the index only when something actually changed (non-fatal: the
+	// config landed even if a typo'd URL fails the refresh).
+	if changed {
+		res, uerr := m.runPriv(ctx, "apt-get", "update")
+		if res.Stdout != "" {
+			log.WriteString(res.Stdout)
+		}
+		if uerr != nil {
+			fmt.Fprintf(&log, "warning: apt-get update failed after configuring %s: %v\n", name, uerr)
+		}
+	}
+
+	return out(log.String(), changed), nil
+}
+
+// buildAptSources renders the deb822 source body. Signed-By takes precedence over
+// the legacy Trusted: yes (only one trust mechanism is emitted).
+func buildAptSources(name string, c *AptConfig, keyFile string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Repository: %s\n", name)
+	b.WriteString("Types: deb\n")
+	fmt.Fprintf(&b, "URIs: %s\n", c.URL)
+	if c.Distribution != "" {
+		fmt.Fprintf(&b, "Suites: %s\n", c.Distribution)
+	} else {
+		b.WriteString("Suites: /\n")
+	}
+	if len(c.Components) > 0 {
+		fmt.Fprintf(&b, "Components: %s\n", strings.Join(c.Components, " "))
+	}
+	if c.Arch != "" {
+		fmt.Fprintf(&b, "Architectures: %s\n", c.Arch)
+	}
+	if len(c.GPGKey) > 0 {
+		fmt.Fprintf(&b, "Signed-By: %s\n", keyFile)
+	} else if c.Trusted {
+		b.WriteString("Trusted: yes\n")
+	}
+	return b.String()
+}
+
+// updateAptKey dearmors the public key (unprivileged; binary on stdout, no file
+// touched) and writes it to keyFile only when it differs from what is installed.
+// Returns whether the keyring changed.
+func (m *manager) updateAptKey(ctx context.Context, keyFile string, key []byte, log *strings.Builder) (bool, error) {
+	res, err := m.runStdin(ctx, key, "gpg", "--dearmor")
+	if err != nil {
+		return false, fmt.Errorf("dearmor GPG key: %w", err)
+	}
+	newKey := []byte(res.Stdout)
+
+	existing, err := m.fsm.ReadFile(ctx, keyFile)
+	if err != nil {
+		return false, fmt.Errorf("read existing GPG key: %w", err)
+	}
+	if existing != nil && bytes.Equal(existing, newKey) {
+		log.WriteString("GPG key already installed and matches\n")
+		return false, nil
+	}
+	if existing == nil {
+		log.WriteString("GPG key not found, installing\n")
+	} else {
+		log.WriteString("GPG key differs, updating\n")
+	}
+	if err := m.fsm.WriteFile(ctx, keyFile, newKey, fs.WriteOptions{Mode: 0o644}); err != nil {
+		return false, fmt.Errorf("install GPG key: %w", err)
+	}
+	return true, nil
+}
+
+// cleanupConflictingApt scans /etc/apt/sources.list.d for any .sources/.list
+// that references url (other than the target's own files) and removes it together
+// with its Signed-By keyring. Returns whether anything was removed. A scan error
+// is surfaced as a warning and treated as "nothing to clean" rather than failing
+// the whole Apply.
+func (m *manager) cleanupConflictingApt(ctx context.Context, url, skipRepoFile, skipKeyFile string, log *strings.Builder) bool {
+	entries, err := m.fsm.ReadDir(ctx, aptSourcesDir)
+	if err != nil {
+		fmt.Fprintf(log, "warning: could not scan %s for conflicts: %v\n", aptSourcesDir, err)
+		return false
+	}
+	cleaned := false
+	for _, e := range entries {
+		if e.IsDir {
+			continue
+		}
+		filename := e.Name
+		if !strings.HasSuffix(filename, ".sources") && !strings.HasSuffix(filename, ".list") {
+			continue
+		}
+		filePath := aptSourcesDir + "/" + filename
+		if filePath == skipRepoFile {
+			continue
+		}
+		// Skip the legacy .list form of the target repo.
+		if strings.TrimSuffix(filePath, ".list")+".sources" == skipRepoFile {
+			continue
+		}
+		contentBytes, rerr := m.fsm.ReadFile(ctx, filePath)
+		if rerr != nil {
+			continue
+		}
+		content := string(contentBytes)
+		if !strings.Contains(content, url) {
+			continue
+		}
+		fmt.Fprintf(log, "removing conflicting repository config: %s\n", filePath)
+		cleaned = true
+		m.removeConflictKeys(ctx, filename, content, skipKeyFile, log)
+		if rerr := m.fsm.Remove(ctx, filePath); rerr != nil {
+			fmt.Fprintf(log, "warning: failed to remove conflicting repo file: %v\n", rerr)
+		}
+	}
+	return cleaned
+}
+
+// removeConflictKeys removes the Signed-By keyrings referenced by a conflicting
+// source file (deb822 `Signed-By:` lines or one-line `signed-by=`), skipping the
+// target repo's own key and any non-absolute reference.
+func (m *manager) removeConflictKeys(ctx context.Context, filename, content, skipKeyFile string, log *strings.Builder) {
+	var keyPaths []string
+	if strings.HasSuffix(filename, ".sources") {
+		for _, line := range strings.Split(content, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "Signed-By:") {
+				continue
+			}
+			keyPaths = append(keyPaths, strings.TrimSpace(strings.TrimPrefix(line, "Signed-By:")))
+		}
+	} else { // .list
+		for _, match := range aptListSignedBy.FindAllStringSubmatch(content, -1) {
+			keyPaths = append(keyPaths, match[1])
+		}
+	}
+	for _, keyPath := range keyPaths {
+		if keyPath == skipKeyFile || !strings.HasPrefix(keyPath, "/") {
+			continue
+		}
+		fmt.Fprintf(log, "removing associated GPG key: %s\n", keyPath)
+		if err := m.fsm.Remove(ctx, keyPath); err != nil {
+			fmt.Fprintf(log, "warning: failed to remove conflicting GPG key: %v\n", err)
+		}
+	}
+}
+
+// removeApt deletes the deb822 source, the legacy .list, and the keyring. It is
+// idempotent: when none of the three exist it reports Changed=false. The primary
+// source removal is fatal; the legacy/key removals are best-effort warnings.
+func (m *manager) removeApt(ctx context.Context, name string) (Outcome, error) {
+	repoFile := aptRepoFile(name)
+	legacyFile := aptLegacyRepoFile(name)
+	keyFile := aptKeyFile(name)
+	var log strings.Builder
+
+	anyExists := false
+	for _, p := range []string{repoFile, legacyFile, keyFile} {
+		exists, err := m.fsm.Exists(ctx, p)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("check %s: %w", p, err)
+		}
+		if exists {
+			anyExists = true
+		}
+	}
+	if !anyExists {
+		fmt.Fprintf(&log, "repository %s already absent\n", name)
+		return out(log.String(), false), nil
+	}
+
+	if err := m.fsm.Remove(ctx, repoFile); err != nil {
+		return Outcome{}, fmt.Errorf("remove repo file: %w", err)
+	}
+	if err := m.fsm.Remove(ctx, legacyFile); err != nil {
+		fmt.Fprintf(&log, "warning: failed to remove legacy repo file: %v\n", err)
+	}
+	if err := m.fsm.Remove(ctx, keyFile); err != nil {
+		fmt.Fprintf(&log, "warning: failed to remove GPG key: %v\n", err)
+	}
+	fmt.Fprintf(&log, "removed repository: %s\n", name)
+	return out(log.String(), true), nil
+}

--- a/sys/repo/apt_test.go
+++ b/sys/repo/apt_test.go
@@ -1,0 +1,336 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// stdinOf reads back the stdin a recorded command carried (the FakeRunner never
+// consumes it, so it is still readable).
+func stdinOf(t *testing.T, c pmexec.Command) string {
+	t.Helper()
+	if c.Stdin == nil {
+		return ""
+	}
+	b, err := io.ReadAll(c.Stdin)
+	if err != nil {
+		t.Fatalf("read recorded stdin: %v", err)
+	}
+	return string(b)
+}
+
+func TestApt_Apply_DearmorsKeyWritesSourcesAndUpdates(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil) // gpg --dearmor → binary keyring on stdout
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{
+		URL:          "https://h/a",
+		Distribution: "bookworm",
+		Components:   []string{"main", "contrib"},
+		Arch:         "amd64",
+		GPGKey:       []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\narmored\n-----END-----\n"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("first Apply reports Changed=true")
+	}
+
+	// The armored key is dearmored via unprivileged gpg with the key on stdin
+	// (never on argv), and the binary result lands in the keyring.
+	calls := fr.Calls()
+	if argvs(fr)[0] != "gpg --dearmor" || calls[0].Escalate {
+		t.Errorf("first cmd = %q (escalate=%v), want an unprivileged `gpg --dearmor`", argvs(fr)[0], calls[0].Escalate)
+	}
+	if got := stdinOf(t, calls[0]); !strings.Contains(got, "BEGIN PGP PUBLIC KEY") {
+		t.Errorf("gpg stdin = %q, want the armored key", got)
+	}
+	if got := ff.wrote("/etc/apt/keyrings/corp.gpg"); got != "BINKEY" {
+		t.Errorf("keyring = %q, want the dearmored bytes", got)
+	}
+
+	wantSources := "# Repository: corp\n" +
+		"Types: deb\n" +
+		"URIs: https://h/a\n" +
+		"Suites: bookworm\n" +
+		"Components: main contrib\n" +
+		"Architectures: amd64\n" +
+		"Signed-By: /etc/apt/keyrings/corp.gpg\n"
+	if got := ff.wrote("/etc/apt/sources.list.d/corp.sources"); got != wantSources {
+		t.Errorf("sources =\n%q\nwant\n%q", got, wantSources)
+	}
+	if !ff.didCall("Mkdir:/etc/apt/keyrings") {
+		t.Error("the keyrings directory must be ensured before the keyring is written")
+	}
+	if argvs(fr)[len(argvs(fr))-1] != "apt-get update" {
+		t.Errorf("last cmd = %q, want `apt-get update`", argvs(fr)[len(argvs(fr))-1])
+	}
+}
+
+func TestApt_Apply_TrustedNoKey(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{
+		URL: "https://h/a", Trusted: true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	got := ff.wrote("/etc/apt/sources.list.d/r.sources")
+	if !strings.Contains(got, "Trusted: yes") {
+		t.Errorf("sources missing Trusted: yes:\n%q", got)
+	}
+	if strings.Contains(got, "Signed-By") {
+		t.Errorf("no key configured, but Signed-By written:\n%q", got)
+	}
+	// No key → no gpg dearmor and no keyring write; only apt-get update runs.
+	if got := argvs(fr); len(got) != 1 || got[0] != "apt-get update" {
+		t.Errorf("commands = %v, want only apt-get update (no gpg)", got)
+	}
+	if ff.didCall("WriteFile:/etc/apt/keyrings/r.gpg") {
+		t.Error("no key configured, but a keyring was written")
+	}
+}
+
+func TestApt_Apply_Idempotent(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil) // gpg --dearmor
+	keyFile := "/etc/apt/keyrings/corp.gpg"
+	repoFile := "/etc/apt/sources.list.d/corp.sources"
+	ff.read[keyFile] = []byte("BINKEY") // keyring already matches the dearmored key
+	ff.read[repoFile] = []byte("# Repository: corp\nTypes: deb\nURIs: https://h/a\nSuites: /\nSigned-By: /etc/apt/keyrings/corp.gpg\n")
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{
+		URL: "https://h/a", GPGKey: []byte("armored"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Changed {
+		t.Errorf("matching key + sources must report Changed=false; sources rewritten? %v", ff.didCall("WriteFile:"+repoFile))
+	}
+	if ff.didCall("WriteFile:" + keyFile) {
+		t.Error("matching keyring must not be rewritten")
+	}
+	if ff.didCall("WriteFile:" + repoFile) {
+		t.Error("matching sources must not be rewritten")
+	}
+	// gpg ran (to compute the comparison) but apt-get update must NOT (nothing changed).
+	for _, c := range argvs(fr) {
+		if c == "apt-get update" {
+			t.Error("idempotent Apply must not refresh the index")
+		}
+	}
+}
+
+func TestApt_Apply_KeyDiffersTriggersRewrite(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{Stdout: "NEWKEY"}, nil)
+	keyFile := "/etc/apt/keyrings/corp.gpg"
+	ff.read[keyFile] = []byte("OLDKEY") // installed key differs from dearmored
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{
+		URL: "https://h/a", GPGKey: []byte("armored"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("a differing key must report Changed=true")
+	}
+	if got := ff.wrote(keyFile); got != "NEWKEY" {
+		t.Errorf("keyring = %q, want the updated NEWKEY", got)
+	}
+	if !strings.Contains(out.Result.Stdout, "GPG key differs, updating") {
+		t.Errorf("expected a 'key differs' note, got %q", out.Result.Stdout)
+	}
+}
+
+func TestApt_Apply_DearmorFailureIsFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{ExitCode: 2, Stderr: "gpg: no valid OpenPGP data"}, nil)
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{
+		URL: "https://h/a", GPGKey: []byte("not a key"),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "dearmor GPG key") {
+		t.Fatalf("err = %v, want a wrapped dearmor failure", err)
+	}
+	if out.Changed {
+		t.Error("a dearmor failure must report Changed=false")
+	}
+}
+
+func TestApt_Apply_ConflictCleanup(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	dir := "/etc/apt/sources.list.d"
+	ff.entries[dir] = []fs.DirEntry{
+		{Name: "other.sources", IsDir: false},
+		{Name: "corp.sources", IsDir: false}, // the target's own file — must be skipped
+		{Name: "sub", IsDir: true},           // a directory — must be skipped
+		{Name: "readme.txt", IsDir: false},   // not a repo file — must be skipped
+	}
+	// A different repo file that references the SAME url under a different key.
+	ff.read[dir+"/other.sources"] = []byte("Types: deb\nURIs: https://h/a\nSigned-By: /etc/apt/keyrings/other.gpg\n")
+	ff.read[dir+"/corp.sources"] = []byte("URIs: https://h/a\n") // would match, but it's the target → skipped
+
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("removing a conflicting repo must report Changed=true")
+	}
+	if !ff.didCall("Remove:" + dir + "/other.sources") {
+		t.Error("the conflicting repo file was not removed")
+	}
+	if !ff.didCall("Remove:/etc/apt/keyrings/other.gpg") {
+		t.Error("the conflicting repo's Signed-By keyring was not removed")
+	}
+	// The target's own files must never be removed by the cleanup.
+	if ff.didCall("Remove:" + dir + "/corp.sources") {
+		t.Error("cleanup must skip the target repo's own .sources file")
+	}
+}
+
+func TestApt_Apply_ConflictCleanup_ListFormatKey(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	dir := "/etc/apt/sources.list.d"
+	ff.entries[dir] = []fs.DirEntry{{Name: "legacy.list", IsDir: false}}
+	ff.read[dir+"/legacy.list"] = []byte("deb [signed-by=/etc/apt/keyrings/legacy.gpg] https://h/a stable main\n")
+	if _, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !ff.didCall("Remove:/etc/apt/keyrings/legacy.gpg") {
+		t.Error("the one-line signed-by= keyring was not extracted and removed")
+	}
+	if !ff.didCall("Remove:" + dir + "/legacy.list") {
+		t.Error("the conflicting .list file was not removed")
+	}
+}
+
+func TestApt_Apply_ConflictScanErrorIsNonFatal(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	ff.errs["ReadDir:/etc/apt/sources.list.d"] = errors.New("io")
+	fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil)
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a", GPGKey: []byte("k")}})
+	if err != nil {
+		t.Fatalf("a conflict-scan error must not fail Apply, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "could not scan") {
+		t.Errorf("expected a scan warning, got %q", out.Result.Stdout)
+	}
+}
+
+func TestApt_Apply_LegacyCleanup(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	ff.present["/etc/apt/sources.list.d/corp.list"] = true
+	ff.present["/etc/apt/trusted.gpg.d/corp.gpg"] = true
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("legacy cleanup must report Changed=true")
+	}
+	if !ff.didCall("Remove:/etc/apt/sources.list.d/corp.list") {
+		t.Error("legacy .list not removed")
+	}
+	if !ff.didCall("Remove:/etc/apt/trusted.gpg.d/corp.gpg") {
+		t.Error("legacy trusted.gpg.d key not removed")
+	}
+}
+
+func TestApt_Apply_MkdirAndWriteErrorsAreFatal(t *testing.T) {
+	t.Run("mkdir error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.errs["Mkdir:/etc/apt/keyrings"] = errors.New("ro")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}}); err == nil ||
+			!strings.Contains(err.Error(), "create keyrings directory") {
+			t.Fatalf("err = %v, want a wrapped mkdir failure", err)
+		}
+	})
+	t.Run("sources write error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.errs["WriteFile:/etc/apt/sources.list.d/r.sources"] = errors.New("ro")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}}); err == nil ||
+			!strings.Contains(err.Error(), "write repo file") {
+			t.Fatalf("err = %v, want a wrapped sources write failure", err)
+		}
+	})
+	t.Run("keyring write error", func(t *testing.T) {
+		m, ff, fr := newTestManager(t, pkg.Apt)
+		fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil)
+		ff.errs["WriteFile:/etc/apt/keyrings/r.gpg"] = errors.New("ro")
+		_, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a", GPGKey: []byte("k")}})
+		if err == nil || !strings.Contains(err.Error(), "install GPG key") {
+			t.Fatalf("err = %v, want a wrapped keyring write failure", err)
+		}
+	})
+}
+
+func TestApt_Apply_UpdateFailureIsNonFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "could not resolve host"}, nil) // apt-get update fails
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatalf("apt-get update failure must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "apt-get update failed") {
+		t.Errorf("expected an update warning, got %q", out.Result.Stdout)
+	}
+}
+
+func TestApt_Remove(t *testing.T) {
+	repoFile := "/etc/apt/sources.list.d/corp.sources"
+	legacyFile := "/etc/apt/sources.list.d/corp.list"
+	keyFile := "/etc/apt/keyrings/corp.gpg"
+
+	t.Run("present removes all three", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.present[repoFile] = true
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.Changed {
+			t.Error("removing a present repo reports Changed=true")
+		}
+		for _, p := range []string{repoFile, legacyFile, keyFile} {
+			if !ff.didCall("Remove:" + p) {
+				t.Errorf("Remove(%s) was not called", p)
+			}
+		}
+	})
+	t.Run("absent is idempotent", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Changed {
+			t.Error("nothing present → Changed=false")
+		}
+		if ff.didCall("Remove:" + repoFile) {
+			t.Error("nothing present → no deletes")
+		}
+	})
+	t.Run("exists probe error fails closed", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.errs["Exists:"+repoFile] = errors.New("probe")
+		if _, err := m.Remove(context.Background(), "corp"); err == nil {
+			t.Fatal("a probe error must fail closed")
+		}
+	})
+	t.Run("primary remove error is fatal", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.present[keyFile] = true // something exists → proceeds to delete
+		ff.errs["Remove:"+repoFile] = errors.New("denied")
+		if _, err := m.Remove(context.Background(), "corp"); err == nil ||
+			!strings.Contains(err.Error(), "remove repo file") {
+			t.Fatalf("err = %v, want a wrapped primary-remove failure", err)
+		}
+	})
+}

--- a/sys/repo/coverage_test.go
+++ b/sys/repo/coverage_test.go
@@ -1,0 +1,294 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// Apply runs Validate first: an invalid config is rejected before any side effect.
+func TestApply_ValidatesBeforeWork(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Dnf)
+	if _, err := m.Apply(context.Background(), Repository{Name: "-rf", Dnf: &DnfConfig{BaseURL: "https://h/r"}}); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("err = %v, want ErrInvalidName", err)
+	}
+	if len(ff.calls) != 0 || len(fr.Calls()) != 0 {
+		t.Error("a validation failure must do no file or command work")
+	}
+}
+
+// A runner-level error (escalation denied, not just a non-zero exit) on a
+// non-fatal step is surfaced as a warning.
+func TestRunPriv_RunnerErrorBranch(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Dnf)
+	fr.Push(pmexec.Result{}, pmexec.ErrEscalationDenied) // makecache (no key → first call)
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r"}})
+	if err != nil {
+		t.Fatalf("a non-fatal step's runner error must not fail Apply, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "warning: failed to refresh repo metadata") {
+		t.Errorf("expected a refresh warning, got %q", out.Result.Stdout)
+	}
+}
+
+// A runner-level error during gpg --dearmor is fatal (the key path can't proceed).
+func TestRunStdin_RunnerErrorBranch(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{}, pmexec.ErrEscalationUnavailable)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a", GPGKey: []byte("k")}}); err == nil ||
+		!strings.Contains(err.Error(), "dearmor GPG key") {
+		t.Fatalf("err = %v, want a wrapped dearmor failure on a runner error", err)
+	}
+}
+
+// Command stdout is appended to the Apply log across backends.
+func TestApply_StdoutIsLogged(t *testing.T) {
+	t.Run("dnf", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Dnf)
+		fr.Push(pmexec.Result{Stdout: "imported-key\n"}, nil)    // rpm --import
+		fr.Push(pmexec.Result{Stdout: "metadata cached\n"}, nil) // makecache
+		out, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r", GPGCheck: true, GPGKey: "https://h/K"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out.Result.Stdout, "imported-key") || !strings.Contains(out.Result.Stdout, "metadata cached") {
+			t.Errorf("command stdout not logged: %q", out.Result.Stdout)
+		}
+	})
+	t.Run("pacman", func(t *testing.T) {
+		m, ff, fr := newTestManager(t, pkg.Pacman)
+		ff.read["/etc/pacman.conf"] = []byte("[options]\n")
+		fr.Push(pmexec.Result{Stdout: "synced db\n"}, nil)
+		out, _ := m.Apply(context.Background(), Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/"}})
+		if !strings.Contains(out.Result.Stdout, "synced db") {
+			t.Errorf("pacman stdout not logged: %q", out.Result.Stdout)
+		}
+	})
+	t.Run("apt update", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Apt)
+		fr.Push(pmexec.Result{Stdout: "Hit:1 https://h/a\n"}, nil) // apt-get update (no key → first call)
+		out, _ := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}})
+		if !strings.Contains(out.Result.Stdout, "Hit:1") {
+			t.Errorf("apt-get update stdout not logged: %q", out.Result.Stdout)
+		}
+	})
+	t.Run("zypper", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		fr.Push(pmexec.Result{}, nil)                       // removerepo
+		fr.Push(pmexec.Result{Stdout: "added repo\n"}, nil) // addrepo
+		fr.Push(pmexec.Result{}, nil)                       // disable
+		fr.Push(pmexec.Result{Stdout: "imported\n"}, nil)   // rpm import
+		fr.Push(pmexec.Result{Stdout: "refreshed\n"}, nil)  // refresh
+		out, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true, GPGKey: "https://h/K"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, want := range []string{"added repo", "imported", "refreshed"} {
+			if !strings.Contains(out.Result.Stdout, want) {
+				t.Errorf("zypper stdout missing %q in %q", want, out.Result.Stdout)
+			}
+		}
+	})
+}
+
+// --- apt legacy-cleanup error / warn branches ------------------------------
+
+func TestApt_Apply_LegacyExistsErrorsAreFatal(t *testing.T) {
+	t.Run("legacy .list probe error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.errs["Exists:/etc/apt/sources.list.d/r.list"] = errors.New("probe")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}}); err == nil ||
+			!strings.Contains(err.Error(), "check legacy repo file") {
+			t.Fatalf("err = %v, want a wrapped legacy-list probe failure", err)
+		}
+	})
+	t.Run("legacy key probe error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Apt)
+		ff.errs["Exists:/etc/apt/trusted.gpg.d/r.gpg"] = errors.New("probe")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}}); err == nil ||
+			!strings.Contains(err.Error(), "check legacy GPG key") {
+			t.Fatalf("err = %v, want a wrapped legacy-key probe failure", err)
+		}
+	})
+}
+
+func TestApt_Apply_LegacyRemoveWarningsAreNonFatal(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	ff.present["/etc/apt/sources.list.d/r.list"] = true
+	ff.present["/etc/apt/trusted.gpg.d/r.gpg"] = true
+	ff.errs["Remove:/etc/apt/sources.list.d/r.list"] = errors.New("busy")
+	ff.errs["Remove:/etc/apt/trusted.gpg.d/r.gpg"] = errors.New("busy")
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatalf("legacy remove failures must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "failed to remove legacy repo file") ||
+		!strings.Contains(out.Result.Stdout, "failed to remove legacy GPG key") {
+		t.Errorf("expected legacy-remove warnings, got %q", out.Result.Stdout)
+	}
+}
+
+func TestApt_Apply_RepoFileReadErrorIsFatal(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	ff.errs["ReadFile:/etc/apt/sources.list.d/r.sources"] = errors.New("io")
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a"}}); err == nil ||
+		!strings.Contains(err.Error(), "read existing repo file") {
+		t.Fatalf("err = %v, want a wrapped sources-read failure", err)
+	}
+}
+
+func TestApt_UpdateAptKey_ReadKeyErrorIsFatal(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil)
+	ff.errs["ReadFile:/etc/apt/keyrings/r.gpg"] = errors.New("io")
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Apt: &AptConfig{URL: "https://h/a", GPGKey: []byte("k")}}); err == nil ||
+		!strings.Contains(err.Error(), "read existing GPG key") {
+		t.Fatalf("err = %v, want a wrapped key-read failure", err)
+	}
+}
+
+// removeConflictKeys: the target's own key and non-absolute references are
+// skipped; an absolute key whose removal fails is warned (non-fatal).
+func TestApt_Cleanup_KeySkipsAndRemoveWarning(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	dir := "/etc/apt/sources.list.d"
+	ff.entries[dir] = []fs.DirEntry{{Name: "c.sources", IsDir: false}}
+	ff.read[dir+"/c.sources"] = []byte(strings.Join([]string{
+		"URIs: https://h/a",
+		"Signed-By: /etc/apt/keyrings/corp.gpg", // == target's key → skipped
+		"Signed-By: relative/key.gpg",           // non-absolute → skipped
+		"Signed-By: /etc/apt/keyrings/doomed.gpg",
+		"",
+	}, "\n"))
+	ff.errs["Remove:/etc/apt/keyrings/doomed.gpg"] = errors.New("busy")
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ff.didCall("Remove:/etc/apt/keyrings/corp.gpg") {
+		t.Error("cleanup must skip the target repo's own key")
+	}
+	if ff.didCall("Remove:relative/key.gpg") {
+		t.Error("cleanup must skip a non-absolute key reference")
+	}
+	if !strings.Contains(out.Result.Stdout, "failed to remove conflicting GPG key") {
+		t.Errorf("expected a conflicting-key remove warning, got %q", out.Result.Stdout)
+	}
+}
+
+// A conflicting repo FILE whose removal fails is warned (non-fatal).
+func TestApt_Cleanup_RepoFileRemoveWarning(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	dir := "/etc/apt/sources.list.d"
+	ff.entries[dir] = []fs.DirEntry{{Name: "c.sources", IsDir: false}}
+	ff.read[dir+"/c.sources"] = []byte("URIs: https://h/a\n")
+	ff.errs["Remove:"+dir+"/c.sources"] = errors.New("busy")
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Result.Stdout, "failed to remove conflicting repo file") {
+		t.Errorf("expected a conflicting-file remove warning, got %q", out.Result.Stdout)
+	}
+}
+
+// removeApt: the secondary (legacy + key) removals are best-effort warnings.
+func TestApt_Remove_SecondaryWarnings(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	ff.present["/etc/apt/sources.list.d/corp.sources"] = true
+	ff.errs["Remove:/etc/apt/sources.list.d/corp.list"] = errors.New("busy")
+	ff.errs["Remove:/etc/apt/keyrings/corp.gpg"] = errors.New("busy")
+	out, err := m.Remove(context.Background(), "corp")
+	if err != nil {
+		t.Fatalf("secondary remove failures must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "failed to remove legacy repo file") ||
+		!strings.Contains(out.Result.Stdout, "failed to remove GPG key") {
+		t.Errorf("expected secondary-remove warnings, got %q", out.Result.Stdout)
+	}
+}
+
+// cleanupConflictingApt skip branches: the target's own legacy .list, an
+// unreadable entry, and an entry that does not reference the URL are all skipped.
+func TestApt_Cleanup_SkipBranches(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Apt)
+	dir := "/etc/apt/sources.list.d"
+	ff.entries[dir] = []fs.DirEntry{
+		{Name: "corp.list", IsDir: false},     // legacy .list form of the target → skipped
+		{Name: "bad.sources", IsDir: false},   // unreadable → skipped
+		{Name: "other.sources", IsDir: false}, // readable but no URL match → skipped
+	}
+	ff.errs["ReadFile:"+dir+"/bad.sources"] = errors.New("io")
+	ff.read[dir+"/other.sources"] = []byte("URIs: https://different/repo\n")
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Apt: &AptConfig{URL: "https://h/a"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Nothing matched → no conflict removals at all.
+	for _, p := range []string{dir + "/corp.list", dir + "/bad.sources", dir + "/other.sources"} {
+		if ff.didCall("Remove:" + p) {
+			t.Errorf("unexpected removal of skipped entry %s", p)
+		}
+	}
+	if strings.Contains(out.Result.Stdout, "removing conflicting") {
+		t.Errorf("no entry should have been treated as a conflict: %q", out.Result.Stdout)
+	}
+}
+
+// The best-effort pre-add removerepo failure is a logged note, never fatal.
+func TestZypper_Apply_PreRemoveFailureIsNoted(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "not found"}, nil) // pre-removerepo fails
+	// addrepo + disable + refresh unscripted → clean.
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true}})
+	if err != nil {
+		t.Fatalf("a failed pre-removerepo must not fail Apply, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "pre-add removerepo failed") {
+		t.Errorf("expected a pre-remove note, got %q", out.Result.Stdout)
+	}
+}
+
+func TestZypper_Apply_DisableFailureIsFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	fr.Push(pmexec.Result{}, nil)                               // removerepo
+	fr.Push(pmexec.Result{}, nil)                               // addrepo
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "disable"}, nil) // modifyrepo --disable fails
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true, Enabled: false}}); err == nil ||
+		!strings.Contains(err.Error(), "disable repo") {
+		t.Fatalf("err = %v, want a wrapped disable failure", err)
+	}
+}
+
+// zypper enable/autorefresh fatal-failure branches.
+func TestZypper_Apply_EnableAndAutorefreshFailures(t *testing.T) {
+	t.Run("enable fails", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		fr.Push(pmexec.Result{}, nil) // removerepo
+		fr.Push(pmexec.Result{}, nil) // addrepo
+		fr.Push(pmexec.Result{ExitCode: 1, Stderr: "enable"}, nil)
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true, Enabled: true}}); err == nil ||
+			!strings.Contains(err.Error(), "enable repo") {
+			t.Fatalf("err = %v, want a wrapped enable failure", err)
+		}
+	})
+	t.Run("refresh failure non-fatal", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		fr.Push(pmexec.Result{}, nil)                                   // removerepo
+		fr.Push(pmexec.Result{}, nil)                                   // addrepo
+		fr.Push(pmexec.Result{}, nil)                                   // disable
+		fr.Push(pmexec.Result{ExitCode: 1, Stderr: "refresh net"}, nil) // refresh
+		out, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true}})
+		if err != nil {
+			t.Fatalf("final refresh failure must be non-fatal, got %v", err)
+		}
+		if !strings.Contains(out.Result.Stdout, "warning: failed to refresh repo") {
+			t.Errorf("expected a refresh warning, got %q", out.Result.Stdout)
+		}
+	})
+}

--- a/sys/repo/dnf.go
+++ b/sys/repo/dnf.go
@@ -1,0 +1,104 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// dnfRepoFile is the .repo path for a named DNF repository.
+func dnfRepoFile(name string) string { return "/etc/yum.repos.d/" + name + ".repo" }
+
+// applyDnf writes /etc/yum.repos.d/<name>.repo (idempotently), imports the GPG
+// key, and refreshes that repo's metadata. A key-import or refresh failure is
+// non-fatal — the repository file was written, so the failure is surfaced as a
+// warning in the output rather than discarding a configured repo.
+func (m *manager) applyDnf(ctx context.Context, name string, c *DnfConfig) (Outcome, error) {
+	repoFile := dnfRepoFile(name)
+	var log strings.Builder
+
+	var content strings.Builder
+	fmt.Fprintf(&content, "[%s]\n", name)
+	if c.Description != "" {
+		fmt.Fprintf(&content, "name=%s\n", c.Description)
+	} else {
+		fmt.Fprintf(&content, "name=%s\n", name)
+	}
+	fmt.Fprintf(&content, "baseurl=%s\n", c.BaseURL)
+	if c.Enabled {
+		content.WriteString("enabled=1\n")
+	} else {
+		content.WriteString("enabled=0\n")
+	}
+	if c.GPGCheck {
+		content.WriteString("gpgcheck=1\n")
+		if c.GPGKey != "" {
+			fmt.Fprintf(&content, "gpgkey=%s\n", c.GPGKey)
+		}
+	} else {
+		content.WriteString("gpgcheck=0\n")
+	}
+	if c.ModuleHotfixes {
+		content.WriteString("module_hotfixes=1\n")
+	}
+	desired := content.String()
+
+	// Idempotency: a byte-identical file means nothing to do.
+	existing, err := m.fsm.ReadFile(ctx, repoFile)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("read existing repo file: %w", err)
+	}
+	if string(existing) == desired {
+		fmt.Fprintf(&log, "repository %s already up to date\n", name)
+		return out(log.String(), false), nil
+	}
+
+	if err := m.fsm.WriteFile(ctx, repoFile, []byte(desired), fs.WriteOptions{Mode: 0o644}); err != nil {
+		return Outcome{}, fmt.Errorf("write repo file: %w", err)
+	}
+	fmt.Fprintf(&log, "configured repository: %s\n", name)
+
+	// rpm --import is idempotent (re-importing an existing key is a no-op).
+	if c.GPGKey != "" {
+		res, kerr := m.runPriv(ctx, "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
+		if res.Stdout != "" {
+			log.WriteString(res.Stdout)
+		}
+		if kerr != nil {
+			fmt.Fprintf(&log, "warning: failed to import GPG key: %v\n", kerr)
+		}
+	}
+
+	res, rerr := m.runPriv(ctx, "dnf", "-y", "makecache", "--repo", name)
+	if res.Stdout != "" {
+		log.WriteString(res.Stdout)
+	}
+	if rerr != nil {
+		fmt.Fprintf(&log, "warning: failed to refresh repo metadata: %v\n", rerr)
+	}
+
+	return out(log.String(), true), nil
+}
+
+// removeDnf deletes /etc/yum.repos.d/<name>.repo. Removing an already-absent
+// repository is an idempotent no-op (Changed=false).
+func (m *manager) removeDnf(ctx context.Context, name string) (Outcome, error) {
+	repoFile := dnfRepoFile(name)
+	var log strings.Builder
+	exists, err := m.fsm.Exists(ctx, repoFile)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("check repo file: %w", err)
+	}
+	if !exists {
+		fmt.Fprintf(&log, "repository %s already absent\n", name)
+		return out(log.String(), false), nil
+	}
+	if err := m.fsm.Remove(ctx, repoFile); err != nil {
+		return Outcome{}, fmt.Errorf("remove repo file: %w", err)
+	}
+	fmt.Fprintf(&log, "removed repository: %s\n", name)
+	return out(log.String(), true), nil
+}

--- a/sys/repo/dnf_test.go
+++ b/sys/repo/dnf_test.go
@@ -1,0 +1,176 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func TestDnf_Apply_WritesRepoFileImportsKeyAndRefreshes(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Dnf)
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Dnf: &DnfConfig{
+		BaseURL:        "https://packages.example.com/el9",
+		Description:    "Corp EL9",
+		Enabled:        true,
+		GPGCheck:       true,
+		GPGKey:         "https://packages.example.com/RPM-GPG-KEY",
+		ModuleHotfixes: true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("first Apply must report Changed=true")
+	}
+	want := "[corp]\n" +
+		"name=Corp EL9\n" +
+		"baseurl=https://packages.example.com/el9\n" +
+		"enabled=1\n" +
+		"gpgcheck=1\n" +
+		"gpgkey=https://packages.example.com/RPM-GPG-KEY\n" +
+		"module_hotfixes=1\n"
+	if got := ff.wrote("/etc/yum.repos.d/corp.repo"); got != want {
+		t.Errorf("repo file =\n%q\nwant\n%q", got, want)
+	}
+	// rpm --import -- <ref> (the `--` blocks a flag-shaped ref), then a
+	// repo-scoped makecache.
+	wantCmds := []string{
+		"rpm --import -- https://packages.example.com/RPM-GPG-KEY",
+		"dnf -y makecache --repo corp",
+	}
+	if got := argvs(fr); strings.Join(got, " | ") != strings.Join(wantCmds, " | ") {
+		t.Errorf("commands = %v\nwant %v", got, wantCmds)
+	}
+}
+
+func TestDnf_Apply_NoKeyDisabledNoGpgcheck(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Dnf)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{
+		BaseURL: "https://h/r", Enabled: false, GPGCheck: false,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	want := "[r]\nname=r\nbaseurl=https://h/r\nenabled=0\ngpgcheck=0\n"
+	if got := ff.wrote("/etc/yum.repos.d/r.repo"); got != want {
+		t.Errorf("repo file = %q, want %q", got, want)
+	}
+	// No gpgkey → no rpm --import; only the makecache runs.
+	if got := argvs(fr); len(got) != 1 || got[0] != "dnf -y makecache --repo r" {
+		t.Errorf("commands = %v, want just makecache (no rpm import)", got)
+	}
+}
+
+func TestDnf_Apply_Idempotent(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Dnf)
+	desired := "[r]\nname=r\nbaseurl=https://h/r\nenabled=1\ngpgcheck=0\n"
+	ff.read["/etc/yum.repos.d/r.repo"] = []byte(desired)
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r", Enabled: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Changed {
+		t.Error("identical existing file must report Changed=false")
+	}
+	if ff.didCall("WriteFile:/etc/yum.repos.d/r.repo") {
+		t.Error("idempotent Apply must not rewrite the file")
+	}
+	if n := len(fr.Calls()); n != 0 {
+		t.Errorf("idempotent Apply ran %d commands, want 0 (no makecache)", n)
+	}
+}
+
+func TestDnf_Apply_KeyImportFailureIsNonFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Dnf)
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "rpm: import failed"}, nil) // rpm --import
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{
+		BaseURL: "https://h/r", GPGCheck: true, GPGKey: "https://h/KEY",
+	}})
+	if err != nil {
+		t.Fatalf("key-import failure must be non-fatal, got err = %v", err)
+	}
+	if !out.Changed {
+		t.Error("the repo file was still written, so Changed=true")
+	}
+	if !strings.Contains(out.Result.Stdout, "warning: failed to import GPG key") {
+		t.Errorf("expected a key-import warning in output, got %q", out.Result.Stdout)
+	}
+}
+
+func TestDnf_Apply_RefreshFailureIsNonFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Dnf)
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "makecache failed"}, nil) // makecache (no key → first cmd)
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r"}})
+	if err != nil {
+		t.Fatalf("refresh failure must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "warning: failed to refresh repo metadata") {
+		t.Errorf("expected a refresh warning, got %q", out.Result.Stdout)
+	}
+}
+
+func TestDnf_Apply_WriteErrorIsFatal(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Dnf)
+	ff.errs["WriteFile:/etc/yum.repos.d/r.repo"] = errors.New("disk full")
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r"}}); err == nil ||
+		!strings.Contains(err.Error(), "write repo file") {
+		t.Fatalf("err = %v, want a wrapped write failure", err)
+	}
+}
+
+func TestDnf_Apply_ReadErrorIsFatal(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Dnf)
+	ff.errs["ReadFile:/etc/yum.repos.d/r.repo"] = errors.New("io error")
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r"}}); err == nil ||
+		!strings.Contains(err.Error(), "read existing repo file") {
+		t.Fatalf("err = %v, want a wrapped read failure", err)
+	}
+}
+
+func TestDnf_Remove(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Dnf)
+		ff.present["/etc/yum.repos.d/r.repo"] = true
+		out, err := m.Remove(context.Background(), "r")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.Changed || !ff.didCall("Remove:/etc/yum.repos.d/r.repo") {
+			t.Errorf("Remove(present) must delete the file and report Changed=true (changed=%v)", out.Changed)
+		}
+	})
+	t.Run("absent is idempotent", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Dnf)
+		out, err := m.Remove(context.Background(), "r")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Changed || ff.didCall("Remove:/etc/yum.repos.d/r.repo") {
+			t.Error("Remove(absent) must be a no-op (Changed=false, no delete)")
+		}
+	})
+	t.Run("exists error is fatal", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Dnf)
+		ff.errs["Exists:/etc/yum.repos.d/r.repo"] = errors.New("probe failed")
+		if _, err := m.Remove(context.Background(), "r"); err == nil {
+			t.Fatal("a probe failure must fail closed, not report absent")
+		}
+	})
+	t.Run("remove error is fatal", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Dnf)
+		ff.present["/etc/yum.repos.d/r.repo"] = true
+		ff.errs["Remove:/etc/yum.repos.d/r.repo"] = errors.New("denied")
+		if _, err := m.Remove(context.Background(), "r"); err == nil {
+			t.Fatal("a remove failure must surface")
+		}
+	})
+	t.Run("invalid name rejected", func(t *testing.T) {
+		m, _, _ := newTestManager(t, pkg.Dnf)
+		if _, err := m.Remove(context.Background(), "-rf"); !errors.Is(err, ErrInvalidName) {
+			t.Fatalf("err = %v, want ErrInvalidName", err)
+		}
+	})
+}

--- a/sys/repo/pacman.go
+++ b/sys/repo/pacman.go
@@ -1,0 +1,105 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// pacmanConf is the pacman configuration file edited in place.
+const pacmanConf = "/etc/pacman.conf"
+
+// removePacmanSection removes a [name] section from pacman.conf content. A
+// section extends from its [name] header to the next [section] header (exclusive)
+// or end of file. Done in Go (no sed) so there is no shell/regex injection risk.
+func removePacmanSection(content, name string) string {
+	sectionHeader := "[" + name + "]"
+	lines := strings.Split(content, "\n")
+	var result []string
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == sectionHeader {
+			inSection = true
+			continue
+		}
+		if inSection && strings.HasPrefix(trimmed, "[") {
+			inSection = false
+		}
+		if !inSection {
+			result = append(result, line)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+// applyPacman appends (or replaces) the repository's [name] section in
+// /etc/pacman.conf and synchronizes the package database. The conf is rewritten
+// atomically; the db sync is non-fatal (surfaced as a warning).
+//
+// A missing /etc/pacman.conf is treated as empty content (fs.Manager.ReadFile
+// reports absence as empty); on a real pacman host the file always exists.
+func (m *manager) applyPacman(ctx context.Context, name string, c *PacmanConfig) (Outcome, error) {
+	var log strings.Builder
+	confBytes, err := m.fsm.ReadFile(ctx, pacmanConf)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("read pacman.conf: %w", err)
+	}
+	confStr := string(confBytes)
+
+	var section strings.Builder
+	fmt.Fprintf(&section, "\n[%s]\n", name)
+	if c.SigLevel != "" {
+		fmt.Fprintf(&section, "SigLevel = %s\n", c.SigLevel)
+	}
+	fmt.Fprintf(&section, "Server = %s\n", c.Server)
+
+	newConf := confStr
+	if strings.Contains(confStr, "["+name+"]") {
+		newConf = removePacmanSection(confStr, name)
+	}
+	newConf += section.String()
+
+	// Idempotency: skip the write + db sync when the conf already matches.
+	if newConf == confStr {
+		fmt.Fprintf(&log, "repository %s already configured\n", name)
+		return out(log.String(), false), nil
+	}
+
+	if err := m.fsm.WriteFile(ctx, pacmanConf, []byte(newConf), fs.WriteOptions{Mode: 0o644}); err != nil {
+		return Outcome{}, fmt.Errorf("write pacman.conf: %w", err)
+	}
+	fmt.Fprintf(&log, "configured repository: %s\n", name)
+
+	res, serr := m.runPriv(ctx, "pacman", "-Sy", "--noconfirm")
+	if res.Stdout != "" {
+		log.WriteString(res.Stdout)
+	}
+	if serr != nil {
+		fmt.Fprintf(&log, "warning: failed to sync repository database: %v\n", serr)
+	}
+	return out(log.String(), true), nil
+}
+
+// removePacman removes the repository's section from /etc/pacman.conf. Removing
+// an absent section is an idempotent no-op.
+func (m *manager) removePacman(ctx context.Context, name string) (Outcome, error) {
+	var log strings.Builder
+	confBytes, err := m.fsm.ReadFile(ctx, pacmanConf)
+	if err != nil {
+		return Outcome{}, fmt.Errorf("read pacman.conf: %w", err)
+	}
+	confStr := string(confBytes)
+	if !strings.Contains(confStr, "["+name+"]") {
+		fmt.Fprintf(&log, "repository %s not found, nothing to remove\n", name)
+		return out(log.String(), false), nil
+	}
+	newConf := removePacmanSection(confStr, name)
+	if err := m.fsm.WriteFile(ctx, pacmanConf, []byte(newConf), fs.WriteOptions{Mode: 0o644}); err != nil {
+		return Outcome{}, fmt.Errorf("write pacman.conf: %w", err)
+	}
+	fmt.Fprintf(&log, "removed repository: %s\n", name)
+	return out(log.String(), true), nil
+}

--- a/sys/repo/pacman_test.go
+++ b/sys/repo/pacman_test.go
@@ -1,0 +1,176 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func TestPacman_Apply_AppendsSectionAndSyncs(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Pacman)
+	ff.read["/etc/pacman.conf"] = []byte("[options]\nHoldPkg = pacman\n\n[core]\nInclude = /etc/pacman.d/mirrorlist\n")
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Pacman: &PacmanConfig{
+		Server: "https://h/$repo/$arch", SigLevel: "Optional TrustAll",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("first Apply must report Changed=true")
+	}
+	got := ff.wrote("/etc/pacman.conf")
+	wantSection := "\n[corp]\nSigLevel = Optional TrustAll\nServer = https://h/$repo/$arch\n"
+	if !strings.HasSuffix(got, wantSection) {
+		t.Errorf("pacman.conf =\n%q\nwant it to end with\n%q", got, wantSection)
+	}
+	// The pre-existing content must be preserved (only appended to).
+	if !strings.Contains(got, "[options]") || !strings.Contains(got, "[core]") {
+		t.Errorf("pacman.conf lost pre-existing sections:\n%q", got)
+	}
+	if cmds := argvs(fr); len(cmds) != 1 || cmds[0] != "pacman -Sy --noconfirm" {
+		t.Errorf("commands = %v, want a single pacman -Sy", cmds)
+	}
+}
+
+func TestPacman_Apply_ReplacesExistingSection(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Pacman)
+	ff.read["/etc/pacman.conf"] = []byte("[options]\nX = 1\n\n[corp]\nServer = https://old/\n\n[extra]\nInclude = /m\n")
+	if _, err := m.Apply(context.Background(), Repository{Name: "corp", Pacman: &PacmanConfig{Server: "https://new/"}}); err != nil {
+		t.Fatal(err)
+	}
+	got := ff.wrote("/etc/pacman.conf")
+	if strings.Contains(got, "https://old/") {
+		t.Errorf("old Server survived the replace:\n%q", got)
+	}
+	if !strings.Contains(got, "Server = https://new/") {
+		t.Errorf("new Server missing:\n%q", got)
+	}
+	// [extra] (a sibling that followed the replaced section) must survive.
+	if !strings.Contains(got, "[extra]") {
+		t.Errorf("replacing [corp] wrongly consumed the following [extra] section:\n%q", got)
+	}
+}
+
+func TestPacman_Apply_Idempotent(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Pacman)
+	// The conf already ends with exactly the section Apply would append.
+	existing := "[options]\nX = 1\n[corp]\nServer = https://h/\n"
+	ff.read["/etc/pacman.conf"] = []byte(existing)
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Pacman: &PacmanConfig{Server: "https://h/"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Changed {
+		t.Errorf("already-configured repo must report Changed=false; conf rewritten to %q", ff.wrote("/etc/pacman.conf"))
+	}
+	if ff.didCall("WriteFile:/etc/pacman.conf") {
+		t.Error("idempotent Apply must not rewrite pacman.conf")
+	}
+	if n := len(fr.Calls()); n != 0 {
+		t.Errorf("idempotent Apply ran %d commands, want 0", n)
+	}
+}
+
+func TestPacman_Apply_NoSigLevel(t *testing.T) {
+	m, ff, _ := newTestManager(t, pkg.Pacman)
+	ff.read["/etc/pacman.conf"] = []byte("[options]\n")
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/"}}); err != nil {
+		t.Fatal(err)
+	}
+	got := ff.wrote("/etc/pacman.conf")
+	if strings.Contains(got, "SigLevel") {
+		t.Errorf("no SigLevel configured, but one was written:\n%q", got)
+	}
+}
+
+func TestPacman_Apply_SyncFailureIsNonFatal(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Pacman)
+	ff.read["/etc/pacman.conf"] = []byte("[options]\n")
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "db sync failed"}, nil)
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/"}})
+	if err != nil {
+		t.Fatalf("db-sync failure must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "warning: failed to sync repository database") {
+		t.Errorf("expected a sync warning, got %q", out.Result.Stdout)
+	}
+}
+
+func TestPacman_Apply_ReadAndWriteErrors(t *testing.T) {
+	t.Run("read error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.errs["ReadFile:/etc/pacman.conf"] = errors.New("io")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/"}}); err == nil ||
+			!strings.Contains(err.Error(), "read pacman.conf") {
+			t.Fatalf("err = %v, want a wrapped read failure", err)
+		}
+	})
+	t.Run("write error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.read["/etc/pacman.conf"] = []byte("[options]\n")
+		ff.errs["WriteFile:/etc/pacman.conf"] = errors.New("ro")
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/"}}); err == nil ||
+			!strings.Contains(err.Error(), "write pacman.conf") {
+			t.Fatalf("err = %v, want a wrapped write failure", err)
+		}
+	})
+}
+
+func TestPacman_Remove(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.read["/etc/pacman.conf"] = []byte("[options]\nX = 1\n[corp]\nServer = https://h/\n")
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.Changed {
+			t.Error("removing a present section must report Changed=true")
+		}
+		if got := ff.wrote("/etc/pacman.conf"); strings.Contains(got, "[corp]") {
+			t.Errorf("[corp] survived removal:\n%q", got)
+		}
+	})
+	t.Run("absent is idempotent", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.read["/etc/pacman.conf"] = []byte("[options]\n")
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.Changed || ff.didCall("WriteFile:/etc/pacman.conf") {
+			t.Error("removing an absent section must be a no-op")
+		}
+	})
+	t.Run("read error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.errs["ReadFile:/etc/pacman.conf"] = errors.New("io")
+		if _, err := m.Remove(context.Background(), "corp"); err == nil {
+			t.Fatal("a read failure must surface")
+		}
+	})
+	t.Run("write error", func(t *testing.T) {
+		m, ff, _ := newTestManager(t, pkg.Pacman)
+		ff.read["/etc/pacman.conf"] = []byte("[corp]\nServer = https://h/\n")
+		ff.errs["WriteFile:/etc/pacman.conf"] = errors.New("ro")
+		if _, err := m.Remove(context.Background(), "corp"); err == nil {
+			t.Fatal("a write failure must surface")
+		}
+	})
+}
+
+func TestRemovePacmanSection_EndOfFile(t *testing.T) {
+	// A section that runs to EOF (no following [section]) is fully removed.
+	in := "[options]\nX = 1\n[last]\nServer = https://h/\nKey = v\n"
+	got := removePacmanSection(in, "last")
+	if strings.Contains(got, "[last]") || strings.Contains(got, "Server = https://h/") {
+		t.Errorf("EOF section not fully removed:\n%q", got)
+	}
+	if !strings.Contains(got, "[options]") {
+		t.Errorf("removed too much:\n%q", got)
+	}
+}

--- a/sys/repo/repo.go
+++ b/sys/repo/repo.go
@@ -1,0 +1,317 @@
+// Package repo configures external package-manager repositories through an
+// injected exec.Runner, the same dependency-injected idiom as pkg/fs/network.
+//
+// A Manager is built for an explicit package-manager backend and a Runner; it
+// owns the per-backend repository file format (apt deb822 .sources + keyrings,
+// dnf .repo, pacman.conf sections, zypper addrepo), GPG public-key import, the
+// idempotency comparison, and the post-configuration metadata refresh:
+//
+//	r, _ := exec.NewRunner(exec.Direct) // the agent runs as root
+//	m, err := repo.New(pkg.Dnf, r)
+//	if err != nil { ... }
+//	out, err := m.Apply(ctx, repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{
+//		BaseURL: "https://packages.example.com/el9", GPGCheck: true,
+//		GPGKey: "https://packages.example.com/RPM-GPG-KEY", Enabled: true,
+//	}})
+//
+// Privileged file writes are delegated to fs.Manager, so on the Direct (root)
+// backend they take the TOCTOU-safe, fd-anchored path — a hardening upgrade over
+// a raw `cp`/sudo write into a world-traversable config directory.
+//
+// GPG keys handled here are PUBLIC repository-signing keys, not secrets: apt
+// receives the key material as bytes (the caller downloads it under its own
+// network policy) which the Manager dearmors into /etc/apt/keyrings; dnf and
+// zypper receive a key reference (an https URL or absolute path) that the package
+// manager itself resolves. No exec.Secret is involved.
+//
+// Repositories belong to a package manager, so callers discover the backend with
+// pkg.Detect — repo has no separate Detect. Flatpak has no native-style repo
+// (its remotes live on pkg.FlatpakManager), so New rejects it.
+package repo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// ErrUnsupportedBackend is returned by New for a backend that has no
+// native-style repository configuration: flatpak (whose remotes live on
+// pkg.FlatpakManager) and the zero/unknown value. Fail-closed: no silent default.
+var ErrUnsupportedBackend = errors.New("repo: unsupported package-manager backend")
+
+// ErrInvalidName is returned when a repository name is empty, too long, or
+// contains characters that would be unsafe as a filename or argv operand.
+var ErrInvalidName = errors.New("repo: invalid repository name")
+
+// ErrMissingConfig is returned by Apply when the Repository carries no
+// configuration for the Manager's backend (e.g. Apply on a Dnf Manager with a
+// nil Dnf field). Fail-closed: a repository with nothing to configure is a
+// caller bug, not a silent no-op.
+var ErrMissingConfig = errors.New("repo: no configuration for this backend")
+
+// ErrInvalidConfig is returned when a repository configuration field is malformed
+// — a control character (config-injection) or a shape that would be unsafe to
+// splice into a config file or command line. The error names the offending field
+// but never echoes its value (URLs/keys can carry per-deployment secrets).
+var ErrInvalidConfig = errors.New("repo: invalid repository configuration")
+
+// Repository is a package repository to configure. Set the sub-configuration
+// matching the Manager's backend; the others are ignored. (The shape mirrors the
+// control-plane RepositoryParams message so a caller maps it field-for-field.)
+type Repository struct {
+	// Name identifies the repository; it is used to name the on-disk config
+	// (and, for apt, the keyring) and as the repo alias for zypper/pacman.
+	Name string
+
+	Apt    *AptConfig
+	Dnf    *DnfConfig
+	Pacman *PacmanConfig
+	Zypper *ZypperConfig
+}
+
+// AptConfig configures a Debian/Ubuntu APT repository, written in the modern
+// deb822 format to /etc/apt/sources.list.d/<name>.sources.
+type AptConfig struct {
+	// URL is the repository root. apt is intentionally not restricted to https:
+	// its trust anchor is the gpg-signed Release file, so an http transport with
+	// a trusted key is a legitimate, long-standing configuration.
+	URL string
+	// Distribution is the suite/codename (e.g. "bookworm"). Empty selects a flat
+	// repository ("Suites: /").
+	Distribution string
+	// Components (e.g. "main", "contrib"). Optional.
+	Components []string
+	// Arch restricts the architecture (e.g. "amd64"). Optional.
+	Arch string
+	// GPGKey is the PUBLIC repository-signing key, ASCII-armored or binary. When
+	// set it is dearmored and written to /etc/apt/keyrings/<name>.gpg and
+	// referenced via Signed-By. The caller downloads it (network policy is the
+	// caller's); the Manager never fetches. Empty → no key.
+	GPGKey []byte
+	// Trusted writes "Trusted: yes" (disables signature verification). Honored
+	// only when GPGKey is empty; a configured key always takes precedence.
+	Trusted bool
+}
+
+// DnfConfig configures a Fedora/RHEL DNF/YUM repository, written to
+// /etc/yum.repos.d/<name>.repo.
+type DnfConfig struct {
+	// BaseURL is the repository base (https required; supports $releasever etc.).
+	BaseURL string
+	// Description is the human-readable repo name (the .repo "name=" field).
+	Description string
+	// Enabled writes enabled=1/0.
+	Enabled bool
+	// GPGCheck writes gpgcheck=1/0.
+	GPGCheck bool
+	// GPGKey is a key reference (https URL or absolute path) written as gpgkey=
+	// and imported with `rpm --import`. Empty → no key import.
+	GPGKey string
+	// ModuleHotfixes writes module_hotfixes=1 when set.
+	ModuleHotfixes bool
+}
+
+// PacmanConfig configures an Arch Linux pacman repository as a section appended
+// to /etc/pacman.conf.
+type PacmanConfig struct {
+	// Server is the repository server URL (https required; supports $repo/$arch).
+	Server string
+	// SigLevel sets the section's SigLevel (e.g. "Optional TrustAll"). Optional.
+	SigLevel string
+}
+
+// ZypperConfig configures an openSUSE zypper repository via `zypper addrepo`.
+type ZypperConfig struct {
+	// URL is the repository URL (https required).
+	URL string
+	// Description is the repo's display name (set with modifyrepo --name).
+	Description string
+	// Enabled enables/disables the repo (modifyrepo --enable/--disable).
+	Enabled bool
+	// Autorefresh enables periodic refresh (modifyrepo --refresh).
+	Autorefresh bool
+	// GPGCheck controls signature checking (addrepo --no-gpgcheck when false).
+	GPGCheck bool
+	// GPGKey is a key reference imported with `rpm --import`. Optional.
+	GPGKey string
+	// Type sets the repository type (addrepo --type, e.g. "rpm-md"). Optional.
+	Type string
+}
+
+// Outcome reports what an Apply/Remove did: the aggregated command output
+// (exit code, the human-readable log of steps taken, and any stderr) plus
+// whether on-disk state actually changed. Changed is false for an idempotent
+// no-op (the configuration already matched), which lets a caller suppress
+// spurious state-change events.
+type Outcome struct {
+	Result  pmexec.Result
+	Changed bool
+}
+
+// Manager is the repository-configuration surface for a single package-manager
+// backend (fixed at construction). Validate is exposed separately so a caller
+// can reject a malformed configuration BEFORE taking any privileged side effect
+// (e.g. remounting a read-only root); Apply re-validates internally regardless.
+type Manager interface {
+	// Backend reports which package-manager backend this Manager configures.
+	Backend() pkg.Backend
+	// Validate checks the repository name and the configuration for this
+	// Manager's backend (if present) without touching the system.
+	Validate(r Repository) error
+	// Apply configures the repository (idempotently) for PRESENT desired state.
+	Apply(ctx context.Context, r Repository) (Outcome, error)
+	// Remove deletes the named repository (and, for apt, its keyring) for ABSENT
+	// desired state. It is idempotent: removing an absent repository reports
+	// Changed=false.
+	Remove(ctx context.Context, name string) (Outcome, error)
+}
+
+// fsManager is the narrow slice of fs.Manager this package uses for privileged
+// file operations. Keeping it minimal lets unit tests inject a small fake via
+// the newFS seam without driving real privileged file ops.
+type fsManager interface {
+	ReadFile(ctx context.Context, path string) ([]byte, error)
+	ReadDir(ctx context.Context, path string) ([]fs.DirEntry, error)
+	WriteFile(ctx context.Context, path string, data []byte, opts fs.WriteOptions) error
+	Remove(ctx context.Context, path string) error
+	Mkdir(ctx context.Context, path string, opts fs.MkdirOptions) error
+	Exists(ctx context.Context, path string) (bool, error)
+}
+
+// newFS builds the fs.Manager each Manager delegates privileged file ops to,
+// over the same injected Runner. A package var so tests override it with a fake.
+var newFS = func(r pmexec.Runner) (fsManager, error) { return fs.New(r) }
+
+// manager is the single Manager implementation; the per-backend behavior is
+// selected by b (validated at construction), so there is no per-backend type.
+type manager struct {
+	b   pkg.Backend
+	r   pmexec.Runner
+	fsm fsManager
+}
+
+// New builds a repository Manager for backend b driven by runner. A nil runner
+// or a backend without native repository support (flatpak, the zero value) is
+// rejected (fail-closed). New is pure — it does not probe the host; use
+// pkg.Detect to learn which backends are installed.
+func New(b pkg.Backend, runner pmexec.Runner) (Manager, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("repo: %w", pmexec.ErrRunnerRequired)
+	}
+	switch b {
+	case pkg.Apt, pkg.Dnf, pkg.Pacman, pkg.Zypper:
+		// supported
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, b)
+	}
+	fsm, err := newFS(runner)
+	if err != nil {
+		return nil, err
+	}
+	return &manager{b: b, r: runner, fsm: fsm}, nil
+}
+
+// Backend reports the configured backend.
+func (m *manager) Backend() pkg.Backend { return m.b }
+
+// Apply validates then dispatches to the backend-specific configuration path.
+func (m *manager) Apply(ctx context.Context, r Repository) (Outcome, error) {
+	if err := m.Validate(r); err != nil {
+		return Outcome{}, err
+	}
+	switch m.b {
+	case pkg.Apt:
+		if r.Apt == nil {
+			return Outcome{}, fmt.Errorf("%w: apt", ErrMissingConfig)
+		}
+		return m.applyApt(ctx, r.Name, r.Apt)
+	case pkg.Dnf:
+		if r.Dnf == nil {
+			return Outcome{}, fmt.Errorf("%w: dnf", ErrMissingConfig)
+		}
+		return m.applyDnf(ctx, r.Name, r.Dnf)
+	case pkg.Pacman:
+		if r.Pacman == nil {
+			return Outcome{}, fmt.Errorf("%w: pacman", ErrMissingConfig)
+		}
+		return m.applyPacman(ctx, r.Name, r.Pacman)
+	case pkg.Zypper:
+		if r.Zypper == nil {
+			return Outcome{}, fmt.Errorf("%w: zypper", ErrMissingConfig)
+		}
+		return m.applyZypper(ctx, r.Name, r.Zypper)
+	default:
+		// Defense-in-depth: New gates the backend, so this is unreachable for a
+		// Manager built through the public constructor.
+		return Outcome{}, fmt.Errorf("%w: %s", ErrUnsupportedBackend, m.b)
+	}
+}
+
+// Remove validates the name then dispatches to the backend-specific removal.
+func (m *manager) Remove(ctx context.Context, name string) (Outcome, error) {
+	if err := validateName(name); err != nil {
+		return Outcome{}, err
+	}
+	switch m.b {
+	case pkg.Apt:
+		return m.removeApt(ctx, name)
+	case pkg.Dnf:
+		return m.removeDnf(ctx, name)
+	case pkg.Pacman:
+		return m.removePacman(ctx, name)
+	case pkg.Zypper:
+		return m.removeZypper(ctx, name)
+	default:
+		return Outcome{}, fmt.Errorf("%w: %s", ErrUnsupportedBackend, m.b)
+	}
+}
+
+// out builds a successful Outcome from an accumulated log and changed flag.
+func out(log string, changed bool) Outcome {
+	return Outcome{Result: pmexec.Result{ExitCode: 0, Stdout: log}, Changed: changed}
+}
+
+// fsResultErr builds a failure Result carrying the accumulated log as stdout and
+// the error text as stderr, for the paths that return both a Result and an error.
+func fsResultErr(log string, err error) pmexec.Result {
+	return pmexec.Result{ExitCode: 1, Stdout: log, Stderr: err.Error()}
+}
+
+// runPriv runs an escalated package-manager command through the Runner and folds
+// a non-zero exit into an *exec.CommandError (the error is nil only on a clean
+// exit). The Result is returned in all cases so a caller can surface stdout.
+func (m *manager) runPriv(ctx context.Context, name string, args ...string) (pmexec.Result, error) {
+	res, err := m.r.Run(ctx, pmexec.Command{Name: name, Args: args, Escalate: true})
+	if err != nil {
+		return res, err
+	}
+	if res.ExitCode != 0 {
+		return res, &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res, nil
+}
+
+// runStdin runs an UNPRIVILEGED command with stdin (the gpg --dearmor path: it
+// processes a public key, needs no privilege, and must not touch any file —
+// fs.Manager performs the privileged keyring write). A non-zero exit folds into
+// an *exec.CommandError.
+func (m *manager) runStdin(ctx context.Context, stdin []byte, name string, args ...string) (pmexec.Result, error) {
+	cmd := pmexec.Command{Name: name, Args: args}
+	if len(stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	res, err := m.r.Run(ctx, cmd)
+	if err != nil {
+		return res, err
+	}
+	if res.ExitCode != 0 {
+		return res, &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return res, nil
+}

--- a/sys/repo/repo_container_test.go
+++ b/sys/repo/repo_container_test.go
@@ -1,0 +1,277 @@
+//go:build container
+
+// Container-based real-execution tests for the repository Manager. The
+// hermetic FakeRunner tests cover every branch with scripted output; these run
+// the REAL Apply/Remove side effects inside a container against the actual
+// package-manager tooling and filesystem, so a deb822/.repo/pacman.conf format
+// change, a real `gpg --dearmor` shape change, or a zypper addrepo/removerepo
+// contract change is caught here.
+//
+// One file, four backends, each Detect-gated: the apt cell runs in the
+// container-tests matrix (Debian base + gnupg); the dnf/pacman/zypper cells run
+// in their distro CI jobs (Fedora/Arch/openSUSE) which invoke this with
+// `-tags=container`. Every lane runs as root, so the Direct runner is correct
+// (Escalate is a no-op wrapper over the already-root process). Mutating tests
+// are gated behind `//go:build container` so a plain `go test ./...` on a
+// developer's real machine never touches their /etc.
+package repo
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// armoredTestKey is a throwaway ed25519 PUBLIC key (no secret committed) used to
+// exercise the real `gpg --dearmor` + keyring-write path for apt.
+const armoredTestKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEajZ3rBYJKwYBBAHaRw8BAQdAwYnGPZg6OfGisPl+/RAOseXCejyrS+CjiSKZ
+lCXoDjG0MVBNIFJlcG8gVGVzdCBLZXkgPHJlcG8tdGVzdEBwb3dlci1tYW5hZ2Uu
+aW52YWxpZD6IkAQTFggAOBYhBN1Qn9dyeqU4SntfyL6U56IHNSDTBQJqNnesAhsj
+BQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAAAoJEL6U56IHNSDTGp4BALFRj253kOzs
+gxVpo/34NPKJga6Orty0loT/fCuEIwhvAQCpfGCUcX2QgqDXxrlS9IQ6wn6JCPNw
+fGAUk8ja+rIzBA==
+=8ls7
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+func realRepoMgr(t *testing.T, b pkg.Backend) Manager {
+	t.Helper()
+	if !slices.Contains(pkg.Detect(context.Background()), b) {
+		t.Skipf("%s not installed here; repo backend not exercisable", b)
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(b, r)
+	if err != nil {
+		t.Fatalf("New(%s): %v", b, err)
+	}
+	return m
+}
+
+func repoCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TestApt_ApplyRemove_Container drives the real apt path end-to-end: dearmor a
+// public key into /etc/apt/keyrings, write the deb822 .sources with Signed-By,
+// prove idempotency, then remove both. Pins the deb822 format + real gpg dearmor.
+func TestApt_ApplyRemove_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-test-apt"
+	repoFile, keyFile := aptRepoFile(name), aptKeyFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	repo := Repository{Name: name, Apt: &AptConfig{
+		URL:          "https://example.com/pm-test-debian",
+		Distribution: "bookworm",
+		Components:   []string{"main"},
+		GPGKey:       []byte(armoredTestKey),
+	}}
+
+	o, err := m.Apply(ctx, repo)
+	if err != nil {
+		t.Fatalf("Apply(apt): %v", err)
+	}
+	if !o.Changed {
+		t.Error("first Apply should report Changed=true")
+	}
+
+	src := readFile(t, repoFile)
+	for _, want := range []string{"Types: deb", "URIs: https://example.com/pm-test-debian", "Suites: bookworm", "Components: main", "Signed-By: " + keyFile} {
+		if !strings.Contains(src, want) {
+			t.Errorf("deb822 source missing %q:\n%s", want, src)
+		}
+	}
+	key := readFile(t, keyFile)
+	if key == "" {
+		t.Error("keyring is empty")
+	}
+	if strings.HasPrefix(key, "-----BEGIN PGP") {
+		t.Error("keyring is still ASCII-armored — real `gpg --dearmor` did not run")
+	}
+
+	// Idempotency: a second identical Apply changes nothing.
+	o2, err := m.Apply(ctx, repo)
+	if err != nil {
+		t.Fatalf("re-Apply(apt): %v", err)
+	}
+	if o2.Changed {
+		t.Error("idempotent re-Apply should report Changed=false")
+	}
+
+	o3, err := m.Remove(ctx, name)
+	if err != nil {
+		t.Fatalf("Remove(apt): %v", err)
+	}
+	if !o3.Changed {
+		t.Error("Remove of a present repo should report Changed=true")
+	}
+	if fileExists(repoFile) || fileExists(keyFile) {
+		t.Errorf("Remove left files behind: source=%v key=%v", fileExists(repoFile), fileExists(keyFile))
+	}
+	o4, err := m.Remove(ctx, name)
+	if err != nil {
+		t.Fatalf("re-Remove(apt): %v", err)
+	}
+	if o4.Changed {
+		t.Error("Remove of an absent repo should report Changed=false")
+	}
+}
+
+// TestDnf_ApplyRemove_Container pins the .repo INI format written to
+// /etc/yum.repos.d against real dnf (the makecache refresh against the unreachable
+// URL is non-fatal by design).
+func TestDnf_ApplyRemove_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Dnf)
+	ctx := repoCtx(t)
+	const name = "pm-test-dnf"
+	repoFile := dnfRepoFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	repo := Repository{Name: name, Dnf: &DnfConfig{
+		BaseURL: "https://example.com/pm-test-el9", Description: "PM Test", Enabled: true, GPGCheck: false,
+	}}
+
+	o, err := m.Apply(ctx, repo)
+	if err != nil {
+		t.Fatalf("Apply(dnf): %v", err)
+	}
+	if !o.Changed {
+		t.Error("first Apply should report Changed=true")
+	}
+	body := readFile(t, repoFile)
+	for _, want := range []string{"[" + name + "]", "name=PM Test", "baseurl=https://example.com/pm-test-el9", "enabled=1", "gpgcheck=0"} {
+		if !strings.Contains(body, want) {
+			t.Errorf(".repo missing %q:\n%s", want, body)
+		}
+	}
+	if o2, err := m.Apply(ctx, repo); err != nil || o2.Changed {
+		t.Errorf("idempotent re-Apply: changed=%v err=%v", o2.Changed, err)
+	}
+	if o3, err := m.Remove(ctx, name); err != nil || !o3.Changed || fileExists(repoFile) {
+		t.Errorf("Remove: changed=%v err=%v exists=%v", o3.Changed, err, fileExists(repoFile))
+	}
+	if o4, err := m.Remove(ctx, name); err != nil || o4.Changed {
+		t.Errorf("idempotent Remove: changed=%v err=%v", o4.Changed, err)
+	}
+}
+
+// TestPacman_ApplyRemove_Container pins the [section] appended to the real
+// /etc/pacman.conf (the `pacman -Sy` against the unreachable Server is non-fatal).
+func TestPacman_ApplyRemove_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Pacman)
+	ctx := repoCtx(t)
+	const name = "pm-test-pacman"
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	repo := Repository{Name: name, Pacman: &PacmanConfig{
+		Server: "https://example.com/pm-test-arch/$repo/os/$arch", SigLevel: "Optional TrustAll",
+	}}
+
+	o, err := m.Apply(ctx, repo)
+	if err != nil {
+		t.Fatalf("Apply(pacman): %v", err)
+	}
+	if !o.Changed {
+		t.Error("first Apply should report Changed=true")
+	}
+	conf := readFile(t, pacmanConf)
+	for _, want := range []string{"[" + name + "]", "SigLevel = Optional TrustAll", "Server = https://example.com/pm-test-arch/$repo/os/$arch"} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("pacman.conf missing %q", want)
+		}
+	}
+	if o2, err := m.Apply(ctx, repo); err != nil || o2.Changed {
+		t.Errorf("idempotent re-Apply: changed=%v err=%v", o2.Changed, err)
+	}
+	if o3, err := m.Remove(ctx, name); err != nil || !o3.Changed {
+		t.Errorf("Remove: changed=%v err=%v", o3.Changed, err)
+	}
+	if strings.Contains(readFile(t, pacmanConf), "["+name+"]") {
+		t.Error("Remove left the [section] in pacman.conf")
+	}
+	if o4, err := m.Remove(ctx, name); err != nil || o4.Changed {
+		t.Errorf("idempotent Remove: changed=%v err=%v", o4.Changed, err)
+	}
+}
+
+// TestZypper_ApplyRemove_Container drives real `zypper addrepo`/`removerepo`:
+// addrepo registers the alias (no fetch at add time with Autorefresh off), and
+// `zypper lr <name>` must then list it. The trailing refresh against the
+// unreachable URL is non-fatal by design.
+func TestZypper_ApplyRemove_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Zypper)
+	ctx := repoCtx(t)
+	const name = "pm-test-zypper"
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	repo := Repository{Name: name, Zypper: &ZypperConfig{
+		URL: "https://example.com/pm-test-suite", Description: "PM Test", Enabled: false, Autorefresh: false, GPGCheck: false,
+	}}
+
+	o, err := m.Apply(ctx, repo)
+	if err != nil {
+		t.Fatalf("Apply(zypper): %v", err)
+	}
+	if !o.Changed {
+		t.Error("Apply should report Changed=true (zypper addrepo has no cheap idempotency probe)")
+	}
+	if !zypperRepoListed(t, name) {
+		t.Errorf("`zypper lr %s` does not list the repo after Apply", name)
+	}
+
+	o3, err := m.Remove(ctx, name)
+	if err != nil {
+		t.Fatalf("Remove(zypper): %v", err)
+	}
+	if !o3.Changed {
+		t.Error("Remove of a present repo should report Changed=true")
+	}
+	if zypperRepoListed(t, name) {
+		t.Errorf("`zypper lr %s` still lists the repo after Remove", name)
+	}
+	o4, err := m.Remove(ctx, name)
+	if err != nil {
+		t.Fatalf("re-Remove(zypper): %v", err)
+	}
+	if o4.Changed {
+		t.Error("Remove of an absent repo should report Changed=false (not found)")
+	}
+}
+
+// zypperRepoListed reports whether `zypper lr <name>` exits 0 (the alias is
+// registered). Run directly (root container) rather than through the Manager —
+// the Manager has no read-back, so this is the independent verification.
+func zypperRepoListed(t *testing.T, name string) bool {
+	t.Helper()
+	return osexec.Command("zypper", "--non-interactive", "lr", name).Run() == nil
+}

--- a/sys/repo/repo_test.go
+++ b/sys/repo/repo_test.go
@@ -1,0 +1,196 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+// fakeFS is a recording fsManager. It records every op (as "Op:path", in order),
+// returns scripted contents/existence/entries per path, and can be forced to
+// error on a given "op:path". It lets repo unit tests assert the exact file
+// operations a backend performs without touching the real filesystem (the real
+// fs.Manager's Direct WriteFile hits real syscalls; its Sudo path stats real
+// parent dirs).
+type fakeFS struct {
+	mu      sync.Mutex
+	calls   []string
+	written map[string][]byte
+	read    map[string][]byte
+	present map[string]bool
+	entries map[string][]fs.DirEntry
+	errs    map[string]error
+}
+
+func newFakeFS() *fakeFS {
+	return &fakeFS{
+		written: map[string][]byte{},
+		read:    map[string][]byte{},
+		present: map[string]bool{},
+		entries: map[string][]fs.DirEntry{},
+		errs:    map[string]error{},
+	}
+}
+
+func (f *fakeFS) record(s string) { f.mu.Lock(); f.calls = append(f.calls, s); f.mu.Unlock() }
+
+func (f *fakeFS) ReadFile(_ context.Context, path string) ([]byte, error) {
+	f.record("ReadFile:" + path)
+	if e := f.errs["ReadFile:"+path]; e != nil {
+		return nil, e
+	}
+	return f.read[path], nil
+}
+
+func (f *fakeFS) ReadDir(_ context.Context, path string) ([]fs.DirEntry, error) {
+	f.record("ReadDir:" + path)
+	if e := f.errs["ReadDir:"+path]; e != nil {
+		return nil, e
+	}
+	return f.entries[path], nil
+}
+
+func (f *fakeFS) WriteFile(_ context.Context, path string, data []byte, _ fs.WriteOptions) error {
+	f.record("WriteFile:" + path)
+	if e := f.errs["WriteFile:"+path]; e != nil {
+		return e
+	}
+	f.written[path] = data
+	return nil
+}
+
+func (f *fakeFS) Remove(_ context.Context, path string) error {
+	f.record("Remove:" + path)
+	return f.errs["Remove:"+path]
+}
+
+func (f *fakeFS) Mkdir(_ context.Context, path string, _ fs.MkdirOptions) error {
+	f.record("Mkdir:" + path)
+	return f.errs["Mkdir:"+path]
+}
+
+func (f *fakeFS) Exists(_ context.Context, path string) (bool, error) {
+	f.record("Exists:" + path)
+	if e := f.errs["Exists:"+path]; e != nil {
+		return false, e
+	}
+	return f.present[path], nil
+}
+
+func (f *fakeFS) wrote(path string) string { return string(f.written[path]) }
+
+func (f *fakeFS) didCall(want string) bool {
+	for _, c := range f.calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// newTestManager builds a Manager for backend b with the fake fs injected via the
+// newFS seam and a Direct FakeRunner for package-manager commands.
+func newTestManager(t *testing.T, b pkg.Backend) (*manager, *fakeFS, *exectest.FakeRunner) {
+	t.Helper()
+	ff := newFakeFS()
+	orig := newFS
+	newFS = func(pmexec.Runner) (fsManager, error) { return ff, nil }
+	t.Cleanup(func() { newFS = orig })
+	fr := exectest.New(pmexec.Direct)
+	m, err := New(b, fr)
+	if err != nil {
+		t.Fatalf("New(%s): %v", b, err)
+	}
+	return m.(*manager), ff, fr
+}
+
+// argvs renders each recorded runner Command as "name arg1 arg2 …".
+func argvs(fr *exectest.FakeRunner) []string {
+	calls := fr.Calls()
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = strings.TrimSpace(c.Name + " " + strings.Join(c.Args, " "))
+	}
+	return out
+}
+
+// --- New -------------------------------------------------------------------
+
+func TestNew_NilRunnerRejected(t *testing.T) {
+	if _, err := New(pkg.Apt, nil); !errors.Is(err, pmexec.ErrRunnerRequired) {
+		t.Fatalf("New(nil runner) err = %v, want ErrRunnerRequired", err)
+	}
+}
+
+func TestNew_UnsupportedBackendRejected(t *testing.T) {
+	fr := exectest.New(pmexec.Direct)
+	for _, b := range []pkg.Backend{pkg.Flatpak, pkg.Backend(0), pkg.Backend(99)} {
+		if _, err := New(b, fr); !errors.Is(err, ErrUnsupportedBackend) {
+			t.Errorf("New(%v) err = %v, want ErrUnsupportedBackend", b, err)
+		}
+	}
+}
+
+func TestNew_SupportedBackends(t *testing.T) {
+	fr := exectest.New(pmexec.Direct)
+	for _, b := range []pkg.Backend{pkg.Apt, pkg.Dnf, pkg.Pacman, pkg.Zypper} {
+		m, err := New(b, fr)
+		if err != nil {
+			t.Fatalf("New(%s): %v", b, err)
+		}
+		if m.Backend() != b {
+			t.Errorf("Backend() = %s, want %s", m.Backend(), b)
+		}
+	}
+}
+
+func TestNew_FSConstructionErrorPropagates(t *testing.T) {
+	orig := newFS
+	sentinel := errors.New("fs boom")
+	newFS = func(pmexec.Runner) (fsManager, error) { return nil, sentinel }
+	t.Cleanup(func() { newFS = orig })
+	if _, err := New(pkg.Apt, exectest.New(pmexec.Direct)); !errors.Is(err, sentinel) {
+		t.Fatalf("New err = %v, want the fs construction error", err)
+	}
+}
+
+// --- Apply / Remove dispatch defense-in-depth ------------------------------
+
+// A Manager with an out-of-range backend (only constructable by bypassing New)
+// must fail closed rather than silently no-op.
+func TestApplyRemove_UnreachableBackendFailsClosed(t *testing.T) {
+	m := &manager{b: pkg.Flatpak, r: exectest.New(pmexec.Direct), fsm: newFakeFS()}
+	if _, err := m.Apply(context.Background(), Repository{Name: "x"}); !errors.Is(err, ErrUnsupportedBackend) {
+		t.Errorf("Apply err = %v, want ErrUnsupportedBackend", err)
+	}
+	if _, err := m.Remove(context.Background(), "x"); !errors.Is(err, ErrUnsupportedBackend) {
+		t.Errorf("Remove err = %v, want ErrUnsupportedBackend", err)
+	}
+}
+
+// Apply with no sub-config for the Manager's backend is a caller bug, not a
+// silent no-op.
+func TestApply_MissingConfigForBackend(t *testing.T) {
+	cases := []struct {
+		b pkg.Backend
+		r Repository
+	}{
+		{pkg.Apt, Repository{Name: "x"}},
+		{pkg.Dnf, Repository{Name: "x"}},
+		{pkg.Pacman, Repository{Name: "x"}},
+		{pkg.Zypper, Repository{Name: "x"}},
+	}
+	for _, c := range cases {
+		m, _, _ := newTestManager(t, c.b)
+		if _, err := m.Apply(context.Background(), c.r); !errors.Is(err, ErrMissingConfig) {
+			t.Errorf("%s Apply(no config) err = %v, want ErrMissingConfig", c.b, err)
+		}
+	}
+}

--- a/sys/repo/validate.go
+++ b/sys/repo/validate.go
@@ -1,0 +1,189 @@
+package repo
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+)
+
+// Field grammars. A repository name becomes a filename (and, for apt, a keyring
+// path) and an argv operand, so it must start alphanumeric and use only a narrow
+// safe set — this also blocks path traversal and option injection. The enum-like
+// fields (distribution, component, arch, siglevel, zypper type) carry naturally
+// narrow grammars; an allowlist costs nothing and removes config/argument
+// injection on the values spliced into config files and command lines.
+var (
+	validName            = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	validAptDistribution = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	validAptComponent    = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	validAptArch         = regexp.MustCompile(`^[a-z0-9][a-z0-9,_-]*$`)
+	validPacmanSigLevel  = regexp.MustCompile(`^[a-zA-Z ]+$`)
+	validZypperType      = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+)
+
+// maxNameLen bounds the repository name. It mirrors the agent's historical
+// runtime guard; the control plane enforces a tighter proto limit upstream, so
+// in practice names are far shorter.
+const maxNameLen = 128
+
+// hasControl reports whether s contains any ASCII control character (NUL,
+// newline, CR, tab, …) or DEL. A newline is the classic config-injection vector
+// — it would smuggle extra directives into a repo file — and control characters
+// have no place in a URL, description, or key reference.
+func hasControl(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// validateName checks a repository name.
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: name is empty", ErrInvalidName)
+	}
+	if len(name) > maxNameLen {
+		return fmt.Errorf("%w: name exceeds %d characters", ErrInvalidName, maxNameLen)
+	}
+	if !validName.MatchString(name) {
+		return fmt.Errorf("%w: name must match [a-zA-Z0-9][a-zA-Z0-9._-]*", ErrInvalidName)
+	}
+	return nil
+}
+
+// rejectControl returns an ErrInvalidConfig naming field if s holds a control
+// character. The value itself is never echoed (it may carry per-deployment
+// secrets); the field name is enough for an operator to find the action.
+func rejectControl(field, s string) error {
+	if hasControl(s) {
+		return fmt.Errorf("%w: field %q contains a control character", ErrInvalidConfig, field)
+	}
+	return nil
+}
+
+// badShape returns an ErrInvalidConfig naming field for a shape violation.
+func badShape(field string) error {
+	return fmt.Errorf("%w: field %q has an invalid shape", ErrInvalidConfig, field)
+}
+
+// Validate checks the name and the configuration for this Manager's backend.
+// A sub-config for a different backend is ignored. A name-only Repository
+// (no sub-config) validates the name alone — the shape Remove uses.
+func (m *manager) Validate(r Repository) error {
+	if err := validateName(r.Name); err != nil {
+		return err
+	}
+	switch m.b {
+	case pkg.Apt:
+		if r.Apt != nil {
+			return validateApt(r.Apt)
+		}
+	case pkg.Dnf:
+		if r.Dnf != nil {
+			return validateDnf(r.Dnf)
+		}
+	case pkg.Pacman:
+		if r.Pacman != nil {
+			return validatePacman(r.Pacman)
+		}
+	case pkg.Zypper:
+		if r.Zypper != nil {
+			return validateZypper(r.Zypper)
+		}
+	}
+	return nil
+}
+
+func validateApt(c *AptConfig) error {
+	if c.URL == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidConfig, "apt.url")
+	}
+	// apt is exempt from the https requirement (its trust is the signed Release);
+	// reject only control characters / argument confusion.
+	if err := rejectControl("apt.url", c.URL); err != nil {
+		return err
+	}
+	if err := rejectControl("apt.distribution", c.Distribution); err != nil {
+		return err
+	}
+	if c.Distribution != "" && !validAptDistribution.MatchString(c.Distribution) {
+		return badShape("apt.distribution")
+	}
+	for _, comp := range c.Components {
+		if err := rejectControl("apt.components", comp); err != nil {
+			return err
+		}
+		if !validAptComponent.MatchString(comp) {
+			return badShape("apt.components")
+		}
+	}
+	if err := rejectControl("apt.arch", c.Arch); err != nil {
+		return err
+	}
+	if c.Arch != "" && !validAptArch.MatchString(c.Arch) {
+		return badShape("apt.arch")
+	}
+	// c.GPGKey is multi-line PUBLIC key content written verbatim to a keyring
+	// file, never spliced into a config line or argv — so it is intentionally not
+	// control-char validated.
+	return nil
+}
+
+func validateDnf(c *DnfConfig) error {
+	if c.BaseURL == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidConfig, "dnf.baseurl")
+	}
+	if err := rejectControl("dnf.description", c.Description); err != nil {
+		return err
+	}
+	// ValidateRepoBaseURL/ValidateGpgKeyRef also reject control chars, so they
+	// subsume an explicit rejectControl for these fields.
+	if pkg.ValidateRepoBaseURL(c.BaseURL) != nil {
+		return badShape("dnf.baseurl")
+	}
+	if c.GPGKey != "" && pkg.ValidateGpgKeyRef(c.GPGKey) != nil {
+		return badShape("dnf.gpgkey")
+	}
+	return nil
+}
+
+func validatePacman(c *PacmanConfig) error {
+	if c.Server == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidConfig, "pacman.server")
+	}
+	if err := rejectControl("pacman.sig_level", c.SigLevel); err != nil {
+		return err
+	}
+	if c.SigLevel != "" && !validPacmanSigLevel.MatchString(c.SigLevel) {
+		return badShape("pacman.sig_level")
+	}
+	if pkg.ValidateRepoBaseURL(c.Server) != nil {
+		return badShape("pacman.server")
+	}
+	return nil
+}
+
+func validateZypper(c *ZypperConfig) error {
+	if c.URL == "" {
+		return fmt.Errorf("%w: field %q is required", ErrInvalidConfig, "zypper.url")
+	}
+	if err := rejectControl("zypper.description", c.Description); err != nil {
+		return err
+	}
+	if err := rejectControl("zypper.type", c.Type); err != nil {
+		return err
+	}
+	if c.Type != "" && !validZypperType.MatchString(c.Type) {
+		return badShape("zypper.type")
+	}
+	if pkg.ValidateRepoBaseURL(c.URL) != nil {
+		return badShape("zypper.url")
+	}
+	if c.GPGKey != "" && pkg.ValidateGpgKeyRef(c.GPGKey) != nil {
+		return badShape("zypper.gpgkey")
+	}
+	return nil
+}

--- a/sys/repo/validate_test.go
+++ b/sys/repo/validate_test.go
@@ -1,0 +1,170 @@
+package repo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+)
+
+// --- name validation -------------------------------------------------------
+
+func TestValidate_Name(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Dnf)
+	good := []string{"corp", "epel-9", "my.repo_1", "A0"}
+	for _, n := range good {
+		// A valid name with a valid config must pass.
+		r := Repository{Name: n, Dnf: &DnfConfig{BaseURL: "https://h/r"}}
+		if err := m.Validate(r); err != nil {
+			t.Errorf("Validate(name=%q) = %v, want nil", n, err)
+		}
+	}
+	bad := map[string]string{
+		"empty":        "",
+		"leading dot":  ".hidden",
+		"leading dash": "-rf",
+		"space":        "a b",
+		"slash":        "a/b",
+		"traversal":    "../etc",
+		"newline":      "a\nb",
+		"too long":     strings.Repeat("a", maxNameLen+1),
+		"non-ascii":    "café",
+		"shell meta":   "a;b",
+	}
+	for label, n := range bad {
+		r := Repository{Name: n, Dnf: &DnfConfig{BaseURL: "https://h/r"}}
+		if err := m.Validate(r); !errors.Is(err, ErrInvalidName) {
+			t.Errorf("Validate(%s=%q) = %v, want ErrInvalidName", label, n, err)
+		}
+	}
+}
+
+// Validate on a name-only Repository (the Remove shape) checks only the name.
+func TestValidate_NameOnlyRepository(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Apt)
+	if err := m.Validate(Repository{Name: "ok"}); err != nil {
+		t.Errorf("Validate(name-only) = %v, want nil (no sub-config to check)", err)
+	}
+	if err := m.Validate(Repository{Name: "-rf"}); !errors.Is(err, ErrInvalidName) {
+		t.Errorf("Validate(name-only bad) = %v, want ErrInvalidName", err)
+	}
+}
+
+// --- apt field validation --------------------------------------------------
+
+func TestValidate_Apt(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Apt)
+	base := func() *AptConfig { return &AptConfig{URL: "https://packages.example.com/apt"} }
+
+	// apt is intentionally exempt from the https requirement (trust = signed Release).
+	if err := m.Validate(Repository{Name: "r", Apt: &AptConfig{URL: "http://old.example.com/apt"}}); err != nil {
+		t.Errorf("Validate(apt http url) = %v, want nil (apt is http-exempt)", err)
+	}
+
+	reject := map[string]*AptConfig{
+		"missing url":          {URL: ""},
+		"control in url":       {URL: "https://h/a\nDeb-Src: x"},
+		"control in dist":      mut(base(), func(c *AptConfig) { c.Distribution = "bad\nline" }),
+		"bad dist shape":       mut(base(), func(c *AptConfig) { c.Distribution = "-bad" }),
+		"control in component": mut(base(), func(c *AptConfig) { c.Components = []string{"main", "x\ny"} }),
+		"bad component shape":  mut(base(), func(c *AptConfig) { c.Components = []string{"@bad"} }),
+		"control in arch":      mut(base(), func(c *AptConfig) { c.Arch = "amd64\n" }),
+		"bad arch shape":       mut(base(), func(c *AptConfig) { c.Arch = "AMD64" }), // arch is lowercase
+	}
+	for label, c := range reject {
+		err := m.Validate(Repository{Name: "r", Apt: c})
+		if err == nil || (!errors.Is(err, ErrInvalidConfig)) {
+			t.Errorf("Validate(apt %s) = %v, want ErrInvalidConfig", label, err)
+		}
+	}
+
+	// A fully populated valid apt config (incl. a multi-line key blob, which is
+	// NOT control-char validated) passes.
+	ok := &AptConfig{
+		URL: "https://h/a", Distribution: "bookworm",
+		Components: []string{"main", "contrib"}, Arch: "amd64",
+		GPGKey: []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\nabc\n-----END-----\n"),
+	}
+	if err := m.Validate(Repository{Name: "r", Apt: ok}); err != nil {
+		t.Errorf("Validate(valid apt) = %v, want nil", err)
+	}
+}
+
+// --- dnf field validation --------------------------------------------------
+
+func TestValidate_Dnf(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Dnf)
+	reject := map[string]*DnfConfig{
+		"missing baseurl":    {BaseURL: ""},
+		"http baseurl":       {BaseURL: "http://h/r"}, // dnf requires https
+		"ftp baseurl":        {BaseURL: "ftp://h/r"},
+		"control in baseurl": {BaseURL: "https://h/r\nrm -rf"},
+		"control in desc":    {BaseURL: "https://h/r", Description: "x\ny"},
+		"http gpgkey":        {BaseURL: "https://h/r", GPGKey: "http://h/key"},
+		"flag gpgkey":        {BaseURL: "https://h/r", GPGKey: "-x"},
+		"traversal gpgkey":   {BaseURL: "https://h/r", GPGKey: "/etc/../key"},
+	}
+	for label, c := range reject {
+		if err := m.Validate(Repository{Name: "r", Dnf: c}); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Validate(dnf %s) = %v, want ErrInvalidConfig", label, err)
+		}
+	}
+	ok := &DnfConfig{BaseURL: "https://h/r", GPGKey: "https://h/RPM-GPG-KEY", Description: "Corp", Enabled: true, GPGCheck: true}
+	if err := m.Validate(Repository{Name: "r", Dnf: ok}); err != nil {
+		t.Errorf("Validate(valid dnf) = %v, want nil", err)
+	}
+	// A file:// gpgkey absolute path is accepted.
+	if err := m.Validate(Repository{Name: "r", Dnf: &DnfConfig{BaseURL: "https://h/r", GPGKey: "/etc/pki/rpm-gpg/KEY"}}); err != nil {
+		t.Errorf("Validate(dnf abs-path gpgkey) = %v, want nil", err)
+	}
+}
+
+// --- pacman field validation -----------------------------------------------
+
+func TestValidate_Pacman(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Pacman)
+	reject := map[string]*PacmanConfig{
+		"missing server":   {Server: ""},
+		"http server":      {Server: "http://h/r"},
+		"control server":   {Server: "https://h/r\nx"},
+		"control siglevel": {Server: "https://h/r", SigLevel: "Optional\nTrustAll"},
+		"bad siglevel":     {Server: "https://h/r", SigLevel: "Optional;rm"},
+	}
+	for label, c := range reject {
+		if err := m.Validate(Repository{Name: "r", Pacman: c}); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Validate(pacman %s) = %v, want ErrInvalidConfig", label, err)
+		}
+	}
+	if err := m.Validate(Repository{Name: "r", Pacman: &PacmanConfig{Server: "https://h/$repo/$arch", SigLevel: "Optional TrustAll"}}); err != nil {
+		t.Errorf("Validate(valid pacman) = %v, want nil", err)
+	}
+}
+
+// --- zypper field validation -----------------------------------------------
+
+func TestValidate_Zypper(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Zypper)
+	reject := map[string]*ZypperConfig{
+		"missing url":  {URL: ""},
+		"http url":     {URL: "http://h/r"},
+		"control url":  {URL: "https://h/r\nx"},
+		"control desc": {URL: "https://h/r", Description: "a\nb"},
+		"control type": {URL: "https://h/r", Type: "rpm\nmd"},
+		"bad type":     {URL: "https://h/r", Type: "rpm md"},
+		"http gpgkey":  {URL: "https://h/r", GPGKey: "http://h/k"},
+		"flag gpgkey":  {URL: "https://h/r", GPGKey: "--import-me"},
+	}
+	for label, c := range reject {
+		if err := m.Validate(Repository{Name: "r", Zypper: c}); !errors.Is(err, ErrInvalidConfig) {
+			t.Errorf("Validate(zypper %s) = %v, want ErrInvalidConfig", label, err)
+		}
+	}
+	ok := &ZypperConfig{URL: "https://h/r", Description: "Corp Repo", Type: "rpm-md", Enabled: true, Autorefresh: true, GPGKey: "https://h/KEY"}
+	if err := m.Validate(Repository{Name: "r", Zypper: ok}); err != nil {
+		t.Errorf("Validate(valid zypper) = %v, want nil", err)
+	}
+}
+
+// mut clones-by-mutation: applies f to c and returns it (test sugar).
+func mut(c *AptConfig, f func(*AptConfig)) *AptConfig { f(c); return c }

--- a/sys/repo/zypper.go
+++ b/sys/repo/zypper.go
@@ -92,17 +92,21 @@ func (m *manager) applyZypper(ctx context.Context, name string, c *ZypperConfig)
 	return out(log.String(), true), nil
 }
 
-// removeZypper removes a zypper repository by alias. A "not found" failure is the
-// idempotent no-op case (Changed=false); any other failure is an error.
+// removeZypper removes a zypper repository by alias. zypper `removerepo` EXITS 0
+// whether or not the alias existed — it reports an absent repo with a "not found"
+// message on stderr rather than a non-zero exit. So idempotency is keyed off that
+// message (a no-op → Changed=false), NOT the exit code; a genuine failure still
+// exits non-zero and surfaces as an error. The Runner forces LC_ALL=C, so the
+// English "not found" match is locale-stable.
 func (m *manager) removeZypper(ctx context.Context, name string) (Outcome, error) {
 	var log strings.Builder
 	res, err := m.runPriv(ctx, "zypper", "--non-interactive", "removerepo", name)
 	if err != nil {
-		if strings.Contains(res.Stderr, "not found") {
-			fmt.Fprintf(&log, "repository %s not found, nothing to remove\n", name)
-			return out(log.String(), false), nil
-		}
 		return Outcome{}, fmt.Errorf("remove repository: %w", err)
+	}
+	if strings.Contains(res.Stdout+res.Stderr, "not found") {
+		fmt.Fprintf(&log, "repository %s not found, nothing to remove\n", name)
+		return out(log.String(), false), nil
 	}
 	fmt.Fprintf(&log, "removed repository: %s\n", name)
 	return out(log.String(), true), nil

--- a/sys/repo/zypper.go
+++ b/sys/repo/zypper.go
@@ -1,0 +1,109 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// applyZypper configures a zypper repository with `zypper addrepo` (preceded by a
+// best-effort removerepo so a reconfigure replaces cleanly), then applies the
+// description / enable / autorefresh modifiers, imports the GPG key, and
+// refreshes. addrepo is command-based with no cheap idempotency probe, so a
+// successful Apply reports Changed=true.
+//
+// The repository URL is https-validated and the name is alphanumeric-validated
+// (validateZypper), so neither can be flag-shaped; the description is passed as
+// `--name=<value>` (glued) so a leading '-' cannot be reparsed as an option.
+func (m *manager) applyZypper(ctx context.Context, name string, c *ZypperConfig) (Outcome, error) {
+	var log strings.Builder
+
+	// Autorefresh is set atomically at add time via the --refresh flag, so a
+	// repo created with Autorefresh=false is never left auto-refreshing (a
+	// separate modifyrepo would have to actively *disable* it otherwise).
+	args := []string{"--non-interactive", "addrepo"}
+	if c.Autorefresh {
+		args = append(args, "--refresh")
+	}
+	if !c.GPGCheck {
+		args = append(args, "--no-gpgcheck")
+	}
+	if c.Type != "" {
+		args = append(args, "--type", c.Type)
+	}
+
+	// Best-effort pre-removal so a reconfigure of an existing alias succeeds.
+	if _, err := m.runPriv(ctx, "zypper", "--non-interactive", "removerepo", name); err != nil {
+		fmt.Fprintf(&log, "note: pre-add removerepo failed (expected if the repo is absent): %v\n", err)
+	}
+
+	args = append(args, c.URL, name)
+	res, err := m.runPriv(ctx, "zypper", args...)
+	if res.Stdout != "" {
+		log.WriteString(res.Stdout)
+	}
+	if err != nil {
+		if res.Stderr != "" {
+			log.WriteString(res.Stderr)
+		}
+		return Outcome{
+			Result:  pmexec.Result{ExitCode: 1, Stdout: log.String(), Stderr: res.Stderr},
+			Changed: false,
+		}, fmt.Errorf("add repository: %w", err)
+	}
+	fmt.Fprintf(&log, "configured repository: %s\n", name)
+
+	// Description / enable / autorefresh diverge from operator intent silently if
+	// they fail, so they are fatal.
+	if c.Description != "" {
+		if _, err := m.runPriv(ctx, "zypper", "--non-interactive", "modifyrepo", "--name="+c.Description, name); err != nil {
+			return Outcome{}, fmt.Errorf("set repo description: %w", err)
+		}
+	}
+	if c.Enabled {
+		if _, err := m.runPriv(ctx, "zypper", "--non-interactive", "modifyrepo", "--enable", name); err != nil {
+			return Outcome{}, fmt.Errorf("enable repo: %w", err)
+		}
+	} else {
+		if _, err := m.runPriv(ctx, "zypper", "--non-interactive", "modifyrepo", "--disable", name); err != nil {
+			return Outcome{}, fmt.Errorf("disable repo: %w", err)
+		}
+	}
+	// Key import + refresh are non-fatal (the repo is configured).
+	if c.GPGKey != "" {
+		res, kerr := m.runPriv(ctx, "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
+		if res.Stdout != "" {
+			log.WriteString(res.Stdout)
+		}
+		if kerr != nil {
+			fmt.Fprintf(&log, "warning: failed to import GPG key: %v\n", kerr)
+		}
+	}
+	res2, rerr := m.runPriv(ctx, "zypper", "--non-interactive", "refresh", name)
+	if res2.Stdout != "" {
+		log.WriteString(res2.Stdout)
+	}
+	if rerr != nil {
+		fmt.Fprintf(&log, "warning: failed to refresh repo: %v\n", rerr)
+	}
+
+	return out(log.String(), true), nil
+}
+
+// removeZypper removes a zypper repository by alias. A "not found" failure is the
+// idempotent no-op case (Changed=false); any other failure is an error.
+func (m *manager) removeZypper(ctx context.Context, name string) (Outcome, error) {
+	var log strings.Builder
+	res, err := m.runPriv(ctx, "zypper", "--non-interactive", "removerepo", name)
+	if err != nil {
+		if strings.Contains(res.Stderr, "not found") {
+			fmt.Fprintf(&log, "repository %s not found, nothing to remove\n", name)
+			return out(log.String(), false), nil
+		}
+		return Outcome{}, fmt.Errorf("remove repository: %w", err)
+	}
+	fmt.Fprintf(&log, "removed repository: %s\n", name)
+	return out(log.String(), true), nil
+}

--- a/sys/repo/zypper_test.go
+++ b/sys/repo/zypper_test.go
@@ -1,0 +1,178 @@
+package repo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+func TestZypper_Apply_FullSequence(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	out, err := m.Apply(context.Background(), Repository{Name: "corp", Zypper: &ZypperConfig{
+		URL:         "https://h/r",
+		Description: "Corp Repo",
+		Enabled:     true,
+		Autorefresh: true,
+		GPGCheck:    true,
+		GPGKey:      "https://h/KEY",
+		Type:        "rpm-md",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Changed {
+		t.Error("a successful addrepo reports Changed=true")
+	}
+	want := []string{
+		"zypper --non-interactive removerepo corp",                                  // best-effort pre-removal
+		"zypper --non-interactive addrepo --refresh --type rpm-md https://h/r corp", // --refresh ⇒ Autorefresh
+		"zypper --non-interactive modifyrepo --name=Corp Repo corp",                 // glued --name= blocks flag injection
+		"zypper --non-interactive modifyrepo --enable corp",
+		"rpm --import -- https://h/KEY",
+		"zypper --non-interactive refresh corp",
+	}
+	if got := argvs(fr); strings.Join(got, " | ") != strings.Join(want, " | ") {
+		t.Errorf("commands =\n%v\nwant\n%v", got, want)
+	}
+}
+
+// Autorefresh must be controlled solely by the addrepo --refresh flag: when
+// Autorefresh is false the repo must NOT be created auto-refreshing. (A prior
+// implementation always passed addrepo --refresh and only re-enabled when true,
+// leaving Autorefresh=false repos auto-refreshing against operator intent.)
+func TestZypper_Apply_AutorefreshControlsAddrepoFlag(t *testing.T) {
+	addrepoCmd := func(fr *exectest.FakeRunner) string {
+		for _, c := range argvs(fr) {
+			if strings.HasPrefix(c, "zypper --non-interactive addrepo") {
+				return c
+			}
+		}
+		return ""
+	}
+	t.Run("true → addrepo carries --refresh", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true, Autorefresh: true}}); err != nil {
+			t.Fatal(err)
+		}
+		if got := addrepoCmd(fr); got != "zypper --non-interactive addrepo --refresh https://h/r r" {
+			t.Errorf("addrepo = %q, want it to carry --refresh", got)
+		}
+	})
+	t.Run("false → addrepo has no --refresh (repo must not auto-refresh)", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true, Autorefresh: false}}); err != nil {
+			t.Fatal(err)
+		}
+		if got := addrepoCmd(fr); got != "zypper --non-interactive addrepo https://h/r r" {
+			t.Errorf("addrepo = %q, want NO --refresh for Autorefresh=false", got)
+		}
+		// And nothing later may re-enable autorefresh.
+		for _, c := range argvs(fr) {
+			if strings.Contains(c, "modifyrepo --refresh") {
+				t.Errorf("Autorefresh=false but a modifyrepo --refresh ran: %q", c)
+			}
+		}
+	})
+}
+
+func TestZypper_Apply_NoGpgcheckAndDisabled(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{
+		URL: "https://h/r", GPGCheck: false, Enabled: false,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	cmds := strings.Join(argvs(fr), " | ")
+	// Autorefresh defaults false here, so addrepo carries no --refresh.
+	if !strings.Contains(cmds, "addrepo --no-gpgcheck https://h/r r") {
+		t.Errorf("addrepo missing --no-gpgcheck for GPGCheck=false: %s", cmds)
+	}
+	if !strings.Contains(cmds, "modifyrepo --disable r") {
+		t.Errorf("expected --disable for Enabled=false: %s", cmds)
+	}
+	if strings.Contains(cmds, "--enable") {
+		t.Errorf("Enabled=false must not --enable: %s", cmds)
+	}
+}
+
+func TestZypper_Apply_AddrepoFailureIsFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	fr.Push(pmexec.Result{}, nil)                                        // removerepo (pre) clean
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "addrepo: bad url"}, nil) // addrepo fails
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{URL: "https://h/r", GPGCheck: true}})
+	if err == nil || !strings.Contains(err.Error(), "add repository") {
+		t.Fatalf("err = %v, want a wrapped addrepo failure", err)
+	}
+	if out.Changed {
+		t.Error("a failed addrepo must report Changed=false")
+	}
+}
+
+func TestZypper_Apply_DescriptionFailureIsFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	fr.Push(pmexec.Result{}, nil)                                        // removerepo
+	fr.Push(pmexec.Result{}, nil)                                        // addrepo ok
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "modifyrepo: name"}, nil) // modifyrepo --name fails
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{
+		URL: "https://h/r", GPGCheck: true, Description: "X",
+	}}); err == nil || !strings.Contains(err.Error(), "set repo description") {
+		t.Fatalf("err = %v, want a wrapped description failure", err)
+	}
+}
+
+func TestZypper_Apply_KeyImportFailureIsNonFatal(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	// removerepo, addrepo, enable all clean; rpm --import fails; refresh clean.
+	fr.Push(pmexec.Result{}, nil)                                  // removerepo
+	fr.Push(pmexec.Result{}, nil)                                  // addrepo
+	fr.Push(pmexec.Result{}, nil)                                  // modifyrepo --enable
+	fr.Push(pmexec.Result{ExitCode: 1, Stderr: "rpm import"}, nil) // rpm --import
+	out, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{
+		URL: "https://h/r", GPGCheck: true, Enabled: true, GPGKey: "https://h/K",
+	}})
+	if err != nil {
+		t.Fatalf("key-import failure must be non-fatal, got %v", err)
+	}
+	if !strings.Contains(out.Result.Stdout, "warning: failed to import GPG key") {
+		t.Errorf("expected key-import warning, got %q", out.Result.Stdout)
+	}
+}
+
+func TestZypper_Remove(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.Changed {
+			t.Error("removing a present repo reports Changed=true")
+		}
+		if got := argvs(fr); len(got) != 1 || got[0] != "zypper --non-interactive removerepo corp" {
+			t.Errorf("commands = %v, want a single removerepo", got)
+		}
+	})
+	t.Run("not found is idempotent", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		fr.Push(pmexec.Result{ExitCode: 1, Stderr: "Repository 'corp' not found by alias."}, nil)
+		out, err := m.Remove(context.Background(), "corp")
+		if err != nil {
+			t.Fatalf("a 'not found' removerepo must be a no-op, got %v", err)
+		}
+		if out.Changed {
+			t.Error("not-found removal must report Changed=false")
+		}
+	})
+	t.Run("other failure is fatal", func(t *testing.T) {
+		m, _, fr := newTestManager(t, pkg.Zypper)
+		fr.Push(pmexec.Result{ExitCode: 1, Stderr: "permission denied"}, nil)
+		if _, err := m.Remove(context.Background(), "corp"); err == nil ||
+			!strings.Contains(err.Error(), "remove repository") {
+			t.Fatalf("err = %v, want a wrapped removerepo failure", err)
+		}
+	})
+}

--- a/sys/repo/zypper_test.go
+++ b/sys/repo/zypper_test.go
@@ -158,7 +158,12 @@ func TestZypper_Remove(t *testing.T) {
 	})
 	t.Run("not found is idempotent", func(t *testing.T) {
 		m, _, fr := newTestManager(t, pkg.Zypper)
-		fr.Push(pmexec.Result{ExitCode: 1, Stderr: "Repository 'corp' not found by alias."}, nil)
+		// REAL zypper behaviour: `removerepo` of an absent alias EXITS 0 and
+		// reports the absence with a "not found" message on stderr — it does NOT
+		// exit non-zero. So idempotency must be keyed off the message, not the
+		// exit code (the earlier fake scripted exit 1, hiding that removing an
+		// absent repo wrongly reported Changed=true against real zypper).
+		fr.Push(pmexec.Result{ExitCode: 0, Stderr: "Repository 'corp' not found by alias, number or URI."}, nil)
 		out, err := m.Remove(context.Background(), "corp")
 		if err != nil {
 			t.Fatalf("a 'not found' removerepo must be a no-op, got %v", err)

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -23,12 +23,14 @@ FROM golang:1.26-bookworm AS base
 #   cryptsetup-bin  — `cryptsetup` for the sys/encryption LUKS tests
 #   nftables        — `nft` for the sys/firewall round-trip tests (CAP_NET_ADMIN)
 #   iproute2        — `ip` for the sys/netconfig read-path tests (CAP_NET_ADMIN)
+#   gnupg           — `gpg --dearmor` for the sys/repo apt keyring tests
 RUN apt-get update && apt-get install -y --no-install-recommends \
     psmisc \
     ca-certificates \
     cryptsetup-bin \
     nftables \
     iproute2 \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace


### PR DESCRIPTION
## What

Lands the **repository-management Manager** (`sys/repo`, gap #2) on main **with real-tool tests** that fit the container-test design — apt/dnf/pacman/zypper repository `Apply`/`Remove` against the actual package managers, not just FakeRunner.

The Manager itself (commit 1) is the previously-unmerged `sys/repo` work: `New(pkg.Backend, runner)` → `Manager{Validate, Apply, Remove}`, per-backend file formats (deb822 `.sources` + keyrings / `.repo` / pacman.conf sections / `zypper addrepo`), GPG public-key handling, idempotency + `Outcome.Changed`, privileged writes delegated to `fs.Manager` (TOCTOU-safe on Direct), plus `fs.Manager.ReadDir`.

## Real-tool tests (commit 2)

`repo_container_test.go` (`//go:build container`) — one file, four Detect-gated backends, each self-skips when its backend is absent:
- **apt** — real `gpg --dearmor` → `/etc/apt/keyrings`, deb822 `.sources` with Signed-By; idempotent re-Apply (`Changed=false`); Remove clears both.
- **dnf** — `/etc/yum.repos.d/<name>.repo` INI body; idempotency; remove.
- **pacman** — `[section]` in `/etc/pacman.conf`; idempotency; remove.
- **zypper** — real `zypper addrepo`, verified with `zypper lr`, then `removerepo`.

Every lane runs as root → Direct runner. Mutating tests are gated behind `//go:build container` so a plain `go test ./...` on a developer's machine never touches their `/etc`. Verified locally in real **debian / fedora / arch / leap** containers.

## Real bug caught by the zypper cell

`zypper removerepo` of an **absent** alias **exits 0** (it reports the absence with a "not found" message on stderr), but `removeZypper` assumed a non-zero exit — so its "not found" branch was dead code and removing an absent repo wrongly reported `Changed=true`. The fake had scripted exit 1, hiding it. Fixed red→green: idempotency is now keyed off the message, not the exit code (the Runner forces `LC_ALL=C`, so the English match is locale-stable).

## CI

apt cell as a container-tests matrix row (Debian base + `gnupg`); dnf/pacman/zypper cells as a `-tags=container -run Container ./sys/repo/` step in each distro job (root containers).

Closes #188