### PR TITLE
test/ci: pkg mutation container lane + repo tool-acceptance readback + vacuous-skip guards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,10 +297,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: pkg/repair (debian/state-locked-apt)
+          - label: pkg (debian/state-locked-apt)
             distro: debian
             state: state-locked-apt
             path: ./sdk/pkg/
+            expect: apt-get fuser
           # LUKS Manager against real cryptsetup. No bad-state needed (each test
           # formats its own LUKS2 container on a /dev/shm file), so it runs on
           # the clean `base` stage. --shm-size gives /dev/shm headroom for the
@@ -309,6 +310,7 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/encryption/
+            expect: cryptsetup
           # nftables round-trip + iproute2 read path. Run on the clean `base`
           # stage; the tests load real kernel netfilter / interface state in the
           # container's own network namespace (CAP_NET_ADMIN, added below).
@@ -316,30 +318,36 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/firewall/
+            expect: nft
           - label: sys/netconfig (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/netconfig/
+            expect: ip
           # /proc + os-release + lsblk + ip parsers against the real container.
           - label: sys/inventory (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/inventory/
+            expect: lsblk ip
           # update-ca-certificates round-trip into the real system trust bundle.
           - label: sys/catrust (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/catrust/
+            expect: update-ca-certificates
           # Real PTY + setresuid privilege drop (creates an unprivileged user).
           - label: sys/terminal (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/terminal/
+            expect: useradd
           # Real `wall` broadcast.
           - label: sys/notify (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/notify/
+            expect: wall
           # Real `osqueryi --json` queries + the sensitive-table deny-list
           # against the actual binary (pinned osquery .deb in the with-osquery
           # stage).
@@ -347,12 +355,14 @@ jobs:
             distro: debian
             state: with-osquery
             path: ./sdk/sys/osquery/
+            expect: osqueryi
           # Real clamscan detection (custom .ndb marker) + freshclam error path
           # against the actual ClamAV binaries (with-clamav stage).
           - label: sys/antivirus (debian/with-clamav)
             distro: debian
             state: with-clamav
             path: ./sdk/sys/antivirus/
+            expect: clamscan
           # repo Manager apt backend: real `gpg --dearmor` + deb822 .sources
           # write/idempotency/remove (base + gnupg). The dnf/pacman/zypper repo
           # cells run in their distro jobs below; each test self-skips when its
@@ -361,6 +371,7 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/repo/
+            expect: apt-get gpg
           # desktop: real runuser privilege-drop + HomeUsers passwd enumeration +
           # per-user Flatpak-install probe (creates real accounts → needs root).
           # The graphical ActiveSessions path runs against real loginctl in the
@@ -369,12 +380,14 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/desktop/
+            expect: useradd runuser
           # smartctl --scan parse + validation + fatal-exit-status-bit path
           # (real passing-SMART-health needs hardware — residual).
           - label: sys/smart (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/smart/
+            expect: smartctl
           # reboot-required marker detection (Schedule/Cancel drive real shutdown
           # — residual).
           - label: sys/reboot (debian/base)
@@ -396,6 +409,16 @@ jobs:
       # --cap-add NET_ADMIN: the firewall/netconfig tests load real netfilter and
       # interface state in the container's own network namespace. It is harmless
       # for the other cells. --shm-size gives /dev/shm headroom for the LUKS cell.
+      - name: Assert expected tools present (no vacuous skip)
+        if: matrix.expect != ''
+        run: |
+          for tool in ${{ matrix.expect }}; do
+            if ! docker run --rm pm-sdk-container sh -c "command -v $tool >/dev/null 2>&1"; then
+              echo "::error::expected tool '$tool' absent from '${{ matrix.label }}' image — its container test would skip VACUOUSLY instead of running"
+              exit 1
+            fi
+          done
+
       - name: Run container tests
         run: |
           docker run --rm --shm-size=512m --cap-add NET_ADMIN pm-sdk-container \

--- a/pkg/mutation_container_test.go
+++ b/pkg/mutation_container_test.go
@@ -1,0 +1,170 @@
+//go:build container
+
+// Container-based real-execution tests for the package-manager MUTATION paths.
+// The fake-runner unit tests assert argv shape; these run REAL apt operations
+// inside a disposable Debian container — Install/Remove, Pin/Unpin, a local-file
+// install (InstallLocal), and a safe full UpgradeAll — and assert the POST-STATE
+// against the real dpkg database, so a wrong flag, a parse mismatch, or a tool-
+// behaviour drift is caught against the actual binary instead of assumed.
+//
+// Destructive by design (it installs and removes a real package); the container
+// is thrown away after the run. apt-only: the matrix runs this on the
+// debian/base stage. The dnf/pacman/zypper query paths are covered per-distro by
+// the read-side integration_test.go; their mutation cells would need their own
+// distro images.
+package pkg
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// mutTestPackage is a tiny, dependency-light package in the Debian archive —
+// fast to install/remove and innocuous.
+const mutTestPackage = "hello"
+
+func aptMutManager(t *testing.T) Manager {
+	t.Helper()
+	if _, err := osexec.LookPath("apt-get"); err != nil {
+		t.Skip("apt-get not on PATH; apt mutation tests not exercisable")
+	}
+	r, err := pmexec.NewRunner(pmexec.Direct) // the container runs the test as root
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(Apt, r)
+	if err != nil {
+		t.Fatalf("New(Apt): %v", err)
+	}
+	// Refresh metadata so Install/InstallLocal can resolve the package in a
+	// fresh container; a failure here means no network/mirror — skip rather than
+	// fail, so the lane is correct on an offline runner.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if _, err := m.Update(ctx); err != nil {
+		t.Skipf("apt-get update failed (no network/mirror?): %v", err)
+	}
+	return m
+}
+
+func mutCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// cleanupPkg registers a best-effort teardown that removes (and optionally first
+// unpins) the test package under a BOUNDED context, so a wedged apt can never
+// hang the cleanup indefinitely.
+func cleanupPkg(t *testing.T, m Manager, unpin bool) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if unpin {
+			_, _ = m.Unpin(ctx, mutTestPackage)
+		}
+		_, _ = m.Remove(ctx, RemoveOptions{}, mutTestPackage)
+	})
+}
+
+// TestApt_InstallRemove_Container installs then removes a real package, asserting
+// the post-state via the real dpkg database (IsInstalled), not just exit 0.
+func TestApt_InstallRemove_Container(t *testing.T) {
+	m := aptMutManager(t)
+	ctx := mutCtx(t)
+	cleanupPkg(t, m, false)
+
+	if _, err := m.Install(ctx, InstallOptions{}, mutTestPackage); err != nil {
+		t.Fatalf("Install(%s): %v", mutTestPackage, err)
+	}
+	if ok, err := m.IsInstalled(ctx, mutTestPackage); err != nil || !ok {
+		t.Fatalf("after Install, IsInstalled(%s) = (%v, %v), want (true, nil)", mutTestPackage, ok, err)
+	}
+
+	if _, err := m.Remove(ctx, RemoveOptions{}, mutTestPackage); err != nil {
+		t.Fatalf("Remove(%s): %v", mutTestPackage, err)
+	}
+	if ok, err := m.IsInstalled(ctx, mutTestPackage); err != nil || ok {
+		t.Fatalf("after Remove, IsInstalled(%s) = (%v, %v), want (false, nil)", mutTestPackage, ok, err)
+	}
+}
+
+// TestApt_PinUnpin_Container holds then releases a real package (apt-mark hold),
+// asserting IsPinned reads the real hold state in both directions.
+func TestApt_PinUnpin_Container(t *testing.T) {
+	m := aptMutManager(t)
+	ctx := mutCtx(t)
+	cleanupPkg(t, m, true)
+	if _, err := m.Install(ctx, InstallOptions{}, mutTestPackage); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if _, err := m.Pin(ctx, mutTestPackage); err != nil {
+		t.Fatalf("Pin: %v", err)
+	}
+	if ok, err := m.IsPinned(ctx, mutTestPackage); err != nil || !ok {
+		t.Fatalf("after Pin, IsPinned = (%v, %v), want (true, nil)", ok, err)
+	}
+	if _, err := m.Unpin(ctx, mutTestPackage); err != nil {
+		t.Fatalf("Unpin: %v", err)
+	}
+	if ok, err := m.IsPinned(ctx, mutTestPackage); err != nil || ok {
+		t.Fatalf("after Unpin, IsPinned = (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
+// TestApt_InstallLocal_Container downloads a real .deb and installs it FROM THE
+// LOCAL FILE — the path the agent's deb executor delegates to — asserting the
+// post-state.
+func TestApt_InstallLocal_Container(t *testing.T) {
+	m := aptMutManager(t)
+	ctx := mutCtx(t)
+	cleanupPkg(t, m, false)
+
+	// apt-get download drops to the unprivileged _apt user, so the target dir
+	// must be writable by it — t.TempDir() is 0700/root-owned. Make it traversable
+	// + writable so the .deb lands.
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatalf("chmod tempdir: %v", err)
+	}
+	dl := osexec.CommandContext(ctx, "apt-get", "download", mutTestPackage)
+	dl.Dir = dir
+	if out, err := dl.CombinedOutput(); err != nil {
+		t.Skipf("apt-get download %s failed (no network/mirror?): %v\n%s", mutTestPackage, err, out)
+	}
+	debs, err := filepath.Glob(filepath.Join(dir, mutTestPackage+"_*.deb"))
+	if err != nil {
+		t.Fatalf("glob for downloaded .deb: %v", err)
+	}
+	if len(debs) == 0 {
+		t.Fatalf("apt-get download produced no .deb in %s", dir)
+	}
+
+	if _, err := m.InstallLocal(ctx, debs[0], InstallLocalOptions{}); err != nil {
+		t.Fatalf("InstallLocal(%s): %v", debs[0], err)
+	}
+	if ok, err := m.IsInstalled(ctx, mutTestPackage); err != nil || !ok {
+		t.Fatalf("after InstallLocal, IsInstalled(%s) = (%v, %v), want (true, nil)", mutTestPackage, ok, err)
+	}
+}
+
+// TestApt_UpgradeAll_Container runs a full dist-upgrade on the freshly-updated
+// container: it must complete without error. The point is that the real
+// dist-upgrade argv/flow succeeds (a flag or parse regression would fail), not a
+// specific upgrade delta — a minimal base image may have nothing to upgrade.
+func TestApt_UpgradeAll_Container(t *testing.T) {
+	m := aptMutManager(t)
+	ctx := mutCtx(t)
+	if _, err := m.UpgradeAll(ctx, UpgradeOptions{}); err != nil {
+		t.Fatalf("UpgradeAll: %v", err)
+	}
+}

--- a/sys/repo/repo_container_test.go
+++ b/sys/repo/repo_container_test.go
@@ -119,6 +119,16 @@ func TestApt_ApplyRemove_Container(t *testing.T) {
 		t.Error("keyring is still ASCII-armored — real `gpg --dearmor` did not run")
 	}
 
+	// Independent tool-acceptance probe (mirrors zypperRepoListed): apt itself
+	// must PARSE the written .sources. `apt-get --print-uris update` parses every
+	// configured source and prints the URIs it WOULD fetch WITHOUT fetching, so
+	// the repo URI appearing proves the deb822 file is well-formed and accepted —
+	// not merely that the bytes we wrote back match. It does not depend on the
+	// unreachable example.com metadata.
+	if !aptParsesRepo(t, "https://example.com/pm-test-debian") {
+		t.Error("apt did not parse the written .sources (`apt-get --print-uris update` omits the repo URI)")
+	}
+
 	// Idempotency: a second identical Apply changes nothing.
 	o2, err := m.Apply(ctx, repo)
 	if err != nil {
@@ -174,6 +184,13 @@ func TestDnf_ApplyRemove_Container(t *testing.T) {
 			t.Errorf(".repo missing %q:\n%s", want, body)
 		}
 	}
+	// Independent tool-acceptance probe: dnf must PARSE the written .repo.
+	// `dnf repolist --all -C` lists configured repos cacheonly (no network refresh
+	// against the unreachable baseurl), so the repo id appearing proves dnf
+	// accepted the file, not merely that the bytes match.
+	if !dnfListsRepo(name) {
+		t.Errorf("dnf did not list %q after Apply (`dnf repolist --all -C` omits it) — config not accepted", name)
+	}
 	if o2, err := m.Apply(ctx, repo); err != nil || o2.Changed {
 		t.Errorf("idempotent re-Apply: changed=%v err=%v", o2.Changed, err)
 	}
@@ -209,6 +226,12 @@ func TestPacman_ApplyRemove_Container(t *testing.T) {
 		if !strings.Contains(conf, want) {
 			t.Errorf("pacman.conf missing %q", want)
 		}
+	}
+	// Independent tool-acceptance probe: pacman's own config parser must accept
+	// the appended [section]. `pacman-conf --repo <name>` dumps the section and
+	// exits non-zero on a malformed/absent one — pure config parse, no network.
+	if !pacmanParsesRepo(name) {
+		t.Errorf("`pacman-conf --repo %s` failed after Apply — pacman did not accept the appended section", name)
 	}
 	if o2, err := m.Apply(ctx, repo); err != nil || o2.Changed {
 		t.Errorf("idempotent re-Apply: changed=%v err=%v", o2.Changed, err)
@@ -274,4 +297,29 @@ func TestZypper_ApplyRemove_Container(t *testing.T) {
 func zypperRepoListed(t *testing.T, name string) bool {
 	t.Helper()
 	return osexec.Command("zypper", "--non-interactive", "lr", name).Run() == nil
+}
+
+// aptParsesRepo reports whether `apt-get --print-uris update` parses the written
+// .sources and would fetch from uri. --print-uris prints the URIs apt WOULD
+// fetch without fetching, so this proves apt accepted the deb822 file with no
+// dependency on the unreachable example.com metadata.
+func aptParsesRepo(t *testing.T, uri string) bool {
+	t.Helper()
+	out, _ := osexec.Command("apt-get", "--print-uris", "update").CombinedOutput()
+	return strings.Contains(string(out), uri)
+}
+
+// dnfListsRepo reports whether `dnf repolist --all -C` lists the named repo.
+// `-C` (cacheonly) reads configuration without a network refresh, so a repo id
+// appearing proves dnf parsed and accepted the .repo file.
+func dnfListsRepo(name string) bool {
+	out, _ := osexec.Command("dnf", "repolist", "--all", "-C").CombinedOutput()
+	return strings.Contains(string(out), name)
+}
+
+// pacmanParsesRepo reports whether `pacman-conf --repo <name>` exits 0. pacman's
+// own config parser dumps the named [section] and fails on a malformed or absent
+// one — a pure config parse with no network.
+func pacmanParsesRepo(name string) bool {
+	return osexec.Command("pacman-conf", "--repo", name).Run() == nil
 }


### PR DESCRIPTION
Closes #235. Container/CI rigor (audit #7, #6, #2), **each validated locally with docker** before pushing:

- **[med] #7** pkg mutations were fake-only → `pkg/mutation_container_test.go`: real apt Install/Remove, Pin/Unpin, **InstallLocal** (downloads a real `hello.deb`, installs from the file), and a safe UpgradeAll in a disposable Debian container, asserting the post-state via the real dpkg DB. Runs on the existing pkg row (the `state-locked-apt` stage only `touch`es the lock files — no held flock — so apt still works; verified locally). Row relabeled `pkg (debian/state-locked-apt)`. All 4 tests pass in a real Debian container locally.
- **[med] #6** apt/dnf/pacman repo tests only string-matched the written file (zypper already did a real `zypper lr` readback). Add a tool-acceptance probe per backend — apt `apt-get --print-uris update`, dnf `dnf repolist --all -C`, pacman `pacman-conf --repo` — proving the package manager PARSES the config with no dependency on the unreachable example.com metadata. apt + dnf validated end-to-end in debian/fedora containers locally.
- **[med] #2** only the NM lane failed (vs skipped) on a missing tool. Add a per-matrix-row `expect:` tool list + an assertion step that runs `command -v` in the built image, so a misbuilt image fails the lane instead of skipping VACUOUSLY. Assertion targets cross-checked against the Dockerfile stages; YAML + shell logic validated locally.

Local cr: 4 minor (unchecked Glob error + 3 best-effort cleanups without a bounded ctx) — all applied (cleanups DRY'd into a 30s-bounded helper).