### PR TITLE
fix: address CodeRabbit findings from #244 (fs ENOENT/ReadDir bugs + secret-cleanup errors)

### DIFF
--- a/sys/encryption/keyfile_fault_test.go
+++ b/sys/encryption/keyfile_fault_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,6 +93,29 @@ func TestWriteKeyFile_FaultPaths(t *testing.T) {
 				t.Errorf("%s: partial key file was not removed", tc.name)
 			}
 		})
+	}
+}
+
+// When the key-file cleanup itself fails after a write failure, the error must
+// surface that plaintext key material may remain on /dev/shm — a dropped
+// removeFile error would hide a leaked LUKS key file.
+func TestWriteKeyFile_CleanupFailureSurfacesResidue(t *testing.T) {
+	defer swapKeyFileSeams(t)()
+	mkdirAll = func(string, os.FileMode) error { return nil }
+	createKeyFile = func(string) (keyFileHandle, error) {
+		return &fakeKeyFile{name: "/dev/shm/pm-luks/key-leak", failWrite: true}, nil
+	}
+	removeFile = func(string) error { return errIO }
+
+	_, err := writeKeyFile(mustSecret(t, "x"))
+	if err == nil {
+		t.Fatal("writeKeyFile err = nil, want a failure")
+	}
+	if !strings.Contains(err.Error(), "write key file") {
+		t.Errorf("err = %v, want the original write failure preserved", err)
+	}
+	if !strings.Contains(err.Error(), "cleanup failed") || !strings.Contains(err.Error(), "/dev/shm/pm-luks/key-leak") {
+		t.Errorf("err = %v, want the key-file cleanup failure (plaintext residue) surfaced", err)
 	}
 }
 

--- a/sys/encryption/luks.go
+++ b/sys/encryption/luks.go
@@ -253,6 +253,18 @@ var (
 	}
 )
 
+// cleanupKeyFileAfter removes a partially-written key file after a failure and
+// folds any removal error into cause. The file holds plaintext key material
+// (Reveal()'d into it), so a failed cleanup must surface rather than vanish — a
+// dropped removal error would leave the secret on /dev/shm unnoticed. A file
+// that is already gone is not a cleanup failure.
+func cleanupKeyFileAfter(stage, name string, cause error) error {
+	if rmErr := removeFile(name); rmErr != nil && !os.IsNotExist(rmErr) {
+		return fmt.Errorf("%s: %w (key file cleanup failed, plaintext key may remain at %s: %v)", stage, cause, name, rmErr)
+	}
+	return fmt.Errorf("%s: %w", stage, cause)
+}
+
 // writeKeyFile writes a Secret to a 0600 temp file in /dev/shm and returns its
 // path. Reveal() here is the single sanctioned key-file sink. Never falls back
 // to disk: an unavailable /dev/shm is a hard error.
@@ -266,17 +278,14 @@ func writeKeyFile(key exec.Secret) (string, error) {
 	}
 	if err := f.Chmod(0o600); err != nil {
 		_ = f.Close()
-		_ = removeFile(f.Name())
-		return "", fmt.Errorf("set key file permissions: %w", err)
+		return "", cleanupKeyFileAfter("set key file permissions", f.Name(), err)
 	}
 	if _, err := f.WriteString(key.Reveal()); err != nil {
 		_ = f.Close()
-		_ = removeFile(f.Name())
-		return "", fmt.Errorf("write key file: %w", err)
+		return "", cleanupKeyFileAfter("write key file", f.Name(), err)
 	}
 	if err := f.Close(); err != nil {
-		_ = removeFile(f.Name())
-		return "", fmt.Errorf("close key file: %w", err)
+		return "", cleanupKeyFileAfter("close key file", f.Name(), err)
 	}
 	return f.Name(), nil
 }

--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -196,6 +196,18 @@ func cmdError(name string, res pmexec.Result) error {
 	return &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
 }
 
