### PR TITLE
feat(remote): make the HTTP client injectable (transport seam)

### DIFF
--- a/docs/03-capabilities/21-remote.md
+++ b/docs/03-capabilities/21-remote.md
@@ -44,7 +44,7 @@ git, err  := remote.NewGit(remote.GitConfig{URL: "https://…", Ref: "v1.2.3"})
 s3, err   := remote.NewS3(remote.S3Config{Bucket: "artifacts", Key: "agent/latest"})
 ```
 
-<!-- docref: begin src=sys/remote/http.go#NewHTTP:d4d3f602,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:8a5701dc -->
+<!-- docref: begin src=sys/remote/http.go#NewHTTP:ba137707,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:8a5701dc -->
 Each constructor validates its configuration up front and returns an error for a
 malformed one, so a bad URL, missing checksum, or unusable S3 config fails at
 construction rather than mid-download. The returned value is a `Source` — the

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -68,6 +68,17 @@ type HTTPConfig struct {
 	Mode  string
 	Owner string
 	Group string
+
+	// Client overrides the *http.Client used for the HEAD/GET round-trips.
+	// Nil (the default) uses an internal client with conservative timeouts and
+	// the cross-origin / scheme-downgrade redirect guard. This is a TRANSPORT
+	// seam — its purpose is to point a test at an httptest TLS server (whose
+	// self-signed cert the default client refuses) or to mock the round-tripper.
+	// It does NOT relax any Fetch invariant: the URL scheme check, the MaxBytes
+	// cap, the sha256 pin, and the atomic rename are enforced in Fetch regardless
+	// of which client transports the bytes. A supplied client owns its own
+	// redirect/transport policy (it does not inherit the default redirect guard).
+	Client *http.Client
 }
 
 // httpSource is the concrete Source implementation.
@@ -105,11 +116,16 @@ func NewHTTP(cfg HTTPConfig) (Source, error) {
 		cfg.MaxBytes = defaultHTTPMaxBytes
 	}
 
+	client := cfg.Client
+	if client == nil {
+		client = defaultHTTPClient()
+	}
+
 	return &httpSource{
 		parsedURL: parsed,
 		cfg:       cfg,
 		checksum:  checksum,
-		client:    defaultHTTPClient(),
+		client:    client,
 	}, nil
 }
 

--- a/sys/remote/injectable_client_test.go
+++ b/sys/remote/injectable_client_test.go
@@ -1,0 +1,94 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTLSFixture serves payload over TLS with a self-signed httptest cert. The
+// default HTTP client rejects that cert, so a Fetch can only succeed if the
+// caller injects srv.Client() via HTTPConfig.Client — exactly the seam under
+// test.
+func newTLSFixture(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"v1"`)
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHTTPFetch_InjectedClient_ReachesTLSServer is the value case: with a
+// caller-supplied client that trusts the test server's cert, Fetch downloads
+// and atomically writes the payload. Without the injectable client this is
+// impossible (the default client won't trust a self-signed httptest cert) —
+// which is why a consumer could not delegate its own download to remote.Fetch.
+func TestHTTPFetch_InjectedClient_ReachesTLSServer(t *testing.T) {
+	payload := []byte("delivered over TLS")
+	srv := newTLSFixture(t, payload)
+	dest := filepath.Join(t.TempDir(), "file")
+	recordDestUnder(t, dest)
+
+	src, err := NewHTTP(HTTPConfig{URL: srv.URL + "/file", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	res, err := src.Fetch(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("Fetch over injected TLS client: %v", err)
+	}
+	if !res.Changed || res.BytesWritten != int64(len(payload)) {
+		t.Fatalf("Result = %+v; want Changed with %d bytes", res, len(payload))
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("dest = %q; want %q", got, payload)
+	}
+}
+
+// TestHTTPFetch_InjectedClient_StillEnforcesChecksum proves the seam is a
+// TRANSPORT override only: injecting a client does not bypass the integrity
+// pin. A wrong checksum over the injected TLS client still fails closed
+// (ErrIntegrity, dest absent).
+func TestHTTPFetch_InjectedClient_StillEnforcesChecksum(t *testing.T) {
+	srv := newTLSFixture(t, []byte("real body"))
+	dest := filepath.Join(t.TempDir(), "file")
+	recordDestUnder(t, dest)
+
+	src, err := NewHTTP(HTTPConfig{
+		URL:            srv.URL + "/file",
+		ChecksumSHA256: strings.Repeat("0", 64),
+		Client:         srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	if _, err := src.Fetch(context.Background(), dest); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("Fetch err = %v; want ErrIntegrity even with an injected client", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("dest must not exist after checksum failure; stat err = %v", err)
+	}
+}
+
+// TestNewHTTP_NilClientUsesDefault pins the contract that omitting Client keeps
+// the hardened default (non-nil) — so existing callers are unchanged.
+func TestNewHTTP_NilClientUsesDefault(t *testing.T) {
+	src, err := NewHTTP(HTTPConfig{URL: "https://example.com/x"})
+	if err != nil {
+		t.Fatalf("NewHTTP: %v", err)
+	}
+	if src.(*httpSource).client == nil {
+		t.Fatal("nil Client must fall back to the default client, got nil")
+	}
+}


### PR DESCRIPTION
`NewHTTP` hardcoded `defaultHTTPClient()`, so a consumer couldn't point `Fetch`
at an `httptest` TLS server (self-signed cert) or mock the round-tripper — the
one thing blocking delegation of a hand-rolled downloader to `remote.Fetch`
(which already does scheme validation + `MaxBytes` cap + sha256 pin + atomic
rename).

- Adds optional `HTTPConfig.Client *http.Client`; nil → the hardened default
  (incl. the cross-origin / scheme-downgrade redirect guard).
- **Transport override only.** Value test: Fetch succeeds over a real
  `NewTLSServer` via an injected client. Guard test: a wrong checksum over that
  same injected client still fails closed (`ErrIntegrity`, dest absent) — the
  seam relaxes no `Fetch` invariant. Nil-client test pins the default fallback.

Additive; existing callers unchanged.