### PR TITLE
feat: InstallLocal (local package-file install) + service Reload — SDK gaps #3, #4

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -63,6 +63,7 @@ An unknown backend or a nil runner is rejected (`pkg.ErrUnknownBackend` /
 
 ```go
 m.Install(ctx, pkg.InstallOptions{}, "nginx")
+m.InstallLocal(ctx, "/var/cache/pm/app.deb", pkg.InstallLocalOptions{}) // a downloaded .deb/.rpm/pacman/flatpak file, deps resolved
 m.Remove(ctx, pkg.RemoveOptions{}, "nginx")
 m.Remove(ctx, pkg.RemoveOptions{Purge: true}, "nginx") // also delete config/data where supported
 m.Update(ctx)                                          // refresh metadata
@@ -172,10 +173,17 @@ reparsed as an option):
 | `ValidateRepoBaseURL` | dnf `baseurl` / zypper `url` / pacman `server` / flatpak remote URL | **https only**, host required, control-char free (template vars `$releasever`/`$arch` allowed). apt is excluded — its security is the gpg-signed Release file. |
 | `ValidateGpgKeyRef` | dnf/zypper `gpgkey` passed to `rpm --import` | https URL, `file:///abs` path, or absolute path; no `..`, no leading `-`, no `http://`, no `ext::` |
 | `ValidateRemoteName` | flatpak remote alias | first char alphanumeric, then `[a-zA-Z0-9._-]`, ≤128 |
+| `ValidateLocalPackagePath` | `InstallLocal` file operand (`apt-get`/`dnf`/`pacman -U`/`zypper`/`flatpak` install) | **absolute path** (never flag-shaped), no `..`, no control chars; a space is allowed |
+| `ValidateSearchQuery` | the free-text `Search` query | must not start with `-` (a search term cannot be `--`-guarded because dnf5 rejects `--`), no control chars; empty allowed |
 
 In addition, pacman's `Pin` runs a stricter `[a-zA-Z0-9][a-zA-Z0-9._+-]*` gate
 before a name is written to `IgnorePkg`, blocking config-injection even for
 names that `ValidatePackageName` would accept.
+
+A self-discovering test (`TestEveryManagerMethodNeutralizesFlagShapedOperands`)
+reflects over the whole `Manager` surface and fails if any method lets a
+flag-shaped operand reach `argv` as an option, so a new method that forgets to
+validate its operand cannot pass CI.
 
 ## Testing
 

--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -106,6 +106,23 @@ func (a *apt) Install(ctx context.Context, opts InstallOptions, packages ...stri
 	return a.write(ctx, "apt", args...)
 }
 
+// InstallLocal installs a local .deb file through apt-get install, which —
+// unlike a bare `dpkg -i` — resolves the package's dependencies from the
+// configured repositories. ValidateLocalPackagePath requires an absolute path,
+// so the operand can never be flag-shaped; the conffile-default options keep a
+// postinst that touches a conffile non-interactive.
+func (a *apt) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return pmexec.Result{}, err
+	}
+	flags := []string{"install", "-y"}
+	flags = append(flags, dpkgConfOptions...)
+	if opts.AllowDowngrade {
+		flags = append(flags, "--allow-downgrades")
+	}
+	return a.write(ctx, "apt", append(flags, path)...)
+}
+
 // Remove removes packages; opts.Purge deletes configuration files too.
 func (a *apt) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
