### PR TITLE
feat(fs,user): file/home/mount primitives (gaps 8/9/10/11)

### DIFF
--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -110,10 +110,14 @@ type Manager interface {
 	// WriteFile writes data to path atomically. When the Runner's backend is
 	// Direct the write is also symlink-safe (fd-anchored); see the package doc.
 	WriteFile(ctx context.Context, path string, data []byte, opts WriteOptions) error
-	// WriteReader streams r to path atomically without buffering the whole
-	// payload — for a large artifact (e.g. a downloaded AppImage) WriteFile
-	// would risk OOM on. A failed/truncated stream never clobbers the existing
-	// file. opts.Backup is unsupported (returns an error).
+	// WriteReader streams r to path without buffering the whole payload — for a
+	// large artifact (e.g. a downloaded AppImage) WriteFile would risk OOM on. A
+	// crash/power-loss never leaves a partial file (temp + rename). On the Direct
+	// backend a reader error also aborts before the rename, so a truncated stream
+	// never clobbers the existing file; on escalated backends a reader error is
+	// surfaced but may occur after a truncated temp was already renamed, so stream
+	// a complete source. opts.Backup is unsupported (returns an error). See the
+	// method doc for detail.
 	WriteReader(ctx context.Context, path string, r io.Reader, opts WriteOptions) error
 	// Exists reports whether path exists. The probe runs through the privilege
 	// backend so it can see paths in directories the caller cannot traverse

--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -146,6 +146,10 @@ type Manager interface {
 	IsReadOnly(ctx context.Context, path string) (bool, error)
 	// RemountRW remounts the filesystem at path read-write.
 	RemountRW(ctx context.Context, path string) error
+	// ListMounts enumerates every mounted filesystem (source/target/fstype/ro).
+	// The enumeration counterpart to IsReadOnly/RemountRW — for acting on every
+	// matching mount (e.g. remounting all read-only on-disk mounts).
+	ListMounts(ctx context.Context) ([]MountInfo, error)
 }
 
 // manager is the single Manager implementation; the privilege strategy is the

--- a/sys/fs/fs.go
+++ b/sys/fs/fs.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -96,18 +97,24 @@ type MkdirOptions struct {
 // the caller controls timeout/cancellation. A non-zero exit from a shelled
 // command becomes an *exec.CommandError carrying the exit code and stderr.
 type Manager interface {
-	// ReadFile returns the contents of path. A path that does not exist yields
-	// (nil, nil) — absence is not an error, matching the "read whatever is
-	// there, empty if nothing" contract callers depend on.
+	// ReadFile returns the contents of path. A path that does not exist yields a
+	// wrapped fs.ErrNotExist (not a silent empty result), so a caller can tell
+	// "absent" from "present but empty"; opt into absent-as-empty with
+	// errors.Is(err, fs.ErrNotExist). A present empty file returns (nil, nil).
 	ReadFile(ctx context.Context, path string) ([]byte, error)
-	// ReadDir lists the immediate entries of a directory (no recursion). A path
-	// that does not exist yields (nil, nil) — absence is an empty listing, the
-	// same "absent is empty" contract as ReadFile — so a caller enumerating a
-	// managed config directory that has never been created treats it as empty.
+	// ReadDir lists the immediate entries of a directory (no recursion). A
+	// missing directory yields a wrapped fs.ErrNotExist (the same explicit-
+	// absence contract as ReadFile); a non-directory target is an error too,
+	// never a silent empty listing.
 	ReadDir(ctx context.Context, path string) ([]DirEntry, error)
 	// WriteFile writes data to path atomically. When the Runner's backend is
 	// Direct the write is also symlink-safe (fd-anchored); see the package doc.
 	WriteFile(ctx context.Context, path string, data []byte, opts WriteOptions) error
+	// WriteReader streams r to path atomically without buffering the whole
+	// payload — for a large artifact (e.g. a downloaded AppImage) WriteFile
+	// would risk OOM on. A failed/truncated stream never clobbers the existing
+	// file. opts.Backup is unsupported (returns an error).
+	WriteReader(ctx context.Context, path string, r io.Reader, opts WriteOptions) error
 	// Exists reports whether path exists. The probe runs through the privilege
 	// backend so it can see paths in directories the caller cannot traverse
 	// (e.g. /etc/sudoers.d, mode 0750). A runner/ctx failure is returned as an
@@ -123,6 +130,10 @@ type Manager interface {
 	RemoveDir(ctx context.Context, path string) error
 	// Copy copies src to dst and applies opts (mode/ownership) to dst.
 	Copy(ctx context.Context, src, dst string, opts WriteOptions) error
+	// CopyTree recursively copies the tree at src to dst (cp -a), merging into
+	// dst rather than nesting under it. A non-zero opts.Mode chmods the dst root;
+	// opts.Owner/Group, if set, are applied recursively.
+	CopyTree(ctx context.Context, src, dst string, opts WriteOptions) error
 	// SetMode sets the file mode (chmod).
 	SetMode(ctx context.Context, path string, mode os.FileMode) error
 	// SetOwnership sets the file owner and group (chown). Either may be empty;

--- a/sys/fs/fs_test.go
+++ b/sys/fs/fs_test.go
@@ -391,6 +391,28 @@ func (r *failingReader) Read(p []byte) (int, error) {
 	return 1, nil
 }
 
+func TestListMounts_Integration(t *testing.T) {
+	mounts, err := intManager(t).ListMounts(context.Background())
+	if err != nil {
+		t.Fatalf("ListMounts: %v", err)
+	}
+	if len(mounts) == 0 {
+		t.Fatal("ListMounts returned nothing; at least / must be mounted")
+	}
+	var root *fs.MountInfo
+	for i := range mounts {
+		if mounts[i].Target == "/" {
+			root = &mounts[i]
+		}
+	}
+	if root == nil {
+		t.Fatalf("/ not present in enumerated mounts: %+v", mounts)
+	}
+	if root.Source == "" || root.FSType == "" {
+		t.Errorf("root mount under-populated: %+v", *root)
+	}
+}
+
 func TestMkdirAndRemoveDir(t *testing.T) {
 	ctx := context.Background()
 	m := intManager(t)

--- a/sys/fs/fs_test.go
+++ b/sys/fs/fs_test.go
@@ -283,6 +283,114 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestCopyTree(t *testing.T) {
+	ctx := context.Background()
+	m := intManager(t)
+	src := tmpPath(t, "treesrc")
+	dst := tmpPath(t, "treedst")
+	defer func() { _ = m.RemoveDir(ctx, src); _ = m.RemoveDir(ctx, dst) }()
+
+	// A src tree with a regular file, a DOTFILE (proves -a copies hidden files),
+	// and a nested subdir (proves recursion). Setup via os.* (the test user owns
+	// /tmp); the subject under test is the privileged CopyTree.
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for path, body := range map[string]string{
+		filepath.Join(src, ".bashrc"):      "export X=1\n",
+		filepath.Join(src, "sub", "f.txt"): "nested\n",
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// dst does not exist yet: -T makes dst a copy of src's CONTENTS (the merge
+	// semantics), never dst/treesrc.
+	if err := m.CopyTree(ctx, src, dst, fs.WriteOptions{}); err != nil {
+		t.Fatalf("CopyTree: %v", err)
+	}
+	for _, rel := range []string{".bashrc", "sub/f.txt"} {
+		if ok, err := m.Exists(ctx, filepath.Join(dst, rel)); err != nil || !ok {
+			t.Errorf("dst is missing %q after CopyTree (Exists=%v, err=%v)", rel, ok, err)
+		}
+	}
+	if ok, _ := m.Exists(ctx, filepath.Join(dst, filepath.Base(src))); ok {
+		t.Error("CopyTree nested the source under dst (dst/<src> exists) — -T should merge into dst")
+	}
+
+	// Idempotent re-run into the now-existing dst must not error (merge).
+	if err := m.CopyTree(ctx, src, dst, fs.WriteOptions{Mode: 0o700}); err != nil {
+		t.Fatalf("CopyTree (re-run/merge): %v", err)
+	}
+	if mode := statMode(t, dst); mode != 0o700 {
+		t.Errorf("dst root mode = %v, want 0700 (Mode applies to the root)", mode)
+	}
+}
+
+func TestWriteReader_StreamsAndIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	m := intManager(t)
+	path := tmpPath(t, "stream")
+	defer cleanup(t, m, path)
+
+	// A payload well past one io.Copy buffer, to exercise chunked streaming. It
+	// is intentionally newline-free and multi-megabyte — exactly the binary
+	// artifact WriteReader exists for. Verification reads the file back with a
+	// direct os.ReadFile (the file is written world-readable below), NOT
+	// m.ReadFile: the escalated ReadFile streams `cat` through the line-buffered
+	// Runner (1 MiB cap, output-oriented) and cannot faithfully return a large
+	// no-newline blob — a limitation of ReadFile, not of WriteReader.
+	payload := strings.Repeat("0123456789abcdef", 200000) // ~3 MB
+	if err := m.WriteReader(ctx, path, strings.NewReader(payload), fs.WriteOptions{Mode: 0o644}); err != nil {
+		t.Fatalf("WriteReader: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != payload {
+		t.Errorf("streamed content mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+	if mode := statMode(t, path); mode != 0o644 {
+		t.Errorf("mode = %v, want 0644", mode)
+	}
+
+	// Reader-error atomicity is guaranteed only on the Direct (root, fd-anchored)
+	// backend — io.Copy aborts before the rename. The escalated path pipes to a
+	// root shell that renames on stdin-EOF, so it intentionally does NOT promise
+	// non-clobber on a truncated reader (see WriteReader's doc); skip there.
+	if os.Geteuid() != 0 {
+		t.Skip("reader-error atomicity is a Direct-backend guarantee; run as root to exercise it")
+	}
+	if err := m.WriteReader(ctx, path, &failingReader{failAfter: 1024}, fs.WriteOptions{Mode: 0o644}); err == nil {
+		t.Fatal("WriteReader with a mid-stream failing reader should error")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back after failed stream: %v", err)
+	}
+	if string(after) != payload {
+		t.Errorf("a failed stream clobbered the existing file: got %d bytes, want the original %d", len(after), len(payload))
+	}
+}
+
+// failingReader yields failAfter bytes then errors, to drive WriteReader's
+// mid-stream failure path.
+type failingReader struct {
+	failAfter int
+	n         int
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.n >= r.failAfter {
+		return 0, errors.New("simulated mid-stream read failure")
+	}
+	p[0] = 'x'
+	r.n++
+	return 1, nil
+}
+
 func TestMkdirAndRemoveDir(t *testing.T) {
 	ctx := context.Background()
 	m := intManager(t)

--- a/sys/fs/manager_test.go
+++ b/sys/fs/manager_test.go
@@ -745,6 +745,71 @@ func TestRemountRW(t *testing.T) {
 	}
 }
 
+func TestListMounts(t *testing.T) {
+	t.Run("parses findmnt rows", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		f.Push(pmexec.Result{Stdout: "/dev/sda1 / ext4 rw,relatime\n/dev/sda2 /usr ext4 ro,relatime\nproc /proc proc rw,nosuid\ntmpfs /run tmpfs rw,nosuid\n"}, nil)
+		got, err := mustManager(t, f).ListMounts(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a := argv(f.Calls()[0]); a != "findmnt -rn -o SOURCE,TARGET,FSTYPE,OPTIONS" {
+			t.Errorf("argv = %q", a)
+		}
+		want := []MountInfo{
+			{"/dev/sda1", "/", "ext4", false},
+			{"/dev/sda2", "/usr", "ext4", true}, // /usr read-only independently of /
+			{"proc", "/proc", "proc", false},
+			{"tmpfs", "/run", "tmpfs", false},
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d mounts, want %d: %+v", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("mount[%d] = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+	t.Run("ro is an exact option token, not a substring", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		// "errors=remount-ro" contains "ro" as a substring but the mount is rw.
+		f.Push(pmexec.Result{Stdout: "/dev/sda1 / ext4 rw,errors=remount-ro\n"}, nil)
+		got, err := mustManager(t, f).ListMounts(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].ReadOnly {
+			t.Errorf("mount = %+v, want ReadOnly=false (errors=remount-ro is not a ro mount)", got)
+		}
+	})
+	t.Run("skips malformed and blank rows", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		f.Push(pmexec.Result{Stdout: "/dev/sda1 / ext4 rw\nbroken\n\n/dev/sdb /data xfs ro\n"}, nil)
+		got, err := mustManager(t, f).ListMounts(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d mounts, want 2 (malformed/blank skipped): %+v", len(got), got)
+		}
+	})
+	t.Run("findmnt non-zero exit is a command error", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "findmnt: bad"}, nil)
+		if _, err := mustManager(t, f).ListMounts(context.Background()); !errors.As(err, new(*pmexec.CommandError)) {
+			t.Errorf("err = %v, want *exec.CommandError", err)
+		}
+	})
+	t.Run("runner error propagates", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		f.Push(pmexec.Result{}, errors.New("findmnt missing"))
+		if _, err := mustManager(t, f).ListMounts(context.Background()); err == nil {
+			t.Error("a runner error must propagate")
+		}
+	})
+}
+
 // --- pure helpers ----------------------------------------------------------
 
 func TestOwnership(t *testing.T) {

--- a/sys/fs/manager_test.go
+++ b/sys/fs/manager_test.go
@@ -178,6 +178,78 @@ func TestWriteFile_Escalated_RunnerErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestWriteReader_Escalated_StreamsStdinThroughTheRootShell(t *testing.T) {
+	f, m := sudoMgr(t)
+	body := "an-appimage-sized-payload-streamed-not-buffered\n"
+	if err := m.WriteReader(context.Background(), "/etc/app.bin", strings.NewReader(body),
+		WriteOptions{Mode: 0o755, Owner: "root", Group: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("ran %d commands, want 1 (a single root sh -c); got %v", len(calls), callNames(calls))
+	}
+	c := calls[0]
+	if !c.Escalate {
+		t.Error("the escalated streaming write must run escalated")
+	}
+	// Same script + arg shape as WriteFile, but the backup arg is ALWAYS empty
+	// (WriteReader rejects Backup), and the payload arrives via stdin.
+	want := []string{"-c", escalatedWriteScript, "sh", "/etc/app.bin", "0755", "root:root", ""}
+	if c.Name != "sh" || strings.Join(c.Args, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("command = %s %q\nwant   = sh %q", c.Name, c.Args, want)
+	}
+	if got := stdinOf(t, c); got != body {
+		t.Errorf("stdin = %q, want the streamed payload (read by `cat` in the script)", got)
+	}
+}
+
+func TestWriteReader_RejectsBackup(t *testing.T) {
+	_, m := sudoMgr(t)
+	err := m.WriteReader(context.Background(), "/etc/app.bin", strings.NewReader("x"),
+		WriteOptions{Backup: "/etc/app.bin.bak"})
+	if !errors.Is(err, ErrInvalidPath) {
+		t.Fatalf("err = %v, want ErrInvalidPath — WriteReader does not support Backup", err)
+	}
+}
+
+func TestWriteReader_RejectsInvalidPath(t *testing.T) {
+	_, m := sudoMgr(t)
+	if err := m.WriteReader(context.Background(), "-rf", strings.NewReader("x"), WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
+		t.Errorf("WriteReader(bad path) err = %v, want ErrInvalidPath", err)
+	}
+}
+
+// A nil reader is rejected rather than panicking the io.Copy on the Direct path
+// or writing an empty file on the escalated one.
+func TestWriteReader_RejectsNilReader(t *testing.T) {
+	for _, b := range []pmexec.PrivilegeBackend{pmexec.Direct, pmexec.Sudo} {
+		f := exectest.New(b)
+		m := mustManager(t, f)
+		if err := m.WriteReader(context.Background(), "/etc/app.bin", nil, WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("backend %v: WriteReader(nil reader) err = %v, want ErrInvalidPath", b, err)
+		}
+		if n := len(f.Calls()); n != 0 {
+			t.Errorf("backend %v: a nil reader reached exec (%d calls)", b, n)
+		}
+	}
+}
+
+func TestWriteReader_Escalated_RefusesUnsafeParent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	f, m := sudoMgr(t)
+	err := m.WriteReader(context.Background(), filepath.Join(dir, "f"), strings.NewReader("x"), WriteOptions{})
+	if !errors.Is(err, ErrUnsafeParentDir) {
+		t.Fatalf("err = %v, want ErrUnsafeParentDir", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("ran %d commands; an unsafe parent must be refused before escalating", n)
+	}
+}
+
 func TestWriteFile_RejectsInvalidPathAndBackup(t *testing.T) {
 	f, m := sudoMgr(t)
 	if err := m.WriteFile(context.Background(), "-rf", []byte("x"), WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
@@ -443,6 +515,68 @@ func TestCopy(t *testing.T) {
 		}
 		if err := m.Copy(context.Background(), "/a", "-b", WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
 			t.Errorf("Copy(bad dst) err = %v", err)
+		}
+	})
+}
+
+func TestCopyTree(t *testing.T) {
+	t.Run("archive merge into target", func(t *testing.T) {
+		f, m := sudoMgr(t)
+		if err := m.CopyTree(context.Background(), "/etc/skel", "/home/alice", WriteOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		// cp -a preserves metadata; -T treats dst as the literal target so the
+		// tree merges INTO /home/alice rather than nesting at /home/alice/skel.
+		if len(calls) != 1 || argv(calls[0]) != "cp -a -T -- /etc/skel /home/alice" {
+			t.Fatalf("calls = %v, want a single archive `cp -a -T`", callNames(calls))
+		}
+		if !calls[0].Escalate {
+			t.Error("CopyTree must escalate")
+		}
+	})
+	t.Run("mode chmods root, ownership is recursive", func(t *testing.T) {
+		f, m := sudoMgr(t)
+		if err := m.CopyTree(context.Background(), "/etc/skel", "/home/alice", WriteOptions{Mode: 0o700, Owner: "alice", Group: "alice"}); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if names := callNames(calls); strings.Join(names, ",") != "cp,chmod,chown" {
+			t.Fatalf("calls = %v, want cp,chmod,chown", names)
+		}
+		var chmod, chown pmexec.Command
+		for _, c := range calls {
+			switch c.Name {
+			case "chmod":
+				chmod = c
+			case "chown":
+				chown = c
+			}
+		}
+		// Mode applies to the dst ROOT only (archive per-file modes are kept).
+		if argv(chmod) != "chmod 0700 -- /home/alice" {
+			t.Errorf("chmod argv = %q, want the dst root only", argv(chmod))
+		}
+		// Ownership is recursive: re-homing a tree copied as root.
+		if argv(chown) != "chown -R -- alice:alice /home/alice" {
+			t.Errorf("chown argv = %q, want a recursive chown", argv(chown))
+		}
+	})
+	t.Run("cp failure wrapped", func(t *testing.T) {
+		f := exectest.New(pmexec.Sudo)
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "cp: cannot stat"}, nil)
+		if err := mustManager(t, f).CopyTree(context.Background(), "/a", "/b", WriteOptions{}); err == nil ||
+			!strings.Contains(err.Error(), "copy tree") {
+			t.Errorf("err = %v, want a wrapped cp failure", err)
+		}
+	})
+	t.Run("validates both paths", func(t *testing.T) {
+		_, m := sudoMgr(t)
+		if err := m.CopyTree(context.Background(), "-a", "/b", WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("CopyTree(bad src) err = %v", err)
+		}
+		if err := m.CopyTree(context.Background(), "/a", "-b", WriteOptions{}); !errors.Is(err, ErrInvalidPath) {
+			t.Errorf("CopyTree(bad dst) err = %v", err)
 		}
 	})
 }

--- a/sys/fs/mount.go
+++ b/sys/fs/mount.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// MountInfo describes one mounted filesystem, as reported by findmnt.
+type MountInfo struct {
+	Source   string // backing device or pseudo-source (e.g. /dev/sda1, tmpfs, proc)
+	Target   string // mountpoint
+	FSType   string // filesystem type (ext4, xfs, tmpfs, ...)
+	ReadOnly bool   // the mount carries the "ro" VFS option
+}
+
 // IsReadOnly reports whether the filesystem mounted at path is read-only, by
 // examining the mount options via findmnt (unprivileged). The caller controls
 // timeout/cancellation through ctx.
@@ -20,12 +28,58 @@ func (m *manager) IsReadOnly(ctx context.Context, path string) (bool, error) {
 	if res.ExitCode != 0 {
 		return false, cmdError("findmnt", res)
 	}
-	for _, opt := range strings.Split(strings.TrimSpace(res.Stdout), ",") {
+	return mountOptionsReadOnly(strings.TrimSpace(res.Stdout)), nil
+}
+
+// mountOptionsReadOnly reports whether a comma-separated findmnt OPTIONS value
+// carries the "ro" VFS flag (an exact token, never a substring of e.g.
+// "errors=remount-ro").
+func mountOptionsReadOnly(options string) bool {
+	for _, opt := range strings.Split(options, ",") {
 		if opt == "ro" {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
+}
+
+// ListMounts enumerates every currently mounted filesystem via findmnt (an
+// unprivileged read). It is the enumeration counterpart to the per-path
+// IsReadOnly/RemountRW: a caller that must act on EVERY matching mount — e.g.
+// remounting all read-only on-disk mounts during a repair, since /usr can go
+// read-only independently of / — lists them here, filters as it needs (typically
+// Source has a "/dev/" prefix and ReadOnly is true), and RemountRWs each.
+//
+// Output is the raw `findmnt -rn` form: one row per mount, SOURCE/TARGET/FSTYPE/
+// OPTIONS. A row that does not split into at least four fields is skipped rather
+// than aborting the whole enumeration.
+func (m *manager) ListMounts(ctx context.Context) ([]MountInfo, error) {
+	res, err := m.runQuery(ctx, "findmnt", "-rn", "-o", "SOURCE,TARGET,FSTYPE,OPTIONS")
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		return nil, cmdError("findmnt", res)
+	}
+	var mounts []MountInfo
+	for _, line := range strings.Split(strings.TrimRight(res.Stdout, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		// -r escapes any whitespace inside a value (\x20 etc.), so the four
+		// columns are always space-separated and Fields recovers them exactly.
+		f := strings.Fields(line)
+		if len(f) < 4 {
+			continue
+		}
+		mounts = append(mounts, MountInfo{
+			Source:   f[0],
+			Target:   f[1],
+			FSType:   f[2],
+			ReadOnly: mountOptionsReadOnly(f[3]),
+		})
+	}
+	return mounts, nil
 }
 
 // RemountRW remounts the filesystem at path read-write through the privilege

--- a/sys/fs/safe_replace.go
+++ b/sys/fs/safe_replace.go
@@ -3,6 +3,7 @@
 package fs
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -38,6 +39,16 @@ import (
 // Returns the resolved temp path on failure so the caller can decide
 // whether to clean it up.
 func safeReplaceFile(path string, data []byte, perm os.FileMode, removeExisting bool) error {
+	return safeReplaceFromReader(path, bytes.NewReader(data), perm, removeExisting)
+}
+
+// safeReplaceFromReader is the streaming form of safeReplaceFile: it copies from
+// src into the same-directory temp file (io.Copy, no buffering of the whole
+// payload), keeping every symlink-aware defense — O_NOFOLLOW temp open,
+// fsync, atomic rename — so an arbitrarily large source (a downloaded AppImage)
+// is placed atomically without holding it all in memory. A failed or truncated
+// copy never clobbers the existing file: the rename is the final step.
+func safeReplaceFromReader(path string, src io.Reader, perm os.FileMode, removeExisting bool) error {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
 
@@ -62,7 +73,7 @@ func safeReplaceFile(path string, data []byte, perm os.FileMode, removeExisting 
 		return fmt.Errorf("reopen temp with O_NOFOLLOW: %w", err)
 	}
 
-	if _, err := f.Write(data); err != nil {
+	if _, err := io.Copy(f, src); err != nil {
 		_ = f.Close()
 		cleanup()
 		return fmt.Errorf("write temp: %w", err)

--- a/sys/fs/write.go
+++ b/sys/fs/write.go
@@ -3,8 +3,11 @@ package fs
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+
+	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
 
 // WriteFile writes data to path atomically, applying opts (mode/ownership, and
@@ -105,6 +108,97 @@ func (m *manager) writeEscalated(ctx context.Context, path string, data []byte, 
 	return nil
 }
 
+// WriteReader streams the bytes from r to path, applying opts, WITHOUT buffering
+// the whole payload in memory — for a large artifact (e.g. a downloaded AppImage
+// of tens-to-hundreds of MB) that WriteFile([]byte) would risk OOM on. The stream
+// lands in a same-directory temp file that is renamed into place only after it is
+// written, so at no instant does a crash or power-loss leave the destination
+// holding a partial file: it always holds either the prior content or the new
+// content in full. On the Direct backend the temp open is O_NOFOLLOW (symlink-
+// safe) and an io.Copy error aborts BEFORE the rename, so a mid-stream READER
+// error also leaves the destination untouched. Under Sudo/Doas the stream is
+// piped through a single root shell that `cat`s stdin into the temp and `mv -T`s
+// it over the target; a reader that errors mid-stream is surfaced as an error,
+// but because the shell renames on its own stdin-EOF the truncated temp may
+// already have been placed — so callers stream a COMPLETE source (the AppImage
+// flow streams a checksum-verified file, where a read error means disk failure).
+//
+// opts.Backup is NOT supported (WriteReader targets a fresh large artifact, not an
+// in-place config edit with a kept backup); setting it is an error. A zero
+// opts.Mode defaults to 0644, as WriteFile does.
+func (m *manager) WriteReader(ctx context.Context, path string, r io.Reader, opts WriteOptions) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := ValidatePath(path); err != nil {
+		return err
+	}
+	if err := validateMode(opts.Mode); err != nil {
+		return err
+	}
+	if r == nil {
+		return fmt.Errorf("%w: WriteReader requires a non-nil reader", ErrInvalidPath)
+	}
+	if opts.Backup != "" {
+		return fmt.Errorf("%w: WriteReader does not support a backup (use WriteFile for in-place edits)", ErrInvalidPath)
+	}
+	if m.direct() {
+		return writeReaderDirect(path, r, opts)
+	}
+	return m.writeReaderEscalated(ctx, path, r, opts)
+}
+
+// writeReaderDirect is the fd-anchored streaming path (root agent): it streams r
+// into an O_NOFOLLOW temp and atomically renames into place, then chowns through
+// an O_NOFOLLOW fd — the symlink-safe Direct write, sourced from a reader.
+func writeReaderDirect(path string, r io.Reader, opts WriteOptions) error {
+	perm := opts.Mode
+	if perm == 0 {
+		perm = 0o644
+	}
+	if err := safeReplaceFromReader(path, r, perm, true); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	if opts.Owner != "" || opts.Group != "" {
+		uid, gid, err := ResolveOwnership(opts.Owner, opts.Group)
+		if err != nil {
+			return err
+		}
+		if err := FchownNoFollow(path, uid, gid); err != nil {
+			return fmt.Errorf("set ownership on %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// writeReaderEscalated streams r through the escalatedWriteScript: the root shell
+// `cat`s stdin into a same-directory temp and `mv -T`s it over the target, so the
+// payload never lands in this (non-root) process's memory. Same parent-safety
+// vetting and single-root-shell atomicity as writeEscalated; backup is always
+// empty (WriteReader rejects Backup up front).
+func (m *manager) writeReaderEscalated(ctx context.Context, path string, r io.Reader, opts WriteOptions) error {
+	perm := opts.Mode
+	if perm == 0 {
+		perm = 0o644
+	}
+	if err := escalatedParentSafe(filepath.Dir(path)); err != nil {
+		return err
+	}
+	res, err := m.r.Run(ctx, pmexec.Command{
+		Name:     "sh",
+		Args:     []string{"-c", escalatedWriteScript, "sh", path, modeArg(perm), Ownership(opts.Owner, opts.Group), ""},
+		Stdin:    r,
+		Escalate: true,
+	})
+	if err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	if cerr := cmdError("write file", res); cerr != nil {
+		return fmt.Errorf("write file %s: %w", path, cerr)
+	}
+	return nil
+}
+
 // escalatedWriteScript performs an atomic, symlink-safe write entirely as root in
 // one process, so there is no cross-process TOCTOU window. Positional args:
 // $1=target, $2=chmod mode, $3=chown owner (":group" form, "" to skip),
@@ -162,6 +256,46 @@ func (m *manager) Copy(ctx context.Context, src, dst string, opts WriteOptions) 
 	}
 	if opts.Owner != "" || opts.Group != "" {
 		if err := m.SetOwnership(ctx, dst, opts.Owner, opts.Group); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CopyTree recursively copies the tree at src to dst, preserving mode, ownership,
+// and timestamps (cp -a), and merges into dst rather than nesting under it: it
+// runs `cp -a -T -- src dst`, where -T (--no-target-directory) makes cp treat dst
+// as the literal destination. So `CopyTree(ctx, "/etc/skel", "/home/alice", …)`
+// makes /home/alice a copy of skel's contents whether or not /home/alice already
+// exists — never /home/alice/skel. cp -a OVERWRITES files that already exist at
+// dst (it does not delete dst-only files); a caller that must not clobber existing
+// content (e.g. a user's customised dotfiles) checks Exists first.
+//
+// opts applies to dst AFTER the copy: a non-zero Mode chmods the destination ROOT
+// only (not recursively — the per-file modes from the archive copy are kept),
+// while Owner/Group, if set, are applied RECURSIVELY (the common intent when
+// re-homing a tree copied as root — e.g. skel → a user's home). Both are skipped
+// when unset, leaving the archive-preserved metadata.
+func (m *manager) CopyTree(ctx context.Context, src, dst string, opts WriteOptions) error {
+	if err := ValidatePath(src); err != nil {
+		return err
+	}
+	if err := ValidatePath(dst); err != nil {
+		return err
+	}
+	if err := validateMode(opts.Mode); err != nil {
+		return err
+	}
+	if err := m.runChecked(ctx, "cp", "-a", "-T", "--", src, dst); err != nil {
+		return fmt.Errorf("copy tree: %w", err)
+	}
+	if opts.Mode != 0 {
+		if err := m.SetMode(ctx, dst, opts.Mode); err != nil {
+			return err
+		}
+	}
+	if opts.Owner != "" || opts.Group != "" {
+		if err := m.SetOwnershipRecursive(ctx, dst, opts.Owner, opts.Group); err != nil {
 			return err
 		}
 	}

--- a/sys/user/ensurehome_test.go
+++ b/sys/user/ensurehome_test.go
@@ -1,0 +1,126 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// passwdLine is the getent passwd reply Get parses for HomeDir.
+const deployPasswd = "deploy:x:1001:1001:Deploy:/home/deploy:/bin/bash\n"
+
+// A missing home is created, seeded from skel, owned recursively by the user,
+// and chmod'd to the home-root mode — the full repair.
+func TestEnsureHome_MissingCreatesSeedsOwnsAndModes(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: deployPasswd}, nil) // Get: getent passwd
+	ffs := newFakeFS().install(t)
+	ffs.present["/etc/skel"] = true // skel exists; home does NOT
+
+	if err := mgr(t, f).EnsureHome(context.Background(), "deploy", EnsureHomeOptions{Group: "deploy"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ffs.mkdirs) != 1 || ffs.mkdirs[0] != "/home/deploy" {
+		t.Errorf("mkdirs = %v, want [/home/deploy]", ffs.mkdirs)
+	}
+	if len(ffs.copies) != 1 || ffs.copies[0].src != "/etc/skel" || ffs.copies[0].dst != "/home/deploy" {
+		t.Errorf("copies = %v, want one /etc/skel → /home/deploy", ffs.copies)
+	}
+	if !ffs.chown.called || ffs.chown.path != "/home/deploy" || ffs.chown.owner != "deploy" || ffs.chown.group != "deploy" {
+		t.Errorf("chown = %+v, want recursive deploy:deploy on /home/deploy", ffs.chown)
+	}
+	if ffs.chmods.path != "/home/deploy" || ffs.chmods.mode != 0o700 {
+		t.Errorf("chmod = %+v, want 0700 on the home root", ffs.chmods)
+	}
+}
+
+// An EXISTING home must NOT be re-seeded from skel (that would clobber the
+// user's customised dotfiles) — but ownership and mode are still re-asserted.
+func TestEnsureHome_ExistingDoesNotReseedButFixesOwnerAndMode(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: deployPasswd}, nil)
+	ffs := newFakeFS().install(t)
+	ffs.present["/home/deploy"] = true // home already exists
+	ffs.present["/etc/skel"] = true
+
+	if err := mgr(t, f).EnsureHome(context.Background(), "deploy", EnsureHomeOptions{Group: "staff", Mode: 0o711}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ffs.mkdirs) != 0 {
+		t.Errorf("mkdirs = %v, want none (home already exists)", ffs.mkdirs)
+	}
+	if len(ffs.copies) != 0 {
+		t.Errorf("copies = %v, want NO skel reseed over an existing home", ffs.copies)
+	}
+	if !ffs.chown.called || ffs.chown.group != "staff" {
+		t.Errorf("chown = %+v, want recursive ownership with group staff", ffs.chown)
+	}
+	if ffs.chmods.mode != 0o711 {
+		t.Errorf("chmod mode = %v, want the requested 0711", ffs.chmods.mode)
+	}
+}
+
+// With no explicit Group, ownership resolves to the user's actual primary group
+// (id -gn), not a hardcoded assumption.
+func TestEnsureHome_DefaultsGroupToPrimary(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: deployPasswd}, nil)                       // Get: getent passwd
+	f.Push(exec.Result{Stdout: "deploy:x:1001:\n"}, nil)                 // Get: getent group 1001
+	f.Push(exec.Result{Stdout: "deploy\n"}, nil)                         // Get: id -Gn
+	f.Push(exec.Result{Stdout: "deploy:$6$h:19000:0:99999:7:::\n"}, nil) // Get: getent shadow (escalated)
+	f.Push(exec.Result{Stdout: "devs\n"}, nil)                           // PrimaryGroup: id -gn
+	ffs := newFakeFS().install(t)
+	ffs.present["/home/deploy"] = true
+
+	if err := mgr(t, f).EnsureHome(context.Background(), "deploy", EnsureHomeOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if ffs.chown.group != "devs" {
+		t.Errorf("chown group = %q, want the resolved primary group 'devs'", ffs.chown.group)
+	}
+}
+
+// Skel absent: the home is still created (empty), no copy attempted.
+func TestEnsureHome_NoSkelStillCreatesEmptyHome(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: deployPasswd}, nil)
+	ffs := newFakeFS().install(t) // neither home nor skel present
+
+	if err := mgr(t, f).EnsureHome(context.Background(), "deploy", EnsureHomeOptions{Group: "deploy"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ffs.mkdirs) != 1 {
+		t.Errorf("mkdirs = %v, want the home created even without skel", ffs.mkdirs)
+	}
+	if len(ffs.copies) != 0 {
+		t.Errorf("copies = %v, want no copy when skel is absent", ffs.copies)
+	}
+}
+
+// A nonexistent account is rejected (Get fails) and the filesystem is untouched.
+func TestEnsureHome_UserNotFoundErrors(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{ExitCode: 2}, nil) // getent passwd: not found
+	ffs := newFakeFS().install(t)
+
+	if err := mgr(t, f).EnsureHome(context.Background(), "ghost", EnsureHomeOptions{}); err == nil {
+		t.Fatal("EnsureHome on a nonexistent user must error")
+	}
+	if len(ffs.mkdirs) != 0 || len(ffs.copies) != 0 || ffs.chown.called {
+		t.Error("EnsureHome touched the filesystem for a nonexistent user")
+	}
+}
+
+// An invalid username is rejected before any lookup or filesystem op.
+func TestEnsureHome_InvalidUsernameRejectedBeforeExec(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	newFakeFS().install(t)
+	if err := mgr(t, f).EnsureHome(context.Background(), "-rf", EnsureHomeOptions{}); err == nil {
+		t.Fatal("a flag-shaped username must be rejected")
+	}
+	if len(f.Calls()) != 0 {
+		t.Errorf("a flag-shaped username reached exec (%d calls)", len(f.Calls()))
+	}
+}

--- a/sys/user/ensurehome_test.go
+++ b/sys/user/ensurehome_test.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
@@ -110,6 +112,25 @@ func TestEnsureHome_UserNotFoundErrors(t *testing.T) {
 	}
 	if len(ffs.mkdirs) != 0 || len(ffs.copies) != 0 || ffs.chown.called {
 		t.Error("EnsureHome touched the filesystem for a nonexistent user")
+	}
+}
+
+// A failed home-directory create aborts EnsureHome with the error wrapped, and
+// the seed/own/mode steps never run on a directory that wasn't created.
+func TestEnsureHome_MkdirFailureAborts(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: deployPasswd}, nil) // Get: getent passwd
+	ffs := newFakeFS().install(t)
+	ffs.present["/etc/skel"] = true // home is missing → Mkdir is attempted
+	ffs.mkdirErr = errors.New("read-only fs")
+
+	err := mgr(t, f).EnsureHome(context.Background(), "deploy", EnsureHomeOptions{Group: "deploy"})
+	if err == nil || !strings.Contains(err.Error(), "create") {
+		t.Fatalf("err = %v, want a wrapped create failure", err)
+	}
+	if len(ffs.copies) != 0 || ffs.chown.called || ffs.chmods.path != "" {
+		t.Errorf("EnsureHome seeded/owned/chmod'd after a failed mkdir (copies=%v chown=%v chmod=%q)",
+			ffs.copies, ffs.chown.called, ffs.chmods.path)
 	}
 }
 

--- a/sys/user/fakefs_test.go
+++ b/sys/user/fakefs_test.go
@@ -42,8 +42,11 @@ func (f *fakeFS) Exists(_ context.Context, path string) (bool, error) {
 
 func (f *fakeFS) Mkdir(_ context.Context, path string, _ fs.MkdirOptions) error {
 	f.mkdirs = append(f.mkdirs, path)
+	if f.mkdirErr != nil {
+		return f.mkdirErr // a failed mkdir must NOT mark the dir present
+	}
 	f.present[path] = true
-	return f.mkdirErr
+	return nil
 }
 
 func (f *fakeFS) CopyTree(_ context.Context, src, dst string, _ fs.WriteOptions) error {

--- a/sys/user/fakefs_test.go
+++ b/sys/user/fakefs_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
@@ -9,8 +10,9 @@ import (
 )
 
 // fakeFS is a hermetic fsManager for user tests: it records the
-// AccountsService write/remove and the home-fixup recursive chown, and returns
-// scripted errors. install() points the newFS seam at it for the test.
+// AccountsService write/remove, the home-fixup recursive chown, and the
+// EnsureHome probe/create/seed/mode calls, and returns scripted errors.
+// install() points the newFS seam at it for the test.
 type fakeFS struct {
 	writes  map[string]string
 	removes []string
@@ -18,10 +20,41 @@ type fakeFS struct {
 		path, owner, group string
 		called             bool
 	}
-	writeErr, removeErr, chownErr error
+	// EnsureHome surface.
+	present map[string]bool // Exists() answers
+	mkdirs  []string
+	copies  []struct{ src, dst string }
+	chmods  struct {
+		path string
+		mode os.FileMode
+	}
+	existsErr, mkdirErr, copyErr, chmodErr error
+	writeErr, removeErr, chownErr          error
 }
 
-func newFakeFS() *fakeFS { return &fakeFS{writes: map[string]string{}} }
+func newFakeFS() *fakeFS {
+	return &fakeFS{writes: map[string]string{}, present: map[string]bool{}}
+}
+
+func (f *fakeFS) Exists(_ context.Context, path string) (bool, error) {
+	return f.present[path], f.existsErr
+}
+
+func (f *fakeFS) Mkdir(_ context.Context, path string, _ fs.MkdirOptions) error {
+	f.mkdirs = append(f.mkdirs, path)
+	f.present[path] = true
+	return f.mkdirErr
+}
+
+func (f *fakeFS) CopyTree(_ context.Context, src, dst string, _ fs.WriteOptions) error {
+	f.copies = append(f.copies, struct{ src, dst string }{src, dst})
+	return f.copyErr
+}
+
+func (f *fakeFS) SetMode(_ context.Context, path string, mode os.FileMode) error {
+	f.chmods.path, f.chmods.mode = path, mode
+	return f.chmodErr
+}
 
 func (f *fakeFS) WriteFile(_ context.Context, path string, data []byte, _ fs.WriteOptions) error {
 	f.writes[path] = string(data)

--- a/sys/user/seams.go
+++ b/sys/user/seams.go
@@ -2,19 +2,24 @@ package user
 
 import (
 	"context"
+	"os"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
 	"github.com/manchtools/power-manage-sdk/sys/fs"
 )
 
 // fsManager is the narrow slice of fs.Manager this package uses: the -M+chown
-// home-fixup path and the AccountsService config write/remove. A small interface
-// so tests inject a fake via the newFS seam instead of touching a real
-// filesystem or privilege.
+// home-fixup path, the AccountsService config write/remove, and the EnsureHome
+// repair path (probe/create/seed/own/mode). A small interface so tests inject a
+// fake via the newFS seam instead of touching a real filesystem or privilege.
 type fsManager interface {
 	WriteFile(ctx context.Context, path string, data []byte, opts fs.WriteOptions) error
 	Remove(ctx context.Context, path string) error
 	SetOwnershipRecursive(ctx context.Context, path, owner, group string) error
+	Exists(ctx context.Context, path string) (bool, error)
+	Mkdir(ctx context.Context, path string, opts fs.MkdirOptions) error
+	CopyTree(ctx context.Context, src, dst string, opts fs.WriteOptions) error
+	SetMode(ctx context.Context, path string, mode os.FileMode) error
 }
 
 // newFS builds the fs.Manager (over the same injected Runner) the Manager writes

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/fs"
 )
 
 // queryTimeout caps a query op when the caller's context carries no deadline so
@@ -67,6 +68,19 @@ type CreateOptions struct {
 	CreateHome   bool     // -m; Create handles the "home already exists" -M/chown dance
 }
 
+// EnsureHomeOptions configures EnsureHome.
+type EnsureHomeOptions struct {
+	// Group owns the home tree (recursively). "" resolves to the user's actual
+	// primary group.
+	Group string
+	// Skel is the skeleton directory copied into a FRESHLY-created home. ""
+	// uses /etc/skel. Ignored when the home already exists — existing content is
+	// never clobbered.
+	Skel string
+	// Mode is the home directory's mode. Zero means 0700.
+	Mode os.FileMode
+}
+
 // ModifyOptions configures Modify. An empty string leaves that attribute
 // unchanged; if every field is empty Modify is a no-op (no usermod run).
 type ModifyOptions struct {
@@ -94,6 +108,7 @@ type Manager interface {
 	Get(ctx context.Context, name string) (Info, error)
 	Exists(ctx context.Context, name string) (bool, error)
 	Create(ctx context.Context, name string, opts CreateOptions) error
+	EnsureHome(ctx context.Context, name string, opts EnsureHomeOptions) error
 	Modify(ctx context.Context, name string, opts ModifyOptions) error
 	Delete(ctx context.Context, name string, opts DeleteOptions) error
 	Lock(ctx context.Context, name string) error
@@ -250,6 +265,76 @@ func (u *shadowUtils) Create(ctx context.Context, name string, opts CreateOption
 		if err := u.fsm.SetOwnershipRecursive(ctx, homeDir, name, group); err != nil {
 			return fmt.Errorf("fix ownership of existing home %q: %w", homeDir, err)
 		}
+	}
+	return nil
+}
+
+// EnsureHome idempotently ensures the existing user `name` has a correctly set
+// up home directory: it exists, is seeded from skel when freshly created, is
+// owned by the user (recursively), and carries the right mode. It is the repair
+// counterpart to Create's creation-time home handling (useradd -m) — for an
+// account whose home was created with -M, deleted, or left mis-owned.
+//
+// When the home is MISSING it is created and seeded from the skeleton (so no
+// existing user file can be clobbered — there are none). When the home already
+// EXISTS, EnsureHome re-asserts ownership and mode only; it does NOT re-copy
+// skel, so a user's customised dotfiles are preserved. The user must already
+// exist (use Create to make the account).
+func (u *shadowUtils) EnsureHome(ctx context.Context, name string, opts EnsureHomeOptions) error {
+	if err := validateUsername(name); err != nil {
+		return err
+	}
+	info, err := u.Get(ctx, name)
+	if err != nil {
+		return fmt.Errorf("ensure home for %q: %w", name, err)
+	}
+	home := info.HomeDir
+	if home == "" {
+		return fmt.Errorf("ensure home for %q: account has no home directory", name)
+	}
+
+	group := opts.Group
+	if group == "" {
+		group, err = u.PrimaryGroup(ctx, name)
+		if err != nil {
+			return fmt.Errorf("ensure home for %q: resolve primary group: %w", name, err)
+		}
+	}
+	mode := opts.Mode
+	if mode == 0 {
+		mode = 0o700
+	}
+	skel := opts.Skel
+	if skel == "" {
+		skel = "/etc/skel"
+	}
+
+	exists, err := u.fsm.Exists(ctx, home)
+	if err != nil {
+		return fmt.Errorf("ensure home for %q: %w", name, err)
+	}
+	if !exists {
+		if err := u.fsm.Mkdir(ctx, home, fs.MkdirOptions{Mode: mode, Recursive: true}); err != nil {
+			return fmt.Errorf("ensure home for %q: create %q: %w", name, home, err)
+		}
+		skelExists, serr := u.fsm.Exists(ctx, skel)
+		if serr != nil {
+			return fmt.Errorf("ensure home for %q: probe skeleton %q: %w", name, skel, serr)
+		}
+		if skelExists {
+			if err := u.fsm.CopyTree(ctx, skel, home, fs.WriteOptions{}); err != nil {
+				return fmt.Errorf("ensure home for %q: seed from skeleton %q: %w", name, skel, err)
+			}
+		}
+	}
+	// Re-assert ownership (recursive, to repair a partially mis-owned tree) and
+	// the home-root mode every call, so EnsureHome is idempotent and also fixes a
+	// home that exists but is wrong.
+	if err := u.fsm.SetOwnershipRecursive(ctx, home, name, group); err != nil {
+		return fmt.Errorf("ensure home for %q: %w", name, err)
+	}
+	if err := u.fsm.SetMode(ctx, home, mode); err != nil {
+		return fmt.Errorf("ensure home for %q: %w", name, err)
 	}
 	return nil
 }

--- a/sys/user/user_integration_test.go
+++ b/sys/user/user_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
@@ -319,5 +320,52 @@ func TestSupplementaryGroups_Integration(t *testing.T) {
 		if g == primary {
 			t.Errorf("primary group %q must not appear in supplementary list", primary)
 		}
+	}
+}
+
+func TestEnsureHome_Integration(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	name := testUsername("eh")
+	defer cleanupUser(t, m, name)
+
+	// Create the account with NO home (-M), simulating a home that is missing.
+	homeDir := "/home/" + name
+	if err := m.Create(ctx, name, user.CreateOptions{HomeDir: homeDir, CreateHome: false}); err != nil {
+		t.Fatalf("Create (-M, no home): %v", err)
+	}
+	if _, err := os.Stat(homeDir); !os.IsNotExist(err) {
+		t.Fatalf("home %q must be absent after a -M create (stat err = %v)", homeDir, err)
+	}
+
+	// EnsureHome must create it, own it by the user, and set 0700.
+	if err := m.EnsureHome(ctx, name, user.EnsureHomeOptions{}); err != nil {
+		t.Fatalf("EnsureHome: %v", err)
+	}
+	fi, err := os.Stat(homeDir)
+	if err != nil {
+		t.Fatalf("EnsureHome did not create the home: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("%q is not a directory", homeDir)
+	}
+	if fi.Mode().Perm() != 0o700 {
+		t.Errorf("home mode = %v, want 0700", fi.Mode().Perm())
+	}
+	info, err := m.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if int(st.Uid) != info.UID {
+			t.Errorf("home owner uid = %d, want the user's uid %d", st.Uid, info.UID)
+		}
+	} else {
+		t.Skip("no syscall.Stat_t on this platform to verify ownership")
+	}
+
+	// Idempotent: a second EnsureHome over the now-existing home must not error.
+	if err := m.EnsureHome(ctx, name, user.EnsureHomeOptions{}); err != nil {
+		t.Fatalf("EnsureHome (idempotent re-run): %v", err)
 	}
 }


### PR DESCRIPTION
Three agent-needed file/home primitives the SDK lacked (gaps 8/9/10 from the
gaps report), so the agent stops reimplementing OS file operations with raw
`os.*` / `runSudoCmd`. Each has unit **and** real-execution (container) coverage,
and the logic-bearing assertions were red-checked.

## fs.WriteReader — atomic streaming writer (gap 8)
A privilege-backed writer that streams an `io.Reader` to a path **without
buffering** the whole payload — for a large artifact (a downloaded AppImage of
tens-to-hundreds of MB) that `WriteFile([]byte)` would risk OOM on. Same
temp-then-rename atomicity as `WriteFile`; on the Direct backend an `io.Copy`
error aborts *before* the rename, so a mid-stream reader error also leaves the
destination untouched (the escalated path's weaker guarantee is documented).
`opts.Backup` is unsupported. The buffered `safeReplaceFile` is now a thin wrapper
over a new streaming `safeReplaceFromReader`, so the O_NOFOLLOW / fsync / atomic-
rename defenses are shared, not duplicated.

## fs.CopyTree — recursive archive copy (gap 9)
`cp -a -T -- src dst`: archive-preserving, recursive, and **merges into** dst
(`-T`) rather than nesting at `dst/<src>`. `opts.Mode` chmods the dst root only;
`opts.Owner`/`Group` apply recursively — the skel-into-home shape EnsureHome needs.

## user.EnsureHome — idempotent home repair (gap 10)
For an account whose home was created `-M`, deleted, or left mis-owned. Missing
home → create + seed from skel + recursive chown + 0700; **existing** home →
re-assert ownership/mode only, never re-seeding skel (so customised dotfiles are
preserved). The user must already exist. The `fsManager` seam widens to
`Exists`/`Mkdir`/`CopyTree`/`SetMode`.

## Also
Fixes the `Manager` interface doc for `ReadFile`/`ReadDir`, which still described
the pre-#244 `(nil, nil)` absence contract instead of the wrapped `fs.ErrNotExist`
that shipped.

## Verification
`go build`, `go vet`, `errcheck -ignoretests`, full `go test ./...`, `gofmt -l`,
`docref check` green. Container-verified on real tools: `cp -aT` merge (dotfiles +
nesting + idempotent re-run), `WriteReader` 3 MB stream + reader-error atomicity,
and `EnsureHome` on a real `-M` account (home created, owned, 0700, idempotent).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `CopyTree` for recursive directory copying with controlled permissions and ownership.
  * Added `ListMounts` to enumerate mounted filesystems with source, target, type, and read-only information.
  * Added `WriteReader` for streaming file writes supporting atomic, safe replacement.
  * Added `EnsureHome` for idempotent home directory creation and repair, including skeleton seeding and ownership management.

* **Documentation**
  * Clarified error behavior: missing files/directories now return wrapped errors instead of nil.

* **Tests**
  * Added comprehensive integration and unit test coverage for all new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->