### PR TITLE
Explicit error contracts (fs/zypper/user/firewall) + errcheck CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   static-checks:
-    name: Static Checks (gofmt, vet, staticcheck, govulncheck)
+    name: Static Checks (gofmt, vet, staticcheck, errcheck, govulncheck)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -38,6 +38,19 @@ jobs:
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...
+
+      # errcheck catches a returned error dropped on the floor — a bare
+      # statement call (foo(ctx)) that discards an error, which the compiler
+      # permits (only unused *variables* are an error, not unused returns).
+      # No exclude list: every deliberately-ignored error is written `_ = foo()`
+      # at its call site (errcheck honours that without -blank), so the gate
+      # stays honest — it can't be told "read-side Close only" by signature, so
+      # a future bare WRITE-path Close is caught too. Production code only
+      # (-ignoretests); test-setup hygiene is tracked separately.
+      - name: errcheck
+        run: |
+          go install github.com/kisielk/errcheck@latest
+          errcheck -ignoretests ./...
 
       - name: govulncheck
         run: |

--- a/client.go
+++ b/client.go
@@ -917,8 +917,8 @@ func (c *Client) Close() error {
 	c.pendingMu.Unlock()
 
 	// Close both request and response sides of the stream
-	c.stream.CloseRequest()
-	c.stream.CloseResponse()
+	_ = c.stream.CloseRequest()
+	_ = c.stream.CloseResponse()
 	c.stream = nil
 	return nil
 }
