### PR TITLE
feat(log): add Kernel filter to Query (journalctl -k)

### DIFF
--- a/docs/03-capabilities/17-log.md
+++ b/docs/03-capabilities/17-log.md
@@ -40,13 +40,14 @@ lines, err := s.Query(ctx, log.Query{
     Unit:     "sshd.service", // journald only
     Priority: "warning",      // journald only
     Grep:     "Failed password",
+    Kernel:   false,          // true → kernel ring only (-k); journald only
     Lines:    200,            // cap; <=0 defaults to 100
 })
 ```
 
-<!-- docref: begin src=sys/log/journald.go#journaldSource.Query:efa18d89 -->
+<!-- docref: begin src=sys/log/journald.go#journaldSource.Query:44fcc941 -->
 `Query` builds the `journalctl` invocation with every dynamic value as an
-option-argument (`-u <unit>`, `--grep <pat>`, …), never a positional operand, so
+option-argument (`-u <unit>`, `--grep <pat>`, `-k`, …), never a positional operand, so
 none can be reinterpreted as a flag. Two real-journald behaviours it normalises:
 journalctl status markers (`-- No entries --`, `-- Boot … --`) are dropped — they
 are not log entries — and a `--grep` that matches nothing (which `journalctl`
@@ -55,7 +56,7 @@ so a caller can tell "no logs matched" from "journalctl broke".
 <!-- docref: end -->
 
 {% callout type="info" title="Backend differences" %}
-`Unit` and `Priority` are journald-only (ignored by the Syslog backend). The
+`Unit`, `Priority`, and `Kernel` are journald-only (ignored by the Syslog backend). The
 Syslog backend tails the log file and applies `Grep`/`Lines` in-process. For
 unit- or priority-scoped queries, use Journald.
 {% /callout %}

--- a/docs/03-capabilities/17-log.md
+++ b/docs/03-capabilities/17-log.md
@@ -56,7 +56,7 @@ so a caller can tell "no logs matched" from "journalctl broke".
 <!-- docref: end -->
 
 {% callout type="info" title="Backend differences" %}
-`Unit`, `Priority`, and `Kernel` are journald-only (ignored by the Syslog backend). The
+`Unit`, `Since`, `Until`, `Priority`, and `Kernel` are journald-only (ignored by the Syslog backend). The
 Syslog backend tails the log file and applies `Grep`/`Lines` in-process. For
 unit- or priority-scoped queries, use Journald.
 {% /callout %}

--- a/sys/log/backends_test.go
+++ b/sys/log/backends_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -48,6 +49,30 @@ func TestJournald_QueryArgv(t *testing.T) {
 	}
 }
 
+// TestJournald_QueryKernel: Kernel=true emits journalctl's -k (kernel ring);
+// Kernel=false must NOT — the absent case proves the flag isn't always-on.
+func TestJournald_QueryKernel(t *testing.T) {
+	r := exectest.New(exec.Direct)
+	r.Push(exec.Result{Stdout: "kmsg\n"}, nil)
+	s, _ := New(Journald, r)
+	if _, err := s.Query(context.Background(), Query{Kernel: true, Lines: 50}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(r.Calls()[0].Args, "-k") {
+		t.Errorf("Kernel=true must add -k; argv=%v", r.Calls()[0].Args)
+	}
+
+	r2 := exectest.New(exec.Direct)
+	r2.Push(exec.Result{Stdout: ""}, nil)
+	s2, _ := New(Journald, r2)
+	if _, err := s2.Query(context.Background(), Query{Kernel: false}); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(r2.Calls()[0].Args, "-k") {
+		t.Errorf("Kernel=false must not add -k; argv=%v", r2.Calls()[0].Args)
+	}
+}
+
 func TestJournald_QueryDefaultsAndMinimal(t *testing.T) {
 	r := exectest.New(exec.Direct)
 	r.Push(exec.Result{Stdout: ""}, nil)
@@ -59,7 +84,7 @@ func TestJournald_QueryDefaultsAndMinimal(t *testing.T) {
 	if !strings.Contains(argv, "-n 100") { // default line cap
 		t.Errorf("default lines should be 100: %q", argv)
 	}
-	for _, absent := range []string{"-u ", "--since", "--until", "-p ", "--grep"} {
+	for _, absent := range []string{"-u ", "--since", "--until", "-p ", "--grep", "-k"} {
 		if strings.Contains(argv, absent) {
 			t.Errorf("minimal query must not emit %q: %q", absent, argv)
 		}

--- a/sys/log/journald.go
+++ b/sys/log/journald.go
@@ -33,6 +33,9 @@ func (s *journaldSource) Query(ctx context.Context, q Query) ([]string, error) {
 	if q.Priority != "" {
 		args = append(args, "-p", q.Priority)
 	}
+	if q.Kernel {
+		args = append(args, "-k") // kernel-ring only (journalctl --dmesg)
+	}
 	if q.Grep != "" {
 		args = append(args, "--grep", q.Grep)
 	}

--- a/sys/log/log.go
+++ b/sys/log/log.go
@@ -69,6 +69,9 @@ type Query struct {
 	// Grep keeps only entries matching this pattern. Capped at 256 chars and
 	// refused if it is a catastrophic-backtracking shape (ReDoS guard).
 	Grep string
+	// Kernel restricts the result to kernel-ring messages (journalctl -k;
+	// Journald only, ignored by Syslog).
+	Kernel bool
 	// Lines caps the number of entries returned. <=0 means 100; values above
 	// 10000 are clamped to 10000.
 	Lines int


### PR DESCRIPTION
`log.Query` could express `-u/--since/--until/-p/--grep` but not the kernel
ring. A consumer needing kernel logs had to hand-roll `journalctl -k` outside
the SDK — and re-copy the ReDoS grep-guard alongside it. This adds a single
additive field:

- `Query.Kernel bool` → emits `journalctl -k` (`--dmesg`); journald-only,
  ignored by the Syslog backend (parity with `Unit`/`Priority`).

Test pins both directions (true→`-k`, false→no `-k`) and extends the
minimal-query absent-set so the flag can't silently become always-on.
Additive only — no existing behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kernel filter option for log queries to restrict results to kernel-ring messages only (journald backend only).

* **Documentation**
  * Updated Log capability documentation to include the new Kernel filter option with backend-specific notes.

* **Tests**
  * Added test coverage for the Kernel filter functionality to ensure proper flag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->