### PR TITLE
fix(repo): scope apt repository URL validation (whitespace / second-URI injection)

### DIFF
--- a/sys/repo/validate.go
+++ b/sys/repo/validate.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/manchtools/power-manage-sdk/pkg"
@@ -97,13 +98,41 @@ func (m *manager) Validate(r Repository) error {
 	return nil
 }
 
-func validateApt(c *AptConfig) error {
-	if c.URL == "" {
+// validateAptURL checks an apt repository URL. apt is exempt from the https
+// requirement (its trust anchor is the gpg-signed Release file), so http is
+// accepted alongside https — but the value must still be a real URL. It is
+// written into a deb822 "URIs:" field, so a raw space (which hasControl allows)
+// or a control character would smuggle a SECOND URI/field into the line
+// ("https://h/a https://evil/" → two URIs); a non-URL, a non-http(s) scheme
+// (file://, ftp://), a host-less URL, or embedded credentials (which would leak
+// into the on-disk config) have no place there either.
+func validateAptURL(rawURL string) error {
+	if rawURL == "" {
 		return fmt.Errorf("%w: field %q is required", ErrInvalidConfig, "apt.url")
 	}
-	// apt is exempt from the https requirement (its trust is the signed Release);
-	// reject only control characters / argument confusion.
-	if err := rejectControl("apt.url", c.URL); err != nil {
+	for _, r := range rawURL {
+		if r <= ' ' || r == 0x7f { // any whitespace (incl. space) or control char
+			return badShape("apt.url")
+		}
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return badShape("apt.url")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return badShape("apt.url")
+	}
+	if u.Host == "" {
+		return badShape("apt.url")
+	}
+	if u.User != nil {
+		return badShape("apt.url")
+	}
+	return nil
+}
+
+func validateApt(c *AptConfig) error {
+	if err := validateAptURL(c.URL); err != nil {
 		return err
 	}
 	if err := rejectControl("apt.distribution", c.Distribution); err != nil {

--- a/sys/repo/validate_test.go
+++ b/sys/repo/validate_test.go
@@ -57,20 +57,33 @@ func TestValidate_Apt(t *testing.T) {
 	m, _, _ := newTestManager(t, pkg.Apt)
 	base := func() *AptConfig { return &AptConfig{URL: "https://packages.example.com/apt"} }
 
-	// apt is intentionally exempt from the https requirement (trust = signed Release).
-	if err := m.Validate(Repository{Name: "r", Apt: &AptConfig{URL: "http://old.example.com/apt"}}); err != nil {
-		t.Errorf("Validate(apt http url) = %v, want nil (apt is http-exempt)", err)
+	// apt is intentionally exempt from the https requirement (trust = signed
+	// Release), so BOTH http and https are accepted.
+	for _, u := range []string{"http://old.example.com/apt", "https://packages.example.com/apt"} {
+		if err := m.Validate(Repository{Name: "r", Apt: &AptConfig{URL: u}}); err != nil {
+			t.Errorf("Validate(apt url %q) = %v, want nil", u, err)
+		}
 	}
 
 	reject := map[string]*AptConfig{
-		"missing url":          {URL: ""},
-		"control in url":       {URL: "https://h/a\nDeb-Src: x"},
-		"control in dist":      mut(base(), func(c *AptConfig) { c.Distribution = "bad\nline" }),
-		"bad dist shape":       mut(base(), func(c *AptConfig) { c.Distribution = "-bad" }),
-		"control in component": mut(base(), func(c *AptConfig) { c.Components = []string{"main", "x\ny"} }),
-		"bad component shape":  mut(base(), func(c *AptConfig) { c.Components = []string{"@bad"} }),
-		"control in arch":      mut(base(), func(c *AptConfig) { c.Arch = "amd64\n" }),
-		"bad arch shape":       mut(base(), func(c *AptConfig) { c.Arch = "AMD64" }), // arch is lowercase
+		"missing url":    {URL: ""},
+		"control in url": {URL: "https://h/a\nDeb-Src: x"},
+		// A raw space splits the deb822 URIs field into a SECOND URI — the
+		// injection the old control-only check let through.
+		"space (second-URI injection)": {URL: "https://h/a https://evil/"},
+		"tab in url":                   {URL: "https://h/a\tb"},
+		"non-http scheme (ftp)":        {URL: "ftp://h/a"},
+		"file scheme":                  {URL: "file:///etc/passwd"},
+		"not a url (no scheme/host)":   {URL: "packages.example.com/apt"},
+		"unparseable (bad host)":       {URL: "http://[oops"}, // url.Parse: missing ']'
+		"no host":                      {URL: "https:///path"},
+		"embedded credentials":         {URL: "https://user:pass@h/a"},
+		"control in dist":              mut(base(), func(c *AptConfig) { c.Distribution = "bad\nline" }),
+		"bad dist shape":               mut(base(), func(c *AptConfig) { c.Distribution = "-bad" }),
+		"control in component":         mut(base(), func(c *AptConfig) { c.Components = []string{"main", "x\ny"} }),
+		"bad component shape":          mut(base(), func(c *AptConfig) { c.Components = []string{"@bad"} }),
+		"control in arch":              mut(base(), func(c *AptConfig) { c.Arch = "amd64\n" }),
+		"bad arch shape":               mut(base(), func(c *AptConfig) { c.Arch = "AMD64" }), // arch is lowercase
 	}
 	for label, c := range reject {
 		err := m.Validate(Repository{Name: "r", Apt: c})


### PR DESCRIPTION
Closes #231. Audit finding [high].

`validateApt` only ran `rejectControl` on `apt.url` — which rejects control characters but **allows a raw space**. Since the URL is written into a deb822 `URIs:` field, `https://h/a https://evil/` passed validation and split into a **second URI** in the sources file. A non-URL, a non-http(s) scheme (`file://`/`ftp://`), a host-less URL, or embedded credentials were also accepted.

Adds `validateAptURL` (url.Parse-based): rejects any whitespace/control char, requires an **http or https** scheme (apt keeps its intentional http exemption — its trust anchor is the gpg-signed Release), requires a host, and rejects embedded credentials (which would leak into the on-disk config). 100% coverage on the validator incl. the second-URI-injection, bad-scheme, no-host, credential, and unparseable cases; http **and** https still accepted. Local cr clean.