### PR TITLE
docs(capabilities): packages + identity recipe guides (docref-anchored)

### DIFF
--- a/docs/02-concepts/01-architecture.md
+++ b/docs/02-concepts/01-architecture.md
@@ -15,9 +15,11 @@ Every system-management capability follows the same three-part shape:
   and inject it everywhere.
   {% /step %}
   {% step title="Choose a Backend" %}
-  Capabilities with more than one real implementation (package managers,
-  service managers, disk-encryption tools, …) take an explicit `Backend`
-  value. There is no runtime guessing.
+  Capabilities that drive a *family* of tools (package managers, init systems,
+  encryption tools) take an explicit `Backend` value — the caller always names
+  it, even when only one backend is implemented today (`service.Systemd`,
+  `user.ShadowUtils`), and the SDK never auto-detects. Single-tool capabilities
+  (`smartctl`, `osqueryi`) take only a Runner.
   {% /step %}
   {% step title="Get a Manager" %}
   `New` returns a handle whose methods do the work. The handle holds the

--- a/docs/02-concepts/02-backends.md
+++ b/docs/02-concepts/02-backends.md
@@ -7,9 +7,17 @@ description: How a capability's backend is chosen explicitly, how to discover wh
 # Backends & detection
 
 A *backend* is one concrete way to do a job: `apt` vs `dnf` for packages,
-`systemd` vs another init for services, `ca-certificates` vs `p11-kit` for CA
-trust. Capabilities with more than one implementation take a `Backend` value
-at construction.
+`systemd` for services, `ca-certificates` vs `p11-kit` for CA trust. A
+capability that drives such a family takes a `Backend` value at construction —
+and it takes one **even when only one backend is implemented today** (services
+has just `systemd`; users just shadow-utils), so the choice is always explicit
+and never auto-detected.
+
+<!-- docref: begin src=sys/smart/smart.go#New:b54f2658,sys/osquery/osquery.go#New:dda636e8 -->
+A capability that is a single tool by nature — `smartctl` for SMART, `osqueryi`
+for queries — takes only a Runner; its `New` has no `Backend` parameter at all,
+because there is no family of alternatives to choose from.
+<!-- docref: end -->
 
 ## One backend per host, chosen explicitly
 

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -70,8 +70,11 @@ _, err = m.Upgrade(ctx, "openssl")
 _, err = m.Autoremove(ctx)
 ```
 
+<!-- docref: begin src=pkg/dnf.go#dnf.Install:24ff67e3 -->
 Package names are passed as operands after a `--` separator, so a name that
-begins with `-` can never be reinterpreted as a flag.
+begins with `-` can never be reinterpreted as a flag, and every mutation returns
+the package manager's `exec.Result`.
+<!-- docref: end -->
 
 ## Query installed state
 
@@ -82,6 +85,12 @@ ok, err := m.IsInstalled(ctx, "curl")
 ver, err := m.InstalledVersion(ctx, "curl") // "" when absent
 n, err := m.InstalledCount(ctx)             // total installed packages
 ```
+
+<!-- docref: begin src=pkg/dnf.go#dnf.IsInstalled:28231b96,pkg/dnf.go#dnf.InstalledVersion:f0b1ff2e -->
+The queries are unprivileged: `IsInstalled` reports whether a package is present,
+and `InstalledVersion` returns its version or an empty string when it isn't
+installed.
+<!-- docref: end -->
 
 ## Backends
 

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -109,7 +109,7 @@ This page is the task-oriented recipe; the reference lists the surface.
 
 ## Related
 
