### PR TITLE
test: rigor fixes — -short skip, run-tests.sh paths, osquery deny-list completeness, PTY sentinel

### DIFF
--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -23,6 +23,12 @@ import (
 // not installed. Reads do not escalate, so Direct is sufficient.
 func realManager(t *testing.T, b Backend) Manager {
 	t.Helper()
+	// These hit the real package manager. `go test -short` (the unit sweep and
+	// the per-package Unit Tests job) must stay hermetic, so skip there; the
+	// dedicated apt/dnf integration jobs run without -short and exercise them.
+	if testing.Short() {
+		t.Skip("-short: skipping real package-manager integration read")
+	}
 	if !slices.Contains(Detect(context.Background()), b) {
 		t.Skipf("%s not available on this host", b)
 	}

--- a/sys/osquery/osquery_container_test.go
+++ b/sys/osquery/osquery_container_test.go
@@ -123,6 +123,56 @@ func TestDenyList_RefusedBeforeExec_Container(t *testing.T) {
 	}
 }
 
+// mustDenyTables is the TEST-OWNED threat model: osquery tables that expose
+// credential material or secrets and MUST be refused by the table path. It is
+// listed here INDEPENDENTLY of the implementation's sensitiveTables map — that
+// is the whole point. The map-driven test above proves "every denied table is
+// refused"; it cannot prove "every table that SHOULD be denied is", because it
+// reads the same map the implementation does, so dropping a table from the
+// deny-list would silently drop it from the test too. This list is the fixed
+// expectation that catches such a regression. Each entry is justified:
+//   - shadow:        password hashes
+//   - process_envs:  a process environment can carry secrets / tokens
+//   - shell_history: pasted passwords / tokens land in command history
+//   - crontab:       scheduled commands can embed credentials
+//   - sudoers:       privilege policy; can name secret-bearing commands
+var mustDenyTables = []string{"shadow", "process_envs", "shell_history", "crontab", "sudoers"}
+
+// TestDenyList_ThreatModelComplete_Container is the INDEPENDENT companion to the
+// map-driven deny-list test: every threat-model-sensitive table that the real
+// osqueryi actually ships MUST be on the deny-list (isSensitiveTable) AND refused
+// before exec. Because the expectation comes from the threat model rather than
+// from sensitiveTables, this fails if the deny-list is regressed or
+// under-specified — the case the map-driven test is structurally blind to.
+func TestDenyList_ThreatModelComplete_Container(t *testing.T) {
+	q := realQuerier(t)
+	ctx := osqCtx(t)
+	tables, err := q.ListTables(ctx)
+	if err != nil {
+		t.Fatalf("ListTables: %v", err)
+	}
+
+	checked := 0
+	for _, want := range mustDenyTables {
+		if !containsTable(tables, want) {
+			// A given osqueryi build may not ship every table; only assert on
+			// the ones actually present so the intersection is real, not vacuous.
+			t.Logf("threat-model table %q absent from this osqueryi build; skipping", want)
+			continue
+		}
+		if !isSensitiveTable(want) {
+			t.Errorf("table %q is threat-model-sensitive but NOT on the deny-list (sensitiveTables) — deny-list regressed/under-specified", want)
+		}
+		if _, err := q.QueryTable(ctx, want); err == nil || !strings.Contains(err.Error(), "not permitted") {
+			t.Errorf("QueryTable(%q): want a 'not permitted' refusal before exec, got %v", want, err)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("matches-zero: no threat-model table was present in the real .tables listing — the completeness check is vacuous (osquery build/parse problem?)")
+	}
+}
+
 // TestRawSqlEscapeHatch_Container proves the documented asymmetry against the
 // real binary: the CA-signed RawSql path is NOT gated by the deny-list, so the
 // very same table the table path refuses (`shadow`) is queryable via RawSql. A

--- a/sys/terminal/terminal_container_test.go
+++ b/sys/terminal/terminal_container_test.go
@@ -42,8 +42,14 @@ func TestOpenRunsShellAsTargetUser_Container(t *testing.T) {
 	}
 	defer sess.Close()
 
-	// Ask the shell who it is, then exit so the PTY reaches EOF.
-	if _, err := sess.Write([]byte("id -un\nexit\n")); err != nil {
+	// Ask the shell who it is via a UNIQUE sentinel, then exit so the PTY reaches
+	// EOF. A bare `id -un` would false-pass: the login-shell prompt (PS1 = \u@\h)
+	// already prints the username, so `strings.Contains(out, u)` could match the
+	// prompt even if the shell ran as the wrong user. The "PM_USER:" prefix only
+	// appears in the command's OUTPUT (the echoed command text carries the
+	// literal "$(id -un)", not its value), so matching "PM_USER:<u>" proves the
+	// shell actually executed as u.
+	if _, err := sess.Write([]byte("printf 'PM_USER:%s\\n' \"$(id -un)\"\nexit\n")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -68,7 +74,7 @@ func TestOpenRunsShellAsTargetUser_Container(t *testing.T) {
 		t.Fatalf("timed out reading PTY output; got so far:\n%s", buf.String())
 	}
 
-	if !strings.Contains(buf.String(), u) {
-		t.Errorf("shell did not run as %q (its `id -un` is absent from PTY output):\n%s", u, buf.String())
+	if marker := "PM_USER:" + u; !strings.Contains(buf.String(), marker) {
+		t.Errorf("shell did not run as %q (sentinel %q absent from PTY output):\n%s", u, marker, buf.String())
 	}
 }

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -41,8 +41,28 @@ echo "==> Running integration tests..."
 # PM_TEST_LOCALE=C (or zh_CN.UTF-8, etc.). The locale is generated in the image.
 TEST_LOCALE="${PM_TEST_LOCALE:-ja_JP.UTF-8}"
 echo "    (locale: ${TEST_LOCALE})"
+
+# Integration-tagged packages that run in THIS systemd container — the set whose
+# //go:build integration tests need systemd as PID 1. Kept explicit (it is an
+# intentional subset of sys/, not every package), but each path is existence-
+# checked below so a module rename/move can never again silently drop a package
+# from the run (the paths read ./sdk/go/sys/... until the go/*→root move, and the
+# stale list passed `go test` vacuously). Paths are relative to /workspace.
+INTEGRATION_PKGS=(
+    sdk/sys/exec
+    sdk/sys/fs
+    sdk/sys/user
+    sdk/sys/service
+)
+for p in "${INTEGRATION_PKGS[@]}"; do
+    if [ ! -d "$p" ]; then
+        echo "ERROR: integration package path '$p' does not exist (stale after a rename/move?)" >&2
+        exit 1
+    fi
+done
+
 podman exec -w /workspace "$CONTAINER_NAME" \
     runuser -u power-manage -- env "LANG=${TEST_LOCALE}" "LC_ALL=${TEST_LOCALE}" \
         /usr/local/go/bin/go test \
         -v -tags=integration -count=1 -timeout=10m \
-        ./sdk/go/sys/exec/ ./sdk/go/sys/fs/ ./sdk/go/sys/user/ ./sdk/go/sys/service/
+        "${INTEGRATION_PKGS[@]/#/./}"


### PR DESCRIPTION
Closes #233. Four audit-driven test-rigor fixes, no workflow changes (the workflow/container-harness findings #2/#6/#7 land in a separate PR):

- **[med]** `pkg/integration_test.go` now skips its real package-manager reads under `testing.Short()` — the unit sweep & Unit Tests jobs run `go test -race -short` but realManager ignored it, so those *unit* jobs hit the real package manager. The dedicated apt/dnf integration jobs (no `-short`) still exercise them.
- **[med]** `test/run-tests.sh`: fix `./sdk/go/sys/...` → `./sdk/sys/...` (stale since the `go/*`→root module move — it matched nothing and passed `go test` vacuously) + a per-path existence guard that fails loudly on a future rename.
- **[high]** osquery: `TestDenyList_ThreatModelComplete_Container` with a **test-owned** threat-model list ∩ real `.tables`. The existing test iterates the implementation's own `sensitiveTables` map, so it is structurally blind to a table that *should* be denied but is missing/regressed; the independent list catches that.
- **[low]** terminal: replace `strings.Contains(out, u)` (false-passes on the login-shell prompt PS1=\u@\h) with a `PM_USER:<id -un>` sentinel + exact-marker assert.

Verified locally: `-short` skips the reads, full run still executes them (real dnf passes); container tests compile under `-tags=container`; gofmt/vet/staticcheck clean. Local cr clean.