### PR TITLE
test(network): real NetworkManager keyfile PSK provisioning (dedicated CI job)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
           path: sdk
 
       - name: Build test image
-        run: docker build -f sdk/test/Dockerfile.integration -t pm-sdk-test .
+        run: docker build -f sdk/test/Dockerfile.integration --target systemd -t pm-sdk-test .
 
       - name: Start systemd container
         run: docker run -d --privileged --name pm-sdk-test pm-sdk-test
@@ -239,6 +239,50 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker rm -f pm-sdk-test 2>/dev/null || true
+
+  # Dedicated job for sys/network: the keyfile-based WiFi provisioning needs BOTH
+  # a live NetworkManager daemon (`nmcli connection reload`) and root (the 0600
+  # keyfile write into /etc/NetworkManager/system-connections) — neither fits the
+  # power-manage test-sys lane. Its own systemd+NM image (`with-networkmanager`,
+  # NM configured to manage no devices) keeps NM out of the test-sys container so
+  # the other integration tests are unaffected.
+  test-network:
+    name: Integration Tests (NetworkManager)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: sdk
+
+      - name: Build systemd + NetworkManager image
+        run: docker build -f sdk/test/Dockerfile.integration --target with-networkmanager -t pm-sdk-nm .
+
+      - name: Start systemd + NM container
+        run: docker run -d --privileged --name pm-sdk-nm pm-sdk-nm
+
+      - name: Wait for NetworkManager
+        run: |
+          # The container reports "degraded" (a hardware-bound unit can't start in
+          # a container) yet NM itself comes up active — wait on NM directly.
+          for i in $(seq 1 60); do
+            if docker exec pm-sdk-nm systemctl is-active NetworkManager >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.5
+          done
+          docker exec pm-sdk-nm systemctl is-active NetworkManager
+
+      - name: Run network integration tests (root, real NetworkManager)
+        run: |
+          # PM_NM_REQUIRED=1 makes the test FAIL (not skip) if NM is somehow
+          # unavailable — this job guarantees it, so a skip would pass vacuously.
+          docker exec -w /workspace -e PM_NM_REQUIRED=1 pm-sdk-nm \
+            /usr/local/go/bin/go test -tags=integration -count=1 -v -timeout=5m \
+              -run Integration ./sdk/sys/network/
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f pm-sdk-nm 2>/dev/null || true
 
   # Container-based real-execution tests (`//go:build container`). Each cell
   # builds one immutable bad-state image stage (the precondition is asserted at