+// isENOENTStderr reports whether a coreutils/find stderr line is the kernel's
+// ENOENT message — "<tool>: <path>: No such file or directory". It matches the
+// TERMINAL phrase, not a substring anywhere in the line, so a path that itself
+// contains "No such file" (e.g. a present file failing with a *different* error
+// like "Permission denied", or a file literally named that) is never
+// misclassified as absent: the error reason always trails the path in this
+// format, so path content can never reach the suffix. The Runner forces
+// LC_ALL=C, keeping the phrase locale-stable.
+func isENOENTStderr(stderr string) bool {
+	return strings.HasSuffix(strings.TrimSpace(stderr), "No such file or directory")
+}
+
 // validateMode rejects a requested file mode that would set the setuid or
 // setgid bit. Creating a setuid/setgid file through a privileged op is a
 // local-root privilege-escalation primitive (a setuid-root helper, or a

--- a/sys/fs/manager_test.go
+++ b/sys/fs/manager_test.go
@@ -276,6 +276,25 @@ func TestReadFile_OtherErrorIsCommandError(t *testing.T) {
 	}
 }
 
+// A PRESENT file whose path literally contains "No such file" but that fails for
+// a DIFFERENT reason (Permission denied). Absence classification by substring
+// (strings.Contains(stderr, "No such file")) would wrongly map this to
+// os.ErrNotExist and hide the real failure; the terminal-phrase match must treat
+// it as a command error. The error reason always trails the path, so only a
+// genuine ENOENT ends with the phrase.
+func TestReadFile_PresentFileWithNoSuchFileInPathNotMisclassified(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{ExitCode: 1, Stderr: "cat: /data/No such file.txt: Permission denied"}, nil)
+	m := mustManager(t, f)
+	_, err := m.ReadFile(context.Background(), "/data/No such file.txt")
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ReadFile err = %v; a present file failing with Permission denied must NOT be classified absent", err)
+	}
+	if !errors.As(err, new(*pmexec.CommandError)) {
+		t.Fatalf("err = %v, want *exec.CommandError", err)
+	}
+}
+
 func TestReadFile_RunnerErrorPropagatesAndValidatesPath(t *testing.T) {
 	f := exectest.New(pmexec.Sudo)
 	f.Push(pmexec.Result{}, pmexec.ErrEscalationUnavailable)

--- a/sys/fs/read.go
+++ b/sys/fs/read.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 )
 
 // ReadFile reads path's contents.