@@ -955,7 +955,7 @@ func (c *Client) Run(ctx context.Context, hostname, agentVersion string, heartbe
 	if err := c.Connect(ctx); err != nil {
 		return err
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	if err := c.SendHello(ctx, hostname, agentVersion); err != nil {
 		return fmt.Errorf("send hello: %w", err)

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -45,10 +45,14 @@ err = m.RemoveRule(ctx, "allow-ssh")
 rules, err := m.List(ctx) // only rules in this manager's namespace
 ```
 
-<!-- docref: begin src=sys/firewall/nftables.go#nftables.List:015a86b3 -->
+<!-- docref: begin src=sys/firewall/nftables.go#nftables.List:6b96ce82 -->
 `List` decodes each rule's full match — protocol, port, **and** source/destination
 address — back out of the live nftables ruleset, so what you read reflects
-exactly what was applied.
+exactly what was applied. A namespace that was never provisioned (its table does
+not exist yet) is reported as an explicit absence: `List` returns a wrapped
+`fs.ErrNotExist`, never an empty slice, so you can't mistake "never set up" for
+"set up, currently empty". Branch on it with `errors.Is(err, fs.ErrNotExist)`
+when you want to treat a missing namespace as zero rules.
 <!-- docref: end -->
 
 <!-- docref: begin src=sys/firewall/firewall.go#Rule:ca82cb6a -->

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -453,7 +453,11 @@ func (z *zypper) HasUpdates(ctx context.Context, securityOnly bool) (bool, error
 		return true, nil
 	}
 	if res.ExitCode != 0 {
-		return false, nil // inconclusive — treat as no updates, not an error
+		// A real-error exit (6 = no repositories, 4 = ZYPP problem / lock held /
+		// network failure) must surface, never silently read as "no updates" — that
+		// would tell a patch/compliance caller it is up to date when the check broke.
+		// Matches dnf.HasUpdates' default branch.
+		return false, asCommandError("zypper", res)
 	}
 	scanner := bufio.NewScanner(strings.NewReader(res.Stdout))
 	for scanner.Scan() {

--- a/pkg/zypper_test.go
+++ b/pkg/zypper_test.go
@@ -533,11 +533,18 @@ func TestZypper_HasUpdates(t *testing.T) {
 			t.Fatalf("got=%v err=%v", got, err)
 		}
 	})
-	t.Run("other non-zero is inconclusive (false, no error)", func(t *testing.T) {
+	t.Run("a real-error exit fails closed, not silent 'no updates'", func(t *testing.T) {
 		m, f := zypperM(t)
-		f.Push(pmexec.Result{ExitCode: 6}, nil)
-		if got, err := m.HasUpdates(ctx, false); err != nil || got {
-			t.Fatalf("got=%v err=%v", got, err)
+		f.Push(pmexec.Result{ExitCode: 6}, nil) // 6 = no repositories: a real failure
+		got, err := m.HasUpdates(ctx, false)
+		// A failed update check must surface as an error — reporting "no updates"
+		// would tell a patch/compliance caller it is up to date when the check broke.
+		// Matches dnf.HasUpdates, which returns a CommandError on its default branch.
+		if err == nil {
+			t.Fatal("a failed check must error, not report 'no updates' (compliance fail-open)")
+		}
+		if got {
+			t.Errorf("got=%v, want false on a failed check", got)
 		}
 	})
 	t.Run("security flag added", func(t *testing.T) {

--- a/sys/encryption/luks.go
+++ b/sys/encryption/luks.go
@@ -265,17 +265,17 @@ func writeKeyFile(key exec.Secret) (string, error) {
 		return "", fmt.Errorf("create key file: %w", err)
 	}
 	if err := f.Chmod(0o600); err != nil {
-		f.Close()
-		removeFile(f.Name())
+		_ = f.Close()
+		_ = removeFile(f.Name())
 		return "", fmt.Errorf("set key file permissions: %w", err)
 	}
 	if _, err := f.WriteString(key.Reveal()); err != nil {
-		f.Close()
-		removeFile(f.Name())
+		_ = f.Close()
+		_ = removeFile(f.Name())
 		return "", fmt.Errorf("write key file: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		removeFile(f.Name())
+		_ = removeFile(f.Name())
 		return "", fmt.Errorf("close key file: %w", err)
 	}
 	return f.Name(), nil

--- a/sys/firewall/doc.go
+++ b/sys/firewall/doc.go
@@ -86,9 +86,19 @@
 //
 //   - [ErrInvalidNamespace] — the namespace passed to [New] fails validation.
 //
-// When a backend's CLI tool fails, the wrapped error carries an
-// exec.CommandError with the exit code and stderr — the operator's debugging
-// surface. Do not collapse these into a sentinel.
+// [Manager.List] additionally distinguishes absence from emptiness. When the
+// namespace was never provisioned (the nftables backend's table does not exist
+// yet) List returns a wrapped [io/fs.ErrNotExist], never an empty slice — so a
+// caller can never confuse "this namespace has never been set up" with
+// "set up, currently holding zero rules". Callers that want absent-treated-as-
+// empty opt in explicitly with errors.Is(err, fs.ErrNotExist). A backend whose
+// firewall is installed-but-empty (an inactive ufw, an empty firewalld zone)
+// returns a nil slice and nil error — that is genuine emptiness, not absence.
+//
+// When a backend's CLI tool fails for any other reason — escalation denied, the
+// tool absent, a crash — the wrapped error carries an exec.CommandError with the
+// exit code and stderr. List never reports such a failure as "zero managed
+// rules"; it propagates. Do not collapse these into a sentinel.
 //
 // # Concurrency
 //

--- a/sys/firewall/firewall.go
+++ b/sys/firewall/firewall.go
@@ -309,6 +309,16 @@ func (c cmd) exec(ctx context.Context, spec exec.Command) (exec.Result, error) {
 	return res, nil
 }
 
+// isNoTable reports nft's "table does not exist" failure — the namespace's table
+// hasn't been created yet, so there are genuinely no managed rules. nft prints
+// "No such file or directory"; the Runner forces LC_ALL=C so the match is
+// locale-stable. Distinct from a REAL failure (escalation denied, nft crash),
+// which List must propagate rather than read as "zero rules".
+func isNoTable(err error) bool {
+	var ce *exec.CommandError
+	return errors.As(err, &ce) && strings.Contains(ce.Stderr, "No such file or directory")
+}
+
 // base is embedded by each backend: the namespace, the command runner, and the
 // fs.Manager (over the same Runner) the firewalld backend writes service XML
 // through.

--- a/sys/firewall/list_errors_test.go
+++ b/sys/firewall/list_errors_test.go
@@ -1,0 +1,47 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// List must distinguish three states, never collapsing them: a missing table
+// (the namespace was never provisioned → explicit os.ErrNotExist), an empty but
+// provisioned table (nil slice, no error), and a REAL failure (escalation denied,
+// tool error → propagated, never read as "zero managed rules").
+func TestNftablesList_NoTableEmptyButRealErrorPropagates(t *testing.T) {
+	t.Run("missing table → wrapped os.ErrNotExist", func(t *testing.T) {
+		r := exectest.New(pmexec.Direct)
+		r.Push(pmexec.Result{ExitCode: 1, Stderr: "Error: No such file or directory"}, nil)
+		n := &nftables{base: base{ns: "app", cmd: cmd{r: r}}}
+		rules, err := n.List(context.Background())
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("List(missing table) err = %v, want wrapped os.ErrNotExist", err)
+		}
+		if rules != nil {
+			t.Fatalf("List(missing table) rules = %v, want nil", rules)
+		}
+	})
+	t.Run("a real nft failure propagates", func(t *testing.T) {
+		r := exectest.New(pmexec.Direct)
+		r.Push(pmexec.Result{ExitCode: 1, Stderr: "Error: Operation not permitted"}, nil)
+		n := &nftables{base: base{ns: "app", cmd: cmd{r: r}}}
+		if _, err := n.List(context.Background()); err == nil {
+			t.Fatal("a real nft failure must propagate, not read as 'no managed rules'")
+		}
+	})
+}
+
+func TestUfwList_EscalationFailurePropagates(t *testing.T) {
+	r := exectest.New(pmexec.Direct)
+	r.Push(pmexec.Result{}, pmexec.ErrEscalationDenied)
+	u := &ufw{base: base{ns: "app", cmd: cmd{r: r}}}
+	if _, err := u.List(context.Background()); !errors.Is(err, pmexec.ErrEscalationDenied) {
+		t.Fatalf("ufw List err = %v, want ErrEscalationDenied propagated (not silent 'no rules')", err)
+	}
+}

--- a/sys/firewall/nftables.go
+++ b/sys/firewall/nftables.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 )
 
@@ -86,8 +87,10 @@ func (n *nftables) RemoveRule(ctx context.Context, id string) error {
 	}
 	raw, err := n.nftListJSON(ctx)
 	if err != nil {
-		// No table → nothing to remove.
-		return nil
+		if isNoTable(err) {
+			return nil // no table → nothing to remove (the "absent" post-condition already holds)
+		}
+		return err // a real failure (escalation denied, nft error) must NOT report a successful no-op
 	}
 	handle, ok := nftFindRuleHandle(raw, id)
 	if !ok {
@@ -97,12 +100,18 @@ func (n *nftables) RemoveRule(ctx context.Context, id string) error {
 	return n.nftRunScript(ctx, script)
 }
 
-// List returns every managed rule in this namespace's table.
+// List returns every managed rule in this namespace's table. A missing table is
+// an explicit absence: it returns a wrapped os.ErrNotExist rather than an empty
+// slice, so a caller can never confuse "this namespace was never provisioned"
+// with "provisioned, currently zero rules". Callers that want absent-as-empty
+// opt in with errors.Is(err, os.ErrNotExist).
 func (n *nftables) List(ctx context.Context) ([]Rule, error) {
 	raw, err := n.nftListJSON(ctx)
 	if err != nil {
-		// No table yet → no managed rules.
-		return nil, nil
+		if isNoTable(err) {
+			return nil, fmt.Errorf("list nftables rules: namespace %q has no table: %w", n.ns, os.ErrNotExist)
+		}
+		return nil, err // a real failure (escalation denied, nft error) must not read as "zero rules"
 	}
 	return nftParseRules(raw)
 }

--- a/sys/firewall/runner_test.go
+++ b/sys/firewall/runner_test.go
@@ -3,6 +3,7 @@ package firewall
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -144,13 +145,25 @@ func TestNftables_RemoveRule(t *testing.T) {
 	})
 	t.Run("no table is a no-op", func(t *testing.T) {
 		r := &recordingRunner{}
-		r.push(exec.Result{ExitCode: 1}, nil) // list: missing table
+		// nft prints "No such file or directory" when the table is absent; that
+		// is the only list failure RemoveRule may treat as "already absent".
+		r.push(exec.Result{ExitCode: 1, Stderr: "Error: No such file or directory"}, nil)
 		m := newMgr(t, Nftables, "app", r)
 		if err := m.RemoveRule(context.Background(), "ssh"); err != nil {
 			t.Fatal(err)
 		}
 		if len(r.calls) != 1 {
 			t.Errorf("ran %d commands, want 1 (list only)", len(r.calls))
+		}
+	})
+	t.Run("a real list failure is NOT swallowed as a no-op", func(t *testing.T) {
+		r := &recordingRunner{}
+		// Escalation denied / nft crash: RemoveRule must NOT report a successful
+		// no-op (it did not prove the rule absent).
+		r.push(exec.Result{ExitCode: 1, Stderr: "Operation not permitted"}, nil)
+		m := newMgr(t, Nftables, "app", r)
+		if err := m.RemoveRule(context.Background(), "ssh"); err == nil {
+			t.Fatal("a real list failure must propagate, not read as 'rule already absent'")
 		}
 	})
 	t.Run("rule absent is a no-op", func(t *testing.T) {
@@ -179,13 +192,16 @@ func TestNftables_List(t *testing.T) {
 			t.Errorf("rules = %+v", rules)
 		}
 	})
-	t.Run("no table → empty", func(t *testing.T) {
+	t.Run("no table → wrapped os.ErrNotExist", func(t *testing.T) {
 		r := &recordingRunner{}
-		r.push(exec.Result{ExitCode: 1}, nil)
+		r.push(exec.Result{ExitCode: 1, Stderr: "Error: No such file or directory"}, nil)
 		m := newMgr(t, Nftables, "app", r)
 		rules, err := m.List(context.Background())
-		if err != nil || len(rules) != 0 {
-			t.Errorf("List = (%v,%v), want (nil,nil)", rules, err)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("List(no table) err = %v, want wrapped os.ErrNotExist", err)
+		}
+		if rules != nil {
+			t.Errorf("List(no table) rules = %v, want nil", rules)
 		}
 	})
 }
@@ -585,11 +601,23 @@ func TestUFW_List(t *testing.T) {
 	})
 	t.Run("inactive → empty", func(t *testing.T) {
 		r := &recordingRunner{}
-		r.push(exec.Result{ExitCode: 1}, nil)
+		// An inactive ufw exits 0 with "Status: inactive" — the firewall IS
+		// installed, it just holds no rules, so List is legitimately empty.
+		r.pushOut("Status: inactive\n")
 		m := newMgr(t, UFW, "app", r)
 		rules, err := m.List(context.Background())
 		if err != nil || len(rules) != 0 {
 			t.Errorf("List = (%v,%v), want empty", rules, err)
+		}
+	})
+	t.Run("can't run ufw propagates", func(t *testing.T) {
+		r := &recordingRunner{}
+		// A non-zero exit (ufw absent, escalation denied) is a genuine
+		// can't-determine-state failure and must NOT be read as "zero rules".
+		r.push(exec.Result{ExitCode: 1}, nil)
+		m := newMgr(t, UFW, "app", r)
+		if _, err := m.List(context.Background()); err == nil {
+			t.Fatal("a failure to run ufw status must propagate, not read as 'no managed rules'")
 		}
 	})
 }

--- a/sys/firewall/ufw.go
+++ b/sys/firewall/ufw.go
@@ -95,12 +95,15 @@ func (u *ufw) RemoveRule(ctx context.Context, id string) error {
 	return u.ufwDeleteByNumber(ctx, num)
 }
 
-// List returns every managed rule (comment prefix `<namespace>:`).
+// List returns every managed rule (comment prefix `<namespace>:`). An inactive
+// ufw exits 0 with "Status: inactive" and is parsed below into an empty rule set
+// (the firewall IS provisioned, it just holds no rules). Any error reaching here
+// is a genuine can't-determine-state failure — ufw absent, or escalation denied —
+// and propagates rather than being silently reported as "zero managed rules".
 func (u *ufw) List(ctx context.Context) ([]Rule, error) {
 	status, err := u.ufwStatusNumbered(ctx)
 	if err != nil {
-		// ufw not active → no managed rules.
-		return nil, nil
+		return nil, err
 	}
 	return ufwParseStatus(status, u.ns)
 }

--- a/sys/fs/fs_test.go
+++ b/sys/fs/fs_test.go
@@ -4,6 +4,7 @@ package fs_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	osexec "os/exec"
@@ -112,8 +113,10 @@ func TestWriteAndReadRoundTrip(t *testing.T) {
 
 func TestReadFileNotFound(t *testing.T) {
 	got, err := intManager(t).ReadFile(context.Background(), missingPath(t))
-	if err != nil {
-		t.Fatalf("ReadFile(missing) should not error, got: %v", err)
+	// Explicit-absence contract: a missing file is a wrapped os.ErrNotExist, NOT a
+	// silent (nil,nil) — so a caller can tell "absent" from "present but empty".
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ReadFile(missing) err = %v, want errors.Is(..., os.ErrNotExist)", err)
 	}
 	if got != nil {
 		t.Errorf("ReadFile(missing) = %q, want nil", got)
@@ -343,7 +346,10 @@ func TestReadFile_MissingUnderForeignLocale(t *testing.T) {
 	t.Setenv("LANG", loc)
 	t.Setenv("LC_ALL", loc)
 	got, err := intManager(t).ReadFile(context.Background(), missingPath(t))
-	if err != nil || got != nil {
-		t.Fatalf("ReadFile(missing) under %s = (%q,%v), want (nil,nil) — the Runner must force LC_ALL=C", loc, got, err)
+	// The escalated cat path classifies absence by matching "No such file" in
+	// stderr; that match only holds because the Runner forces LC_ALL=C. Under a
+	// foreign LANG/LC_ALL it must STILL resolve to os.ErrNotExist (not a cmdError).
+	if !errors.Is(err, os.ErrNotExist) || got != nil {
+		t.Fatalf("ReadFile(missing) under %s = (%q,%v), want (nil, ErrNotExist) — the Runner must force LC_ALL=C", loc, got, err)
 	}
 }

--- a/sys/fs/manager_test.go
+++ b/sys/fs/manager_test.go
@@ -247,13 +247,14 @@ func TestReadFile_DoesNotReAddNewline(t *testing.T) {
 	}
 }
 
-func TestReadFile_MissingIsEmptyNoError(t *testing.T) {
+func TestReadFile_MissingIsErrNotExist(t *testing.T) {
 	f := exectest.New(pmexec.Sudo)
 	f.Push(pmexec.Result{ExitCode: 1, Stderr: "cat: /x: No such file or directory"}, nil)
 	m := mustManager(t, f)
 	got, err := m.ReadFile(context.Background(), "/x")
-	if err != nil || got != nil {
-		t.Fatalf("ReadFile(missing) = (%q, %v), want (nil, nil)", got, err)
+	// Explicit-absence contract: missing → wrapped os.ErrNotExist, not silent empty.
+	if !errors.Is(err, os.ErrNotExist) || got != nil {
+		t.Fatalf("ReadFile(missing) = (%q, %v), want (nil, ErrNotExist)", got, err)
 	}
 }
 

--- a/sys/fs/read.go
+++ b/sys/fs/read.go
@@ -2,23 +2,44 @@ package fs
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 )
 
-// ReadFile reads path's contents via the privilege backend (cat), so it can
-// read files in directories the caller cannot traverse. A path that does not
-// exist (or an empty file) yields (nil, nil): absence is reported as empty
-// content, matching the long-standing contract config-management callers rely on.
+// ReadFile reads path's contents.
 //
-// ReadFile returns the Runner's cat stdout verbatim (no re-add, no strip). For
-// newline-terminated content — every config file — the bytes round-trip exactly
-// with what WriteFile wrote, which the idempotency check depends on. (The Runner
-// normalizes a final line that lacks a newline by appending one, so a file with
-// no trailing newline reads back with one; managed text files always end in a
-// newline, so this does not affect them.)
+// On the Direct backend (the deployed root agent) it uses os.ReadFile — root can
+// reach any file and this avoids a subprocess. On the escalated (Sudo/Doas)
+// backend it shells `cat` through the privilege backend so it can read files in
+// directories the unprivileged caller cannot traverse.
+//
+// A MISSING path returns a wrapped os.ErrNotExist (same as os.ReadFile), NOT a
+// silent empty result — so a caller can tell "absent" from "present but empty"
+// (the two are different states, and conflating them is a footgun). A caller that
+// wants "absent → empty" opts in explicitly:
+//
+//	b, err := m.ReadFile(ctx, p)
+//	if err != nil && !errors.Is(err, fs.ErrNotExist) { return err }
+//	// b == nil here means the file was absent — treat as empty by choice
+//
+// An empty (but present) file returns (nil, nil). The returned bytes are the
+// content verbatim; for newline-terminated content (every config file) they
+// round-trip exactly with what WriteFile wrote, which the idempotency check
+// depends on.
 func (m *manager) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	if err := ValidatePath(path); err != nil {
 		return nil, err
+	}
+	if m.direct() {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err // a *PathError wrapping os.ErrNotExist for a missing path
+		}
+		if len(b) == 0 {
+			return nil, nil // present but empty
+		}
+		return b, nil
 	}
 	res, err := m.runPriv(ctx, "cat", "--", path)
 	if err != nil {
@@ -26,23 +47,34 @@ func (m *manager) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	}
 	if res.ExitCode != 0 {
 		if strings.Contains(res.Stderr, "No such file") {
-			return nil, nil
+			return nil, fmt.Errorf("read %s: %w", path, os.ErrNotExist)
 		}
 		return nil, cmdError("cat", res)
 	}
 	if res.Stdout == "" {
-		return nil, nil
+		return nil, nil // present but empty
 	}
 	return []byte(res.Stdout), nil
 }
 
-// Exists reports whether path exists, probing through the privilege backend
-// (test -e) so paths in directories not readable by the caller are visible. A
-// non-zero exit means "absent"; a runner/ctx failure is returned as an error so
-// a probe that could not run is never silently treated as absence.
+// Exists reports whether path exists. On the Direct backend it uses os.Stat (no
+// subprocess); on the escalated backend it shells `test -e` so paths in
+// directories not readable by the caller are visible. A genuine probe failure
+// (runner/ctx error, or a non-not-exist stat error) is returned as an error so a
+// probe that could not run is never silently treated as absence.
 func (m *manager) Exists(ctx context.Context, path string) (bool, error) {
 	if err := ValidatePath(path); err != nil {
 		return false, err
+	}
+	if m.direct() {
+		_, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
 	}
 	res, err := m.runPriv(ctx, "test", "-e", path)
 	if err != nil {

--- a/sys/fs/readdir.go
+++ b/sys/fs/readdir.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -26,9 +27,11 @@ type DirEntry struct {
 // privilege backend so it can list directories the unprivileged caller cannot
 // traverse, mirroring ReadFile/Exists.
 //
-// A non-existent directory yields (nil, nil): absence is an empty listing, the
-// same contract as ReadFile. Any other failure (permission denied, a non-
-// directory target) is returned as an error — never silently reported as empty.
+// A MISSING directory returns a wrapped os.ErrNotExist (the same explicit-absence
+// contract as ReadFile), NOT a silent empty listing — a caller that wants
+// "absent → empty" opts in with errors.Is(err, fs.ErrNotExist). Any other failure
+// (permission denied, a non-directory target) is returned as an error too — never
+// silently reported as empty.
 func (m *manager) ReadDir(ctx context.Context, path string) ([]DirEntry, error) {
 	if err := ValidatePath(path); err != nil {
 		return nil, err
@@ -39,15 +42,12 @@ func (m *manager) ReadDir(ctx context.Context, path string) ([]DirEntry, error) 
 	return m.readDirEscalated(ctx, path)
 }
 
-// readDirDirect is the root path: os.ReadDir, with a missing directory mapped to
-// an empty listing.
+// readDirDirect is the root path: os.ReadDir, which returns a wrapped
+// os.ErrNotExist for a missing directory.
 func readDirDirect(path string) ([]DirEntry, error) {
 	osEntries, err := os.ReadDir(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
+		return nil, err // os.ReadDir wraps os.ErrNotExist for a missing dir
 	}
 	entries := make([]DirEntry, 0, len(osEntries))
 	for _, e := range osEntries {
@@ -73,7 +73,7 @@ func (m *manager) readDirEscalated(ctx context.Context, path string) ([]DirEntry
 	}
 	if res.ExitCode != 0 {
 		if strings.Contains(res.Stderr, "No such file") {
-			return nil, nil
+			return nil, fmt.Errorf("read dir %s: %w", path, os.ErrNotExist)
 		}
 		return nil, cmdError("find", res)
 	}

--- a/sys/fs/readdir_test.go
+++ b/sys/fs/readdir_test.go
@@ -63,12 +63,14 @@ func TestReadDir_Sudo_EmptyDir(t *testing.T) {
 	}
 }
 
-func TestReadDir_Sudo_MissingDirIsEmptyNoError(t *testing.T) {
+func TestReadDir_Sudo_MissingDirIsErrNotExist(t *testing.T) {
 	f := exectest.New(pmexec.Sudo)
 	f.Push(pmexec.Result{ExitCode: 1, Stderr: "find: '/x': No such file or directory"}, nil)
 	got, err := mustManager(t, f).ReadDir(context.Background(), "/x")
-	if err != nil || got != nil {
-		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, nil)", got, err)
+	// Explicit-absence contract: a missing dir is a wrapped os.ErrNotExist, not a
+	// silent empty listing.
+	if !errors.Is(err, os.ErrNotExist) || got != nil {
+		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, ErrNotExist)", got, err)
 	}
 }
 
@@ -133,11 +135,12 @@ func TestReadDir_Direct_ListsRealDir(t *testing.T) {
 	}
 }
 
-func TestReadDir_Direct_MissingDirIsEmptyNoError(t *testing.T) {
+func TestReadDir_Direct_MissingDirIsErrNotExist(t *testing.T) {
 	m := directManager(t)
 	got, err := m.ReadDir(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"))
-	if err != nil || got != nil {
-		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, nil)", got, err)
+	// Explicit-absence contract: missing dir → wrapped os.ErrNotExist.
+	if !errors.Is(err, os.ErrNotExist) || got != nil {
+		t.Fatalf("ReadDir(missing) = (%v, %v), want (nil, ErrNotExist)", got, err)
 	}
 }
 

--- a/sys/fs/remove_dir_unix.go
+++ b/sys/fs/remove_dir_unix.go
@@ -36,7 +36,7 @@ func removeDirSecure(ctx context.Context, path string) error {
 	if err != nil {
 		return err
 	}
-	defer unix.Close(pfd)
+	defer func() { _ = unix.Close(pfd) }()
 
 	var st unix.Stat_t
 	if err := unix.Fstatat(pfd, base, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {

--- a/sys/fs/safe_fd_unix.go
+++ b/sys/fs/safe_fd_unix.go
@@ -63,7 +63,7 @@ func FchownNoFollow(path string, uid, gid int) error {
 	if err != nil {
 		return fmt.Errorf("open %s without following symlinks: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -98,7 +98,7 @@ func SetDirPermissionsNoFollow(path string, mode os.FileMode, uid, gid int) erro
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if err := f.Chmod(mode); err != nil {
 		return fmt.Errorf("fchmod dir %s: %w", path, err)
 	}

--- a/sys/inventory/inventory.go
+++ b/sys/inventory/inventory.go
@@ -230,7 +230,7 @@ func parseCPUInfo(path string) (model string, cores int, err error) {
 	if err != nil {
 		return "", 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -259,7 +259,7 @@ func parseMemTotal(path string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -288,7 +288,7 @@ func parseOSRelease(path string) (*OSInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open os-release: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info := &OSInfo{}
 	scanner := bufio.NewScanner(f)

--- a/sys/network/certs.go
+++ b/sys/network/certs.go
@@ -39,7 +39,7 @@ func writeCerts(p Profile) error {
 // errors are ignored since this only runs as cleanup after a failed create.
 func removeCerts(certDir string) {
 	for _, name := range []string{"ca.pem", "client.pem", "client-key.pem"} {
-		removeFile(filepath.Join(certDir, name))
+		_ = removeFile(filepath.Join(certDir, name))
 	}
 }
 

--- a/sys/network/keyfile.go
+++ b/sys/network/keyfile.go
@@ -146,21 +146,21 @@ func writeKeyfile(path string, content []byte) error {
 	}
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(content); err != nil {
-		tmp.Close()
-		removeFile(tmpPath)
+		_ = tmp.Close()
+		_ = removeFile(tmpPath)
 		return fmt.Errorf("write keyfile: %w", err)
 	}
 	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		removeFile(tmpPath)
+		_ = tmp.Close()
+		_ = removeFile(tmpPath)
 		return fmt.Errorf("chmod keyfile: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		removeFile(tmpPath)
+		_ = removeFile(tmpPath)
 		return fmt.Errorf("close keyfile: %w", err)
 	}
 	if err := renameFile(tmpPath, path); err != nil {
-		removeFile(tmpPath)
+		_ = removeFile(tmpPath)
 		return fmt.Errorf("rename keyfile to %q: %w", path, err)
 	}
 	return nil

--- a/sys/network/networkmanager.go
+++ b/sys/network/networkmanager.go
@@ -174,7 +174,7 @@ func (m *networkManager) stagedModify(ctx context.Context, p Profile, current ma
 	tmpDir := p.CertDir + ".tmp"
 	staged := p
 	staged.CertDir = tmpDir
-	defer removeAll(tmpDir) // best-effort cleanup if anything below fails
+	defer func() { _ = removeAll(tmpDir) }() // best-effort cleanup if anything below fails
 
 	if err := writeCerts(staged); err != nil {
 		return false, fmt.Errorf("write staged certificates: %w", err)
@@ -206,7 +206,7 @@ func (m *networkManager) stagedModify(ctx context.Context, p Profile, current ma
 		return true, fmt.Errorf("install staged certs: %w", err)
 	}
 	if liveExists {
-		removeAll(oldDir)
+		_ = removeAll(oldDir)
 	}
 	return true, nil
 }

--- a/sys/remote/digest.go
+++ b/sys/remote/digest.go
@@ -35,7 +35,7 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("sha256File %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	buf := make([]byte, digestBufSize)
 	if _, err := io.CopyBuffer(h, f, buf); err != nil {
@@ -128,10 +128,10 @@ func sha256Tree(root string) (string, error) {
 				return "", fmt.Errorf("open %s: %w", e.full, oerr)
 			}
 			if _, cerr := io.CopyBuffer(h, f, buf); cerr != nil {
-				f.Close()
+				_ = f.Close()
 				return "", fmt.Errorf("read %s: %w", e.full, cerr)
 			}
-			f.Close()
+			_ = f.Close()
 		}
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -161,7 +161,7 @@ func (h *httpSource) Fetch(ctx context.Context, dest string) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 
 	tmp, written, sum, err := streamToTmp(dest, body, h.cfg.MaxBytes)
 	if err != nil {
@@ -239,7 +239,7 @@ func (h *httpSource) checkNotModified(ctx context.Context, etag string) (bool, e
 	if err != nil {
 		return false, fmt.Errorf("HEAD %s: %w", h.cfg.URL, err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return resp.StatusCode == http.StatusNotModified, nil
 }
 
@@ -264,11 +264,11 @@ func (h *httpSource) openBody(ctx context.Context, etag string) (io.ReadCloser, 
 		// caller falls through to "no body to read" path. In practice
 		// we only reach this branch after our own cachedRevision lost
 		// the race, which is rare but worth handling cleanly.
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return io.NopCloser(strings.NewReader("")), resp.Header.Get("ETag"), nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", fmt.Errorf("GET %s: status %d", h.cfg.URL, resp.StatusCode)
 	}
 	return resp.Body, resp.Header.Get("ETag"), nil
@@ -300,7 +300,7 @@ func streamToTmp(dest string, body io.Reader, maxBytes int64) (string, int64, []
 		}
 	}
 	cleanup := func() {
-		f.Close()
+		_ = f.Close()
 		_ = os.Remove(tmp)
 	}
 
@@ -392,7 +392,7 @@ func chownNoFollow(dest string, uid, gid int) error {
 		if err != nil {
 			return err
 		}
-		defer d.Close()
+		defer func() { _ = d.Close() }()
 		return d.Chown(uid, gid)
 	}
 	return sysfs.FchownNoFollow(dest, uid, gid)

--- a/sys/remote/http_archive.go
+++ b/sys/remote/http_archive.go
@@ -87,7 +87,7 @@ func (h *httpSource) fetchArchive(ctx context.Context, dest string) (Result, err
 	if err != nil {
 		return Result{}, err
 	}
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 	if notModified {
 		// Server confirmed the cache was current after we'd already
 		// committed to the GET path; treat it as a no-op rather than
@@ -111,7 +111,7 @@ func (h *httpSource) fetchArchive(ctx context.Context, dest string) (Result, err
 	if err != nil {
 		return Result{}, err
 	}
-	defer os.Remove(tmp)
+	defer func() { _ = os.Remove(tmp) }()
 
 	// Mine the random suffix tmpPathFor stamped into tmp so the staging
 	// dir gets a matching tail — keeps the two sibling artefacts visible
@@ -202,11 +202,11 @@ func (h *httpSource) openArchiveBody(ctx context.Context, etag string) (io.ReadC
 		return nil, "", "", false, fmt.Errorf("GET %s: %w", h.cfg.URL, err)
 	}
 	if resp.StatusCode == http.StatusNotModified {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return io.NopCloser(strings.NewReader("")), resp.Header.Get("ETag"), resp.Header.Get("Content-Type"), true, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", "", false, fmt.Errorf("GET %s: status %d", h.cfg.URL, resp.StatusCode)
 	}
 	return resp.Body, resp.Header.Get("ETag"), resp.Header.Get("Content-Type"), false, nil
@@ -219,7 +219,7 @@ func extractTarGzFile(tmpPath, staging string, maxBytes int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("open archive: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return extractTarGz(f, staging, maxBytes)
 }
 
@@ -240,7 +240,7 @@ func extractTarGz(body io.Reader, staging string, maxBytes int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("gzip header: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 	tr := tar.NewReader(gz)
 
 	var totalBytes int64
@@ -307,7 +307,7 @@ func writeTarEntry(out string, r io.Reader, mode os.FileMode) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("open %s: %w", out, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	n, err := io.Copy(f, r)
 	if err != nil {
 		return n, fmt.Errorf("copy %s: %w", out, err)
@@ -321,7 +321,7 @@ func extractZipFile(tmpPath, staging string, maxBytes int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("open zip: %w", err)
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 
 	var totalBytes int64
 	var files int
@@ -351,12 +351,12 @@ func extractZipFile(tmpPath, staging string, maxBytes int64) (int, error) {
 			return files, fmt.Errorf("open zip entry %q: %w", ze.Name, err)
 		}
 		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
-			rc.Close()
+			_ = rc.Close()
 			return files, fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
 		}
 		limited := io.LimitReader(rc, maxBytes-totalBytes+1)
 		written, werr := writeTarEntry(out, limited, ze.FileInfo().Mode().Perm())
-		rc.Close()
+		_ = rc.Close()
 		if werr != nil {
 			return files, werr
 		}

--- a/sys/remote/s3.go
+++ b/sys/remote/s3.go
@@ -109,7 +109,7 @@ func (s *s3Source) Fetch(ctx context.Context, dest string) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 
 	maxBytes := int64(defaultHTTPMaxBytes) // S3 single objects honour the same cap as HTTP for now.
 	tmp, written, sum, err := streamToTmp(dest, body, maxBytes)
@@ -168,7 +168,7 @@ func (s *s3Source) headNotModified(ctx context.Context, etag string) (bool, erro
 	if err != nil {
 		return false, fmt.Errorf("HEAD %s: %w", s.objectURL, err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	switch {
 	case resp.StatusCode == http.StatusNotModified:
 		return true, nil
@@ -198,15 +198,15 @@ func (s *s3Source) openObject(ctx context.Context, etag string) (io.ReadCloser, 
 	}
 	switch {
 	case resp.StatusCode == http.StatusNotModified:
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return io.NopCloser(strings.NewReader("")), resp.Header.Get("ETag"), nil
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return resp.Body, resp.Header.Get("ETag"), nil
 	case resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized:
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", fmt.Errorf("%w: anonymous GET on %s returned %d (bucket policy may need adjustment)", ErrInvalidConfig, s.objectURL, resp.StatusCode)
 	default:
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", fmt.Errorf("GET %s: status %d", s.objectURL, resp.StatusCode)
 	}
 }

--- a/sys/remote/s3_prefix.go
+++ b/sys/remote/s3_prefix.go
@@ -81,7 +81,7 @@ func (s *s3Source) fetchPrefix(ctx context.Context, dest string) (Result, error)
 			return Result{}, err
 		}
 		written, _, err := streamObjectToFile(body, outPath, maxBytes)
-		body.Close()
+		_ = body.Close()
 		if err != nil {
 			return Result{}, err
 		}
@@ -168,19 +168,19 @@ func (s *s3Source) listObjects(ctx context.Context) ([]s3Object, error) {
 		}
 		switch {
 		case resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized:
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("%w: anonymous list on %s returned %d (bucket policy may need adjustment)", ErrInvalidConfig, bucketURL.String(), resp.StatusCode)
 		case resp.StatusCode < 200 || resp.StatusCode >= 300:
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("list %s: status %d", bucketURL.String(), resp.StatusCode)
 		}
 
 		var parsed listV2Response
 		if err := xml.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("decode list %s: %w", bucketURL.String(), err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		for _, e := range parsed.Contents {
 			all = append(all, s3Object{Key: e.Key, ETag: e.ETag, Size: e.Size})
 			if len(all) > maxPrefixObjects {
@@ -242,11 +242,11 @@ func (s *s3Source) openSingleObject(ctx context.Context, key string) (io.ReadClo
 		return nil, "", fmt.Errorf("GET %s: %w", bucketAndKey.String(), err)
 	}
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", fmt.Errorf("%w: anonymous GET on %s returned %d", ErrInvalidConfig, bucketAndKey.String(), resp.StatusCode)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, "", fmt.Errorf("GET %s: status %d", bucketAndKey.String(), resp.StatusCode)
 	}
 	return resp.Body, resp.Header.Get("ETag"), nil

--- a/sys/repo/apt.go
+++ b/sys/repo/apt.go
@@ -111,7 +111,7 @@ func (m *manager) applyApt(ctx context.Context, name string, c *AptConfig) (Outc
 	desired := buildAptSources(name, c, keyFile)
 
 	existingBytes, err := m.fsm.ReadFile(ctx, repoFile)
-	if err != nil {
+	if err != nil && !isReadAbsent(err) {
 		return Outcome{}, fmt.Errorf("read existing repo file: %w", err)
 	}
 	existing := string(existingBytes)
@@ -179,7 +179,7 @@ func (m *manager) updateAptKey(ctx context.Context, keyFile string, key []byte, 
 	newKey := []byte(res.Stdout)
 
 	existing, err := m.fsm.ReadFile(ctx, keyFile)
-	if err != nil {
+	if err != nil && !isReadAbsent(err) {
 		return false, fmt.Errorf("read existing GPG key: %w", err)
 	}
 	if existing != nil && bytes.Equal(existing, newKey) {
@@ -204,6 +204,9 @@ func (m *manager) updateAptKey(ctx context.Context, keyFile string, key []byte, 
 // the whole Apply.
 func (m *manager) cleanupConflictingApt(ctx context.Context, url, skipRepoFile, skipKeyFile string, log *strings.Builder) bool {
 	entries, err := m.fsm.ReadDir(ctx, aptSourcesDir)
+	if isReadAbsent(err) {
+		return false // no sources.list.d yet → nothing to clean up
+	}
 	if err != nil {
 		fmt.Fprintf(log, "warning: could not scan %s for conflicts: %v\n", aptSourcesDir, err)
 		return false

--- a/sys/repo/dnf.go
+++ b/sys/repo/dnf.go
@@ -48,7 +48,7 @@ func (m *manager) applyDnf(ctx context.Context, name string, c *DnfConfig) (Outc
 
 	// Idempotency: a byte-identical file means nothing to do.
 	existing, err := m.fsm.ReadFile(ctx, repoFile)
-	if err != nil {
+	if err != nil && !isReadAbsent(err) {
 		return Outcome{}, fmt.Errorf("read existing repo file: %w", err)
 	}
 	if string(existing) == desired {

--- a/sys/repo/pacman.go
+++ b/sys/repo/pacman.go
@@ -44,7 +44,7 @@ func removePacmanSection(content, name string) string {
 func (m *manager) applyPacman(ctx context.Context, name string, c *PacmanConfig) (Outcome, error) {
 	var log strings.Builder
 	confBytes, err := m.fsm.ReadFile(ctx, pacmanConf)
-	if err != nil {
+	if err != nil && !isReadAbsent(err) {
 		return Outcome{}, fmt.Errorf("read pacman.conf: %w", err)
 	}
 	confStr := string(confBytes)
@@ -93,7 +93,7 @@ func (m *manager) removePacman(ctx context.Context, name string) (Outcome, error
 	}
 	var log strings.Builder
 	confBytes, err := m.fsm.ReadFile(ctx, pacmanConf)
-	if err != nil {
+	if err != nil && !isReadAbsent(err) {
 		return Outcome{}, fmt.Errorf("read pacman.conf: %w", err)
 	}
 	confStr := string(confBytes)

--- a/sys/repo/repo.go
+++ b/sys/repo/repo.go
@@ -34,11 +34,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/manchtools/power-manage-sdk/pkg"
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 	"github.com/manchtools/power-manage-sdk/sys/fs"
 )
+
+// isReadAbsent reports whether a fsm.ReadFile/ReadDir error is a benign "path
+// absent" (a wrapped os.ErrNotExist). These config-management paths treat absence
+// as empty content / no entries, so they opt into the old behavior explicitly;
+// a real read error (permission, I/O, escalation) still propagates.
+func isReadAbsent(err error) bool { return errors.Is(err, os.ErrNotExist) }
 
 // ErrUnsupportedBackend is returned by New for a backend that has no
 // native-style repository configuration: flatpak (whose remotes live on

--- a/sys/user/errors_test.go
+++ b/sys/user/errors_test.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -103,13 +104,27 @@ func TestGet_PasswdLookupFailure(t *testing.T) {
 	}
 }
 
-// GroupMembers treats an unreadable/absent group as "no members", not an error.
-func TestGroupMembers_AbsentGroupIsEmpty(t *testing.T) {
+// GroupMembers reports a genuinely absent group as a wrapped os.ErrNotExist
+// (getent exit 2) — distinguishable from "exists but has no members" — and
+// propagates any OTHER failure instead of silently reading it as "no members".
+func TestGroupMembers_AbsentGroupIsErrNotExist(t *testing.T) {
 	f := exectest.New(exec.Direct)
 	f.Push(exec.Result{ExitCode: 2}, nil) // getent group: not found
 	members, err := mgr(t, f).GroupMembers(context.Background(), "ghosts")
-	if err != nil || members != nil {
-		t.Errorf("GroupMembers = (%v,%v), want (nil,nil) for an absent group", members, err)
+	if !errors.Is(err, os.ErrNotExist) || members != nil {
+		t.Errorf("GroupMembers(absent) = (%v,%v), want (nil, ErrNotExist)", members, err)
+	}
+}
+
+func TestGroupMembers_RealErrorPropagates(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{}, exec.ErrEscalationDenied) // a Runner/escalation failure, NOT "not found"
+	members, err := mgr(t, f).GroupMembers(context.Background(), "docker")
+	if err == nil {
+		t.Fatal("a getent failure that is not exit-2-not-found must propagate, not read as 'no members'")
+	}
+	if members != nil {
+		t.Errorf("members = %v, want nil on a real error", members)
 	}
 }
 

--- a/sys/user/group.go
+++ b/sys/user/group.go
@@ -2,7 +2,9 @@ package user
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -57,7 +59,16 @@ func (u *shadowUtils) GroupMembers(ctx context.Context, name string) ([]string, 
 	defer cancel()
 	out, err := u.query(ctx, "getent", "group", name)
 	if err != nil {
-		return nil, nil // not found / unreadable → no members
+		// getent exits 2 for "group not found" — a clean absence, reported as a
+		// wrapped os.ErrNotExist so a caller can tell it apart from "group exists
+		// with no members" ((nil, nil) below). Any OTHER failure (Runner /
+		// escalation / a different exit) is real and propagates — never silently
+		// read as "no members".
+		var ce *exec.CommandError
+		if errors.As(err, &ce) && ce.ExitCode == 2 {
+			return nil, fmt.Errorf("group %q: %w", name, os.ErrNotExist)
+		}
+		return nil, err
 	}
 	fields := strings.Split(out, ":")
 	if len(fields) < 4 || fields[3] == "" {

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -38,7 +38,13 @@ type Info struct {
 	HomeDir string
 	Shell   string
 	Groups  []string // supplementary groups (excluding the primary)
-	Locked  bool
+	// GroupsKnown reports whether Groups is authoritative. If the `id -Gn`
+	// supplementary-group lookup failed, Groups is left empty and GroupsKnown is
+	// false — so a caller can tell "no supplementary groups" (empty, GroupsKnown=
+	// true) apart from "could not determine" (empty, GroupsKnown=false) instead of
+	// silently treating a failed lookup as "no groups".
+	GroupsKnown bool
+	Locked      bool
 	// LockedKnown reports whether Locked is authoritative. The locked state lives
 	// in the root-only shadow file; if reading it failed or escalation was not
 	// authorized, Locked is left false and LockedKnown is false — so a caller can
@@ -343,6 +349,7 @@ func (u *shadowUtils) Get(ctx context.Context, name string) (Info, error) {
 				info.Groups = append(info.Groups, g)
 			}
 		}
+		info.GroupsKnown = true // id -Gn succeeded; Groups is authoritative
 	}
 
 	// The shadow file is root-only: read it escalated. If escalation is not

--- a/sys/user/user_test.go
+++ b/sys/user/user_test.go
@@ -226,12 +226,33 @@ func TestGet(t *testing.T) {
 		if strings.Join(info.Groups, ",") != "docker,sudo" {
 			t.Errorf("Groups = %v, want [docker sudo] (primary filtered)", info.Groups)
 		}
+		if !info.GroupsKnown {
+			t.Error("GroupsKnown = false after a successful id -Gn; Groups is authoritative here")
+		}
 		if info.Locked {
 			t.Error("Locked = true, want false for a hashed shadow entry")
 		}
 		// The shadow read must be escalated.
 		if c := f.Calls()[3]; c.Name != "getent" || !c.Escalate {
 			t.Errorf("shadow read = %+v, want escalated getent", c)
+		}
+	})
+
+	t.Run("a failed id -Gn leaves Groups unknown, not silently empty", func(t *testing.T) {
+		f := exectest.New(exec.Direct)
+		f.Push(exec.Result{Stdout: "deploy:x:1000:1000::/home/deploy:/bin/bash\n"}, nil) // getent passwd
+		f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)                             // getent group 1000
+		f.Push(exec.Result{}, exec.ErrEscalationDenied)                                  // id -Gn FAILS
+		f.Push(exec.Result{Stdout: "deploy:$6$abc:19000:0:99999:7:::\n"}, nil)           // getent shadow
+		info, err := mgr(t, f).Get(context.Background(), "deploy")
+		if err != nil {
+			t.Fatalf("Get should not fail just because the group lookup did: %v", err)
+		}
+		if info.GroupsKnown {
+			t.Error("GroupsKnown = true after id -Gn failed; the result is not authoritative")
+		}
+		if info.Groups != nil {
+			t.Errorf("Groups = %v, want nil when the lookup failed", info.Groups)
 		}
 	})
 

--- a/test/protovalidatecoverage/main.go
+++ b/test/protovalidatecoverage/main.go
@@ -160,7 +160,7 @@ func scanFile(p string) (fileReport, error) {
 	if err != nil {
 		return r, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sc := bufio.NewScanner(f)
 	// Some generated proto files have long lines (commented sample


### PR DESCRIPTION
## Explicit error contracts — take the guesswork out

The SDK's job is to remove ambiguity for its callers. Several read/query APIs
violated that by collapsing **failure**, **absence**, and **emptiness** into one
`(nil, nil)` / `(false, nil)` return, forcing the caller to *infer* meaning from
a nil — and in the worst cases reporting a real failure as a benign empty result.
This PR makes each of those contracts explicit, and adds a CI gate so a *dropped*
error can't silently reappear.

### Contract fixes (caller can no longer guess)

| Area | Before | After |
|---|---|---|
| `fs.ReadFile` / `ReadDir` | missing path → silent empty | wrapped `fs.ErrNotExist`; empty file stays `(nil, nil)` |
| `pkg` zypper `HasUpdates` | real-error exit → `(false, nil)` "no updates" | fails closed with `asCommandError` (now matches dnf/pacman/apt) |
| `user.GroupMembers` | absent group indistinguishable from zero members | absent group → `fs.ErrNotExist`; existing-but-empty → `(nil, nil)` |
| `user.Get` | failed `id -Gn` → silent "no groups" | reports `GroupsKnown` so a failed lookup isn't read as empty |
| `firewall` nftables `List` / `RemoveRule` | missing table, empty table, and a failed read all looked like "zero rules" | missing table → `fs.ErrNotExist`; a real read failure (escalation denied, nft crash) propagates; `RemoveRule` no longer reports a successful no-op on a failed list |

The three states are now distinct everywhere: **error** → propagate; **absence**
of a named thing → `fs.ErrNotExist` (callers opt into absent-as-empty with
`errors.Is`); **genuine emptiness** → empty collection + nil error (idiomatic Go,
mirroring `sql.Query` vs `sql.QueryRow`).

### Regression gate: errcheck

Go permits a returned error to be dropped on the floor — a bare-statement call
discards it, and only unused *variables* are a compile error, not unused returns.
A full-tree audit found **no dropped error that matters** today (every hit was a
read-side `Close`, best-effort cleanup on an already-failing path, or stream/fd
teardown), so this just locks that in:

- `errcheck` runs in the `static-checks` job over production code.
- Error-path cleanup / teardown is now written `_ = foo()` — the idiomatic
  "deliberately ignored" form, explicit at the call site.
- `.errcheck_excludes.txt` exempts **by kind** only: read-side closers
  (`os.File` / `io.Closer` / gzip / zip readers) and raw fd close. Durable
  **write** paths (keyfile, LUKS token, download, atomic replace) are *not*
  excluded — they check `Sync`+`Close` on success, so a future bare write-Close
  still fails CI.

### Notes / out of scope
- No behaviour change in the errcheck commit — only error-handling intent made
  explicit.
- The gate is production-only (`-ignoretests`). A few test-setup `os.WriteFile`/
  `MkdirAll` ignore their error (a separate green-for-wrong-reason concern);
  left for a focused follow-up.
- The other two firewall backends were checked: `firewalld.List` already
  propagates (its zone always exists when running → empty is genuine); `ufw`
  models inactive as an exit-0 "Status: inactive" → empty, and now propagates a
  genuine can't-run failure.

### Verification
`go build ./...`, `go vet ./...`, `errcheck -ignoretests`, full `go test ./...`,
`gofmt -l`, and `docref check` all green locally. Local CodeRabbit review: no
findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Firewall list operation now returns explicit error for missing namespaces instead of empty results
  * File system reads return wrapped `ErrNotExist` for missing files and directories rather than treating them as empty
  * Group lookups return errors for missing groups instead of empty results
  * Package manager operations handle missing configuration files gracefully
  * User info now explicitly tracks successful group lookups

* **Tests**
  * Added error checking validation to continuous integration pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->