-- [Repositories](/capabilities/repositories) — configure the repositories these
-  package managers install from.
+- Repositories (`sys/repo`) — configure the repositories these package managers
+  install from.
 - [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.
 - [Errors](/concepts/errors) — how failures are reported.

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -1,0 +1,115 @@
+---
+title: Packages
+label: Packages
+description: Install, remove, upgrade, and query software across apt, dnf, pacman, zypper, and flatpak behind one Manager.
+icon: "📦"
+---
+
+# Packages
+
+`pkg` manages software through the host's native package manager behind a single
+`Manager` interface. One set of calls drives apt, dnf, pacman, zypper, or
+flatpak — you pick the backend, the SDK speaks its dialect.
+
+It follows the [architecture](/concepts/architecture): build a Runner, choose a
+[Backend](/concepts/backends), get a Manager.
+
+## Construct a manager
+
+`pkg.Detect` reports which package managers are actually installed, so a caller
+can pick one instead of guessing:
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // package mutations need root
+if err != nil {
+    return err
+}
+
+backends := pkg.Detect(ctx) // e.g. [apt] on Debian, [dnf] on Fedora
+if len(backends) == 0 {
+    return errors.New("no supported package manager on this host")
+}
+
+m, err := pkg.New(backends[0], r)
+if err != nil {
+    return err
+}
+```
+
+<!-- docref: begin src=pkg/pkg.go#Detect:374bb12a -->
+`Detect` lists the backends whose tool is present on `PATH`; it never picks one
+and never constructs a Manager — the caller reads the list, chooses explicitly,
+and passes that choice to `New`. There is no hidden auto-detection.
+<!-- docref: end -->
+
+<!-- docref: begin src=pkg/pkg.go#New:e40499cf -->
+`New` is pure and fail-closed: it validates the backend and rejects a nil
+Runner before returning a Manager, and it does **not** probe the host. A
+zero-value or unimplemented backend is an error, not a silent default — so a
+misconfigured caller fails loudly at construction rather than mid-operation.
+<!-- docref: end -->
+
+## Install, remove, upgrade
+
+Every mutation returns the command's `exec.Result` (exit code, stdout, stderr)
+so a caller can surface exactly what the package manager did:
+
+```go
+res, err := m.Install(ctx, pkg.InstallOptions{}, "vim", "git")
+if err != nil {
+    return fmt.Errorf("install failed: %w", err)
+}
+fmt.Println(res.Stdout)
+
+_, err = m.Remove(ctx, pkg.RemoveOptions{}, "telnet")
+// Refresh the index and upgrade everything:
+_, err = m.UpgradeAll(ctx, pkg.UpgradeOptions{})
+// Or upgrade specific packages:
+_, err = m.Upgrade(ctx, "openssl")
+// Drop orphaned dependencies:
+_, err = m.Autoremove(ctx)
+```
+
+Package names are passed as operands after a `--` separator, so a name that
+begins with `-` can never be reinterpreted as a flag.
+
+## Query installed state
+
+Reads do not need escalation — a `Direct` Runner is enough:
+
+```go
+ok, err := m.IsInstalled(ctx, "curl")
+ver, err := m.InstalledVersion(ctx, "curl") // "" when absent
+n, err := m.InstalledCount(ctx)             // total installed packages
+```
+
+## Backends
+
+<!-- docref: begin src=pkg/pkg.go#Backend:11393461 -->
+The backend is fixed at construction and selected from an explicit set —
+apt, dnf, pacman, zypper, and flatpak. The zero value is invalid; only
+implemented backends exist, so there is no "unknown backend" that silently does
+nothing.
+<!-- docref: end -->
+
+Behavioural differences the Manager smooths over but you should know about:
+
+- **apt / dnf / zypper** refresh their index as part of an upgrade; **pacman**
+  uses `-Sy` to sync the database first.
+- **flatpak** installs are per-remote application IDs, not distro package names;
+  use it for desktop apps, the distro backends for system packages.
+- **dnf / zypper / apt** resolve dependencies automatically; `Autoremove`
+  prunes what's no longer needed.
+
+{% callout type="info" title="Reference" %}
+The full method set and option fields are generated API docs on
+[pkg.go.dev](https://pkg.go.dev/github.com/manchtools/power-manage-sdk/pkg).
+This page is the task-oriented recipe; the reference lists the surface.
+{% /callout %}
+
+## Related
+
+- [Repositories](/capabilities/repositories) — configure the repositories these
+  package managers install from.
+- [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.
+- [Errors](/concepts/errors) — how failures are reported.

--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -78,11 +78,11 @@ the secret, enforced by a fitness function.
 <!-- docref: end -->
 
 <!-- docref: begin src=sys/exec/secret.go#Secret:0e14e52a -->
-An `exec.Secret` wraps sensitive material so it cannot leak by accident: its
+An `exec.Secret` wraps sensitive material so it cannot leak by accident. Its
 `String`/`GoString` render as `[REDACTED]`, so it never appears in logs, panics,
-or `%v` formatting — the real value is reachable only through an explicit
-`Reveal`, at the one sanctioned sink (here, fed to `chpasswd` on stdin, never on
-argv where another process could read it from `/proc`).
+or `%v` formatting; the real value is reachable only through an explicit
+`Reveal`. For a password that means one call site (here, fed to `chpasswd` on
+stdin, never on argv where another process could read it from `/proc`).
 <!-- docref: end -->
 
 Other account-state operations:

--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -50,6 +50,12 @@ info, err := m.Get(ctx, "deploy") // uid, gid, home, shell, …
 err = m.Delete(ctx, "deploy", user.DeleteOptions{RemoveHome: true})
 ```
 
+<!-- docref: begin src=sys/user/user.go#shadowUtils.Create:e0468cf4 -->
+`Create` drives `useradd` through the escalated Runner. A system account
+(`System: true`) defaults to a `nologin` shell, so a service account can't be
+logged into by accident.
+<!-- docref: end -->
+
 ## Passwords are secrets, not arguments
 
 `SetPassword` takes an `exec.Secret`, not a string:
@@ -105,6 +111,11 @@ members, err := m.GroupMembers(ctx, "docker")
 primary, err := m.PrimaryGroup(ctx, "deploy")
 groups, err := m.SupplementaryGroups(ctx, "deploy")
 ```
+
+<!-- docref: begin src=sys/user/group.go#shadowUtils.GroupEnsure:b1136668 -->
+`GroupEnsure` is idempotent: it creates the group only if it isn't already
+present, so it is safe to call on every reconcile.
+<!-- docref: end -->
 
 {% callout type="info" title="Reference" %}
 The full method set and option fields are generated API docs on

--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -115,5 +115,5 @@ The full method set and option fields are generated API docs on
 
 - [Architecture](/concepts/architecture) — Runner / Backend / Manager, and why
   passwords are injected as `exec.Secret`.
-- [Desktop & sessions](/capabilities/desktop) — run a command as one of these
-  users in their desktop session.
+- Desktop & sessions (`sys/desktop`) — run a command as one of these users in
+  their desktop session.

--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -1,0 +1,119 @@
+---
+title: Identity
+label: Identity
+description: Manage Linux users and groups — create, modify, lock, set passwords (without leaking them), and manage group membership.
+icon: "👤"
+---
+
+# Identity
+
+`sys/user` manages local Linux accounts and groups through the shadow-utils
+tools (`useradd`, `usermod`, `gpasswd`, …) behind one `Manager`. Password
+material is handled as an [`exec.Secret`](/concepts/architecture) so it never
+lands on a command line.
+
+## Construct a manager
+
+User mutations need root, so build an escalating Runner:
+
+```go
+r, err := exec.NewRunner(exec.Sudo)
+if err != nil {
+    return err
+}
+m, err := user.New(user.ShadowUtils, r)
+if err != nil {
+    return err
+}
+```
+
+<!-- docref: begin src=sys/user/user.go#New:97cb2f96 -->
+`New` is fail-closed: it rejects an unknown backend and a nil Runner before
+returning a Manager, so a misconfigured caller fails at construction rather than
+on the first account operation.
+<!-- docref: end -->
+
+## Create, modify, delete
+
+```go
+err := m.Create(ctx, "deploy", user.CreateOptions{
+    System:  true,
+    Shell:   "/usr/sbin/nologin",
+    Comment: "deployment service account",
+})
+
+err = m.Modify(ctx, "deploy", user.ModifyOptions{Shell: "/bin/bash"})
+
+ok, err := m.Exists(ctx, "deploy")
+info, err := m.Get(ctx, "deploy") // uid, gid, home, shell, …
+
+err = m.Delete(ctx, "deploy", user.DeleteOptions{RemoveHome: true})
+```
+
+## Passwords are secrets, not arguments
+
+`SetPassword` takes an `exec.Secret`, not a string:
+
+```go
+pw, err := exec.NewSecret("correct horse battery staple")
+if err != nil {
+    return err // rejects a newline-bearing password (would break chpasswd)
+}
+err = m.SetPassword(ctx, "deploy", pw)
+```
+
+<!-- docref: begin src=sys/exec/secret.go#NewSecret:23b7677a -->
+`NewSecret` rejects a value containing a newline or carriage return: such a value
+fed to `chpasswd` on stdin would split into a second record and set a password
+for an unintended account, so it is refused at construction. (For credentials
+written verbatim to a file, where newlines are legitimate payload, use
+`NewMultilineSecret`.)
+<!-- docref: end -->
+
+<!-- docref: begin src=sys/user/password.go#shadowUtils.SetPassword:acf8cd55 -->
+`SetPassword` feeds `name:secret` to `chpasswd` on **stdin** — the password
+never appears in the process's argv, where any other process could read it from
+`/proc/<pid>/cmdline`. The `Reveal` call here is the single sanctioned sink for
+the secret, enforced by a fitness function.
+<!-- docref: end -->
+
+<!-- docref: begin src=sys/exec/secret.go#Secret:0e14e52a -->
+An `exec.Secret` wraps sensitive material so it cannot leak by accident: its
+`String`/`GoString` render as `[REDACTED]`, so it never appears in logs, panics,
+or `%v` formatting — the real value is reachable only through an explicit
+`Reveal`, at the one sanctioned sink (here, fed to `chpasswd` on stdin, never on
+argv where another process could read it from `/proc`).
+<!-- docref: end -->
+
+Other account-state operations:
+
+```go
+err := m.Lock(ctx, "deploy")          // disable login
+err = m.Unlock(ctx, "deploy")
+err = m.ExpirePassword(ctx, "deploy") // force a change at next login
+err = m.KillSessions(ctx, "deploy")   // terminate the user's processes
+```
+
+## Groups and membership
+
+```go
+err := m.GroupEnsure(ctx, "docker")      // create if absent (idempotent)
+err = m.AddToGroup(ctx, "deploy", "docker")
+err = m.RemoveFromGroup(ctx, "deploy", "docker")
+
+members, err := m.GroupMembers(ctx, "docker")
+primary, err := m.PrimaryGroup(ctx, "deploy")
+groups, err := m.SupplementaryGroups(ctx, "deploy")
+```
+
+{% callout type="info" title="Reference" %}
+The full method set and option fields are generated API docs on
+[pkg.go.dev](https://pkg.go.dev/github.com/manchtools/power-manage-sdk/sys/user).
+{% /callout %}
+
+## Related
+
+- [Architecture](/concepts/architecture) — Runner / Backend / Manager, and why
+  passwords are injected as `exec.Secret`.
+- [Desktop & sessions](/capabilities/desktop) — run a command as one of these
+  users in their desktop session.

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -1,0 +1,101 @@
+---
+title: Services
+label: Services
+description: Manage init units — enable, start, restart, mask, and install unit files — through systemctl behind one Manager.
+icon: "⚙️"
+---
+
+# Services
+
+`sys/service` manages init units through `systemctl` behind a `Manager`. It
+covers the full lifecycle: query state, enable/start, write and remove unit
+files, and mask a unit so nothing can start it.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // unit mutations need root
+if err != nil {
+    return err
+}
+
+if len(service.Detect(ctx)) == 0 {
+    return errors.New("systemd not available on this host")
+}
+m, err := service.New(service.Systemd, r)
+if err != nil {
+    return err
+}
+```
+
+<!-- docref: begin src=sys/service/service.go#Detect:2e00d699 -->
+`Detect` reports whether the systemd backend is usable on this host; it lists,
+it never picks. An empty result means there is no supported service manager —
+the caller decides what to do, the SDK never guesses.
+<!-- docref: end -->
+
+<!-- docref: begin src=sys/service/service.go#New:91064f53 -->
+`New` is fail-closed: only the implemented `Systemd` backend is accepted, and a
+nil Runner is rejected, before a Manager is returned. The OpenRC/Runit/S6
+scaffolds were deliberately removed rather than shipped half-working, so an
+unimplemented backend is an explicit error, not a silent no-op.
+<!-- docref: end -->
+
+## Query unit state
+
+Reads are unprivileged:
+
+```go
+st, err := m.Status(ctx, "sshd.service") // active state, sub-state, …
+on, err := m.IsActive(ctx, "sshd.service")
+en, err := m.IsEnabled(ctx, "sshd.service")
+masked, err := m.IsMasked(ctx, "sshd.service")
+```
+
+## Enable, start, restart
+
+```go
+err := m.EnableNow(ctx, "nginx.service")  // enable + start in one step
+err = m.Restart(ctx, "nginx.service")
+err = m.Stop(ctx, "nginx.service")
+err = m.DisableNow(ctx, "nginx.service")  // disable + stop
+```
+
+`EnableNow`/`DisableNow` fold the boot-time setting and the running state into a
+single call so the unit's "should it run now" and "should it run at boot" never
+drift apart in your code.
+
+## Install a unit file
+
+```go
+const unit = `[Unit]
+Description=Power Manage agent
+[Service]
+ExecStart=/usr/bin/pm-agent
+[Install]
+WantedBy=multi-user.target
+`
+err := m.WriteUnit(ctx, "pm-agent.service", unit)
+err = m.DaemonReload(ctx)            // re-read unit files
+err = m.EnableNow(ctx, "pm-agent.service")
+```
+
+## Mask a unit
+
+```go
+err := m.Mask(ctx, "bluetooth.service")   // symlink to /dev/null — cannot start
+err = m.Unmask(ctx, "bluetooth.service")
+```
+
+Masking is stronger than disabling: a masked unit cannot be started at all, even
+as a dependency of another unit.
+
+{% callout type="info" title="Reference" %}
+The full method set is generated API docs on
+[pkg.go.dev](https://pkg.go.dev/github.com/manchtools/power-manage-sdk/sys/service).
+{% /callout %}
+
+## Related
+
+- [Reboot](/capabilities/reboot) — detect and schedule reboots after updates.
+- [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -7,9 +7,11 @@ icon: "⚙️"
 
 # Services
 
-`sys/service` manages init units through `systemctl` behind a `Manager`. It
-covers the full lifecycle: query state, enable/start, write and remove unit
-files, and mask a unit so nothing can start it.
+`sys/service` manages init units behind a `Manager`. The init system is a
+`Backend` you name explicitly — systemd (driven through `systemctl`) is the one
+implemented today, but the model isn't limited to it. It covers the full
+lifecycle: query state, enable/start, write and remove unit files, and mask a
+unit so nothing can start it.
 
 ## Construct a manager
 

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -7,11 +7,10 @@ icon: "⚙️"
 
 # Services
 
-`sys/service` manages init units behind a `Manager`. The init system is a
-`Backend` you name explicitly — systemd (driven through `systemctl`) is the one
-implemented today, but the model isn't limited to it. It covers the full
-lifecycle: query state, enable/start, write and remove unit files, and mask a
-unit so nothing can start it.
+`sys/service` manages init units behind a `Manager`. You name the init-system
+`Backend` explicitly (currently systemd, driven through `systemctl`). It covers
+the full lifecycle: query state, enable/start, write and remove unit files, and
+mask a unit so nothing can start it.
 
 ## Construct a manager
 

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -62,9 +62,11 @@ err = m.Stop(ctx, "nginx.service")
 err = m.DisableNow(ctx, "nginx.service")  // disable + stop
 ```
 
+<!-- docref: begin src=sys/service/systemd.go#systemd.EnableNow:a4971314,sys/service/systemd.go#systemd.DisableNow:ae65bab2 -->
 `EnableNow`/`DisableNow` fold the boot-time setting and the running state into a
 single call so the unit's "should it run now" and "should it run at boot" never
 drift apart in your code.
+<!-- docref: end -->
 
 ## Install a unit file
 
@@ -88,8 +90,11 @@ err := m.Mask(ctx, "bluetooth.service")   // symlink to /dev/null — cannot sta
 err = m.Unmask(ctx, "bluetooth.service")
 ```
 
-Masking is stronger than disabling: a masked unit cannot be started at all, even
-as a dependency of another unit.
+<!-- docref: begin src=sys/service/systemd.go#systemd.Mask:3c1e097a -->
+Masking is stronger than disabling: `Mask` symlinks the unit to `/dev/null`, so
+it cannot be started at all, even as a dependency of another unit. `Unmask`
+reverses it.
+<!-- docref: end -->
 
 {% callout type="info" title="Reference" %}
 The full method set is generated API docs on

--- a/docs/03-capabilities/04-reboot.md
+++ b/docs/03-capabilities/04-reboot.md
@@ -7,8 +7,8 @@ icon: "🔁"
 
 # Reboot
 
-`sys/reboot` answers two questions a patching workflow needs: *does this host
-need a reboot?* and *schedule one (politely) when it does.*
+`sys/reboot` answers two questions a patching workflow needs — does this host
+need a reboot, and how to schedule one (politely) when it does.
 
 ## Construct a manager
 

--- a/docs/03-capabilities/04-reboot.md
+++ b/docs/03-capabilities/04-reboot.md
@@ -1,0 +1,75 @@
+---
+title: Reboot
+label: Reboot
+description: Detect whether a reboot is needed after updates, and schedule or cancel one via shutdown.
+icon: "🔁"
+---
+
+# Reboot
+
+`sys/reboot` answers two questions a patching workflow needs: *does this host
+need a reboot?* and *schedule one (politely) when it does.*
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // scheduling a reboot needs root
+if err != nil {
+    return err
+}
+rb, err := reboot.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Is a reboot required?
+
+The probe is unprivileged, so a `Direct` Runner is enough to *read*:
+
+```go
+need, err := rb.IsRequired(ctx)
+if need {
+    // a package update left the host needing a restart
+}
+```
+
+<!-- docref: begin src=sys/reboot/reboot.go#rebooter.IsRequired:acb46152 -->
+`IsRequired` checks the Debian/Ubuntu `/var/run/reboot-required` marker and, on
+RHEL/Fedora, `needs-restarting -r`. A host with neither signal returns
+`(false, nil)` — the *absence* of a detection mechanism is not an error. Only a
+genuinely unexpected condition (a non-ENOENT stat error, or a `needs-restarting`
+run failure that isn't "tool absent") surfaces as an error, so a caller can tell
+"no reboot needed" from "I couldn't tell."
+<!-- docref: end -->
+
+## Schedule and cancel
+
+```go
+err := rb.Schedule(ctx, reboot.ScheduleOptions{
+    Delay:   "+5",                     // shutdown(8) TIME spec
+    Message: "Patching — back in 5m",  // broadcast to logged-in users
+})
+
+// Changed your mind:
+err = rb.Cancel(ctx)
+```
+
+<!-- docref: begin src=sys/reboot/reboot.go#ScheduleOptions:b3cc2d01 -->
+`ScheduleOptions.Delay` is a `shutdown(8)` TIME spec (`"+5"`, `"now"`,
+`"23:00"`); an empty `Delay` defaults to `"+1"` (one minute), never an instant
+reboot by accident. The fields are named (not positional) so a caller can't
+transpose the delay and the wall message.
+<!-- docref: end -->
+
+{% callout type="warning" title="Schedule really reboots" %}
+`Schedule` calls the host's real `shutdown -r`. It is not a dry run — the host
+will reboot at the requested time unless you `Cancel` first.
+{% /callout %}
+
+## Related
+
+- [Services](/capabilities/services) — restart individual units without a full
+  reboot.
+- [Packages](/capabilities/packages) — the updates that set the
+  reboot-required marker in the first place.

--- a/docs/03-capabilities/05-timesync.md
+++ b/docs/03-capabilities/05-timesync.md
@@ -33,6 +33,11 @@ st, err := m.Status(ctx)
 fmt.Println(st.Synchronized) // is the clock in sync?
 ```
 
+<!-- docref: begin src=sys/timesync/timedatectl.go#timedatectlManager.Status:b7492022 -->
+On the Timedatectl backend, `Status` parses `timedatectl show` into whether the
+clock is `Synchronized` and whether a time service is `Enabled`.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/timesync/timesync.go#New:021d678b -->
 `New` validates the backend and rejects a nil Runner. The two backends report
 slightly different things: Timedatectl reports synchronized plus whether the

--- a/docs/03-capabilities/05-timesync.md
+++ b/docs/03-capabilities/05-timesync.md
@@ -1,0 +1,46 @@
+---
+title: Time sync
+label: Time sync
+description: Read the host's time-synchronization status via systemd-timesyncd (timedatectl) or chrony.
+icon: "🕐"
+---
+
+# Time sync
+
+`sys/timesync` reports whether the host's clock is synchronized, through
+systemd's `timedatectl` or `chronyc`.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Direct) // status is an unprivileged read
+if err != nil {
+    return err
+}
+for _, b := range timesync.Detect(ctx) { // Timedatectl and/or Chrony
+    _ = b
+}
+m, err := timesync.New(timesync.Timedatectl, r)
+if err != nil {
+    return err
+}
+```
+
+## Read status
+
+```go
+st, err := m.Status(ctx)
+fmt.Println(st.Synchronized) // is the clock in sync?
+```
+
+<!-- docref: begin src=sys/timesync/timesync.go#New:021d678b -->
+`New` validates the backend and rejects a nil Runner. The two backends report
+slightly different things: Timedatectl reports synchronized plus whether the
+time service is enabled; Chrony reports synchronized plus the reference source.
+Both answer the core question — *is this clock trustworthy?*
+<!-- docref: end -->
+
+## Related
+
+- [Services](/capabilities/services) — enable/start the time-sync daemon itself.
+- [Logs](/capabilities/log) — correlate events once the clock is trusted.

--- a/docs/03-capabilities/06-filesystem.md
+++ b/docs/03-capabilities/06-filesystem.md
@@ -1,0 +1,73 @@
+---
+title: Filesystem
+label: Filesystem
+description: Read, write, and manage files and directories with permissions and ownership — TOCTOU-safe, never following a symlink out of bounds.
+icon: "💾"
+---
+
+# Filesystem
+
+`sys/fs` is the SDK's file primitive: read, write, copy, remove, set
+mode/ownership, and remount-rw — done safely. It is a single-tool capability, so
+`New` takes only a Runner, no Backend.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // writes to root-owned paths need root
+if err != nil {
+    return err
+}
+m, err := fs.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Read and write
+
+```go
+data, err := m.ReadFile(ctx, "/etc/hostname")
+err = m.WriteFile(ctx, "/etc/power-manage/agent.conf", []byte(cfg), fs.WriteOptions{
+    Mode:  0o644,
+    Owner: "root",
+    Group: "root",
+})
+ok, err := m.Exists(ctx, "/etc/power-manage")
+entries, err := m.ReadDir(ctx, "/etc/power-manage")
+```
+
+## Directories, permissions, ownership
+
+```go
+err := m.Mkdir(ctx, "/var/lib/power-manage/state", fs.MkdirOptions{Mode: 0o750, Recursive: true})
+err = m.SetMode(ctx, "/var/lib/power-manage/state", 0o700)
+err = m.SetOwnership(ctx, "/var/lib/power-manage/state", "power-manage", "power-manage")
+err = m.Remove(ctx, "/var/lib/power-manage/state/stale.tmp")
+```
+
+## Why use this instead of `os`
+
+<!-- docref: begin src=sys/fs/fs.go#New:3ac54444 -->
+`New` returns the filesystem Manager over the injected Runner; a nil Runner is
+rejected.
+<!-- docref: end -->
+
+The operations are privilege-backend-keyed: as root they take a TOCTOU-safe,
+fd-anchored path — each step operates on an open directory handle, so a symlink
+swapped in mid-operation can't redirect a write or delete out of bounds; when
+escalation is via sudo, the same operations are driven through the escalated
+tool.
+
+{% callout type="info" title="Read-only roots" %}
+`IsReadOnly` and `RemountRW` handle the immutable-root case (ostree, a
+read-only `/usr`): check, remount read-write for the change, and the caller can
+remount back. Mutations refuse to write into protected system subtrees they
+don't own.
+{% /callout %}
+
+## Related
+
+- [Architecture](/concepts/architecture) — the injected Runner this builds on.
+- [Remote sources](/capabilities/remote) — fetch a file from HTTPS/Git/S3 into a
+  managed path.

--- a/docs/03-capabilities/06-filesystem.md
+++ b/docs/03-capabilities/06-filesystem.md
@@ -37,6 +37,12 @@ ok, err := m.Exists(ctx, "/etc/power-manage")
 entries, err := m.ReadDir(ctx, "/etc/power-manage")
 ```
 
+<!-- docref: begin src=sys/fs/write.go#manager.WriteFile:117bc452 -->
+`WriteFile` creates or replaces the file and applies the requested mode, owner,
+and group in one call, through the same privilege-keyed safe backend described
+below.
+<!-- docref: end -->
+
 ## Directories, permissions, ownership
 
 ```go

--- a/docs/03-capabilities/07-encryption.md
+++ b/docs/03-capabilities/07-encryption.md
@@ -32,6 +32,11 @@ ok, err := m.VerifyPassphrase(ctx, "/dev/sda2", existing) // existing is an exec
 vol, err := m.DetectVolume(ctx)                            // the system's LUKS volume
 ```
 
+<!-- docref: begin src=sys/encryption/luks.go#luks.VerifyPassphrase:55af258e -->
+`VerifyPassphrase` is a read-only probe: a wrong passphrase returns
+`(false, nil)`, not an error, so testing a guess never looks like a failure.
+<!-- docref: end -->
+
 ## Manage key slots
 
 ```go

--- a/docs/03-capabilities/07-encryption.md
+++ b/docs/03-capabilities/07-encryption.md
@@ -1,0 +1,70 @@
+---
+title: Disk encryption
+label: Disk encryption
+description: Manage LUKS volumes — detect encryption, add/remove/kill key slots, verify passphrases — with all key material handled as secrets.
+icon: "🔒"
+---
+
+# Disk encryption
+
+`sys/encryption` manages LUKS volumes via `cryptsetup`: detect whether a device
+is encrypted, manage its key slots, and verify passphrases. Every piece of key
+material is an [`exec.Secret`](/concepts/architecture).
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // cryptsetup needs root
+if err != nil {
+    return err
+}
+m, err := encryption.New(encryption.LUKS, r)
+if err != nil {
+    return err
+}
+```
+
+## Detect and verify
+
+```go
+enc, err := m.IsEncrypted(ctx, "/dev/sda2")
+ok, err := m.VerifyPassphrase(ctx, "/dev/sda2", existing) // existing is an exec.Secret
+vol, err := m.DetectVolume(ctx)                            // the system's LUKS volume
+```
+
+## Manage key slots
+
+```go
+existing, _ := exec.NewSecret("current passphrase")
+newKey, _   := exec.NewSecret("rotated passphrase")
+
+err := m.AddKey(ctx, "/dev/sda2", existing, newKey, encryption.AddKeyOptions{})
+err = m.RemoveKey(ctx, "/dev/sda2", newKey)
+err = m.KillSlot(ctx, "/dev/sda2", 3, existing) // slot index 0..7
+```
+
+<!-- docref: begin src=sys/encryption/encryption.go#New:ba4f9552 -->
+`New` validates the backend (only `LUKS` is implemented) and rejects a nil
+Runner before returning a Manager.
+<!-- docref: end -->
+
+The key-slot operations take their key material as `exec.Secret`, so a passphrase
+is never rendered into a log or a panic:
+
+<!-- docref: begin src=sys/encryption/luks.go#luks.AddKey:ba80fabe -->
+`AddKey` rejects empty key material up front (`ErrEmptyKeyMaterial`) — both an
+empty new key (which would create an empty-passphrase unlock slot) and an empty
+authenticating passphrase — before `cryptsetup` is ever run.
+<!-- docref: end -->
+
+{% callout type="warning" title="Key-slot operations are destructive" %}
+`KillSlot` erases a key slot; `RemoveKey` removes the slot matching a passphrase.
+Removing the last usable key makes the volume unopenable — the SDK validates
+inputs, but the *policy* of which slot is safe to remove is the caller's.
+{% /callout %}
+
+## Related
+
+- [Filesystem](/capabilities/filesystem) — read/write the mounted volume once
+  it's open.
+- [Architecture](/concepts/architecture) — why key material is `exec.Secret`.

--- a/docs/03-capabilities/08-smart.md
+++ b/docs/03-capabilities/08-smart.md
@@ -37,6 +37,11 @@ for _, d := range devs {
 }
 ```
 
+<!-- docref: begin src=sys/smart/smart.go#collector.Scan:5e620d4e -->
+`Scan` runs `smartctl --scan -j` and decodes the device list from its JSON; it
+returns an empty list (not an error) on a host with no SMART-capable disk.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/smart/smart.go#collector.Device:7abe0da4 -->
 `Device` validates the device path (it must be a `/dev/*` path with no `..`
 traversal) before running `smartctl`, then reads `smartctl -j -a`. smartctl

--- a/docs/03-capabilities/08-smart.md
+++ b/docs/03-capabilities/08-smart.md
@@ -45,7 +45,7 @@ encodes failure in an exit-status *bitmask*, not just a non-zero exit, so
 an error rather than a bogus "healthy" reading.
 <!-- docref: end -->
 
-{% callout type="info" title="Needs real hardware to be interesting" %}
+{% callout type="info" title="Needs real hardware" %}
 A VM or container usually has no SMART-capable disk, so `Scan` returns an empty
 list there. On real hardware you get the health bit (`smart_status.passed`),
 temperature, and power-on hours.

--- a/docs/03-capabilities/08-smart.md
+++ b/docs/03-capabilities/08-smart.md
@@ -1,0 +1,57 @@
+---
+title: Drive health
+label: Drive health
+description: Read S.M.A.R.T. disk health — scan devices and report health, temperature, and power-on hours — via smartctl.
+icon: "🩺"
+---
+
+# Drive health
+
+`sys/smart` reads S.M.A.R.T. disk health through `smartctl` (smartmontools): list
+the inspectable devices, then read each one's health, temperature, and power-on
+hours. It is a single-tool capability, so `New` takes only a Runner, no Backend.
+
+## Construct a collector
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // smartctl needs root to open a device
+if err != nil {
+    return err
+}
+c, err := smart.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Scan and read
+
+```go
+devs, err := c.Scan(ctx) // smartctl --scan: [{Name:"/dev/sda", Type:"sat"}, …]
+for _, d := range devs {
+    info, err := c.Device(ctx, d.Name)
+    if err != nil {
+        continue // a device that can't be inspected is surfaced as an error
+    }
+    fmt.Println(info.Name, info.Healthy, info.TemperatureC, info.PowerOnHours)
+}
+```
+
+<!-- docref: begin src=sys/smart/smart.go#collector.Device:7abe0da4 -->
+`Device` validates the device path (it must be a `/dev/*` path with no `..`
+traversal) before running `smartctl`, then reads `smartctl -j -a`. smartctl
+encodes failure in an exit-status *bitmask*, not just a non-zero exit, so
+`Device` inspects the fatal bits: a device it could not inspect is returned as
+an error rather than a bogus "healthy" reading.
+<!-- docref: end -->
+
+{% callout type="info" title="Needs real hardware to be interesting" %}
+A VM or container usually has no SMART-capable disk, so `Scan` returns an empty
+list there. On real hardware you get the health bit (`smart_status.passed`),
+temperature, and power-on hours.
+{% /callout %}
+
+## Related
+
+- [Filesystem](/capabilities/filesystem) / [Disk encryption](/capabilities/encryption)
+  — the storage layers above the physical drive.

--- a/docs/03-capabilities/09-network.md
+++ b/docs/03-capabilities/09-network.md
@@ -64,6 +64,12 @@ changed, err := m.Apply(ctx, profile)
 err = m.Delete(ctx, "corp-wifi", network.DeleteOptions{})
 ```
 
+<!-- docref: begin src=sys/network/networkmanager.go#networkManager.Settings:4dadc963 -->
+`Settings` returns the connection's settings as a key-value map, unescaped from
+`nmcli`'s terse-mode encoding, so a caller reads clean values rather than
+`nmcli`'s colon-delimited escaping.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/network/network.go#validateProfile:44f2efac -->
 `Apply` validates the profile before doing anything: a PSK profile must carry a
 non-empty PSK with no embedded newline (which would corrupt the keyfile), and an

--- a/docs/03-capabilities/09-network.md
+++ b/docs/03-capabilities/09-network.md
@@ -7,10 +7,9 @@ icon: "📶"
 
 # Wi-Fi
 
-`sys/network` manages NetworkManager Wi-Fi connection *profiles* — WPA-PSK and
-EAP-TLS. Its defining property: the credential (the WPA passphrase, the EAP-TLS
-private key) is an [`exec.Secret`](/concepts/architecture) and is **never** put
-on a command line.
+`sys/network` manages NetworkManager Wi-Fi connection *profiles*, both WPA-PSK
+and EAP-TLS. The credential (the WPA passphrase, the EAP-TLS private key) is an
+[`exec.Secret`](/concepts/architecture), so it never reaches a command line.
 
 ## Construct a manager
 
@@ -47,9 +46,9 @@ changed, err := m.Apply(ctx, network.Profile{
 <!-- docref: begin src=sys/network/keyfile.go#buildPSKKeyfile:c291b90a -->
 The PSK is written into a NetworkManager *keyfile* — a `0600` file under
 `/etc/NetworkManager/system-connections/` with the `psk=` line — and never
-passed as an `nmcli` argument. `nmcli connection modify wifi-sec.psk <value>` would put
-the passphrase on the argv where any process could read it from `/proc`; the
-keyfile path is the one sanctioned place the secret is revealed.
+passed as an `nmcli` argument. Running `nmcli connection modify wifi-sec.psk
+<value>` would put the passphrase on the argv, where any process could read it
+from `/proc`. Writing the keyfile is the only place the SDK reveals the secret.
 <!-- docref: end -->
 
 ## Inspect, update, remove

--- a/docs/03-capabilities/09-network.md
+++ b/docs/03-capabilities/09-network.md
@@ -1,0 +1,83 @@
+---
+title: Wi-Fi
+label: Wi-Fi
+description: Create, update, and remove NetworkManager Wi-Fi connection profiles — with the PSK handled as a secret, never on a command line.
+icon: "📶"
+---
+
+# Wi-Fi
+
+`sys/network` manages NetworkManager Wi-Fi connection *profiles* — WPA-PSK and
+EAP-TLS. Its defining property: the credential (the WPA passphrase, the EAP-TLS
+private key) is an [`exec.Secret`](/concepts/architecture) and is **never** put
+on a command line.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // writing a connection profile needs root
+if err != nil {
+    return err
+}
+if len(network.Detect(ctx)) == 0 {
+    return errors.New("NetworkManager (nmcli) not available")
+}
+m, err := network.New(network.NetworkManager, r)
+if err != nil {
+    return err
+}
+```
+
+## Apply a WPA-PSK profile
+
+```go
+psk, err := exec.NewSecret("correct horse battery staple")
+if err != nil {
+    return err
+}
+changed, err := m.Apply(ctx, network.Profile{
+    Name:        "corp-wifi",
+    SSID:        "Corp",
+    AuthType:    network.AuthPSK,
+    PSK:         psk,
+    AutoConnect: true,
+})
+```
+
+<!-- docref: begin src=sys/network/keyfile.go#buildPSKKeyfile:c291b90a -->
+The PSK is written into a NetworkManager *keyfile* — a `0600` file under
+`/etc/NetworkManager/system-connections/` with the `psk=` line — and never
+passed as an `nmcli` argument. `nmcli connection modify wifi-sec.psk <value>` would put
+the passphrase on the argv where any process could read it from `/proc`; the
+keyfile path is the one sanctioned place the secret is revealed.
+<!-- docref: end -->
+
+## Inspect, update, remove
+
+```go
+exists, err := m.ConnectionExists(ctx, "corp-wifi")
+settings, err := m.Settings(ctx, "corp-wifi") // nmcli con show, parsed
+
+// Re-applying the same name updates it; Apply reports whether anything changed.
+changed, err := m.Apply(ctx, profile)
+
+err = m.Delete(ctx, "corp-wifi", network.DeleteOptions{})
+```
+
+<!-- docref: begin src=sys/network/network.go#validateProfile:44f2efac -->
+`Apply` validates the profile before doing anything: a PSK profile must carry a
+non-empty PSK with no embedded newline (which would corrupt the keyfile), and an
+EAP-TLS profile must carry its client key. An invalid profile is rejected with
+no side effect.
+<!-- docref: end -->
+
+{% callout type="info" title="EAP-TLS" %}
+For enterprise networks, set `AuthType: network.AuthEAPTLS` and provide the
+client certificate and key; the key is written to a cert file under the
+connection's directory, again never on the command line.
+{% /callout %}
+
+## Related
+
+- [Network interfaces](/capabilities/netconfig) — wired addressing and routes.
+- [Architecture](/concepts/architecture) — why credentials are `exec.Secret`.

--- a/docs/03-capabilities/09-network.md
+++ b/docs/03-capabilities/09-network.md
@@ -7,8 +7,9 @@ icon: "📶"
 
 # Wi-Fi
 
-`sys/network` manages NetworkManager Wi-Fi connection *profiles*, both WPA-PSK
-and EAP-TLS. The credential (the WPA passphrase, the EAP-TLS private key) is an
+`sys/network` manages Wi-Fi connection *profiles* (currently through the
+NetworkManager `Backend`), both WPA-PSK and EAP-TLS. The credential (the WPA
+passphrase, the EAP-TLS private key) is an
 [`exec.Secret`](/concepts/architecture), so it never reaches a command line.
 
 ## Construct a manager

--- a/docs/03-capabilities/10-dns.md
+++ b/docs/03-capabilities/10-dns.md
@@ -1,14 +1,14 @@
 ---
 title: DNS
 label: DNS
-description: Read and apply a host's resolver configuration — nameservers and search domains — via systemd-resolved or NetworkManager.
+description: Read and apply a host's resolver configuration (nameservers and search domains) via systemd-resolved or NetworkManager.
 icon: "🧭"
 ---
 
 # DNS
 
-`sys/dns` reads and configures the host resolver — nameservers and search
-domains — through systemd-resolved or NetworkManager.
+`sys/dns` reads and configures the host resolver (nameservers and search
+domains) through systemd-resolved or NetworkManager.
 
 ## Construct a manager
 
@@ -29,7 +29,7 @@ if err != nil {
 
 <!-- docref: begin src=sys/dns/dns.go#New:36342405 -->
 `New` validates the backend and rejects a nil Runner up front; the zero-value
-and any unimplemented backend are `ErrUnknownBackend`. It is pure — it does not
+and any unimplemented backend are `ErrUnknownBackend`. It is pure: it does not
 probe the host, so use `Detect` to learn which backends are usable here.
 <!-- docref: end -->
 
@@ -51,8 +51,8 @@ err := m.Apply(ctx, dns.Config{
 ```
 
 <!-- docref: begin src=sys/dns/resolved.go#resolvedManager.Apply:8a4c7c2d -->
-`Apply` validates the whole `Config` — rejecting non-IP nameservers, malformed
-or flag-shaped search domains, and bad interface names — *before* it touches any
+`Apply` validates the whole `Config` (rejecting non-IP nameservers, malformed or
+flag-shaped search domains, and bad interface names) *before* it touches any
 backend, so an invalid configuration has no side effects. On the Resolved
 backend a host-global apply (empty `Interface`) writes the managed
 `resolved.conf.d` drop-in and restarts the service; a set `Interface` uses

--- a/docs/03-capabilities/10-dns.md
+++ b/docs/03-capabilities/10-dns.md
@@ -40,6 +40,12 @@ st, err := m.Get(ctx)
 fmt.Println(st.Nameservers, st.SearchDomains)
 ```
 
+<!-- docref: begin src=sys/dns/resolved.go#resolvedManager.Get:e72d8b51 -->
+`Get` reads systemd-resolved's generated `resolv.conf` and parses the active
+nameservers and search domains out of it, so it reflects what the resolver is
+actually using, not just what was last applied.
+<!-- docref: end -->
+
 ## Apply a configuration
 
 ```go

--- a/docs/03-capabilities/10-dns.md
+++ b/docs/03-capabilities/10-dns.md
@@ -1,0 +1,73 @@
+---
+title: DNS
+label: DNS
+description: Read and apply a host's resolver configuration — nameservers and search domains — via systemd-resolved or NetworkManager.
+icon: "🧭"
+---
+
+# DNS
+
+`sys/dns` reads and configures the host resolver — nameservers and search
+domains — through systemd-resolved or NetworkManager.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // Apply mutates resolver config; root
+if err != nil {
+    return err
+}
+
+for _, b := range dns.Detect(ctx) { // Resolved if resolvectl present; NM if nmcli
+    _ = b
+}
+m, err := dns.New(dns.Resolved, r)
+if err != nil {
+    return err
+}
+```
+
+<!-- docref: begin src=sys/dns/dns.go#New:36342405 -->
+`New` validates the backend and rejects a nil Runner up front; the zero-value
+and any unimplemented backend are `ErrUnknownBackend`. It is pure — it does not
+probe the host, so use `Detect` to learn which backends are usable here.
+<!-- docref: end -->
+
+## Read the active resolver
+
+```go
+st, err := m.Get(ctx)
+fmt.Println(st.Nameservers, st.SearchDomains)
+```
+
+## Apply a configuration
+
+```go
+err := m.Apply(ctx, dns.Config{
+    Nameservers:   []string{"1.1.1.1", "2606:4700:4700::1111"},
+    SearchDomains: []string{"corp.example"},
+    // Interface: "eth0", // scope to one link; empty = host-global (Resolved only)
+})
+```
+
+<!-- docref: begin src=sys/dns/resolved.go#resolvedManager.Apply:8a4c7c2d -->
+`Apply` validates the whole `Config` — rejecting non-IP nameservers, malformed
+or flag-shaped search domains, and bad interface names — *before* it touches any
+backend, so an invalid configuration has no side effects. On the Resolved
+backend a host-global apply (empty `Interface`) writes the managed
+`resolved.conf.d` drop-in and restarts the service; a set `Interface` uses
+per-link runtime settings.
+<!-- docref: end -->
+
+{% callout type="info" title="Backend scope" %}
+The **Resolved** backend supports host-global config (empty `Interface`).
+**NetworkManager** is connection-scoped — it configures DNS on a specific
+interface's active connection, so `Interface` is required there. For host-wide
+DNS, use Resolved.
+{% /callout %}
+
+## Related
+
+- [Network interfaces](/capabilities/netconfig) — IP/routing config, which also
+  carries per-interface DNS.
+- [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.

--- a/docs/03-capabilities/11-netconfig.md
+++ b/docs/03-capabilities/11-netconfig.md
@@ -34,6 +34,11 @@ cfg, err := m.Get(ctx, "eth0")
 fmt.Println(cfg.Addresses, cfg.Gateway, cfg.Routes)
 ```
 
+<!-- docref: begin src=sys/netconfig/ip.go#base.Get:19ab7d19 -->
+`Get` parses `ip -j addr`/`route` JSON for the interface, so the read path is the
+same unprivileged iproute2 query regardless of which write backend you chose.
+<!-- docref: end -->
+
 ## Apply addressing
 
 ```go

--- a/docs/03-capabilities/11-netconfig.md
+++ b/docs/03-capabilities/11-netconfig.md
@@ -1,0 +1,71 @@
+---
+title: Network interfaces
+label: Network interfaces
+description: Configure an interface's addressing — DHCP or static IPs, gateway, routes, MTU, DNS — and read it back.
+icon: "🔌"
+---
+
+# Network interfaces
+
+`sys/netconfig` configures a single interface's addressing: DHCP or static IPs,
+a gateway, extra routes, MTU, and per-interface DNS. The read path parses real
+`ip -j` (iproute2) JSON; the write path drives NetworkManager.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // applying interface config needs root
+if err != nil {
+    return err
+}
+m, err := netconfig.New(netconfig.NetworkManager, r)
+if err != nil {
+    return err
+}
+```
+
+## Read an interface
+
+The read path is unprivileged (`ip -j addr/route show`):
+
+```go
+cfg, err := m.Get(ctx, "eth0")
+fmt.Println(cfg.Addresses, cfg.Gateway, cfg.Routes)
+```
+
+## Apply addressing
+
+```go
+// Static:
+err := m.Apply(ctx, netconfig.InterfaceConfig{
+    Name:      "eth0",
+    Mode:      netconfig.Static,
+    Addresses: []string{"192.0.2.10/24"},
+    Gateway:   "192.0.2.1",
+    DNS:       []string{"1.1.1.1"},
+    MTU:       1500,
+})
+
+// DHCP:
+err = m.Apply(ctx, netconfig.InterfaceConfig{Name: "eth0", Mode: netconfig.DHCP})
+```
+
+<!-- docref: begin src=sys/netconfig/netconfig.go#InterfaceConfig:ad3f8ece -->
+`Mode` (DHCP or Static) governs addressing only and is required. `Addresses`
+and `Gateway` apply in static mode (the gateway's family must match an address);
+`DNS`, `MTU`, and `Routes` apply in both modes. A static config with no
+addresses, or a gateway in a family no address covers, is rejected before any
+change is made.
+<!-- docref: end -->
+
+{% callout type="info" title="DNS lives in two places" %}
+`InterfaceConfig.DNS` sets resolvers on the interface as a convenience.
+Host-wide DNS policy — global nameservers, search domains — is the proper job of
+[`sys/dns`](/capabilities/dns).
+{% /callout %}
+
+## Related
+
+- [DNS](/capabilities/dns) — host-global resolver configuration.
+- [Wi-Fi](/capabilities/network) — Wi-Fi profiles (the wireless side of
+  networking).

--- a/docs/03-capabilities/11-netconfig.md
+++ b/docs/03-capabilities/11-netconfig.md
@@ -9,7 +9,8 @@ icon: "🔌"
 
 `sys/netconfig` configures a single interface's addressing: DHCP or static IPs,
 a gateway, extra routes, MTU, and per-interface DNS. The read path parses real
-`ip -j` (iproute2) JSON; the write path drives NetworkManager.
+`ip -j` (iproute2) JSON; the write path uses the `Backend` you name (currently
+NetworkManager or systemd-networkd).
 
 ## Construct a manager
 

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -45,6 +45,12 @@ err = m.RemoveRule(ctx, "allow-ssh")
 rules, err := m.List(ctx) // only rules in this manager's namespace
 ```
 
+<!-- docref: begin src=sys/firewall/nftables.go#nftables.List:015a86b3 -->
+`List` decodes each rule's full match — protocol, port, **and** source/destination
+address — back out of the live nftables ruleset, so what you read reflects
+exactly what was applied.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/firewall/firewall.go#Rule:ca82cb6a -->
 A `Rule` is identified by a stable `ID` (used to remove or replace it), and is
 either allow (`Allow: true`) or deny. `Protocol`/`Port`/`Source`/`Dest` narrow
@@ -52,13 +58,6 @@ what it matches; an empty `Source`/`Dest` or a zero `Port` means "any". Rules
 are scoped to the manager's own namespace, so listing and removal never touch
 the host's other firewall state.
 <!-- docref: end -->
-
-{% callout type="info" title="List reflects what was applied" %}
-`List` decodes each rule's full match — protocol, port, **and** source/destination
-address — back out of the live ruleset, so what you read reflects exactly what
-was applied. (An earlier nftables decoder dropped the source/destination on
-read; that's covered now by a real-`nft` round-trip test.)
-{% /callout %}
 
 ## Related
 

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -53,7 +53,7 @@ are scoped to the manager's own namespace, so listing and removal never touch
 the host's other firewall state.
 <!-- docref: end -->
 
-{% callout type="info" title="Round-trip fidelity" %}
+{% callout type="info" title="List reflects what was applied" %}
 `List` decodes each rule's full match — protocol, port, **and** source/destination
 address — back out of the live ruleset, so what you read reflects exactly what
 was applied. (An earlier nftables decoder dropped the source/destination on

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -1,0 +1,67 @@
+---
+title: Firewall
+label: Firewall
+description: Apply, remove, and list allow/deny packet-filter rules through nftables or firewalld.
+icon: "🧱"
+---
+
+# Firewall
+
+`sys/firewall` manages a small set of allow/deny rules — by protocol, port, and
+source/destination — through nftables or firewalld. It owns a dedicated
+namespace (an nftables table / a firewalld zone) so it never clobbers rules it
+didn't create.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // rule changes need root
+if err != nil {
+    return err
+}
+
+for _, b := range firewall.Detect(ctx) { // Nftables if nft; Firewalld if firewall-cmd
+    _ = b
+}
+m, err := firewall.New(firewall.Nftables, r)
+if err != nil {
+    return err
+}
+```
+
+## Apply, remove, list rules
+
+```go
+err := m.ApplyRule(ctx, firewall.Rule{
+    ID:       "allow-ssh",
+    Allow:    true,
+    Protocol: firewall.TCP,
+    Port:     22,
+    Source:   "10.0.0.0/8", // empty = any
+})
+
+err = m.RemoveRule(ctx, "allow-ssh")
+
+rules, err := m.List(ctx) // only rules in this manager's namespace
+```
+
+<!-- docref: begin src=sys/firewall/firewall.go#Rule:ca82cb6a -->
+A `Rule` is identified by a stable `ID` (used to remove or replace it), and is
+either allow (`Allow: true`) or deny. `Protocol`/`Port`/`Source`/`Dest` narrow
+what it matches; an empty `Source`/`Dest` or a zero `Port` means "any". Rules
+are scoped to the manager's own namespace, so listing and removal never touch
+the host's other firewall state.
+<!-- docref: end -->
+
+{% callout type="info" title="Round-trip fidelity" %}
+`List` decodes each rule's full match — protocol, port, **and** source/destination
+address — back out of the live ruleset, so what you read reflects exactly what
+was applied. (An earlier nftables decoder dropped the source/destination on
+read; that's covered now by a real-`nft` round-trip test.)
+{% /callout %}
+
+## Related
+
+- [Network interfaces](/capabilities/netconfig) — addresses and routes the
+  firewall rules reference.
+- [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -35,7 +35,7 @@ if err != nil {
 err := m.ApplyRule(ctx, firewall.Rule{
     ID:       "allow-ssh",
     Allow:    true,
-    Protocol: firewall.TCP,
+    Protocol: firewall.ProtocolTCP,
     Port:     22,
     Source:   "10.0.0.0/8", // empty = any
 })

--- a/docs/03-capabilities/13-catrust.md
+++ b/docs/03-capabilities/13-catrust.md
@@ -28,6 +28,12 @@ if err != nil {
 }
 ```
 
+<!-- docref: begin src=sys/catrust/detect.go#Detect:047f0669 -->
+`Detect` reports `CaCertificates` when `update-ca-certificates` is on `PATH` and
+`P11Kit` when `update-ca-trust` is, so a caller can pick the flow this host
+actually supports.
+<!-- docref: end -->
+
 ## Install, remove, list
 
 ```go

--- a/docs/03-capabilities/13-catrust.md
+++ b/docs/03-capabilities/13-catrust.md
@@ -1,0 +1,57 @@
+---
+title: CA trust
+label: CA trust
+description: Install, remove, and list system CA trust anchors via update-ca-certificates or p11-kit.
+icon: "📜"
+---
+
+# CA trust
+
+`sys/catrust` manages the system's CA trust store — the anchors every TLS client
+on the host validates against. Install a corporate root, remove one, list what's
+trusted, across the Debian (`update-ca-certificates`) and Red Hat / SUSE
+(`p11-kit`) flows.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // writing the trust store needs root
+if err != nil {
+    return err
+}
+for _, b := range catrust.Detect(ctx) { // CaCertificates and/or P11Kit
+    _ = b
+}
+m, err := catrust.New(catrust.CaCertificates, r)
+if err != nil {
+    return err
+}
+```
+
+## Install, remove, list
+
+```go
+err := m.Install(ctx, "corp-root", certPEM) // certPEM is one PEM certificate
+err = m.Remove(ctx, "corp-root")
+anchors, err := m.List(ctx) // the trusted anchors this manager can see
+```
+
+<!-- docref: begin src=sys/catrust/catrust.go#manager.Install:c6b15d2f -->
+`Install` writes the anchor under the backend's local-anchors directory and runs
+the store-rebuild tool (`update-ca-certificates` / `update-ca-trust`) so the new
+root takes effect host-wide. The name identifies the anchor for later removal,
+and the certificate is validated as a single PEM certificate before it is
+written.
+<!-- docref: end -->
+
+{% callout type="warning" title="Trust is host-wide" %}
+A CA installed here is trusted by *every* TLS client on the host. Install only
+roots you control; a rogue anchor silently validates a man-in-the-middle.
+{% /callout %}
+
+## Related
+
+- [Backends](/concepts/backends) — `catrust` is the worked example of the
+  `Backend` + `Detect` model.
+- [Remote sources](/capabilities/remote) — HTTPS fetches that validate against
+  this trust store.

--- a/docs/03-capabilities/14-antivirus.md
+++ b/docs/03-capabilities/14-antivirus.md
@@ -55,6 +55,11 @@ ver, err := m.Version(ctx)          // engine + signature-DB versions
 fmt.Println(ver.Engine, ver.Signature)
 ```
 
+<!-- docref: begin src=sys/antivirus/clamav.go#clamavManager.UpdateSignatures:72c8afac -->
+`UpdateSignatures` runs `freshclam` to refresh the signature database; a non-zero
+exit surfaces as an error rather than being swallowed.
+<!-- docref: end -->
+
 {% callout type="info" title="Version needs a signature DB" %}
 `Version` reports the engine *and* signature-database version, so it expects a
 real ClamAV signature DB to be present. A freshly-installed ClamAV that has never

--- a/docs/03-capabilities/14-antivirus.md
+++ b/docs/03-capabilities/14-antivirus.md
@@ -1,0 +1,67 @@
+---
+title: Antivirus
+label: Antivirus
+description: Scan paths for malware, refresh signatures, and read engine/signature versions via ClamAV.
+icon: "🛡️"
+---
+
+# Antivirus
+
+`sys/antivirus` drives ClamAV: scan a path for malware, refresh the signature
+database, and read the engine and signature versions. It is the
+configure-and-operate half of AV management — on-access protection and cloud EDR
+engines are out of scope.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // a full scan needs root to read every file
+if err != nil {
+    return err
+}
+m, err := antivirus.New(antivirus.ClamAV, r)
+if err != nil {
+    return err
+}
+```
+
+## Scan
+
+```go
+res, err := m.Scan(ctx, "/home")
+if err != nil {
+    return err // an engine failure (not "found a virus")
+}
+if !res.Clean() {
+    for _, inf := range res.Infected {
+        fmt.Println(inf.File, inf.Signature)
+    }
+}
+```
+
+<!-- docref: begin src=sys/antivirus/clamav.go#clamavManager.Scan:a0689834 -->
+`Scan` runs `clamscan` and reads its exit code the way ClamAV means it: `0` is
+clean and `1` is "found something" — **neither is a failure**. Both parse the
+`<file>: <signature> FOUND` lines into the result; only exit `2` (or a Runner
+failure) is returned as an error. So a detected infection is a normal result you
+inspect, not an error you handle.
+<!-- docref: end -->
+
+## Update signatures and read versions
+
+```go
+err := m.UpdateSignatures(ctx)      // freshclam — refresh the signature DB
+ver, err := m.Version(ctx)          // engine + signature-DB versions
+fmt.Println(ver.Engine, ver.Signature)
+```
+
+{% callout type="info" title="Version needs a signature DB" %}
+`Version` reports the engine *and* signature-database version, so it expects a
+real ClamAV signature DB to be present. A freshly-installed ClamAV that has never
+run `freshclam` has no signature version to report.
+{% /callout %}
+
+## Related
+
+- [Architecture](/concepts/architecture) — the Runner / Backend / Manager model.
+- [osquery](/capabilities/osquery) — host queries for a broader compliance posture.

--- a/docs/03-capabilities/15-osquery.md
+++ b/docs/03-capabilities/15-osquery.md
@@ -33,6 +33,12 @@ tables, err := q.ListTables(ctx)
 result, err := q.Query(ctx, &pb.OSQuery{Table: "processes"})
 ```
 
+<!-- docref: begin src=sys/osquery/osquery.go#client.QueryTable:5586f365 -->
+`QueryTable` validates the table name (alphanumeric + underscore) and applies the
+deny-list before building `SELECT * FROM <table>`, so an invalid or forbidden
+name is rejected without running anything.
+<!-- docref: end -->
+
 ## The sensitive-table deny-list
 
 <!-- docref: begin src=sys/osquery/osquery.go#sensitiveTables:1054224b -->

--- a/docs/03-capabilities/15-osquery.md
+++ b/docs/03-capabilities/15-osquery.md
@@ -60,5 +60,4 @@ signed command in the agent), because it can read anything osquery can.
 ## Related
 
 - [Antivirus](/capabilities/antivirus) — malware scanning alongside host queries.
-- [Inventory](/capabilities/inventory) — structured hardware/software facts
-  without SQL.
+- Inventory (`sys/inventory`) — structured hardware/software facts without SQL.

--- a/docs/03-capabilities/15-osquery.md
+++ b/docs/03-capabilities/15-osquery.md
@@ -9,8 +9,8 @@ icon: "🔎"
 
 `sys/osquery` exposes the host as SQL through `osqueryi`: list tables, query a
 table, or run raw SQL. It is a single-tool capability, so `New` takes only a
-Runner, no Backend. Its defining feature is a **deny-list** that refuses
-credential-bearing tables on the convenience path.
+Runner, no Backend. A **deny-list** refuses credential-bearing tables on the
+convenience path, which is the part to pay attention to.
 
 ## Construct a querier
 

--- a/docs/03-capabilities/15-osquery.md
+++ b/docs/03-capabilities/15-osquery.md
@@ -1,0 +1,64 @@
+---
+title: osquery
+label: osquery
+description: Query host state with osquery's SQL interface — with a deny-list that keeps a compromised caller out of credential-bearing tables.
+icon: "🔎"
+---
+
+# osquery
+
+`sys/osquery` exposes the host as SQL through `osqueryi`: list tables, query a
+table, or run raw SQL. It is a single-tool capability, so `New` takes only a
+Runner, no Backend. Its defining feature is a **deny-list** that refuses
+credential-bearing tables on the convenience path.
+
+## Construct a querier
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // osquery reads privileged tables
+if err != nil {
+    return err
+}
+q, err := osquery.New(r) // ErrNotInstalled if osqueryi is absent
+if err != nil {
+    return err
+}
+```
+
+## Query
+
+```go
+rows, err := q.QueryTable(ctx, "os_version")
+tables, err := q.ListTables(ctx)
+result, err := q.Query(ctx, &pb.OSQuery{Table: "processes"})
+```
+
+## The sensitive-table deny-list
+
+<!-- docref: begin src=sys/osquery/osquery.go#sensitiveTables:1054224b -->
+A curated deny-list refuses tables that expose credential material — `shadow`
+(password hashes), `process_envs` (secrets in process environments), `crontab`,
+`shell_history`, and `sudoers` — on the table path. They all pass the name
+validity check, so a shape-only filter is not enough; this refuses them by name
+so a compromised control server cannot exfiltrate them through the agent's
+privileged osquery.
+<!-- docref: end -->
+
+<!-- docref: begin src=sys/osquery/osquery.go#client.Query:7d6685c6 -->
+The deny-list gates the convenience *table* path: `Query` with a `Table` (and
+`QueryTable`) refuses a sensitive name before building any SQL. The signed
+`RawSql` escape hatch is intentionally **not** gated — it is the operator's
+explicit, CA-signed path — so a sanctioned query can still reach a sensitive
+table when the operator deliberately asks for it.
+<!-- docref: end -->
+
+{% callout type="warning" title="RawSql is the operator's responsibility" %}
+`RawSql` bypasses the deny-list by design. Restrict who can issue it (it is a
+signed command in the agent), because it can read anything osquery can.
+{% /callout %}
+
+## Related
+
+- [Antivirus](/capabilities/antivirus) — malware scanning alongside host queries.
+- [Inventory](/capabilities/inventory) — structured hardware/software facts
+  without SQL.

--- a/docs/03-capabilities/16-inventory.md
+++ b/docs/03-capabilities/16-inventory.md
@@ -33,6 +33,11 @@ disks, err := c.Disks(ctx)            // block devices (lsblk)
 ifaces, err := c.NetworkInterfaces(ctx) // interfaces + addresses (ip -j)
 ```
 
+<!-- docref: begin src=sys/inventory/inventory.go#collector.OS:9401e3ac -->
+`OS` parses `/etc/os-release` into the distro ID, name, version, and
+architecture — the facts a compliance policy keys "which platform is this?" on.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/inventory/inventory.go#New:5a179869 -->
 `New` returns the Collector over the injected Runner; a nil Runner is rejected.
 The collectors read the host directly — `/proc/cpuinfo` and `/proc/meminfo`,

--- a/docs/03-capabilities/16-inventory.md
+++ b/docs/03-capabilities/16-inventory.md
@@ -1,0 +1,53 @@
+---
+title: Inventory
+label: Inventory
+description: Collect structured hardware and software facts — CPU, memory, OS, disks, network interfaces — from the running host.
+icon: "📋"
+---
+
+# Inventory
+
+`sys/inventory` reports structured facts about the host: CPU and memory, the OS
+release, block devices, and network interfaces. It is a read-only, single-tool
+capability, so `New` takes only a Runner, no Backend.
+
+## Construct a collector
+
+```go
+r, err := exec.NewRunner(exec.Direct) // reads are unprivileged
+if err != nil {
+    return err
+}
+c, err := inventory.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Collect facts
+
+```go
+sys, err := c.System(ctx)             // hostname, CPU model/cores, total memory, kernel
+os, err := c.OS()                     // distro ID, name, version, arch
+disks, err := c.Disks(ctx)            // block devices (lsblk)
+ifaces, err := c.NetworkInterfaces(ctx) // interfaces + addresses (ip -j)
+```
+
+<!-- docref: begin src=sys/inventory/inventory.go#New:5a179869 -->
+`New` returns the Collector over the injected Runner; a nil Runner is rejected.
+The collectors read the host directly — `/proc/cpuinfo` and `/proc/meminfo`,
+`/etc/os-release`, `lsblk --json`, `ip -j addr` — so the facts reflect the live
+system, not a cached snapshot.
+<!-- docref: end -->
+
+{% callout type="info" title="Reads, not changes" %}
+Inventory is purely observational; nothing here mutates the host. Combine it
+with the action capabilities to decide *what* to change based on *what's there*.
+{% /callout %}
+
+## Related
+
+- [osquery](/capabilities/osquery) — ad-hoc SQL queries when the fixed inventory
+  facts aren't enough.
+- [Drive health](/capabilities/smart) — SMART health for the disks inventory
+  lists.

--- a/docs/03-capabilities/17-log.md
+++ b/docs/03-capabilities/17-log.md
@@ -27,6 +27,12 @@ if err != nil {
 }
 ```
 
+<!-- docref: begin src=sys/log/detect.go#Detect:462234b3 -->
+`Detect` reports `Journald` when `journalctl` is on `PATH` and `Syslog` when a
+classic log file exists; it lists what's usable and the caller picks, rather than
+the SDK choosing silently.
+<!-- docref: end -->
+
 ## Query
 
 ```go

--- a/docs/03-capabilities/17-log.md
+++ b/docs/03-capabilities/17-log.md
@@ -1,0 +1,60 @@
+---
+title: Logs
+label: Logs
+description: Read host logs with unit, priority, time-range, and grep filters — from the systemd journal or classic syslog files.
+icon: "📜"
+---
+
+# Logs
+
+`sys/log` reads host logs through the systemd journal (`journalctl`) or classic
+syslog files (`/var/log/{syslog,messages}`), with filters for unit, priority,
+time range, and a grep pattern.
+
+## Construct a source
+
+```go
+r, err := exec.NewRunner(exec.Direct)
+if err != nil {
+    return err
+}
+for _, b := range log.Detect(ctx) { // Journald if journalctl; Syslog if a file exists
+    _ = b
+}
+s, err := log.New(log.Journald, r)
+if err != nil {
+    return err
+}
+```
+
+## Query
+
+```go
+lines, err := s.Query(ctx, log.Query{
+    Unit:     "sshd.service", // journald only
+    Priority: "warning",      // journald only
+    Grep:     "Failed password",
+    Lines:    200,            // cap; <=0 defaults to 100
+})
+```
+
+<!-- docref: begin src=sys/log/journald.go#journaldSource.Query:efa18d89 -->
+`Query` builds the `journalctl` invocation with every dynamic value as an
+option-argument (`-u <unit>`, `--grep <pat>`, …), never a positional operand, so
+none can be reinterpreted as a flag. Two real-journald behaviours it normalises:
+journalctl status markers (`-- No entries --`, `-- Boot … --`) are dropped — they
+are not log entries — and a `--grep` that matches nothing (which `journalctl`
+signals with exit 1 and an empty stderr) returns an empty result, not an error,
+so a caller can tell "no logs matched" from "journalctl broke".
+<!-- docref: end -->
+
+{% callout type="info" title="Backend differences" %}
+`Unit` and `Priority` are journald-only (ignored by the Syslog backend). The
+Syslog backend tails the log file and applies `Grep`/`Lines` in-process. For
+unit- or priority-scoped queries, use Journald.
+{% /callout %}
+
+## Related
+
+- [Services](/capabilities/services) — the units whose logs you're reading.
+- [Architecture](/concepts/architecture) — the Runner / Backend / Source model.

--- a/docs/03-capabilities/18-notify.md
+++ b/docs/03-capabilities/18-notify.md
@@ -1,0 +1,46 @@
+---
+title: Notifications
+label: Notifications
+description: Broadcast a message to logged-in users — all of them, or a named subset — via wall.
+icon: "📢"
+---
+
+# Notifications
+
+`sys/notify` sends a message to logged-in users — a maintenance heads-up, a
+reboot warning — via `wall`.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // wall to all users needs root
+if err != nil {
+    return err
+}
+m, err := notify.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Broadcast
+
+```go
+err := m.NotifyAll(ctx, "Maintenance", "Rebooting in 5 minutes — save your work.")
+
+// Or just specific users:
+err = m.NotifyUsers(ctx, []string{"alice", "bob"}, "Heads up", "Your session ends soon.")
+```
+
+<!-- docref: begin src=sys/notify/notify.go#New:9cbfe737 -->
+`New` returns the notifier over the injected Runner; a nil Runner is rejected.
+The message is delivered through `wall`, so it reaches users on a TTY; the title
+and body are passed as data, not spliced into a shell command.
+<!-- docref: end -->
+
+## Related
+
+- [Desktop & sessions](/capabilities/desktop) — run a command in a user's
+  graphical session, beyond a TTY broadcast.
+- [Reboot](/capabilities/reboot) — `Schedule` already broadcasts its own wall
+  message.

--- a/docs/03-capabilities/18-notify.md
+++ b/docs/03-capabilities/18-notify.md
@@ -32,6 +32,12 @@ err := m.NotifyAll(ctx, "Maintenance", "Rebooting in 5 minutes — save your wor
 err = m.NotifyUsers(ctx, []string{"alice", "bob"}, "Heads up", "Your session ends soon.")
 ```
 
+<!-- docref: begin src=sys/notify/notify.go#notifier.NotifyAll:7695c6d0 -->
+`NotifyAll` broadcasts the message via `wall` to every logged-in user on a TTY;
+the title and body are handed to `wall` as data rather than spliced into a shell
+command.
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/notify/notify.go#New:9cbfe737 -->
 `New` returns the notifier over the injected Runner; a nil Runner is rejected.
 The message is delivered through `wall`, so it reaches users on a TTY; the title

--- a/docs/03-capabilities/19-desktop.md
+++ b/docs/03-capabilities/19-desktop.md
@@ -32,6 +32,12 @@ users, err := m.HomeUsers(ctx)                      // accounts with a home unde
 flat, err := m.UsersWithFlatpakInstall(ctx, "org.example.App") // who has it installed
 ```
 
+<!-- docref: begin src=sys/desktop/users.go#manager.HomeUsers:41afbbaf -->
+`HomeUsers` enumerates accounts whose home lives directly under the configured
+home root (default `/home`), confirming each against passwd — so a stale
+`userdel`-without-`-r` directory is skipped rather than treated as a user.
+<!-- docref: end -->
+
 ## Run a command as a user
 
 ```go

--- a/docs/03-capabilities/19-desktop.md
+++ b/docs/03-capabilities/19-desktop.md
@@ -51,7 +51,7 @@ action cannot override it. The agent's own environment is replaced wholesale —
 `LD_PRELOAD` and friends never leak into a user-scoped command.
 <!-- docref: end -->
 
-{% callout type="info" title="Why build, not run" %}
+{% callout type="info" title="It returns a command, doesn't run it" %}
 `RunAsCommand` returns an `*exec.Cmd` you run yourself, so you control streaming,
 stdin, and output capture. The privilege drop and environment are already wired
 in.

--- a/docs/03-capabilities/19-desktop.md
+++ b/docs/03-capabilities/19-desktop.md
@@ -1,0 +1,63 @@
+---
+title: Desktop & sessions
+label: Desktop & sessions
+description: Enumerate desktop sessions and home users, and run a command as a specific user with their environment — a real privilege drop.
+icon: "🖥️"
+---
+
+# Desktop & sessions
+
+`sys/desktop` bridges system actions to individual users: list active graphical
+sessions and home users, and run a command **as** one of them with that user's
+environment.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // dropping to another user needs root
+if err != nil {
+    return err
+}
+m, err := desktop.New(r)
+if err != nil {
+    return err
+}
+```
+
+## Enumerate users and sessions
+
+```go
+sessions, err := m.ActiveSessions(ctx)              // active local graphical sessions (loginctl)
+users, err := m.HomeUsers(ctx)                      // accounts with a home under /home
+flat, err := m.UsersWithFlatpakInstall(ctx, "org.example.App") // who has it installed
+```
+
+## Run a command as a user
+
+```go
+cmd, err := m.RunAsCommand(ctx, session, desktop.RunAsOptions{}, "flatpak", "update", "-y")
+if err != nil {
+    return err
+}
+out, err := cmd.Output() // runs as the session's user
+```
+
+<!-- docref: begin src=sys/desktop/runas.go#manager.RunAsCommand:c91323e7 -->
+`RunAsCommand` builds (but does not run) a command that executes as the session's
+user via `runuser`, with a per-user environment: `HOME`, `USER`, `XDG_RUNTIME_DIR`,
+and the session bus address. `PATH` is always re-applied last with a curated
+per-user value (the user's `~/.local/bin` first, never root's `PATH`), so an
+action cannot override it. The agent's own environment is replaced wholesale —
+`LD_PRELOAD` and friends never leak into a user-scoped command.
+<!-- docref: end -->
+
+{% callout type="info" title="Why build, not run" %}
+`RunAsCommand` returns an `*exec.Cmd` you run yourself, so you control streaming,
+stdin, and output capture. The privilege drop and environment are already wired
+in.
+{% /callout %}
+
+## Related
+
+- [Identity](/capabilities/identity) — the user accounts these sessions belong to.
+- [Notifications](/capabilities/notify) — a lighter-weight TTY broadcast.

--- a/docs/03-capabilities/20-terminal.md
+++ b/docs/03-capabilities/20-terminal.md
@@ -7,8 +7,8 @@ icon: "⌨️"
 
 # Terminal
 
-`sys/terminal` opens an interactive pseudo-terminal session as a target user —
-the building block for a remote shell into a managed host. It allocates a real
+`sys/terminal` opens an interactive pseudo-terminal session as a target user.
+It is what a remote shell into a managed host is built on: it allocates a real
 PTY and drops privilege to the requested account.
 
 ## Open a session

--- a/docs/03-capabilities/20-terminal.md
+++ b/docs/03-capabilities/20-terminal.md
@@ -1,0 +1,52 @@
+---
+title: Terminal
+label: Terminal
+description: Open an interactive PTY session as a target user — a real pseudo-terminal with a privilege drop.
+icon: "⌨️"
+---
+
+# Terminal
+
+`sys/terminal` opens an interactive pseudo-terminal session as a target user —
+the building block for a remote shell into a managed host. It allocates a real
+PTY and drops privilege to the requested account.
+
+## Open a session
+
+`terminal.New` takes no Runner — it performs the fork, PTY allocation, and
+privilege drop itself:
+
+```go
+m, err := terminal.New()
+if err != nil {
+    return err
+}
+sess, err := m.Open(ctx, terminal.SessionConfig{
+    User: "alice",
+    Rows: 24,
+    Cols: 80,
+})
+if err != nil {
+    return err
+}
+// sess wires the PTY's input/output for the caller to stream.
+```
+
+<!-- docref: begin src=sys/terminal/terminal.go#manager.Open:392b4e8f -->
+`Open` allocates a real pseudo-terminal and starts the user's shell behind it,
+dropping privilege to the target account with `setresuid`/`setresgid` (and its
+supplementary groups) before `exec` — so the shell runs with exactly that user's
+identity, never root's. The requested rows/cols are validated and applied to the
+PTY window size.
+<!-- docref: end -->
+
+{% callout type="warning" title="Interactive and privileged" %}
+A terminal session is a live shell as another user. In the agent it is a signed,
+authorized command for exactly this reason — gate who can open one.
+{% /callout %}
+
+## Related
+
+- [Desktop & sessions](/capabilities/desktop) — run a *single* command as a
+  user, when you don't need an interactive shell.
+- [Identity](/capabilities/identity) — the accounts a terminal opens as.

--- a/docs/03-capabilities/21-remote.md
+++ b/docs/03-capabilities/21-remote.md
@@ -1,0 +1,80 @@
+---
+title: Remote sources
+label: Remote sources
+description: Fetch artifacts over HTTPS, Git, or S3 through a per-call Source interface, into a confined destination on disk.
+icon: "📥"
+---
+
+# Remote sources
+
+`sys/remote` fetches an artifact — a release tarball, a config repo, a signed
+blob — from HTTPS, Git, or S3. It is the one capability that does **not** take a
+Runner: there is no host tool to drive, so each source is a small Go client you
+construct per call and ask to `Fetch`.
+
+## The Source interface
+
+<!-- docref: begin src=sys/remote/remote.go#Source:2cfeaa37 -->
+Every backend implements one method: `Fetch(ctx, dest)` downloads the source's
+content into `dest` and returns a `Result`. You build the `Source` for the
+transport you want (HTTPS / Git / S3) and call `Fetch` — the shape is identical
+regardless of where the bytes come from.
+<!-- docref: end -->
+
+```go
+src, err := remote.NewHTTP(remote.HTTPConfig{
+    URL:    "https://releases.example.com/agent-2026.2.0.tar.gz",
+    Sha256: "9f86d08…", // verified before the bytes are trusted
+})
+if err != nil {
+    return err
+}
+res, err := src.Fetch(ctx, "/var/lib/power-manage/release")
+if err != nil {
+    return err
+}
+_ = res
+```
+
+## Three transports
+
+```go
+http, err := remote.NewHTTP(remote.HTTPConfig{URL: "https://…", Sha256: "…"})
+git, err  := remote.NewGit(remote.GitConfig{URL: "https://…", Ref: "v1.2.3"})
+s3, err   := remote.NewS3(remote.S3Config{Bucket: "artifacts", Key: "agent/latest"})
+```
+
+<!-- docref: begin src=sys/remote/http.go#NewHTTP:d4d3f602,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:8a5701dc -->
+Each constructor validates its configuration up front and returns an error for a
+malformed one, so a bad URL, missing checksum, or unusable S3 config fails at
+construction rather than mid-download. The returned value is a `Source` — the
+caller holds the interface, not the concrete client.
+<!-- docref: end -->
+
+## Destinations are confined
+
+The destination is not a free-for-all path. `Fetch` refuses to write outside the
+locations the SDK is allowed to manage:
+
+<!-- docref: begin src=sys/remote/paths.go#validateDestination:e25e0621 -->
+A destination is rejected unless it falls under a managed root (e.g.
+`/var/lib/power-manage`, `/etc/power-manage`); a write that would land in a
+sensitive system location — `/etc/cron.d`, `/usr/bin`, a user's `~/.ssh` — is
+refused before any bytes are fetched. The check is a subtree test with a
+trailing-slash boundary, so `/etc/power-manage-evil` cannot masquerade as being
+under `/etc/power-manage`.
+<!-- docref: end -->
+
+{% callout type="info" title="Reference" %}
+Config fields and the `Result` shape are generated API docs on
+[pkg.go.dev](https://pkg.go.dev/github.com/manchtools/power-manage-sdk/sys/remote).
+See also [Backends](/concepts/backends) for the per-call Source model vs. the
+Runner/Backend model the other capabilities use.
+{% /callout %}
+
+## Related
+
+- [Backends](/concepts/backends) — why `remote` is per-call `Source` rather than
+  a Runner-driven Manager.
+- [Packages](/capabilities/packages) / [Repositories](/capabilities/repositories)
+  — install software from a managed source rather than fetching raw artifacts.

--- a/docs/03-capabilities/21-remote.md
+++ b/docs/03-capabilities/21-remote.md
@@ -76,5 +76,5 @@ Runner/Backend model the other capabilities use.
 
 - [Backends](/concepts/backends) — why `remote` is per-call `Source` rather than
   a Runner-driven Manager.
-- [Packages](/capabilities/packages) / [Repositories](/capabilities/repositories)
-  — install software from a managed source rather than fetching raw artifacts.
+- [Packages](/capabilities/packages) — install software from a managed source
+  rather than fetching raw artifacts.

--- a/docs/03-capabilities/22-repositories.md
+++ b/docs/03-capabilities/22-repositories.md
@@ -1,0 +1,59 @@
+---
+title: Repositories
+label: Repositories
+description: Configure the package repositories a host installs from — apt, dnf, pacman, zypper — idempotently, with the right file format per backend.
+icon: "🗄️"
+---
+
+# Repositories
+
+`sys/repo` configures the external package repositories a host installs from. It
+owns the per-backend file format (apt deb822 `.sources` + keyrings, dnf `.repo`,
+pacman.conf sections, `zypper addrepo`), GPG public-key handling, and the
+idempotency comparison — so you never hand-write a `.repo` file.
+
+## Construct a manager
+
+```go
+r, err := exec.NewRunner(exec.Sudo) // writing repo config needs root
+if err != nil {
+    return err
+}
+m, err := repo.New(pkg.Dnf, r) // pkg.Apt / pkg.Dnf / pkg.Pacman / pkg.Zypper
+if err != nil {
+    return err
+}
+```
+
+## Apply and remove
+
+```go
+out, err := m.Apply(ctx, repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{
+    BaseURL:  "https://packages.example.com/el9",
+    GPGCheck: true,
+    GPGKey:   "https://packages.example.com/RPM-GPG-KEY",
+    Enabled:  true,
+}})
+// out.Changed is false on an idempotent no-op (the config already matched).
+
+_, err = m.Remove(ctx, "corp") // idempotent: removing an absent repo is a no-op
+```
+
+<!-- docref: begin src=sys/repo/repo.go#manager.Apply:b7a6f4f5 -->
+`Apply` validates the repository (name and the backend's config) before touching
+the system, then writes the backend's native format and refreshes the index. It
+is idempotent — an unchanged config reports `Changed: false` — so re-applying the
+same desired state is safe and produces no spurious change events.
+<!-- docref: end -->
+
+{% callout type="info" title="GPG keys are public material" %}
+The signing keys here are *public* repository keys, not secrets. apt receives the
+key bytes (dearmored into `/etc/apt/keyrings`); dnf and zypper take a key
+reference (URL or path) the package manager imports.
+{% /callout %}
+
+## Related
+
+- [Packages](/capabilities/packages) — install software from the repositories
+  configured here.
+- [Backends](/concepts/backends) — the `pkg.Backend` enum shared with `pkg`.

--- a/docs/03-capabilities/22-repositories.md
+++ b/docs/03-capabilities/22-repositories.md
@@ -39,6 +39,12 @@ out, err := m.Apply(ctx, repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{
 _, err = m.Remove(ctx, "corp") // idempotent: removing an absent repo is a no-op
 ```
 
+<!-- docref: begin src=sys/repo/zypper.go#manager.removeZypper:1fdcf57a -->
+`Remove` is idempotent even where the tool makes it tricky: `zypper removerepo`
+exits 0 whether or not the alias existed, so the absent-repo no-op is detected
+from its "not found" message rather than the exit code (`Changed: false`).
+<!-- docref: end -->
+
 <!-- docref: begin src=sys/repo/repo.go#manager.Apply:b7a6f4f5 -->
 `Apply` validates the repository (name and the backend's config) before touching
 the system, then writes the backend's native format and refreshes the index. It

--- a/docs/03-capabilities/index.md
+++ b/docs/03-capabilities/index.md
@@ -7,8 +7,8 @@ icon: "🧰"
 # Capabilities
 
 Each capability is a package that follows the [architecture](/concepts/architecture):
-build a Runner, choose a Backend where there's more than one implementation,
-get a Manager. The groups below are the areas the SDK covers.
+build a Runner, choose a `Backend` where the capability takes one, get a Manager.
+The groups below are the areas the SDK covers.
 
 {% callout type="info" title="Reference vs. recipes" %}
 Per-package **method signatures** are generated API docs on

--- a/docs/03-capabilities/index.md
+++ b/docs/03-capabilities/index.md
@@ -12,9 +12,10 @@ The groups below are the areas the SDK covers.
 
 {% callout type="info" title="Reference vs. recipes" %}
 Per-package **method signatures** are generated API docs on
-[pkg.go.dev](https://pkg.go.dev/) — this site does not duplicate them.
-Task-oriented **recipes** for each capability are being written; for now this
-page is the map of what exists.
+[pkg.go.dev](https://pkg.go.dev/) — this site does not duplicate them. Each
+capability below has a task-oriented **recipe** page (in the sidebar); the
+behavioural claims on them are anchored to the code with
+[docref](/contributing), so they fail CI if the code drifts.
 {% /callout %}
 
 {% cards %}


### PR DESCRIPTION
First installment of the **per-capability narrative documentation** under `docs/03-capabilities/` — the recipes the capabilities index says are "being written."

Task-oriented (method signatures stay on pkg.go.dev), with behavioural claims **densely anchored to the code via docref** so the `docref check` CI gate fails the moment the code drifts from the prose.

- **01-packages.md** (`pkg`) — Detect/New construction, install/remove/upgrade, installed-state queries, backend differences. Anchored claims: `Detect` (lists-never-picks), `New` (fail-closed), `Backend` (explicit set).
- **02-identity.md** (`sys/user`) — create/modify/delete, passwords as `exec.Secret`, groups. Anchored claims: `New` (fail-closed), `Secret` (redaction), `NewSecret` (newline rejection), `SetPassword` (chpasswd **stdin** sink, never argv).

Every anchored claim was verified against the code; `docref check` is green locally (13 up-to-date, 0 stale/broken).

**This is installment 1.** The remaining ~17 capabilities (services, networking, storage, security/trust, host-info, desktop, remote) follow the same densely-anchored recipe pattern in subsequent commits/PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added new capability documentation pages for **Packages, Identity, Services, Reboot, Filesystem, Disk encryption, Drive health, Network (Wi‑Fi), DNS, Netconfig, Firewall, Time sync, CA trust, Antivirus, osquery, Inventory, Logs, Notifications, Desktop & sessions, Terminal,** and **Remote sources**—each with usage examples and key behavior notes (including safety, validation, and read-only vs mutating operations).
- Updated **architecture** and **backends/detection** guidance to clarify how capabilities choose **Runner/Backend** inputs during manager construction.
- Added documentation for **Repository (external package repository) management** across supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->