@@ -233,6 +250,9 @@ func (a *apt) Repair(ctx context.Context) (pmexec.Result, error) {
 // search` produces a multi-line, presentation-oriented format that would not
 // parse, and `--names-only` would drop the description (and the separator).
 func (a *apt) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	if err := ValidateSearchQuery(query); err != nil {
+		return nil, err
+	}
 	out, err := readOut(ctx, a.r, "apt-cache", "search", query)
 	if err != nil {
 		return nil, err

--- a/pkg/argv_safety_test.go
+++ b/pkg/argv_safety_test.go
@@ -1,0 +1,167 @@
+package pkg
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// indexOf returns the first index of want in args, or -1.
+func indexOf(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestEveryManagerMethodNeutralizesFlagShapedOperands is a self-discovering
+// guard over the WHOLE Manager surface: for every method and every string (or
+// variadic ...string) operand, a flag-shaped value ("-rf") must never reach the
+// package manager as a parseable option. Each method satisfies this one of two
+// honest ways:
+//
+//   - it REJECTS the value before any command runs — the package-name, the
+//     local-package-path, and the search-query validators all do this (a search
+//     query cannot be "--"-guarded because dnf5's `search` rejects "--", so a
+//     flag-shaped query is refused instead), or
+//   - the value reaches argv only AFTER a "--" end-of-options separator, so the
+//     tool treats it as an operand, not a flag.
+//
+// The method set is discovered by reflection over the interface and the check is
+// run against every backend, with a matches-zero guard so a future refactor that
+// drops the operands cannot pass it vacuously. This is the package-wide analogue
+// of service's TestEveryMethodRejectsUnsafeUnitNameBeforeRunner.
+func TestEveryManagerMethodNeutralizesFlagShapedOperands(t *testing.T) {
+	const flag = "-rf"       // flag-shaped: must never be parsed as an option
+	const safe = "coreutils" // a valid package name for any non-target string param
+
+	// Resolve every backend's binary so a method that probes PATH before
+	// rejecting still reaches its validation rather than a "not found".
+	stubLookPath(t, "apt", "apt-get", "dnf", "pacman", "zypper", "flatpak")
+
+	mt := reflect.TypeOf((*Manager)(nil)).Elem()
+	if mt.NumMethod() == 0 {
+		t.Fatal("matches-zero guard: Manager has no methods")
+	}
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	backends := []Backend{Apt, Dnf, Pacman, Zypper, Flatpak}
+	checked := 0
+
+	isStringOperand := func(ft reflect.Type, p int) bool {
+		pt := ft.In(p)
+		if pt.Kind() == reflect.String {
+			return true
+		}
+		return ft.IsVariadic() && p == ft.NumIn()-1 && pt.Elem().Kind() == reflect.String
+	}
+
+	for _, b := range backends {
+		probe, _ := mustNew(t, b)
+		for i := 0; i < mt.NumMethod(); i++ {
+			name := mt.Method(i).Name
+			ft := reflect.ValueOf(probe).MethodByName(name).Type()
+
+			var targets []int
+			for p := 0; p < ft.NumIn(); p++ {
+				if isStringOperand(ft, p) {
+					targets = append(targets, p)
+				}
+			}
+
+			for _, target := range targets {
+				f := newFake()
+				m, err := New(b, f)
+				if err != nil {
+					t.Fatalf("New(%v): %v", b, err)
+				}
+				fn := reflect.ValueOf(m).MethodByName(name)
+
+				args := make([]reflect.Value, ft.NumIn())
+				for p := 0; p < ft.NumIn(); p++ {
+					pt := ft.In(p)
+					val := safe
+					if p == target {
+						val = flag
+					}
+					switch {
+					case pt == ctxType:
+						args[p] = reflect.ValueOf(context.Background())
+					case ft.IsVariadic() && p == ft.NumIn()-1 && pt.Elem().Kind() == reflect.String:
+						args[p] = reflect.ValueOf([]string{val})
+					case pt.Kind() == reflect.String:
+						args[p] = reflect.ValueOf(val)
+					default:
+						args[p] = reflect.Zero(pt)
+					}
+				}
+				if ft.IsVariadic() {
+					fn.CallSlice(args)
+				} else {
+					fn.Call(args)
+				}
+
+				for _, c := range f.Calls() {
+					idx := indexOf(c.Args, flag)
+					if idx < 0 {
+						continue // this command does not carry the flag-shaped token
+					}
+					sep := indexOf(c.Args, pmexec.EndOfOptions)
+					if sep < 0 || sep > idx {
+						t.Errorf("%s.%s (operand #%d): %q reaches argv as an OPTION — no %q separator before it: %s %v",
+							b, name, target, flag, pmexec.EndOfOptions, c.Name, c.Args)
+					}
+				}
+				checked++
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("matches-zero guard: no operand-taking Manager methods were exercised")
+	}
+}
+
+// TestSearch_RejectsFlagShapedQuery is the per-backend, behaviour-level companion
+// to the reflective guard above: a flag-shaped query is refused on every backend
+// BEFORE the package manager runs (so it can never be reparsed as an option),
+// while an ordinary query reaches the tool unchanged.
+func TestSearch_RejectsFlagShapedQuery(t *testing.T) {
+	ctx := context.Background()
+	for _, b := range []Backend{Apt, Dnf, Pacman, Zypper, Flatpak} {
+		t.Run(b.String(), func(t *testing.T) {
+			stubLookPath(t, "apt", "apt-get", "dnf", "pacman", "zypper", "flatpak")
+			m, f := mustNew(t, b)
+			if _, err := m.Search(ctx, "-rf"); err == nil {
+				t.Errorf("Search(%q) = nil error, want a validation error", "-rf")
+			}
+			if n := len(f.Calls()); n != 0 {
+				t.Errorf("Search ran %d command(s) on a flag-shaped query; want 0", n)
+			}
+			// A normal query still runs.
+			ok(f, "")
+			if _, err := m.Search(ctx, "vim"); err != nil {
+				t.Errorf("Search(vim) = %v, want nil", err)
+			}
+			if n := len(f.Calls()); n != 1 {
+				t.Errorf("Search(vim) ran %d command(s); want 1", n)
+			}
+		})
+	}
+}
+
+// TestValidateSearchQuery covers the query validator directly.
+func TestValidateSearchQuery(t *testing.T) {
+	for _, q := range []string{"vim", "lib-foo", "c++", "gtk3.0", "", "x86_64"} {
+		if err := ValidateSearchQuery(q); err != nil {
+			t.Errorf("ValidateSearchQuery(%q) = %v, want nil", q, err)
+		}
+	}
+	for _, q := range []string{"-rf", "--installed", "-x", "vim\nrm", "a\x00b"} {
+		if err := ValidateSearchQuery(q); err == nil {
+			t.Errorf("ValidateSearchQuery(%q) = nil, want an error", q)
+		}
+	}
+}

--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -94,6 +94,32 @@ func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...stri
 	return res, err
 }
 
+// InstallLocal installs a local .rpm file through dnf, resolving its
+// dependencies from the configured repositories (unlike a bare `rpm -i`). When
+// the file is OLDER than the installed version dnf refuses to "install" it; with
+// opts.AllowDowngrade that rejection is retried as an explicit `dnf downgrade`.
+// dnf5 rejects a "--" end-of-options separator, so it is NOT used; the path is
+// kept safe by ValidateLocalPackagePath, which requires an absolute path that
+// can never be flag-shaped.
+func (d *dnf) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return pmexec.Result{}, err
+	}
+	flags := []string{"install", "-y"}
+	if opts.AllowDowngrade {
+		flags = append(flags, "--allowerasing")
+	}
+	res, err := d.write(ctx, append(flags, path)...)
+	// Retry as an explicit downgrade ONLY when dnf itself rejected the install
+	// (a non-zero exit); an exec/escalation/context failure must not trigger a
+	// second escalated command.
+	var ce *pmexec.CommandError
+	if errors.As(err, &ce) && opts.AllowDowngrade {
+		return d.write(ctx, "downgrade", "-y", path)
+	}
+	return res, err
+}
+
 // Remove removes packages. dnf has no purge concept, so opts.Purge is a no-op.
 func (d *dnf) Remove(ctx context.Context, _ RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
@@ -216,6 +242,9 @@ func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 
 // Search searches package names/summaries (exit 1 = no matches).
 func (d *dnf) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	if err := ValidateSearchQuery(query); err != nil {
+		return nil, err
+	}
 	res, err := runRead(ctx, d.r, "dnf", "search", "-q", query)
 	if err != nil {
 		return nil, err

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -74,6 +74,18 @@ func (f *flatpak) Install(ctx context.Context, opts InstallOptions, packages ...
 	return f.write(ctx, args...)
 }
 
+// InstallLocal installs a local flatpak bundle (a single-file .flatpak) or a
+// .flatpakref. A bundle has no version-ordering concept, so opts.AllowDowngrade
+// is ignored; system scope escalates, --user does not. ValidateLocalPackagePath
+// requires an absolute path, so the operand can never be flag-shaped.
+func (f *flatpak) InstallLocal(ctx context.Context, path string, _ InstallLocalOptions) (pmexec.Result, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return pmexec.Result{}, err
+	}
+	flags := []string{"install", "-y", "--noninteractive", f.scope()}
+	return f.write(ctx, append(flags, path)...)
+}
+
 // Remove uninstalls bundles; opts.Purge also deletes per-app data (--delete-data).
 func (f *flatpak) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
@@ -134,6 +146,9 @@ func (f *flatpak) Repair(ctx context.Context) (pmexec.Result, error) {
 
 // Search searches configured remotes (exit 1 = no matches).
 func (f *flatpak) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	if err := ValidateSearchQuery(query); err != nil {
+		return nil, err
+	}
 	res, err := runRead(ctx, f.r, "flatpak", "search", query)
 	if err != nil {
 		return nil, err

--- a/pkg/install_local_test.go
+++ b/pkg/install_local_test.go
@@ -1,0 +1,278 @@
+package pkg
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// TestInstallLocal_GoldenArgv pins the per-backend command for installing a
+// package from a local file already on disk (a downloaded .deb/.rpm/pacman
+// package/flatpak bundle) — the capability the agent's deb/rpm/AppImage actions
+// need so they can delegate `dpkg -i`/`rpm -i` to the SDK instead of shelling
+// out. Each backend resolves dependencies from the configured repos where it
+// can and runs escalated (except user-scope flatpak); the absolute-path
+// requirement (not a "--" separator, which dnf5 rejects) keeps the path from
+// being parsed as an option.
+func TestInstallLocal_GoldenArgv(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("apt resolves deps via apt-get install of the file", func(t *testing.T) {
+		m, f := aptM(t)
+		ok(f, "Setting up app ...\n")
+		if _, err := m.InstallLocal(ctx, "/opt/app.deb", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		want := "apt install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold /opt/app.deb"
+		if argv(c) != want || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v)\n want %q escalated", argv(c), c.Escalate, want)
+		}
+	})
+
+	t.Run("dnf installs the local rpm and pulls deps", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "dnf install -y /opt/app.rpm" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v)", argv(c), c.Escalate)
+		}
+	})
+
+	t.Run("zypper installs the local rpm", func(t *testing.T) {
+		m, f := zypperM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "zypper --non-interactive install /opt/app.rpm" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v)", argv(c), c.Escalate)
+		}
+	})
+
+	t.Run("pacman -U installs the local package file", func(t *testing.T) {
+		m, f := pacmanM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.pkg.tar.zst", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "pacman -U --noconfirm /opt/app.pkg.tar.zst" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v)", argv(c), c.Escalate)
+		}
+	})
+
+	t.Run("flatpak installs a bundle, system scope escalated", func(t *testing.T) {
+		m, f := flatpakM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.flatpak", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "flatpak install -y --noninteractive --system /opt/app.flatpak" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v)", argv(c), c.Escalate)
+		}
+	})
+
+	t.Run("flatpak user scope is unescalated", func(t *testing.T) {
+		m, f := flatpakM(t, WithUserScope())
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.flatpak", InstallLocalOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		c := f.Calls()[0]
+		if argv(c) != "flatpak install -y --noninteractive --user /opt/app.flatpak" || c.Escalate {
+			t.Errorf("argv = %q (escalate=%v), want --user unescalated", argv(c), c.Escalate)
+		}
+	})
+}
+
+// TestInstallLocal_AllowDowngrade pins how each backend permits installing a
+// local file older than the installed version.
+func TestInstallLocal_AllowDowngrade(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("apt adds --allow-downgrades", func(t *testing.T) {
+		m, f := aptM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.deb", InstallLocalOptions{AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); !strings.Contains(a, "--allow-downgrades") {
+			t.Errorf("argv = %q, want --allow-downgrades", a)
+		}
+	})
+
+	t.Run("zypper adds --oldpackage", func(t *testing.T) {
+		m, f := zypperM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); !strings.Contains(a, "--oldpackage") {
+			t.Errorf("argv = %q, want --oldpackage", a)
+		}
+	})
+
+	t.Run("dnf retries as an explicit downgrade when the install is rejected", func(t *testing.T) {
+		m, f := dnfM(t)
+		// dnf refuses to "install" an older local rpm (non-zero exit) — the
+		// AllowDowngrade path must retry it as `dnf downgrade`.
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "package app-1.0 is already installed"}, nil)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 2 {
+			t.Fatalf("got %d calls, want 2 (install then downgrade)", len(calls))
+		}
+		if argv(calls[0]) != "dnf install -y --allowerasing /opt/app.rpm" {
+			t.Errorf("first argv = %q", argv(calls[0]))
+		}
+		if argv(calls[1]) != "dnf downgrade -y /opt/app.rpm" || !calls[1].Escalate {
+			t.Errorf("retry argv = %q (escalate=%v)", argv(calls[1]), calls[1].Escalate)
+		}
+	})
+
+	t.Run("dnf does NOT retry on a runner/exec failure", func(t *testing.T) {
+		m, f := dnfM(t)
+		// An exec/escalation failure (err != nil, not a non-zero exit) must not
+		// trigger a second escalated command — mirrors Install's guard.
+		f.Push(pmexec.Result{}, pmexec.ErrEscalationUnavailable)
+		_, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowDowngrade: true})
+		if !errors.Is(err, pmexec.ErrEscalationUnavailable) {
+			t.Fatalf("err = %v, want ErrEscalationUnavailable", err)
+		}
+		if n := len(f.Calls()); n != 1 {
+			t.Errorf("got %d calls, want 1 (no downgrade retry after an exec failure)", n)
+		}
+	})
+
+	t.Run("pacman -U downgrades natively, no extra flag", func(t *testing.T) {
+		m, f := pacmanM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.pkg.tar.zst", InstallLocalOptions{AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "pacman -U --noconfirm /opt/app.pkg.tar.zst" {
+			t.Errorf("argv = %q, want the plain -U form", a)
+		}
+	})
+
+	t.Run("flatpak ignores AllowDowngrade", func(t *testing.T) {
+		m, f := flatpakM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.flatpak", InstallLocalOptions{AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "flatpak install -y --noninteractive --system /opt/app.flatpak" {
+			t.Errorf("argv = %q, want the unchanged bundle-install form", a)
+		}
+	})
+}
+
+// TestInstallLocal_RejectsUnsafePathBeforeRunner is the rejection half of the
+// contract: an absent, relative, traversing, flag-shaped, or control-bearing
+// path is refused BEFORE any escalated command runs, on every backend.
+func TestInstallLocal_RejectsUnsafePathBeforeRunner(t *testing.T) {
+	ctx := context.Background()
+	bad := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"relative", "app.deb"},
+		{"relative dotslash", "./app.deb"},
+		{"flag-shaped", "-rf.deb"},
+		{"traversal", "/opt/../etc/cron.d/x.deb"},
+		{"newline", "/opt/a\nb.deb"},
+		{"nul", "/opt/a\x00b.deb"},
+	}
+	backends := []Backend{Apt, Dnf, Pacman, Zypper, Flatpak}
+
+	for _, b := range backends {
+		for _, tc := range bad {
+			t.Run(b.String()+"/"+tc.name, func(t *testing.T) {
+				m, f := mustNew(t, b)
+				if _, err := m.InstallLocal(ctx, tc.path, InstallLocalOptions{}); err == nil {
+					t.Errorf("InstallLocal(%q) on %s = nil error, want a validation error", tc.path, b)
+				}
+				if n := len(f.Calls()); n != 0 {
+					t.Errorf("InstallLocal(%q) on %s ran %d command(s) before validation; want 0", tc.path, b, n)
+				}
+			})
+		}
+	}
+}
+
+// TestInstallLocal_SurfacesResultAndError pins that, like the other mutations,
+// InstallLocal returns the package manager's output on success and the output +
+// a typed *exec.CommandError on a non-zero exit.
+func TestInstallLocal_SurfacesResultAndError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success surfaces stdout", func(t *testing.T) {
+		m, f := dnfM(t)
+		f.Push(pmexec.Result{Stdout: "Installed: app-2.0\n"}, nil)
+		res, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Stdout != "Installed: app-2.0\n" {
+			t.Errorf("Stdout = %q", res.Stdout)
+		}
+	})
+
+	t.Run("non-zero exit surfaces CommandError with the Result", func(t *testing.T) {
+		m, f := dnfM(t)
+		f.Push(pmexec.Result{Stdout: "out\n", Stderr: "Error: nothing provides libfoo\n", ExitCode: 1}, nil)
+		res, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{})
+		var ce *pmexec.CommandError
+		if !errors.As(err, &ce) || ce.ExitCode != 1 {
+			t.Fatalf("err = %v, want *exec.CommandError exit 1", err)
+		}
+		if res.ExitCode != 1 || res.Stderr != "Error: nothing provides libfoo\n" {
+			t.Errorf("Result = %+v, want stderr+exit preserved", res)
+		}
+	})
+}
+
+// TestValidateLocalPackagePath covers the path validator directly: an absolute,
+// traversal-free, control-free path is accepted; everything else is rejected.
+func TestValidateLocalPackagePath(t *testing.T) {
+	good := []string{
+		"/opt/app.deb",
+		"/var/cache/pm/app.rpm",
+		"/opt/My Apps/app.flatpak", // a space is argv-safe; not rejected
+		"/tmp/123.pkg.tar.zst",
+	}
+	for _, p := range good {
+		if err := ValidateLocalPackagePath(p); err != nil {
+			t.Errorf("ValidateLocalPackagePath(%q) = %v, want nil", p, err)
+		}
+	}
+	bad := []string{
+		"",              // empty
+		"app.deb",       // relative
+		"./app.deb",     // relative
+		"-rf",           // flag-shaped (not absolute)
+		"/opt/../etc/x", // traversal
+		"/opt/a\nb",     // newline
+		"/opt/a\tb",     // tab
+		"/opt/a\x00b",   // NUL
+		"/opt/a\x7fb",   // DEL
+	}
+	for _, p := range bad {
+		if err := ValidateLocalPackagePath(p); err == nil {
+			t.Errorf("ValidateLocalPackagePath(%q) = nil, want an error", p)
+		}
+	}
+}

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -77,6 +77,18 @@ func (p *pacman) Install(ctx context.Context, opts InstallOptions, packages ...s
 	return p.write(ctx, "-S", "--noconfirm", fmt.Sprintf("%s=%s", packages[0], opts.Version))
 }
 
