### PR TITLE
SDK gaps report: flatpak remote (Gap 6) + per-user flatpak (Gap 7) + apt LocalPackageInfo fix (BUG 1)

### DIFF
--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -440,26 +440,38 @@ func (a *apt) LocalPackageInfo(ctx context.Context, path string) (*LocalPackage,
 	if err := ValidateLocalPackagePath(path); err != nil {
 		return nil, err
 	}
+	// dpkg-deb -f with MULTIPLE fields prints a labeled "Field: value" stanza (a
+	// SINGLE field would print the bare value). Parse by field name so the
+	// "Package:" label never leaks into the package name (which would then fail
+	// ValidatePackageName).
 	out, err := readOut(ctx, a.r, "dpkg-deb", "-f", path, "Package", "Version", "Architecture")
 	if err != nil {
 		return nil, err
 	}
-	lines := splitPositionalFields(out)
-	if len(lines) == 0 {
+	fields := parseControlFields(out)
+	name := fields["Package"]
+	if name == "" {
 		return nil, fmt.Errorf("pkg: dpkg-deb reported no Package field for %q", path)
 	}
-	name := lines[0]
 	if err := ValidatePackageName(name); err != nil {
 		return nil, fmt.Errorf("pkg: local .deb reports an unsafe package name: %w", err)
 	}
-	info := &LocalPackage{Name: name}
-	if len(lines) > 1 {
-		info.Version = lines[1]
+	return &LocalPackage{Name: name, Version: fields["Version"], Arch: fields["Architecture"]}, nil
+}
+
+// parseControlFields parses dpkg-deb -f's labeled "Field: value" stanza into a
+// field map. The value is taken after the FIRST ":" so an epoch'd version
+// ("1:2.0") survives intact, and the field LABEL never becomes part of a value.
+func parseControlFields(out string) map[string]string {
+	fields := make(map[string]string)
+	for _, line := range strings.Split(out, "\n") {
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		fields[strings.TrimSpace(key)] = strings.TrimSpace(val)
 	}
-	if len(lines) > 2 {
-		info.Arch = lines[2]
-	}
-	return info, nil
+	return fields
 }
 
 // IsInstalled reports whether a package is installed (dpkg -s exits 0).

--- a/pkg/exec.go
+++ b/pkg/exec.go
@@ -130,9 +130,9 @@ func rpmLocalPackageInfo(ctx context.Context, r pmexec.Runner, path string) (*Lo
 // splitPositionalFields splits VALUE-ONLY one-field-per-line command output (rpm
 // -qp --qf with "\n" separators) into its POSITIONAL fields, trimming each line
 // but PRESERVING an empty leading/middle field so the name/version/arch positions
-// never shift. NOTE: it is NOT for dpkg-deb -f with multiple fields, which emits a
-// labeled "Field: value" stanza (use parseControlFields). A
-// crafted file that emits an empty NAME must surface as an empty field[0]
+// never shift. NOTE: it is NOT for dpkg-deb -f with multiple fields, which emits
+// a labeled "Field: value" stanza (use parseControlFields). A crafted file that
+// emits an empty NAME must surface as an empty field[0]
 // (rejected by the name validator) — NOT silently promote the version into the
 // name slot. Only the trailing blank line the tool appends is dropped.
 func splitPositionalFields(data string) []string {

--- a/pkg/exec.go
+++ b/pkg/exec.go
@@ -127,9 +127,11 @@ func rpmLocalPackageInfo(ctx context.Context, r pmexec.Runner, path string) (*Lo
 	return info, nil
 }
 
-// splitPositionalFields splits one-field-per-line command output (dpkg-deb -f /
-// rpm -qp --qf) into its POSITIONAL fields, trimming each line but PRESERVING an
-// empty leading/middle field so the name/version/arch positions never shift. A
+// splitPositionalFields splits VALUE-ONLY one-field-per-line command output (rpm
+// -qp --qf with "\n" separators) into its POSITIONAL fields, trimming each line
+// but PRESERVING an empty leading/middle field so the name/version/arch positions
+// never shift. NOTE: it is NOT for dpkg-deb -f with multiple fields, which emits a
+// labeled "Field: value" stanza (use parseControlFields). A
 // crafted file that emits an empty NAME must surface as an empty field[0]
 // (rejected by the name validator) — NOT silently promote the version into the
 // name slot. Only the trailing blank line the tool appends is dropped.

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -67,10 +67,22 @@ func (f *flatpak) Install(ctx context.Context, opts InstallOptions, packages ...
 	if err := ValidatePackageVersion(opts.Version); err != nil {
 		return pmexec.Result{}, err
 	}
+	if opts.Remote != "" {
+		if err := ValidateRemoteName(opts.Remote); err != nil {
+			return pmexec.Result{}, err
+		}
+	}
 	if len(packages) == 0 {
 		return pmexec.Result{}, nil
 	}
-	args := append([]string{"install", "-y", "--noninteractive", f.scope()}, packages...)
+	// An explicit remote is the operator's disambiguation of which remote provides
+	// the app; it precedes the app refs (`flatpak install <scope> <remote> <refs>`).
+	// ValidateRemoteName has rejected a flag-shaped value, so it is a safe operand.
+	args := []string{"install", "-y", "--noninteractive", f.scope()}
+	if opts.Remote != "" {
+		args = append(args, opts.Remote)
+	}
+	args = append(args, packages...)
 	return f.write(ctx, args...)
 }
 

--- a/pkg/flatpak_test.go
+++ b/pkg/flatpak_test.go
@@ -53,6 +53,39 @@ func TestFlatpak_Version(t *testing.T) {
 	})
 }
 
+func TestFlatpak_InstallFromRemote(t *testing.T) {
+	ctx := context.Background()
+	t.Run("explicit remote operand precedes the appid", func(t *testing.T) {
+		m, f := flatpakM(t)
+		ok(f, "")
+		if _, err := m.Install(ctx, InstallOptions{Remote: "flathub"}, "org.vim.Vim"); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "flatpak install -y --noninteractive --system flathub org.vim.Vim" {
+			t.Errorf("argv=%q, want the remote operand before the appid", a)
+		}
+	})
+	t.Run("flag-shaped remote is rejected before running", func(t *testing.T) {
+		m, f := flatpakM(t)
+		if _, err := m.Install(ctx, InstallOptions{Remote: "-evil"}, "org.vim.Vim"); err == nil {
+			t.Fatal("want a validation error for a flag-shaped remote")
+		}
+		if len(f.Calls()) != 0 {
+			t.Error("a rejected remote must run nothing")
+		}
+	})
+	t.Run("empty remote keeps the existing no-remote behavior", func(t *testing.T) {
+		m, f := flatpakM(t)
+		ok(f, "")
+		if _, err := m.Install(ctx, InstallOptions{}, "org.vim.Vim"); err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "flatpak install -y --noninteractive --system org.vim.Vim" {
+			t.Errorf("argv=%q, want no remote operand", a)
+		}
+	})
+}
+
 func TestFlatpak_Install(t *testing.T) {
 	ctx := context.Background()
 	t.Run("system scope, escalated", func(t *testing.T) {

--- a/pkg/localpackage_container_test.go
+++ b/pkg/localpackage_container_test.go
@@ -1,0 +1,61 @@
+//go:build container
+
+// Real-execution coverage for LocalPackageInfo. The fake-runner unit tests assert
+// the dpkg-deb/rpm argv and parse scripted output; this builds a REAL .deb with
+// dpkg-deb and reads it back through the actual binary — which is what caught the
+// apt parse bug the fake-runner test could not (dpkg-deb -f with multiple fields
+// emits a labeled "Package: <name>" stanza, not bare values, so the label leaked
+// into Name). apt-only: runs on the debian/base pkg cell.
+package pkg
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+func TestLocalPackageInfo_AptRealDeb_Container(t *testing.T) {
+	if _, err := osexec.LookPath("dpkg-deb"); err != nil {
+		t.Skip("dpkg-deb not on PATH")
+	}
+	dir := t.TempDir()
+	pkgRoot := filepath.Join(dir, "pm-testpkg")
+	if err := os.MkdirAll(filepath.Join(pkgRoot, "DEBIAN"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	control := "Package: pm-testpkg\n" +
+		"Version: 1.2.3\n" +
+		"Architecture: all\n" +
+		"Maintainer: PM Test <test@power-manage.invalid>\n" +
+		"Description: PM LocalPackageInfo real-execution fixture\n"
+	if err := os.WriteFile(filepath.Join(pkgRoot, "DEBIAN", "control"), []byte(control), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	debPath := filepath.Join(dir, "pm-testpkg.deb")
+	if out, err := osexec.Command("dpkg-deb", "--build", pkgRoot, debPath).CombinedOutput(); err != nil {
+		t.Fatalf("dpkg-deb --build: %v\n%s", err, out)
+	}
+
+	r, err := pmexec.NewRunner(pmexec.Direct)
+	if err != nil {
+		t.Fatalf("NewRunner(Direct): %v", err)
+	}
+	m, err := New(Apt, r)
+	if err != nil {
+		t.Fatalf("New(Apt): %v", err)
+	}
+	info, err := m.LocalPackageInfo(context.Background(), debPath)
+	if err != nil {
+		t.Fatalf("LocalPackageInfo on a real .deb: %v", err)
+	}
+	if info.Name != "pm-testpkg" {
+		t.Errorf("Name = %q, want pm-testpkg (the VALUE, not the 'Package:' label)", info.Name)
+	}
+	if info.Version != "1.2.3" || info.Arch != "all" {
+		t.Errorf("info = %+v, want version=1.2.3 arch=all", info)
+	}
+}

--- a/pkg/localpackage_test.go
+++ b/pkg/localpackage_test.go
@@ -33,8 +33,10 @@ import (
 // name, version, and architecture, via an UNPRIVILEGED dpkg-deb read.
 func TestLocalPackageInfo_AptHappyPath(t *testing.T) {
 	m, f := aptM(t)
-	// dpkg-deb -f emits each requested field on its own line, in order.
-	ok(f, "nginx\n1.24.0-1ubuntu1\namd64\n")
+	// dpkg-deb -f with MULTIPLE fields emits a labeled "Field: value" stanza (NOT
+	// bare values — that is only the single-field shape). The parse must read the
+	// value, not the "Package:" label.
+	ok(f, "Package: nginx\nVersion: 1.24.0-1ubuntu1\nArchitecture: amd64\n")
 	info, err := m.LocalPackageInfo(context.Background(), "/tmp/nginx.deb")
 	if err != nil {
 		t.Fatalf("LocalPackageInfo err = %v", err)

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -62,6 +62,12 @@ type InstallOptions struct {
 	Version string
 	// AllowDowngrade permits installing a lower version than the one installed.
 	AllowDowngrade bool
+	// Remote names the flatpak remote to install FROM (e.g. "flathub"). It is
+	// honored only by the flatpak backend — where it disambiguates which remote
+	// provides the app instead of relying on flatpak's auto-resolution — and is
+	// ignored by the native package managers. Empty selects flatpak's default
+	// resolution.
+	Remote string
 }
 
 // InstallLocalOptions configures an InstallLocal call.

--- a/sys/desktop/peruser_flatpak_test.go
+++ b/sys/desktop/peruser_flatpak_test.go
@@ -1,0 +1,49 @@
+package desktop_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/pkg"
+	"github.com/manchtools/power-manage-sdk/sys/desktop"
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// TestPerUserFlatpak_Composition pins the agent's per-user flatpak pattern end to
+// end: a flatpak Manager built on a desktop.RunAsRunner runs its --user
+// transaction AS the target desktop user (Gap 7), honoring an explicit remote
+// (Gap 6) — with NO flatpak-backend changes, composed purely through the Runner.
+func TestPerUserFlatpak_Composition(t *testing.T) {
+	base := exectest.New(pmexec.Direct)
+	base.Push(pmexec.Result{}, nil)
+	s := desktop.Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+
+	ru, err := desktop.RunAsRunner(base, s)
+	if err != nil {
+		t.Fatalf("RunAsRunner: %v", err)
+	}
+	fp, err := pkg.New(pkg.Flatpak, ru, pkg.WithUserScope())
+	if err != nil {
+		t.Fatalf("pkg.New(Flatpak): %v", err)
+	}
+	if _, err := fp.Install(context.Background(), pkg.InstallOptions{Remote: "flathub"}, "org.x.App"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	c := base.Calls()[0]
+	got := strings.Join(append([]string{c.Name}, c.Args...), " ")
+	if !strings.HasPrefix(got, "/usr/sbin/runuser -u alice -- /usr/bin/env ") {
+		t.Errorf("install did not run as alice via runuser: %q", got)
+	}
+	if !strings.Contains(got, "HOME=/home/alice") || !strings.Contains(got, "XDG_RUNTIME_DIR=/run/user/1000") {
+		t.Errorf("missing alice's session env: %q", got)
+	}
+	if !strings.HasSuffix(got, "flatpak install -y --noninteractive --user flathub org.x.App") {
+		t.Errorf("not the expected per-user flatpak install (remote + --user): %q", got)
+	}
+	if c.Escalate {
+		t.Error("per-user flatpak must not escalate (runuser already dropped privilege)")
+	}
+}

--- a/sys/desktop/runas_runner.go
+++ b/sys/desktop/runas_runner.go
@@ -1,0 +1,90 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+)
+
+// RunAsRunner wraps a base [exec.Runner] so every command it runs executes AS the
+// session's user via runuser, with that user's desktop session environment (HOME,
+// USER, XDG_RUNTIME_DIR, the session bus address) and the curated per-user PATH.
+//
+// It lets a capability built on the SDK Runner operate on behalf of a specific
+// logged-in user without that capability knowing anything about runuser — most
+// usefully a per-user Flatpak Manager:
+//
+//	r, _ := exec.NewRunner(exec.Direct) // the agent runs as root
+//	ru, _ := desktop.RunAsRunner(r, session)
+//	fp, _ := pkg.New(pkg.Flatpak, ru, pkg.WithUserScope())
+//	fp.Install(ctx, pkg.InstallOptions{Remote: "flathub"}, "org.x.App") // installs for `session`
+//
+// The base Runner MUST run as root: runuser performs the privilege DROP to the
+// target user, so the wrapped command is never escalated again. The caller's
+// command env is screened by the same hijack blocklist as RunAsCommand.
+func RunAsRunner(base pmexec.Runner, s Session) (pmexec.Runner, error) {
+	if base == nil {
+		return nil, fmt.Errorf("desktop.RunAsRunner: %w", pmexec.ErrRunnerRequired)
+	}
+	if s.Username == "" {
+		return nil, fmt.Errorf("desktop.RunAsRunner: session has empty Username")
+	}
+	return &runAsRunner{base: base, s: s}, nil
+}
+
+type runAsRunner struct {
+	base pmexec.Runner
+	s    Session
+}
+
+func (ra *runAsRunner) Backend() pmexec.PrivilegeBackend { return ra.base.Backend() }
+
+func (ra *runAsRunner) Run(ctx context.Context, c pmexec.Command) (pmexec.Result, error) {
+	wrapped, err := ra.wrap(c)
+	if err != nil {
+		return pmexec.Result{}, err
+	}
+	return ra.base.Run(ctx, wrapped)
+}
+
+func (ra *runAsRunner) Stream(ctx context.Context, c pmexec.Command, onLine pmexec.OutputCallback) (pmexec.Result, error) {
+	wrapped, err := ra.wrap(c)
+	if err != nil {
+		return pmexec.Result{}, err
+	}
+	return ra.base.Stream(ctx, wrapped, onLine)
+}
+
+// wrap rewrites c into `runuser -u <user> -- env <session-env> PATH=<curated>
+// <name> <args...>`, running it as the session user with that user's desktop
+// environment. PATH is forced last (a caller PATH is dropped, like RunAsCommand);
+// the rest of the caller's env is screened through the hijack blocklist because
+// it is spliced into the inner env wrapper, which the base Runner does not screen.
+func (ra *runAsRunner) wrap(c pmexec.Command) (pmexec.Command, error) {
+	if c.Name == "" {
+		return pmexec.Command{}, fmt.Errorf("desktop.RunAsRunner: command name is required")
+	}
+	if err := validateExtraEnv(c.Env); err != nil {
+		return pmexec.Command{}, err
+	}
+	env := EnvFor(ra.s)
+	for _, e := range c.Env {
+		if key, _, ok := strings.Cut(e, "="); ok && key == "PATH" {
+			continue // PATH is always forced to the curated UserPath below
+		}
+		env = append(env, e)
+	}
+	env = append(env, "PATH="+UserPath(ra.s))
+
+	args := append([]string{"-u", ra.s.Username, "--", envPath}, env...)
+	args = append(args, c.Name)
+	args = append(args, c.Args...)
+	return pmexec.Command{
+		Name:     runuserPath,
+		Args:     args,
+		Stdin:    c.Stdin,
+		Escalate: false, // runuser from root IS the privilege drop
+	}, nil
+}

--- a/sys/desktop/runas_runner_test.go
+++ b/sys/desktop/runas_runner_test.go
@@ -1,0 +1,63 @@
+package desktop
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+func TestRunAsRunner_WrapsCommandAsUser(t *testing.T) {
+	base := exectest.New(pmexec.Direct)
+	base.Push(pmexec.Result{}, nil)
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+	ra, err := RunAsRunner(base, s)
+	if err != nil {
+		t.Fatalf("RunAsRunner: %v", err)
+	}
+	if _, err := ra.Run(context.Background(), pmexec.Command{Name: "flatpak", Args: []string{"install", "--user", "org.x.App"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	c := base.Calls()[0]
+	got := strings.Join(append([]string{c.Name}, c.Args...), " ")
+	// The base Runner must receive a runuser-wrapped command that drops to alice,
+	// applies her session env via `env`, forces the curated PATH last, then runs
+	// the original command.
+	want := runuserPath + " -u alice -- " + envPath +
+		" HOME=/home/alice USER=alice LOGNAME=alice XDG_RUNTIME_DIR=/run/user/1000" +
+		" DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus" +
+		" PATH=" + UserPath(s) + " flatpak install --user org.x.App"
+	if got != want {
+		t.Errorf("wrapped command:\n got=%q\nwant=%q", got, want)
+	}
+	if c.Escalate {
+		t.Error("runuser-from-root is a privilege DROP; the wrapped command must not also escalate")
+	}
+}
+
+func TestRunAsRunner_Rejects(t *testing.T) {
+	if _, err := RunAsRunner(nil, Session{Username: "alice"}); err == nil {
+		t.Error("nil base Runner must be rejected")
+	}
+	if _, err := RunAsRunner(exectest.New(pmexec.Direct), Session{}); err == nil {
+		t.Error("a session with no Username must be rejected (would silently run as the agent's UID)")
+	}
+}
+
+// TestRunAsRunner_ScreensHijackEnv: a caller command carrying an LD_* hijack in
+// its Env must be refused before it reaches the user-scoped command (the inner
+// env bypasses the base Runner's own screening).
+func TestRunAsRunner_ScreensHijackEnv(t *testing.T) {
+	base := exectest.New(pmexec.Direct)
+	s := Session{Username: "alice", UID: 1000, Home: "/home/alice", RuntimeDir: "/run/user/1000"}
+	ra, _ := RunAsRunner(base, s)
+	_, err := ra.Run(context.Background(), pmexec.Command{Name: "flatpak", Args: []string{"list"}, Env: []string{"LD_PRELOAD=/tmp/evil.so"}})
+	if err == nil {
+		t.Fatal("LD_PRELOAD in the command env must be rejected")
+	}
+	if len(base.Calls()) != 0 {
+		t.Error("a rejected hijack env must run nothing")
+	}
+}


### PR DESCRIPTION
Addresses the open SDK-GAPS-REPORT findings (gaps 1–5 were already covered).

## Gap 6 — flatpak install from an explicit remote
`InstallOptions.Remote string` (flatpak-only; ignored by native backends);
`Install` validates it (`ValidateRemoteName`) and emits
`flatpak install <scope> <remote> <refs>`.

## Gap 7 — per-user flatpak as a specific desktop user
New `desktop.RunAsRunner(base, session)` — an `exec.Runner` decorator that runs
every command AS the session's user via `runuser`, with that user's session env
(HOME/USER/XDG_RUNTIME_DIR/DBUS) and curated PATH. A per-user flatpak Manager is
then pure composition, with ZERO flatpak-backend changes:

    ru, _ := desktop.RunAsRunner(r, session)
    fp, _ := pkg.New(pkg.Flatpak, ru, pkg.WithUserScope())
    fp.Install(ctx, pkg.InstallOptions{Remote: "flathub"}, "org.x.App")

The base Runner must run as root (runuser is the privilege drop; the wrapped
command never escalates again); the caller's command env is screened by the same
hijack blocklist as RunAsCommand. A composition test pins the agent's pattern.

## BUG 1 (high) — apt LocalPackageInfo returned the field LABEL
Fixed: `LocalPackageInfo` on apt returned `Name == "Package: <name>"` because
`dpkg-deb -f` with multiple fields prints a labeled stanza, not bare values. Now
parses by field name. The unit test had fed value-only scripted output (the wrong
shape), so it never caught it — corrected it to the real labeled output AND added
a real-execution container test that builds a real .deb (verified in a debian
container).

## BUG 2 (to confirm) — zypper Update 10m timeout
Audited: every zypper command in the Update/UpgradeAll/HasUpdates path already
carries `--non-interactive` (no interactive-prompt hang), and nothing in that path
changed in the gaps release. This matches the report's "CI network-refresh flake"
hypothesis rather than an SDK regression — no code change made; re-run to confirm.

All TDD'd (red-checked); whole module + container tests green.
