### PR TITLE
test(desktop): real runuser privilege-drop + HomeUsers/Flatpak + loginctl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
               /usr/local/go/bin/go test \
               -v -tags=integration -count=1 -timeout=10m \
               ./sdk/sys/exec/ ./sdk/sys/fs/ ./sdk/sys/user/ ./sdk/sys/service/ \
-              ./sdk/sys/timesync/ ./sdk/sys/log/ ./sdk/sys/dns/
+              ./sdk/sys/timesync/ ./sdk/sys/log/ ./sdk/sys/dns/ ./sdk/sys/desktop/
 
       - name: Cleanup
         if: always()
@@ -317,6 +317,14 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/repo/
+          # desktop: real runuser privilege-drop + HomeUsers passwd enumeration +
+          # per-user Flatpak-install probe (creates real accounts → needs root).
+          # The graphical ActiveSessions path runs against real loginctl in the
+          # systemd job; here ActiveSessions covers the loginctl-absent path.
+          - label: sys/desktop (debian/base)
+            distro: debian
+            state: base
+            path: ./sdk/sys/desktop/
     steps:
       - uses: actions/checkout@v5
         with:

--- a/sys/desktop/desktop_container_test.go
+++ b/sys/desktop/desktop_container_test.go
@@ -1,0 +1,208 @@
+//go:build container
+
+// Container-based real-execution tests for the desktop Manager. The hermetic
+// FakeRunner/seam tests cover every branch with injected passwd lookups and
+// loginctl output; these create REAL accounts and home directories inside the
+// container and exercise the actual privilege drop (runuser), passwd/NSS
+// enumeration, and per-user filesystem probes — so a real `runuser` env/identity
+// change or an os/user lookup behaviour change is caught here.
+//
+// Runs in the container-tests lane (root): HomeUsers/UsersWithFlatpakInstall need
+// to create accounts and RunAsCommand drops privilege to a *different* user, both
+// of which require root. The Direct runner is correct (the lane is already root).
+//
+// ActiveSessions' populated GRAPHICAL path needs a real logind session of type
+// x11/wayland, which cannot exist in headless CI (no display); that branch is
+// unit-tested and exercised against real loginctl — empty — in the systemd
+// integration test. Here ActiveSessions covers the loginctl-absent path.
+package desktop
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func requireUseradd(t *testing.T) {
+	t.Helper()
+	if _, err := osexec.LookPath("useradd"); err != nil {
+		t.Skip("useradd not on PATH; account-based desktop tests not exercisable")
+	}
+}
+
+// mkUser creates a real account whose home is homeDir (created + skel-populated),
+// registering a best-effort userdel cleanup. Returns the resolved *user.User.
+func mkUser(t *testing.T, name, homeDir string) *user.User {
+	t.Helper()
+	_ = osexec.Command("userdel", "-r", name).Run() // clean slate
+	if out, err := osexec.Command("useradd", "-m", "-d", homeDir, "-s", "/bin/bash", name).CombinedOutput(); err != nil {
+		t.Fatalf("useradd %s: %v\n%s", name, err, out)
+	}
+	t.Cleanup(func() { _ = osexec.Command("userdel", "-r", name).Run() })
+	u, err := user.Lookup(name)
+	if err != nil {
+		t.Fatalf("lookup %s after useradd: %v", name, err)
+	}
+	return u
+}
+
+func realDesktop(t *testing.T, opts ...Option) Manager {
+	t.Helper()
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(r, opts...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+func deskCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestHomeUsers_Container enumerates real accounts whose homes live under a
+// custom home root, against real passwd/NSS: two real users are returned, while a
+// stale dir with no account, a dot-dir, and lost+found are all skipped.
+func TestHomeUsers_Container(t *testing.T) {
+	requireUseradd(t)
+	root := t.TempDir()
+	alice := mkUser(t, "pmhomealice", filepath.Join(root, "pmhomealice"))
+	_ = mkUser(t, "pmhomebob", filepath.Join(root, "pmhomebob"))
+
+	// Decoys that must NOT be enumerated.
+	if err := os.Mkdir(filepath.Join(root, "ghost"), 0o755); err != nil { // dir with no account
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, ".hidden"), 0o755); err != nil { // dot-dir
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "lost+found"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := realDesktop(t, WithHomeRoot(root)).HomeUsers(deskCtx(t))
+	if err != nil {
+		t.Fatalf("HomeUsers: %v", err)
+	}
+	names := make([]string, 0, len(got))
+	for _, s := range got {
+		names = append(names, s.Username)
+	}
+	slices.Sort(names)
+	if want := []string{"pmhomealice", "pmhomebob"}; !slices.Equal(names, want) {
+		t.Errorf("HomeUsers = %v, want %v (ghost/.hidden/lost+found must be skipped)", names, want)
+	}
+	// The returned account must carry the canonical UID/Home from passwd.
+	for _, s := range got {
+		if s.Username == "pmhomealice" {
+			if strconv.Itoa(s.UID) != alice.Uid || s.Home != alice.HomeDir {
+				t.Errorf("alice session = uid %d home %q, want uid %s home %q", s.UID, s.Home, alice.Uid, alice.HomeDir)
+			}
+		}
+	}
+}
+
+// TestRunAsCommand_Container is the security-critical real test: the built
+// command must actually run AS the target user (privilege dropped via runuser)
+// with the per-user HOME/USER and the curated PATH, in the user's home dir.
+func TestRunAsCommand_Container(t *testing.T) {
+	requireUseradd(t)
+	home := filepath.Join(t.TempDir(), "pmrunas")
+	u := mkUser(t, "pmrunas", home)
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+	s := Session{Username: "pmrunas", UID: uid, GID: gid, Home: u.HomeDir, RuntimeDir: "/run/user/" + u.Uid}
+	m := realDesktop(t)
+	ctx := deskCtx(t)
+
+	// Identity: `id -un` must print the target user — proves the real privilege drop.
+	cmd, err := m.RunAsCommand(ctx, s, RunAsOptions{}, "id", "-un")
+	if err != nil {
+		t.Fatalf("RunAsCommand(id): %v", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run id -un as pmrunas: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "pmrunas" {
+		t.Errorf("id -un = %q, want pmrunas (privilege was not dropped)", got)
+	}
+
+	// Environment: HOME/USER are the user's; PATH is the curated UserPath (the
+	// user's ~/.local/bin first), NOT root's inherited PATH.
+	cmd2, err := m.RunAsCommand(ctx, s, RunAsOptions{}, "sh", "-c", `printf '%s|%s|%s' "$HOME" "$USER" "$PATH"`)
+	if err != nil {
+		t.Fatalf("RunAsCommand(sh): %v", err)
+	}
+	out2, err := cmd2.Output()
+	if err != nil {
+		t.Fatalf("run env probe as pmrunas: %v", err)
+	}
+	parts := strings.SplitN(string(out2), "|", 3)
+	if len(parts) != 3 || parts[0] != u.HomeDir || parts[1] != "pmrunas" {
+		t.Errorf("env = %v, want HOME=%q USER=pmrunas", parts, u.HomeDir)
+	}
+	if !strings.HasPrefix(parts[2], u.HomeDir+"/.local/bin:") {
+		t.Errorf("PATH = %q, want it to start with the user's ~/.local/bin", parts[2])
+	}
+	if cmd2.Dir != u.HomeDir {
+		t.Errorf("cmd.Dir = %q, want the user's home %q", cmd2.Dir, u.HomeDir)
+	}
+}
+
+// TestUsersWithFlatpakInstall_Container probes the real per-user Flatpak install
+// directory: only the user with $HOME/.local/share/flatpak/app/<appID> is returned.
+func TestUsersWithFlatpakInstall_Container(t *testing.T) {
+	requireUseradd(t)
+	const appID = "org.test.PMApp"
+	root := t.TempDir()
+	flat := mkUser(t, "pmflatuser", filepath.Join(root, "pmflatuser"))
+	_ = mkUser(t, "pmplainuser", filepath.Join(root, "pmplainuser"))
+	if err := os.MkdirAll(filepath.Join(flat.HomeDir, ".local/share/flatpak/app", appID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := realDesktop(t, WithHomeRoot(root)).UsersWithFlatpakInstall(deskCtx(t), appID)
+	if err != nil {
+		t.Fatalf("UsersWithFlatpakInstall: %v", err)
+	}
+	if len(got) != 1 || got[0].Username != "pmflatuser" {
+		names := make([]string, len(got))
+		for i, s := range got {
+			names[i] = s.Username
+		}
+		t.Errorf("UsersWithFlatpakInstall = %v, want [pmflatuser] only", names)
+	}
+}
+
+// TestActiveSessions_NoLoginctl_Container: with loginctl absent (the container-
+// tests base image ships no systemd), ActiveSessions returns an empty slice and
+// NO error — the documented "no logind, no sessions" contract, against the real
+// (absent) binary.
+func TestActiveSessions_NoLoginctl_Container(t *testing.T) {
+	if _, err := osexec.LookPath("loginctl"); err == nil {
+		t.Skip("loginctl present here; the absent-path assertion does not apply")
+	}
+	got, err := realDesktop(t).ActiveSessions(deskCtx(t))
+	if err != nil {
+		t.Fatalf("ActiveSessions with loginctl absent must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ActiveSessions = %v, want empty when loginctl is absent", got)
+	}
+}

--- a/sys/desktop/integration_test.go
+++ b/sys/desktop/integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package desktop_test
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/desktop"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func systemdRunning() bool {
+	_, err := os.Stat("/run/systemd/system")
+	return err == nil
+}
+
+// TestActiveSessions_Integration drives ActiveSessions against a REAL
+// systemd-logind: under the test-sys container loginctl is present and logind is
+// running, so list-sessions + per-session show-session must run and parse without
+// error (the drift guard against a `loginctl` output-format change). The result
+// is typically empty — a headless container has no GRAPHICAL (x11/wayland)
+// session, and one cannot be created without a display — so this pins the
+// real read path and the active/local/graphical filter on real output, with the
+// populated-graphical enumeration remaining a documented hard-CI residual.
+func TestActiveSessions_Integration(t *testing.T) {
+	if _, err := osexec.LookPath("loginctl"); err != nil {
+		t.Skip("loginctl not present; logind path not exercisable")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	m, err := desktop.New(r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	sessions, err := m.ActiveSessions(context.Background())
+
+	// Universal invariant: whatever is returned, every session must have passed
+	// the active/local/graphical filter — checked regardless of how logind is
+	// (or isn't) reached.
+	for _, s := range sessions {
+		if s.Type != "x11" && s.Type != "wayland" && s.Type != "mir" {
+			t.Errorf("ActiveSessions returned a non-graphical session type %q", s.Type)
+		}
+	}
+
+	if systemdRunning() {
+		// loginctl present + logind running: the real read+parse+filter MUST
+		// succeed (empty is fine; an error means the loginctl contract drifted).
+		if err != nil {
+			t.Fatalf("ActiveSessions against real logind: %v", err)
+		}
+		t.Logf("ActiveSessions returned %d graphical session(s)", len(sessions))
+		return
+	}
+	// No systemd as PID 1: ActiveSessions reports "no logind, no sessions" as an
+	// empty slice with NO error — or skips if loginctl can't reach a bus at all.
+	if err != nil {
+		t.Skipf("loginctl present but logind not reachable here: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("without a running logind, ActiveSessions should be empty, got %d", len(sessions))
+	}
+}


### PR DESCRIPTION
## What

Adds real-execution coverage for `sys/desktop` (FakeRunner/seam-only until now) — the account-based surface (real passwd + a real privilege drop) and the loginctl read path.

## Container lane (root → Direct)

`desktop_container_test.go` (`//go:build container` — creating accounts and dropping privilege to a *different* user both need root):
- **`RunAsCommand`** — the security-critical test: the built command runs **as the target user** via real `runuser` (`id -un` == user), with per-user `HOME`/`USER`, the curated `UserPath` (`~/.local/bin` first, **not** root's PATH), in the user's home dir.
- **`HomeUsers`** — enumerates real accounts under a custom home root against real passwd/NSS; a stale dir with no account, a dot-dir, and `lost+found` are all skipped; the returned session carries the canonical UID/Home.
- **`UsersWithFlatpakInstall`** — only the user with a real `$HOME/.local/share/flatpak/app/<appID>` dir is returned.
- **`ActiveSessions`** — the loginctl-absent path returns `[]` with no error.

## systemd lane

`integration_test.go` (`//go:build integration`): **`ActiveSessions`** against real systemd-logind — list-sessions + show-session + the active/local/graphical filter must run and parse without error (drift guard; empty on a headless container). Every returned session is asserted graphical; the no-logind path is asserted empty.

## Residual (documented)

The populated **graphical** (x11/wayland) `ActiveSessions` enumeration needs a real display, impossible in headless CI — unit-tested, and the real loginctl read path is exercised empty here.

CI: `sys/desktop (debian/base)` container matrix row + `./sys/desktop/` in the test-sys job. Verified locally in a real Debian base container + the systemd PID 1 container.

Closes #218