### PR TITLE
feat(pkg): InstallLocalOptions.AllowUnsigned — opt-in GPG-check skip for out-of-band-verified local installs

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -124,6 +124,14 @@ type InstallOptions struct {
     AllowDowngrade bool
 }
 
+type InstallLocalOptions struct {
+    AllowDowngrade bool // install a file older than the installed version
+    AllowUnsigned  bool // skip the backend GPG check (dnf --nogpgcheck / zypper
+                        // --allow-unsigned-rpm) for an out-of-band-verified file;
+                        // secure-default-off. apt/flatpak: no-op; pacman: NOT
+                        // honored (pacman -U always enforces SigLevel).
+}
+
 type RemoveOptions struct {
     Purge bool // also remove config/data (apt purge / pacman -Rns / flatpak --delete-data)
 }

--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -110,7 +110,8 @@ func (a *apt) Install(ctx context.Context, opts InstallOptions, packages ...stri
 // unlike a bare `dpkg -i` — resolves the package's dependencies from the
 // configured repositories. ValidateLocalPackagePath requires an absolute path,
 // so the operand can never be flag-shaped; the conffile-default options keep a
-// postinst that touches a conffile non-interactive.
+// postinst that touches a conffile non-interactive. opts.AllowUnsigned is a
+// no-op here — a local .deb carries no per-file signature to skip.
 func (a *apt) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
 	if err := ValidateLocalPackagePath(path); err != nil {
 		return pmexec.Result{}, err

--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -98,24 +98,33 @@ func (d *dnf) Install(ctx context.Context, opts InstallOptions, packages ...stri
 // dependencies from the configured repositories (unlike a bare `rpm -i`). When
 // the file is OLDER than the installed version dnf refuses to "install" it; with
 // opts.AllowDowngrade that rejection is retried as an explicit `dnf downgrade`.
-// dnf5 rejects a "--" end-of-options separator, so it is NOT used; the path is
-// kept safe by ValidateLocalPackagePath, which requires an absolute path that
-// can never be flag-shaped.
+// opts.AllowUnsigned adds --nogpgcheck so an out-of-band-verified unsigned rpm is
+// accepted (it is carried into the downgrade retry too). dnf5 rejects a "--"
+// end-of-options separator, so it is NOT used; the path is kept safe by
+// ValidateLocalPackagePath, which requires an absolute path that can never be
+// flag-shaped.
 func (d *dnf) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
 	if err := ValidateLocalPackagePath(path); err != nil {
 		return pmexec.Result{}, err
 	}
 	flags := []string{"install", "-y"}
+	if opts.AllowUnsigned {
+		flags = append(flags, "--nogpgcheck")
+	}
 	if opts.AllowDowngrade {
 		flags = append(flags, "--allowerasing")
 	}
 	res, err := d.write(ctx, append(flags, path)...)
 	// Retry as an explicit downgrade ONLY when dnf itself rejected the install
 	// (a non-zero exit); an exec/escalation/context failure must not trigger a
-	// second escalated command.
+	// second escalated command. The downgrade carries the same GPG policy.
 	var ce *pmexec.CommandError
 	if errors.As(err, &ce) && opts.AllowDowngrade {
-		return d.write(ctx, "downgrade", "-y", path)
+		dargs := []string{"downgrade", "-y"}
+		if opts.AllowUnsigned {
+			dargs = append(dargs, "--nogpgcheck")
+		}
+		return d.write(ctx, append(dargs, path)...)
 	}
 	return res, err
 }

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -76,8 +76,10 @@ func (f *flatpak) Install(ctx context.Context, opts InstallOptions, packages ...
 
 // InstallLocal installs a local flatpak bundle (a single-file .flatpak) or a
 // .flatpakref. A bundle has no version-ordering concept, so opts.AllowDowngrade
-// is ignored; system scope escalates, --user does not. ValidateLocalPackagePath
-// requires an absolute path, so the operand can never be flag-shaped.
+// is ignored; opts.AllowUnsigned is a no-op (a bundle's signing is not a
+// per-file GPG check). System scope escalates, --user does not.
+// ValidateLocalPackagePath requires an absolute path, so the operand can never
+// be flag-shaped.
 func (f *flatpak) InstallLocal(ctx context.Context, path string, _ InstallLocalOptions) (pmexec.Result, error) {
 	if err := ValidateLocalPackagePath(path); err != nil {
 		return pmexec.Result{}, err

--- a/pkg/install_local_test.go
+++ b/pkg/install_local_test.go
@@ -179,6 +179,115 @@ func TestInstallLocal_AllowDowngrade(t *testing.T) {
 	})
 }
 
+// TestInstallLocal_AllowUnsigned pins the opt-in GPG-skip knob. The agent
+// establishes a local artifact's authenticity out of band (HTTPS + a mandatory
+// SHA256 checksum), so the file is typically unsigned and dnf/zypper would
+// refuse it; AllowUnsigned says "the checksum is the verification, skip the GPG
+// check". It is secure-default-OFF — when false every backend's GPG check stays
+// in force.
+func TestInstallLocal_AllowUnsigned(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("dnf adds --nogpgcheck", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowUnsigned: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "dnf install -y --nogpgcheck /opt/app.rpm" {
+			t.Errorf("argv = %q, want --nogpgcheck", a)
+		}
+	})
+
+	t.Run("zypper adds --allow-unsigned-rpm (per-package, not global)", func(t *testing.T) {
+		m, f := zypperM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowUnsigned: true}); err != nil {
+			t.Fatal(err)
+		}
+		a := argv(f.Calls()[0])
+		if a != "zypper --non-interactive install --allow-unsigned-rpm /opt/app.rpm" {
+			t.Errorf("argv = %q, want --allow-unsigned-rpm", a)
+		}
+		if strings.Contains(a, "--no-gpg-checks") {
+			t.Error("must use per-package --allow-unsigned-rpm, never the global --no-gpg-checks")
+		}
+	})
+
+	t.Run("dnf carries --nogpgcheck into the downgrade retry too", func(t *testing.T) {
+		m, f := dnfM(t)
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "package app-1.0 is already installed"}, nil)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.rpm", InstallLocalOptions{AllowUnsigned: true, AllowDowngrade: true}); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 2 {
+			t.Fatalf("got %d calls, want 2", len(calls))
+		}
+		if argv(calls[0]) != "dnf install -y --nogpgcheck --allowerasing /opt/app.rpm" {
+			t.Errorf("install argv = %q", argv(calls[0]))
+		}
+		if argv(calls[1]) != "dnf downgrade -y --nogpgcheck /opt/app.rpm" {
+			t.Errorf("downgrade retry argv = %q, want --nogpgcheck carried through", argv(calls[1]))
+		}
+	})
+
+	t.Run("apt is a no-op (a local .deb has no per-file signature)", func(t *testing.T) {
+		m, f := aptM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.deb", InstallLocalOptions{AllowUnsigned: true}); err != nil {
+			t.Fatal(err)
+		}
+		want := "apt install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold /opt/app.deb"
+		if a := argv(f.Calls()[0]); a != want {
+			t.Errorf("argv = %q, want the UNCHANGED apt form (no GPG flag)", a)
+		}
+	})
+
+	t.Run("pacman is unaffected (pacman -U enforces SigLevel; no per-invocation bypass)", func(t *testing.T) {
+		m, f := pacmanM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.pkg.tar.zst", InstallLocalOptions{AllowUnsigned: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "pacman -U --noconfirm /opt/app.pkg.tar.zst" {
+			t.Errorf("argv = %q, want the unchanged -U form", a)
+		}
+	})
+
+	t.Run("flatpak is a no-op", func(t *testing.T) {
+		m, f := flatpakM(t)
+		ok(f, "")
+		if _, err := m.InstallLocal(ctx, "/opt/app.flatpak", InstallLocalOptions{AllowUnsigned: true}); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "flatpak install -y --noninteractive --system /opt/app.flatpak" {
+			t.Errorf("argv = %q, want the unchanged bundle-install form", a)
+		}
+	})
+
+	t.Run("default OFF keeps every backend's GPG check (no skip flag)", func(t *testing.T) {
+		for _, tc := range []struct {
+			b    Backend
+			path string
+			skip string
+		}{
+			{Dnf, "/opt/app.rpm", "--nogpgcheck"},
+			{Zypper, "/opt/app.rpm", "--allow-unsigned-rpm"},
+		} {
+			m, f := mustNew(t, tc.b)
+			ok(f, "")
+			if _, err := m.InstallLocal(ctx, tc.path, InstallLocalOptions{}); err != nil {
+				t.Fatal(err)
+			}
+			if a := argv(f.Calls()[0]); strings.Contains(a, tc.skip) {
+				t.Errorf("%s: default argv %q must NOT contain %q", tc.b, a, tc.skip)
+			}
+		}
+	})
+}
+
 // TestInstallLocal_RejectsUnsafePathBeforeRunner is the rejection half of the
 // contract: an absent, relative, traversing, flag-shaped, or control-bearing
 // path is refused BEFORE any escalated command runs, on every backend.

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -80,8 +80,11 @@ func (p *pacman) Install(ctx context.Context, opts InstallOptions, packages ...s
 // InstallLocal installs a local package file through `pacman -U`, which resolves
 // its dependencies from the sync repositories and downgrades naturally when the
 // file is older than the installed version — so opts.AllowDowngrade needs no
-// extra flag and is ignored. ValidateLocalPackagePath requires an absolute path,
-// so the operand can never be flag-shaped.
+// extra flag and is ignored. opts.AllowUnsigned is NOT honored either: `pacman
+// -U` enforces the repo SigLevel and has no per-invocation signature bypass, so
+// the install stays signature-checked (a relaxed SigLevel is a pacman.conf
+// concern, out of scope here). ValidateLocalPackagePath requires an absolute
+// path, so the operand can never be flag-shaped.
 func (p *pacman) InstallLocal(ctx context.Context, path string, _ InstallLocalOptions) (pmexec.Result, error) {
 	if err := ValidateLocalPackagePath(path); err != nil {
 		return pmexec.Result{}, err

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -142,7 +142,9 @@ type Manager interface {
 	// pacman). path must be an ABSOLUTE filesystem path to the package file;
 	// fetching and verifying the artifact (https transport, checksum) is the
 	// caller's responsibility. opts.AllowDowngrade permits a lower version than
-	// the one currently installed.
+	// the one currently installed; opts.AllowUnsigned skips the backend's GPG
+	// check (dnf --nogpgcheck / zypper --allow-unsigned-rpm) for a file whose
+	// authenticity is established out of band — secure-default-off.
 	InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error)
 	// Remove removes the named packages. opts.Purge also deletes configuration
 	// where the backend distinguishes it (apt/pacman/flatpak); elsewhere Purge

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -60,6 +60,20 @@ type InstallLocalOptions struct {
 	// zypper (--oldpackage). pacman -U downgrades regardless, and a flatpak
 	// bundle has no version-ordering concept, so it is a no-op on those two.
 	AllowDowngrade bool
+	// AllowUnsigned skips the backend's GPG signature check for the local file.
+	// It is secure-default-OFF: with the default (false) an unsigned local .rpm
+	// is rejected by dnf/zypper. Set it ONLY when the file's authenticity is
+	// established out of band — e.g. an HTTPS transport plus a verified SHA256
+	// checksum — so the package manager's per-file GPG check is redundant. Per
+	// backend:
+	//   - dnf:    adds --nogpgcheck
+	//   - zypper: adds --allow-unsigned-rpm (per-package; never the global
+	//             --no-gpg-checks, which would also drop repo-metadata checks)
+	//   - apt:    no-op — a local .deb carries no per-file signature to skip
+	//   - pacman: NOT honored — `pacman -U` enforces the repo SigLevel and has no
+	//             per-invocation bypass; the install stays signature-checked
+	//   - flatpak: no-op — a bundle's signing is not a per-file GPG check
+	AllowUnsigned bool
 }
 
 // RemoveOptions configures a Remove call.

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -83,6 +83,8 @@ func (z *zypper) Install(ctx context.Context, opts InstallOptions, packages ...s
 // InstallLocal installs a local .rpm file through zypper, resolving its
 // dependencies from the configured repositories. opts.AllowDowngrade adds
 // --oldpackage so a file older than the installed version is accepted.
+// opts.AllowUnsigned adds the per-package --allow-unsigned-rpm (NOT the global
+// --no-gpg-checks, which would also drop repository-metadata verification).
 // ValidateLocalPackagePath requires an absolute path, so the operand can never
 // be flag-shaped.
 func (z *zypper) InstallLocal(ctx context.Context, path string, opts InstallLocalOptions) (pmexec.Result, error) {
@@ -90,6 +92,9 @@ func (z *zypper) InstallLocal(ctx context.Context, path string, opts InstallLoca
 		return pmexec.Result{}, err
 	}
 	flags := []string{"--non-interactive", "install"}
+	if opts.AllowUnsigned {
+		flags = append(flags, "--allow-unsigned-rpm")
+	}
 	if opts.AllowDowngrade {
 		flags = append(flags, "--oldpackage")
 	}


### PR DESCRIPTION
Closes #229.

The agent establishes a local artifact's authenticity **out of band** — HTTPS transport + a mandatory SHA256 checksum (`requireVerifiedArtifact`) — before it ever calls the package manager. The local `.rpm`s it installs are therefore typically **unsigned**: `rpm -i` installs them, but `dnf install`/`zypper install` GPG-check the local file and refuse. There was no way to express "the checksum is the verification, skip the redundant per-file GPG check" — so the agent's rpm executor can't yet delegate to `InstallLocal`.

Adds one field, **secure-default-OFF**:

```go
type InstallLocalOptions struct {
    AllowDowngrade bool
    AllowUnsigned  bool // NEW
}
```

Per-backend when `AllowUnsigned == true`:

| backend | behaviour |
|---|---|
| dnf | `--nogpgcheck` (carried into the `downgrade` retry too) |
| zypper | `--allow-unsigned-rpm` (per-package; **never** the global `--no-gpg-checks`, which would also drop repo-metadata verification) |
| apt | no-op (a local `.deb` has no per-file signature) |
| pacman | **NOT honored** — `pacman -U` enforces the repo SigLevel; no per-invocation bypass, so the install stays signature-checked |
| flatpak | no-op |

When `false` (default) every backend's GPG check stays in force. **No proto change** (the agent's trust model is checksum, not signature). The `GPGKey`/operator-signed-package idea stays parked — it's a genuine new capability gated by an install-action proto field.

### Verification
- The dnf5 `--nogpgcheck` flag was verified against **real dnf5 5.4.2** for both `install` and `downgrade` (parses to the file-open stage, not "unknown argument") — same real-tool caution that caught the dnf5 `--` rejection in #228.
- 100% statement coverage on the new branches; rejection/secure-default cases pinned (default-off adds no skip flag; zypper uses per-package not global). gofmt/vet/staticcheck clean; full pkg suite incl. the live dnf integration green.

Unblocks the agent: rpm executor `install` → `InstallLocal{AllowUnsigned:true}`, `remove` → existing `Remove` (dropping `rpm -i`/`rpm -e`).