@@ -46,7 +45,7 @@ func (m *manager) ReadFile(ctx context.Context, path string) ([]byte, error) {
 		return nil, err
 	}
 	if res.ExitCode != 0 {
-		if strings.Contains(res.Stderr, "No such file") {
+		if isENOENTStderr(res.Stderr) {
 			return nil, fmt.Errorf("read %s: %w", path, os.ErrNotExist)
 		}
 		return nil, cmdError("cat", res)

--- a/sys/fs/readdir.go
+++ b/sys/fs/readdir.go
@@ -58,7 +58,7 @@ func readDirDirect(path string) ([]DirEntry, error) {
 
 // readDirEscalated is the privilege-backend path. It runs
 //
-//	find <path> -maxdepth 1 -mindepth 1 -printf '%y/%f\n'
+//	find <path>/ -maxdepth 1 -mindepth 1 -printf '%y/%f\n'
 //
 // emitting one line per entry as "<type-char>/<basename>". A basename never
 // contains '/', so the first '/' unambiguously separates the single type char
@@ -66,13 +66,21 @@ func readDirDirect(path string) ([]DirEntry, error) {
 // line framing; managed config directories never hold such names, and the
 // Direct/root path — which the deployed agent always takes — handles them
 // correctly via os.ReadDir.)
+//
+// The trailing slash is load-bearing: `find /file` on a REGULAR file exits 0
+// with no output (which would otherwise read as a silently-empty directory),
+// whereas `find /file/` reports ENOTDIR and exits non-zero. It makes the
+// escalated path enforce the same "non-directory target is an error, never an
+// empty listing" contract the Direct (os.ReadDir) path already honours.
 func (m *manager) readDirEscalated(ctx context.Context, path string) ([]DirEntry, error) {
-	res, err := m.runPriv(ctx, "find", path, "-maxdepth", "1", "-mindepth", "1", "-printf", `%y/%f\n`)
+	res, err := m.runPriv(ctx, "find", path+"/", "-maxdepth", "1", "-mindepth", "1", "-printf", `%y/%f\n`)
 	if err != nil {
 		return nil, err
 	}
 	if res.ExitCode != 0 {
-		if strings.Contains(res.Stderr, "No such file") {
+		// ENOENT (missing dir) → explicit-absence contract; ENOTDIR (a regular
+		// file) and any other failure → a real error, never a silent empty list.
+		if isENOENTStderr(res.Stderr) {
 			return nil, fmt.Errorf("read dir %s: %w", path, os.ErrNotExist)
 		}
 		return nil, cmdError("find", res)

--- a/sys/fs/readdir_test.go
+++ b/sys/fs/readdir_test.go
@@ -46,8 +46,10 @@ func TestReadDir_Sudo_ParsesFindOutput(t *testing.T) {
 		t.Errorf("entries = %v, want %v", names(got), want)
 	}
 	// A symlink reports type 'l' from find's %y → classified as not-a-dir, so a
-	// caller iterating files (e.g. apt conflict cleanup) processes it.
-	if got := argv(f.Calls()[0]); got != `find /etc/apt/sources.list.d -maxdepth 1 -mindepth 1 -printf %y/%f\n` {
+	// caller iterating files (e.g. apt conflict cleanup) processes it. The target
+	// carries a trailing slash so find reports ENOTDIR on a non-directory rather
+	// than exiting 0 with no output.
+	if got := argv(f.Calls()[0]); got != `find /etc/apt/sources.list.d/ -maxdepth 1 -mindepth 1 -printf %y/%f\n` {
 		t.Errorf("argv = %q", got)
 	}
 	if !f.Calls()[0].Escalate {
@@ -87,6 +89,42 @@ func TestReadDir_Sudo_RunnerErrorPropagates(t *testing.T) {
 	f.Push(pmexec.Result{}, pmexec.ErrEscalationUnavailable)
 	if _, err := mustManager(t, f).ReadDir(context.Background(), "/x"); !errors.Is(err, pmexec.ErrEscalationUnavailable) {
 		t.Fatalf("err = %v, want ErrEscalationUnavailable", err)
+	}
+}
+
+// A regular file (not a directory): `find /path/` reports ENOTDIR. It must
+// surface as an error mirroring the Direct path — never a silent empty listing,
+// and NOT the absence sentinel (the file exists, it just isn't a directory).
+func TestReadDir_Sudo_NotADirIsError(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{ExitCode: 1, Stderr: "find: '/etc/hostname/': Not a directory"}, nil)
+	got, err := mustManager(t, f).ReadDir(context.Background(), "/etc/hostname")
+	if err == nil || got != nil {
+		t.Fatalf("ReadDir(regular file) = (%v, %v), want (nil, error)", got, err)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want a non-directory command error, not the absence sentinel", err)
+	}
+	if !errors.As(err, new(*pmexec.CommandError)) {
+		t.Fatalf("err = %v, want *exec.CommandError", err)
+	}
+}
+
+// The escalated find target carries a trailing slash so `find` reports ENOTDIR
+// on a non-directory (a bare `find /file` exits 0 with no output, which would
+// read as a silently-empty directory). Pin that the slash reaches the argv.
+func TestReadDir_Sudo_FindTargetsDirectoryWithTrailingSlash(t *testing.T) {
+	f := exectest.New(pmexec.Sudo)
+	f.Push(pmexec.Result{Stdout: "f/a.conf\n"}, nil)
+	if _, err := mustManager(t, f).ReadDir(context.Background(), "/etc/app"); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 1 || calls[0].Name != "find" {
+		t.Fatalf("calls = %+v, want a single find", calls)
+	}
+	if len(calls[0].Args) == 0 || calls[0].Args[0] != "/etc/app/" {
+		t.Fatalf("find target = %q, want \"/etc/app/\" (trailing slash enforces directory-only semantics)", calls[0].Args)
 	}
 }
 

--- a/sys/network/certs.go
+++ b/sys/network/certs.go
@@ -35,12 +35,19 @@ func writeCerts(p Profile) error {
 	return nil
 }
 
-// removeCerts removes the certificate files written by writeCerts. Best-effort —
-// errors are ignored since this only runs as cleanup after a failed create.
-func removeCerts(certDir string) {
+// removeCerts removes the certificate files written by writeCerts (cleanup after
+// a failed create). It returns the first removal failure: client-key.pem is a
+// private key, so a file that can't be removed is key material left on disk that
+// the caller must learn about — not something to silently drop. A file that is
+// already absent is not a failure.
+func removeCerts(certDir string) error {
+	var firstErr error
 	for _, name := range []string{"ca.pem", "client.pem", "client-key.pem"} {
-		_ = removeFile(filepath.Join(certDir, name))
+		if err := removeFile(filepath.Join(certDir, name)); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = fmt.Errorf("remove %s: %w", name, err)
+		}
 	}
+	return firstErr
 }
 
 // certsChanged reports whether any desired PEM content differs from the file

--- a/sys/network/certs_test.go
+++ b/sys/network/certs_test.go
@@ -119,11 +119,31 @@ func TestRemoveCerts(t *testing.T) {
 	if err := writeCerts(eapProfile(t, dir)); err != nil {
 		t.Fatal(err)
 	}
-	removeCerts(dir)
+	if err := removeCerts(dir); err != nil {
+		t.Fatalf("removeCerts(present) = %v, want nil", err)
+	}
 	for _, name := range []string{"ca.pem", "client.pem", "client-key.pem"} {
 		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
 			t.Errorf("%s should be gone after removeCerts", name)
 		}
+	}
+	// An already-absent file is not a failure (idempotent cleanup).
+	if err := removeCerts(dir); err != nil {
+		t.Errorf("removeCerts(already gone) = %v, want nil", err)
+	}
+}
+
+// A removal failure on the private key must surface, not vanish: a client-key.pem
+// that can't be deleted is key material left on disk the caller has to know about.
+func TestRemoveCerts_SurfacesRemovalFailure(t *testing.T) {
+	swapCertSeams(t)
+	removeFile = func(string) error { return errors.New("read-only fs") }
+	err := removeCerts("/etc/nm/certs")
+	if err == nil {
+		t.Fatal("removeCerts with a failing remove = nil, want the failure surfaced")
+	}
+	if !strings.Contains(err.Error(), "ca.pem") {
+		t.Errorf("err = %v, want the first failing file named", err)
 	}
 }
 
@@ -237,6 +257,33 @@ func TestStagedModify_InstallRenameFails_RollbackAlsoFails(t *testing.T) {
 	_, err := m.stagedModify(context.Background(), eapProfile(t, certDir), nil)
 	if err == nil || !strings.Contains(err.Error(), "rollback also failed") {
 		t.Errorf("err = %v, want the double-failure (install + rollback) message", err)
+	}
+}
+
+// New certs install fine, but the cleanup of the .old backup directory — which
+// holds the PREVIOUS private key — fails. That must surface (changed still true),
+// not be silently dropped: a stale private key left on disk is the caller's
+// concern.
+func TestStagedModify_OldCertCleanupFailureSurfaces(t *testing.T) {
+	swapCertSeams(t)
+	certDir := filepath.Join(t.TempDir(), "eap")
+	if err := os.MkdirAll(certDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	oldDir := certDir + ".old"
+	removeAll = func(p string) error {
+		if p == oldDir {
+			return errors.New("read-only fs")
+		}
+		return os.RemoveAll(p)
+	}
+	m := &networkManager{r: &recordingRunner{}}
+	changed, err := m.stagedModify(context.Background(), eapProfile(t, certDir), nil)
+	if !changed {
+		t.Error("changed = false, want true (the new certs are installed and live)")
+	}
+	if err == nil || !strings.Contains(err.Error(), "old cert directory") {
+		t.Errorf("err = %v, want the stale-private-key cleanup failure surfaced", err)
 	}
 }
 

--- a/sys/network/keyfile.go
+++ b/sys/network/keyfile.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -147,21 +148,28 @@ func writeKeyfile(path string, content []byte) error {
 	tmpPath := tmp.Name()
 	if _, err := tmp.Write(content); err != nil {
 		_ = tmp.Close()
-		_ = removeFile(tmpPath)
-		return fmt.Errorf("write keyfile: %w", err)
+		return cleanupTempKeyfile(tmpPath, fmt.Errorf("write keyfile: %w", err))
 	}
 	if err := tmp.Chmod(0o600); err != nil {
 		_ = tmp.Close()
-		_ = removeFile(tmpPath)
-		return fmt.Errorf("chmod keyfile: %w", err)
+		return cleanupTempKeyfile(tmpPath, fmt.Errorf("chmod keyfile: %w", err))
 	}
 	if err := tmp.Close(); err != nil {
-		_ = removeFile(tmpPath)
-		return fmt.Errorf("close keyfile: %w", err)
+		return cleanupTempKeyfile(tmpPath, fmt.Errorf("close keyfile: %w", err))
 	}
 	if err := renameFile(tmpPath, path); err != nil {
-		_ = removeFile(tmpPath)
-		return fmt.Errorf("rename keyfile to %q: %w", path, err)
+		return cleanupTempKeyfile(tmpPath, fmt.Errorf("rename keyfile to %q: %w", path, err))
 	}
 	return nil
+}
+
+// cleanupTempKeyfile removes a partially-written temp keyfile after a failure and
+// folds any removal error into cause. The temp file holds the plaintext PSK/key
+// body, so a dropped removal error would silently leave the secret on disk — a
+// failed cleanup must be visible. A file that is already gone is not a failure.
+func cleanupTempKeyfile(tmpPath string, cause error) error {
+	if rmErr := removeFile(tmpPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		return fmt.Errorf("%w (temp keyfile cleanup failed, plaintext secret may remain at %s: %v)", cause, tmpPath, rmErr)
+	}
+	return cause
 }

--- a/sys/network/keyfile_test.go
+++ b/sys/network/keyfile_test.go
@@ -174,6 +174,29 @@ func TestWriteKeyfile_WriteChmodCloseRenameFail(t *testing.T) {
 	}
 }
 
+// When the temp-keyfile cleanup itself fails after a write failure, both the
+// original failure AND the cleanup failure must surface — a dropped removeFile
+// error would silently leave a keyfile holding the plaintext PSK on disk.
+func TestWriteKeyfile_CleanupFailureSurfacesPlaintextResidue(t *testing.T) {
+	swapSeams(t)
+	mkdirAll = func(string, os.FileMode) error { return nil }
+	createTemp = func(string, string) (keyfileHandle, error) {
+		return &fakeHandle{name: "/tmp/seam.tmp", failWrite: true}, nil
+	}
+	removeFile = func(string) error { return errors.New("disk gone") }
+
+	err := writeKeyfile("/etc/nm/y.nmconnection", []byte("super-secret-psk"))
+	if err == nil {
+		t.Fatal("writeKeyfile err = nil, want a failure")
+	}
+	if !strings.Contains(err.Error(), "write keyfile") {
+		t.Errorf("err = %v, want the original write failure preserved", err)
+	}
+	if !strings.Contains(err.Error(), "cleanup failed") || !strings.Contains(err.Error(), "/tmp/seam.tmp") {
+		t.Errorf("err = %v, want the temp-keyfile cleanup failure (plaintext residue) surfaced", err)
+	}
+}
+
 // Belt-and-braces: a PSK with a newline can never be constructed, so it can never
 // inject extra keyfile lines.
 func TestPSKSecret_RejectsNewlineAtConstruction(t *testing.T) {

--- a/sys/network/networkmanager.go
+++ b/sys/network/networkmanager.go
@@ -120,7 +120,9 @@ func (m *networkManager) create(ctx context.Context, p Profile) (bool, error) {
 		return false, fmt.Errorf("write certificates: %w", err)
 	}
 	if err := m.nmcliWrite(ctx, buildAddArgs(p)...); err != nil {
-		removeCerts(p.CertDir)
+		if rmErr := removeCerts(p.CertDir); rmErr != nil {
+			return false, fmt.Errorf("create connection: %w (cert cleanup failed, private key may remain on disk: %v)", err, rmErr)
+		}
 		return false, fmt.Errorf("create connection: %w", err)
 	}
 	return true, nil
@@ -206,7 +208,12 @@ func (m *networkManager) stagedModify(ctx context.Context, p Profile, current ma
 		return true, fmt.Errorf("install staged certs: %w", err)
 	}
 	if liveExists {
-		_ = removeAll(oldDir)
+		if err := removeAll(oldDir); err != nil {
+			// New certs are installed and live; the only failure here is cleanup
+			// of the .old backup, which holds the previous private key. Surface it
+			// (changed is still true) so stale key material on disk isn't silent.
+			return true, fmt.Errorf("certs updated but failed to remove old cert directory %s (stale private key may remain): %w", oldDir, err)
+		}
 	}
 	return true, nil
 }


### PR DESCRIPTION
Follow-up to #244, addressing all 7 of CodeRabbit's actionable comments on that
PR (the merge happened before they were all worked through — owning that). Two
are genuine bugs in the new code; four surface dropped cleanup errors for secret
material; one (the errcheck exclude file) was already resolved in #244. Every fix
has a regression test that was red-checked (fails on the pre-fix code).

## Logic bugs

**fs.ReadFile / ReadDir — ENOENT misclassification.** Absence was detected with
`strings.Contains(stderr, "No such file")`, which misfires when the *path* text
contains that phrase: a **present** file failing for another reason (e.g.
`cat: /data/No such file.txt: Permission denied`) was wrongly reported absent,
hiding the real error. Now matches the **terminal** phrase via a shared
`isENOENTStderr` (the error reason always trails the path, so path content can't
reach the suffix).

**readDirEscalated — non-directory returned silent-empty.** `find <path>` on a
**regular file** exits 0 with no output, so the escalated path returned
`(empty, nil)` for a non-directory — violating the contract the Direct
(`os.ReadDir`) path enforces. Now runs `find <path>/`: the trailing slash makes
`find` report ENOTDIR (non-zero), which the terminal-phrase classifier surfaces
as an error rather than the absence sentinel.

## Dropped cleanup errors for secret material

Silently dropping a failed *removal* of key material is the opposite of this
PR-series' "explicit errors" intent. Now folded into the returned error (guarded
by `os.IsNotExist`, so already-absent is not a failure):

- `encryption.writeKeyFile` — failed key-file removal (plaintext LUKS key on /dev/shm)
- `network.writeKeyfile` — failed temp-keyfile removal (plaintext PSK)
- `network.removeCerts` — now returns its first removal failure (a `client-key.pem` that won't delete is a private key left on disk)
- `network.stagedModify` — failed cleanup of the `.old` backup dir (previous private key), with `changed` still true

## Verification

`go build`, `go vet`, `errcheck -ignoretests` (the gate from #244), full
`go test ./...`, `gofmt -l`, and `docref check` all green. 7 new/updated
regression tests, each confirmed to fail on the pre-fix code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting when encryption key and certificate cleanup operations fail, ensuring critical cleanup failures are no longer silently ignored.
  * Enhanced file-not-found detection for privileged operations to prevent incorrect error classification when file paths contain misleading strings.
  * Cleanup failures now surface detailed error messages including affected file paths, strengthening observability.

* **Tests**
  * Expanded test coverage for cleanup failure scenarios and edge cases in file and directory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->