+// InstallLocal installs a local package file through `pacman -U`, which resolves
+// its dependencies from the sync repositories and downgrades naturally when the
+// file is older than the installed version — so opts.AllowDowngrade needs no
+// extra flag and is ignored. ValidateLocalPackagePath requires an absolute path,
+// so the operand can never be flag-shaped.
+func (p *pacman) InstallLocal(ctx context.Context, path string, _ InstallLocalOptions) (pmexec.Result, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return pmexec.Result{}, err
+	}
+	return p.write(ctx, "-U", "--noconfirm", path)
+}
+
 // Remove removes packages; opts.Purge uses -Rns (with deps + config files).
 func (p *pacman) Remove(ctx context.Context, opts RemoveOptions, packages ...string) (pmexec.Result, error) {
 	if err := ValidatePackageNames(packages); err != nil {
@@ -157,6 +169,9 @@ func (p *pacman) Repair(ctx context.Context) (pmexec.Result, error) {
 
 // Search searches packages (-Ss; exit 1 = no matches).
 func (p *pacman) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	if err := ValidateSearchQuery(query); err != nil {
+		return nil, err
+	}
 	res, err := runRead(ctx, p.r, "pacman", "-Ss", query)
 	if err != nil {
 		return nil, err

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -10,9 +10,10 @@
 //	if err := m.Install(ctx, pkg.InstallOptions{}, "vim", "git"); err != nil { ... }
 //
 // Reads (Search/List/Show/IsInstalled/…) run unprivileged; mutations
-// (Install/Remove/Update/Upgrade/Pin/Unpin/Repair/Autoremove) run through the
-// Runner's privilege backend. Every package-name and version argument is
-// validated before it can reach argv — there is no opt-out.
+// (Install/InstallLocal/Remove/Update/Upgrade/Pin/Unpin/Repair/Autoremove) run
+// through the Runner's privilege backend. Every package-name, version, and
+// local-file-path argument is validated before it can reach argv — there is no
+// opt-out.
 //
 // Use Detect to discover which backends are installed; it lists and never picks,
 // so the caller decides (a host can have both a native manager and flatpak).
@@ -134,6 +135,15 @@ type Manager interface {
 	// (exactly one name required when set); opts.AllowDowngrade permits a lower
 	// version than installed.
 	Install(ctx context.Context, opts InstallOptions, packages ...string) (pmexec.Result, error)
+	// InstallLocal installs a package from a local file already on disk — a
+	// downloaded .deb, .rpm, pacman package, or flatpak bundle — rather than by
+	// name from a configured repository, resolving dependencies from the
+	// configured repositories where the backend supports it (apt/dnf/zypper/
+	// pacman). path must be an ABSOLUTE filesystem path to the package file;
+	// fetching and verifying the artifact (https transport, checksum) is the
+	// caller's responsibility. opts.AllowDowngrade permits a lower version than
+	// the one currently installed.
+	InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error)
 	// Remove removes the named packages. opts.Purge also deletes configuration
 	// where the backend distinguishes it (apt/pacman/flatpak); elsewhere Purge
 	// is equivalent to a plain remove.

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -52,6 +52,16 @@ type InstallOptions struct {
 	AllowDowngrade bool
 }
 
+// InstallLocalOptions configures an InstallLocal call.
+type InstallLocalOptions struct {
+	// AllowDowngrade permits installing a package file whose version is lower
+	// than the one currently installed. Honored on apt (--allow-downgrades),
+	// dnf (retried as an explicit downgrade when the install is rejected) and
+	// zypper (--oldpackage). pacman -U downgrades regardless, and a flatpak
+	// bundle has no version-ordering concept, so it is a no-op on those two.
+	AllowDowngrade bool
+}
+
 // RemoveOptions configures a Remove call.
 type RemoveOptions struct {
 	// Purge also removes configuration/data where the backend distinguishes it

--- a/pkg/validate.go
+++ b/pkg/validate.go
@@ -128,6 +128,76 @@ func ValidateRpmPackageName(name string) error {
 	return nil
 }
 
+// ValidateLocalPackagePath validates a filesystem path before it reaches a
+// package manager as the operand of a local-file install (apt-get install
+// <file>, dnf install <file>, pacman -U <file>, zypper install <file>, flatpak
+// install <bundle>). It is NOT a package name, so the package-name grammar does
+// not apply; what matters is that the path cannot masquerade as an option and
+// cannot smuggle a config/log-injecting control character:
+//
+//   - absolute (a leading '/'): a relative path is ambiguous w.r.t. the
+//     privileged process's working directory, and an absolute path can never be
+//     flag-shaped. Callers pass a concrete file location (typically a temp file
+//     they downloaded and checksum-verified), so this costs them nothing.
+//   - no ".." segment: defence-in-depth against a traversing path, mirroring
+//     ValidateGpgKeyRef.
+//   - no control characters (incl. NUL, newline, tab) or DEL: a space is left
+//     alone (it is argv-safe and legal in a path), but control characters are
+//     refused so a crafted path can neither break a log line nor confuse a tool.
+//
+// Existence is NOT checked: the Manager has no host access (it drives an
+// injected Runner), and a missing file surfaces cleanly as the tool's own
+// non-zero exit. The absolute-path requirement — not a "--" end-of-options
+// separator — is what keeps the path from being read as an option, because some
+// tools (dnf5) reject "--" for their install/search subcommands entirely.
+func ValidateLocalPackagePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("local package path is empty")
+	}
+	if hasControlChar(path) {
+		return fmt.Errorf("local package path contains control characters")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("local package path %q must be an absolute path", path)
+	}
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("local package path %q must not contain '..'", path)
+	}
+	return nil
+}
+
+// ValidateSearchQuery guards the free-text query passed to a package-manager
+// search. A search term is not a fixed grammar (it may carry '+', '.', glob
+// characters, etc.), so it is deliberately NOT run through validPackageName;
+// the one thing that must be refused is a value that could be reparsed as an
+// OPTION. A leading '-' is rejected — a search term never legitimately starts
+// with a dash, and a "--" end-of-options separator is NOT portable here (dnf5's
+// `search` subcommand rejects "--"), so validation is the honest defense. Control
+// characters are rejected too. An empty query is allowed (a backend may list
+// everything).
+func ValidateSearchQuery(query string) error {
+	if strings.HasPrefix(query, "-") {
+		return fmt.Errorf("invalid search query %q: must not start with '-'", query)
+	}
+	if hasControlChar(query) {
+		return fmt.Errorf("search query contains control characters")
+	}
+	return nil
+}
+
+// hasControlChar reports whether s contains any ASCII control character (NUL
+// through US, including newline and tab) or DEL. Unlike hasCtrlOrSpace it does
+// NOT reject a plain space (0x20), which is a legal, argv-safe character in a
+// filesystem path.
+func hasControlChar(s string) bool {
+	for _, r := range s {
+		if r < ' ' || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
 // validRemoteName matches a flatpak remote alias (e.g. "flathub",
 // "gnome-nightly"). Same leading-alphanumeric anti-option-injection
 // rule; remote aliases never contain a path separator or whitespace.

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -80,6 +80,22 @@ func (z *zypper) Install(ctx context.Context, opts InstallOptions, packages ...s
 	return z.write(ctx, args...)
 }
 
+// InstallLocal installs a local .rpm file through zypper, resolving its
+// dependencies from the configured repositories. opts.AllowDowngrade adds
+// --oldpackage so a file older than the installed version is accepted.
+// ValidateLocalPackagePath requires an absolute path, so the operand can never
+// be flag-shaped.
+func (z *zypper) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return pmexec.Result{}, err
+	}
+	flags := []string{"--non-interactive", "install"}
+	if opts.AllowDowngrade {
+		flags = append(flags, "--oldpackage")
+	}
+	return z.write(ctx, append(flags, path)...)
+}
+
 // Remove removes packages. zypper does not distinguish purge from remove, so
 // opts.Purge is a no-op.
 func (z *zypper) Remove(ctx context.Context, _ RemoveOptions, packages ...string) (pmexec.Result, error) {
@@ -139,6 +155,9 @@ func (z *zypper) Repair(ctx context.Context) (pmexec.Result, error) {
 
 // Search searches packages (exit 104 = no matches).
 func (z *zypper) Search(ctx context.Context, query string) ([]SearchResult, error) {
+	if err := ValidateSearchQuery(query); err != nil {
+		return nil, err
+	}
 	res, err := runRead(ctx, z.r, "zypper", "--non-interactive", "search", query)
 	if err != nil {
 		return nil, err

--- a/sys/service/service.go
+++ b/sys/service/service.go
@@ -58,6 +58,11 @@ type Manager interface {
 	Start(ctx context.Context, unit string) error
 	Stop(ctx context.Context, unit string) error
 	Restart(ctx context.Context, unit string) error
+	// Reload asks a running unit to re-read its configuration via its
+	// ExecReload command, without restarting it (so it keeps open connections
+	// and child processes). A unit that defines no ExecReload makes systemctl
+	// exit non-zero, returned as a *exec.CommandError — use Restart for those.
+	Reload(ctx context.Context, unit string) error
 	Mask(ctx context.Context, unit string) error
 	Unmask(ctx context.Context, unit string) error
 	DaemonReload(ctx context.Context) error

--- a/sys/service/service_test.go
+++ b/sys/service/service_test.go
@@ -68,6 +68,7 @@ func TestMutations_GoldenArgv(t *testing.T) {
 		{"Start", func(m Manager) error { return m.Start(context.Background(), unit) }, []string{"start", "--", unit}},
 		{"Stop", func(m Manager) error { return m.Stop(context.Background(), unit) }, []string{"stop", "--", unit}},
 		{"Restart", func(m Manager) error { return m.Restart(context.Background(), unit) }, []string{"restart", "--", unit}},
+		{"Reload", func(m Manager) error { return m.Reload(context.Background(), unit) }, []string{"reload", "--", unit}},
 		{"Mask", func(m Manager) error { return m.Mask(context.Background(), unit) }, []string{"mask", "--", unit}},
 		{"Unmask", func(m Manager) error { return m.Unmask(context.Background(), unit) }, []string{"unmask", "--", unit}},
 		{"DaemonReload", func(m Manager) error { return m.DaemonReload(context.Background()) }, []string{"daemon-reload"}},
@@ -81,6 +82,43 @@ func TestMutations_GoldenArgv(t *testing.T) {
 			wantOneCmd(t, f, tc.args, true)
 		})
 	}
+}
+
+// TestReload pins the per-unit reload contract added so a caller (the agent's
+// user/SSH action: `systemctl reload sshd`) can ask a running unit to re-read
+// its config WITHOUT a restart through the SDK. It must run the `reload` verb
+// (not `restart` — a restart drops connections a reload preserves), escalated,
+// with the "--" separator; and a unit that defines no ExecReload makes
+// systemctl exit non-zero, which must surface as a typed *exec.CommandError
+// rather than a silent success.
+func TestReload(t *testing.T) {
+	t.Run("reloads via the reload verb, escalated", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Reload(context.Background(), "nginx.service"); err != nil {
+			t.Fatalf("Reload: %v", err)
+		}
+		wantOneCmd(t, f, []string{"reload", "--", "nginx.service"}, true)
+	})
+
+	t.Run("unit without ExecReload surfaces a CommandError", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{ExitCode: 1, Stderr: "Failed to reload nginx.service: Job type reload is not applicable for unit nginx.service."}, nil)
+		err := mgr(t, f).Reload(context.Background(), "nginx.service")
+		var ce *exec.CommandError
+		if !errors.As(err, &ce) || ce.ExitCode != 1 {
+			t.Errorf("Reload err = %v, want *exec.CommandError exit 1", err)
+		}
+	})
+
+	t.Run("rejects an unsafe unit name before the Runner", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		if err := mgr(t, f).Reload(context.Background(), "evil.txt"); err == nil {
+			t.Error("Reload accepted a non-unit name; want a validation error")
+		}
+		if n := len(f.Calls()); n != 0 {
+			t.Errorf("Reload ran %d command(s) on an invalid unit name; want 0", n)
+		}
+	})
 }
 
 // Queries run UNescalated as `systemctl <verb> -- <unit>`.

--- a/sys/service/systemd.go
+++ b/sys/service/systemd.go
@@ -203,6 +203,13 @@ func (s *systemd) Restart(ctx context.Context, unit string) error {
 	return s.mutate(ctx, "restart", "--", unit)
 }
 
+func (s *systemd) Reload(ctx context.Context, unit string) error {
+	if err := ValidateUnitName(unit); err != nil {
+		return err
+	}
+	return s.mutate(ctx, "reload", "--", unit)
+}
+
 func (s *systemd) Mask(ctx context.Context, unit string) error {
 	if err := ValidateUnitName(unit); err != nil {
 		return err


### PR DESCRIPTION
Closes the last two **SDK API gaps** the agent-as-SDK-proof idiom program surfaced — both currently block the agent rework because the agent still has to shell out for them.

## Gap #3 — `pkg.InstallLocal` (closes #226)
Install a package from a local file already on disk (a downloaded `.deb`/`.rpm`/pacman package/flatpak bundle) instead of by name from a repo, so the agent's deb/rpm/AppImage actions can stop shelling out to `dpkg -i`/`rpm -i`.

- `InstallLocal(ctx, path, InstallLocalOptions)` on all 5 backends — `apt-get install` / `dnf install` / `zypper install` / `pacman -U` / `flatpak install`, **resolving dependencies** where the backend supports it (an improvement over the agent's raw `dpkg -i`/`rpm -i`).
- `opts.AllowDowngrade` mapped per backend: apt `--allow-downgrades`, zypper `--oldpackage`, dnf install-then-`downgrade` retry (only on a non-zero exit, never on an exec failure); pacman `-U` and flatpak bundles need no flag.
- `ValidateLocalPackagePath` (absolute, no `..`, no control chars) keeps the operand from ever being flag-shaped — **deliberately not a `--` separator**, because dnf5 rejects `--` for its install/search subcommands (verified live against dnf5 5.4.2; a FakeRunner could not have caught this).

## Gap #4 — `service.Reload` (closes #227)
`service.Manager` had Start/Stop/Restart/DaemonReload but no per-unit reload, so `systemctl reload sshd` had to be shelled out. Adds `Reload(ctx, unit)` (`systemctl reload -- <unit>`, escalated, unit-name validated); a unit with no `ExecReload` surfaces a typed `*exec.CommandError`.

## Bonus: a self-discovering argv-safety guard found a real gap
While adding `InstallLocal` I added `TestEveryManagerMethodNeutralizesFlagShapedOperands` — a reflective guard over the whole `Manager` surface that fails if any method lets a flag-shaped operand reach `argv` as an option. It surfaced that **`Search` passed its free-text query as a bare operand on every backend**, so a query like `-rf` reached argv as an option on the unprivileged read path. `Search` now validates the query (`ValidateSearchQuery`: no leading `-`, no control chars). The real-tool fix (no `--`) was confirmed against dnf5, which rejects `--` for `search` too.

## Tests
- 100% statement coverage on all new code; `gofmt`/`go vet`/`staticcheck` clean.
- Rejection-first: unsafe path / flag-shaped query refused before any command runs (all backends); dnf downgrade retry fires only on a non-zero exit, never on an exec failure.
- The live dnf5 integration test validates the Search hardening end-to-end.