--- a/sys/network/integration_test.go
+++ b/sys/network/integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+package network_test
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/network"
+)
+
+// These exercise the REAL NetworkManager keyfile-based WiFi provisioning against
+// a live nmcli + NM daemon (the dedicated with-networkmanager CI job, run as
+// root): Apply writes a 0600 keyfile carrying the PSK and `nmcli connection
+// reload`s it, NM recognises the profile, and Delete removes it. The security
+// property under test is that the PSK is provisioned via the root-owned 0600
+// keyfile — never on a command line — proven end-to-end against the real daemon.
+//
+// No WiFi radio is needed: Apply creates a connection PROFILE, it does not
+// activate it, so the keyfile + reload + con-show round-trip works headless.
+
+const keyfileDir = "/etc/NetworkManager/system-connections"
+
+// requireNM gates the test on root + a usable NetworkManager. It SKIPS when
+// those are absent so the file is safe to run anywhere — EXCEPT when
+// PM_NM_REQUIRED=1 (set by the dedicated test-network CI job, which guarantees
+// NM), where a missing prerequisite is a setup failure and must FAIL rather than
+// let the job pass vacuously (matches-zero guard: the one test in this job must
+// actually run).
+func requireNM(t *testing.T) {
+	t.Helper()
+	bail := t.Skipf
+	if os.Getenv("PM_NM_REQUIRED") == "1" {
+		bail = t.Fatalf
+	}
+	if os.Geteuid() != 0 {
+		bail("not root; keyfile write + nmcli reload need root")
+		return
+	}
+	if _, err := osexec.LookPath("nmcli"); err != nil {
+		bail("nmcli not present; NetworkManager backend not exercisable")
+		return
+	}
+	if len(network.Detect(context.Background())) == 0 {
+		bail("nmcli present but NetworkManager not usable here")
+		return
+	}
+}
+
+func TestApplyPSK_Integration(t *testing.T) {
+	requireNM(t)
+	r, err := pmexec.NewRunner(pmexec.Direct) // root → Direct
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	m, err := network.New(network.NetworkManager, r)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const name = "pm-test-wifi"
+	const ssid = "PMTestNet"
+	const pskValue = "pm-test-passphrase-123"
+	keyfile := keyfileDir + "/" + name + ".nmconnection"
+	t.Cleanup(func() { _ = m.Delete(context.Background(), name, network.DeleteOptions{}) })
+
+	psk, err := pmexec.NewSecret(pskValue)
+	if err != nil {
+		t.Fatalf("NewSecret: %v", err)
+	}
+
+	changed, err := m.Apply(ctx, network.Profile{Name: name, SSID: ssid, AuthType: network.AuthPSK, PSK: psk})
+	if err != nil {
+		t.Fatalf("Apply(PSK) against real NetworkManager: %v", err)
+	}
+	if !changed {
+		t.Error("first Apply should report changed=true")
+	}
+
+	// The PSK must land in a root-owned 0600 keyfile (the secure sink) — not on
+	// any argv. Verify both the perms and that the secret is actually there.
+	fi, err := os.Stat(keyfile)
+	if err != nil {
+		t.Fatalf("stat keyfile: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("keyfile mode = %o, want 0600 (the PSK file must not be world/group readable)", perm)
+	}
+	body := string(mustRead(t, keyfile))
+	if !strings.Contains(body, "psk="+pskValue) {
+		t.Error("keyfile does not carry the PSK in [wifi-security] (the secure provisioning sink)")
+	}
+	if !strings.Contains(body, "ssid="+ssid) {
+		t.Errorf("keyfile missing ssid=%s", ssid)
+	}
+
+	// The live daemon must recognise the reloaded profile.
+	exists, err := m.ConnectionExists(ctx, name)
+	if err != nil {
+		t.Fatalf("ConnectionExists: %v", err)
+	}
+	if !exists {
+		t.Error("NetworkManager did not pick up the connection after `nmcli connection reload`")
+	}
+	settings, err := m.Settings(ctx, name)
+	if err != nil {
+		t.Fatalf("Settings: %v", err)
+	}
+	if len(settings) == 0 {
+		t.Error("Settings returned no keys for the real connection")
+	}
+
+	// Delete removes the profile and its keyfile; a second delete is a no-op.
+	if err := m.Delete(ctx, name, network.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if exists, err := m.ConnectionExists(ctx, name); err != nil {
+		t.Errorf("ConnectionExists after Delete: %v", err)
+	} else if exists {
+		t.Error("connection still present after Delete")
+	}
+	if _, err := os.Stat(keyfile); !os.IsNotExist(err) {
+		t.Errorf("keyfile still present after Delete: %v", err)
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm
+FROM golang:1.26-bookworm AS systemd
 
 RUN apt-get update && apt-get install -y \
     sudo \
@@ -109,3 +109,19 @@ RUN chown -R power-manage:power-manage /workspace /home/power-manage
 # Use systemd as PID 1 for systemctl daemon-reload, enable, start, etc.
 STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/sbin/init"]
+
+# with-networkmanager: the `systemd` image plus a real NetworkManager daemon, for
+# the dedicated network CI job (the sys/network keyfile-based WiFi provisioning
+# runs `nmcli connection reload` against a live NM and writes a root-owned 0600
+# keyfile, so it needs both a running daemon and root — hence its own job rather
+# than the power-manage test-sys lane). `unmanaged-devices=*` keeps NM from
+# touching the container's eth0 / DNS, so it manages profile config only and
+# never disrupts the container's own networking. Inherits ENTRYPOINT/STOPSIGNAL
+# from `systemd`.
+FROM systemd AS with-networkmanager
+RUN apt-get update && apt-get install -y --no-install-recommends network-manager \
+    && rm -rf /var/lib/apt/lists/* \
+    && systemctl enable NetworkManager \
+    && mkdir -p /etc/NetworkManager/conf.d \
+    && printf '[keyfile]\nunmanaged-devices=*\n' > /etc/NetworkManager/conf.d/90-pm-test-unmanaged.conf \
+    && nmcli --version


### PR DESCRIPTION
## What

`sys/network` was FakeRunner-only. Adds an integration test that drives the secure WiFi provisioning path end-to-end against a **live NetworkManager**: `Apply` writes a 0600 keyfile carrying the PSK in `[wifi-security]` + `nmcli connection reload`; the daemon picks up the profile (`ConnectionExists`/`Settings`); `Delete` removes it.

**Security property proven against the real daemon:** the PSK is provisioned via the root-owned **0600 keyfile, never on a command line**. No WiFi radio needed — Apply creates a profile, it does not activate it.

## Dedicated CI job (NM runs in the existing systemd image — no purpose-built base)

This needs BOTH a running NM daemon and root (the keyfile write), so it gets its own job rather than the unprivileged power-manage test-sys lane:
- `Dockerfile.integration`: split into a named `systemd` stage (image unchanged) + a `with-networkmanager` stage that adds NM and sets `unmanaged-devices=*` so NM manages profile config only and never touches the container's eth0/DNS.
- `test.yml`: test-sys now builds `--target systemd`; a new **`test-network`** job builds `--target with-networkmanager`, boots it, and runs the test as root against real NM.

The job's lone test **fails closed** (`PM_NM_REQUIRED=1`): if NM is somehow unavailable it errors rather than skipping, so the dedicated job can't pass vacuously.

Verified locally: the Apply→reload→ConnectionExists→Delete round-trip passes in a real systemd+NM container.

Closes #221