### PR TITLE
feat(pkg): complete zypper Repair + fix the zypp.pid stale-lock probe

### DIFF
--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -231,7 +231,7 @@ func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 	}{
 		{"dnf history redo last", func() (pmexec.Result, error) { return d.write(ctx, "history", "redo", "last", "-y") }},
 		{"dnf remove --duplicates", func() (pmexec.Result, error) { return d.write(ctx, "remove", "--duplicates", "-y") }},
-		{"rpm --verifydb", func() (pmexec.Result, error) { return d.verifyOrRebuildDB(ctx) }},
+		{"rpm --verifydb", func() (pmexec.Result, error) { return verifyOrRebuildRPMDB(ctx, d.r) }},
 	}
 	var last pmexec.Result
 	for _, s := range steps {
@@ -242,31 +242,6 @@ func (d *dnf) Repair(ctx context.Context) (pmexec.Result, error) {
 		}
 	}
 	return last, nil
-}
-
-// verifyOrRebuildDB runs `rpm --verifydb` (an unprivileged read) and, ONLY when
-// it reports corruption (a non-zero exit — a genuine rpmdb verdict, as opposed
-// to a runner failure where rpm could not run at all), escalates to a full
-// `rpm --rebuilddb` to rebuild the database. The rebuild is itself best-effort:
-// its result/error is returned to the caller's bestEffortStep, so a wedged
-// rebuild is logged rather than fatal, while a cancelled context fails the
-// rebuild closed (runPriv refuses to spawn) and propagates as the cancellation.
-func (d *dnf) verifyOrRebuildDB(ctx context.Context) (pmexec.Result, error) {
-	res, err := runRead(ctx, d.r, "rpm", "--verifydb")
-	if err != nil {
-		// rpm could not be run at all (binary missing, context cancelled): there is
-		// no corruption verdict to act on, so do not rebuild.
-		return res, err
-	}
-	if res.ExitCode == 0 {
-		return res, nil // database is clean — no rebuild
-	}
-	// Corruption reported: escalate to a rebuild of the rpm database.
-	rebuilt, rerr := runPriv(ctx, d.r, true, nil, "rpm", "--rebuilddb")
-	if rerr != nil {
-		return rebuilt, rerr
-	}
-	return rebuilt, asCommandError("rpm", rebuilt)
 }
 
 // Search searches package names/summaries (exit 1 = no matches).

--- a/pkg/repair.go
+++ b/pkg/repair.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
@@ -12,6 +13,10 @@ import (
 // statFile is the os.Stat seam used by removeStaleLock so the lock-file probe
 // can be exercised hermetically in tests.
 var statFile = os.Stat
+
+// readFile is the os.ReadFile seam used by removeStaleZyppLock so the PID-file
+// read can be exercised hermetically in tests.
+var readFile = os.ReadFile
 
 // bestEffortStep classifies the outcome of one best-effort repair step. A nil
 // err means success. A cancelled context returns ctx.Err() so the caller stops
@@ -99,4 +104,112 @@ func removeStaleLock(ctx context.Context, r pmexec.Runner, path string) error {
 		slog.Warn("failed to remove stale lock", "path", path, "error", err)
 	}
 	return nil
+}
+
+// removeStaleZyppLock removes a zypp PID file (/run/zypp.pid) only when the PID
+// it names is dead. Unlike the flock-style lockfiles removeStaleLock handles
+// (apt/dpkg/pacman hold the descriptor open for the lock's lifetime, so fuser
+// sees a live holder), zypp.pid is a PID FILE: zypper writes its PID and closes
+// the descriptor, so NO process holds it open and fuser would always report "no
+// holder" — wrongly green-lighting removal while zypper still runs. Probe the
+// named PID's liveness directly instead.
+//
+// The liveness probe (kill -0) runs ESCALATED so a non-zero exit reliably means
+// ESRCH (the process is gone): probed unprivileged, a root-owned zypper process
+// would return EPERM (non-zero) and be misread as dead. Non-numeric content —
+// including a leading-dash value kill would treat as a flag/process group — is
+// never spliced into kill and never triggers removal. An empty file has no live
+// holder and is removed. Like removeStaleLock, a cancelled context wins over the
+// best-effort warning paths, and a failed probe/read leaves the lock in place
+// (never delete on an inconclusive result).
+func removeStaleZyppLock(ctx context.Context, r pmexec.Runner, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, err := statFile(path); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if os.IsNotExist(err) {
+			return nil // file doesn't exist — nothing to remove
+		}
+		slog.Warn("failed to stat zypp PID file; leaving it in place", "path", path, "error", err)
+		return nil
+	}
+
+	content, err := readFile(path)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		// A read failure is not proof of absence; leave the lock untouched.
+		slog.Warn("cannot read zypp PID file; leaving it in place", "path", path, "error", err)
+		return nil
+	}
+
+	pid := strings.TrimSpace(string(content))
+	if pid != "" && !isAllDigits(pid) {
+		// Non-numeric content (garbage, or a leading-dash value kill would
+		// interpret as a flag/process group): never probe with it, never remove.
+		slog.Warn("zypp PID file is non-numeric; leaving it in place", "path", path, "content", pid)
+		return nil
+	}
+
+	if pid != "" {
+		res, err := runPriv(ctx, r, true, nil, "kill", "-0", pid)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			slog.Warn("zypp PID liveness probe failed; leaving the lock in place", "path", path, "pid", pid, "error", err)
+			return nil
+		}
+		if res.ExitCode == 0 {
+			return nil // process is alive — keep the lock
+		}
+	}
+
+	// Empty file or a dead PID: no live holder. Remove (escalated, best-effort).
+	if _, err := runPriv(ctx, r, true, nil, "rm", "-f", path); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		slog.Warn("failed to remove stale zypp PID file", "path", path, "error", err)
+	}
+	return nil
+}
+
+// isAllDigits reports whether s is non-empty and every rune is an ASCII digit.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// verifyOrRebuildRPMDB runs `rpm --verifydb` (an unprivileged read) and, ONLY
+// when it reports corruption (a non-zero exit — a genuine rpmdb verdict, as
+// opposed to a runner failure where rpm could not run at all), escalates to a
+// full `rpm --rebuilddb`. Shared by the rpm-based managers (dnf, zypper). A
+// runner failure (binary missing, context cancelled) yields no corruption
+// verdict, so no rebuild. The rebuild's result/error is returned for the
+// caller's best-effort handling.
+func verifyOrRebuildRPMDB(ctx context.Context, r pmexec.Runner) (pmexec.Result, error) {
+	res, err := runRead(ctx, r, "rpm", "--verifydb")
+	if err != nil {
+		return res, err
+	}
+	if res.ExitCode == 0 {
+		return res, nil // database is clean — no rebuild
+	}
+	rebuilt, rerr := runPriv(ctx, r, true, nil, "rpm", "--rebuilddb")
+	if rerr != nil {
+		return rebuilt, rerr
+	}
+	return rebuilt, asCommandError("rpm", rebuilt)
 }

--- a/pkg/repair_container_test.go
+++ b/pkg/repair_container_test.go
@@ -19,6 +19,8 @@ package pkg
 import (
 	"context"
 	"os"
+	osexec "os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -97,5 +99,52 @@ func TestRepair_KeepsHeldLock_Container(t *testing.T) {
 	}
 	if _, err := os.Stat(lock); !os.IsNotExist(err) {
 		t.Fatalf("released lock not removed; stat err = %v — fuser did not discriminate held vs unheld", err)
+	}
+}
+
+// TestRepair_ZyppLockLiveness_Container pins the zypp.pid PID-liveness path
+// against a REAL kill -0: a PID file naming a LIVE process must be kept, one
+// naming a DEAD process must be removed. fuser is deliberately NOT the probe
+// here — zypp.pid has no open holder, so fuser would report "no holder" and
+// wrongly green-light removal even while zypper runs; this proves the PID-based
+// probe is what discriminates.
+//
+// Two-phase so it cannot pass for the wrong reason (mirrors the held-lock test):
+// a kill -0 that always failed would remove in BOTH phases (failing phase 1); one
+// that always succeeded would keep in BOTH (failing phase 2). Only a probe that
+// genuinely discriminates a live PID from a dead one passes both.
+func TestRepair_ZyppLockLiveness_Container(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := dir + "/zypp.pid"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	r := containerRunner(t)
+
+	// Phase 1: a LIVE pid (this test process) → the lock must remain.
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatalf("write live pid file: %v", err)
+	}
+	if err := removeStaleZyppLock(ctx, r, pidFile); err != nil {
+		t.Fatalf("removeStaleZyppLock(live) returned error: %v", err)
+	}
+	if _, err := os.Stat(pidFile); err != nil {
+		t.Fatalf("a PID file naming a LIVE process was removed (or stat failed): %v — never delete a live lock", err)
+	}
+
+	// Phase 2: a DEAD pid (a child run to completion and reaped — not a zombie,
+	// which would still answer kill -0) → the lock must now be removed.
+	done := osexec.Command("true")
+	if err := done.Run(); err != nil {
+		t.Fatalf("run throwaway child: %v", err)
+	}
+	deadPID := done.Process.Pid
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(deadPID)+"\n"), 0o644); err != nil {
+		t.Fatalf("write dead pid file: %v", err)
+	}
+	if err := removeStaleZyppLock(ctx, r, pidFile); err != nil {
+		t.Fatalf("removeStaleZyppLock(dead) returned error: %v", err)
+	}
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("a PID file naming a DEAD process was not removed; stat err = %v — kill -0 did not discriminate live vs dead", err)
 	}
 }

--- a/pkg/repair_test.go
+++ b/pkg/repair_test.go
@@ -221,3 +221,140 @@ func TestRepairErr(t *testing.T) {
 		}
 	})
 }
+
+// stubReadFile overrides the readFile seam used by removeStaleZyppLock.
+func stubReadFile(t *testing.T, content string, err error) {
+	t.Helper()
+	orig := readFile
+	readFile = func(string) ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []byte(content), nil
+	}
+	t.Cleanup(func() { readFile = orig })
+}
+
+// /run/zypp.pid is a PID FILE, not an flock: zypper writes its PID and closes
+// the descriptor, so fuser always reports "no holder" and would green-light
+// removal while zypper runs. removeStaleZyppLock must instead probe the named
+// PID's liveness and only remove the lock when the process is gone.
+
+func TestRemoveStaleZyppLock_FileAbsent(t *testing.T) {
+	stubStatFile(t, nil) // nothing exists
+	f := newFake()
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatalf("absent pid file must be a no-op, got %v", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("absent pid file must run nothing, ran %d", n)
+	}
+}
+
+func TestRemoveStaleZyppLock_LivePIDKept(t *testing.T) {
+	stubStatFile(t, nil, "/run/zypp.pid")
+	stubReadFile(t, "4242\n", nil)
+	f := newFake()
+	f.Push(pmexec.Result{ExitCode: 0}, nil) // kill -0: process is alive
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("a live PID must be probed but NOT removed, ran %d commands", len(calls))
+	}
+	if argv(calls[0]) != "kill -0 4242" {
+		t.Errorf("probe argv = %q, want \"kill -0 4242\"", argv(calls[0]))
+	}
+	// The probe MUST escalate: probed unprivileged, a root-owned zypper would
+	// return EPERM (non-zero) and be misread as dead.
+	if !calls[0].Escalate {
+		t.Error("kill -0 liveness probe must escalate so EPERM cannot be confused with ESRCH")
+	}
+}
+
+func TestRemoveStaleZyppLock_DeadPIDRemoved(t *testing.T) {
+	stubStatFile(t, nil, "/run/zypp.pid")
+	stubReadFile(t, "4242\n", nil)
+	f := newFake()
+	f.Push(pmexec.Result{ExitCode: 1}, nil) // kill -0: ESRCH, the process is gone
+	f.Push(pmexec.Result{}, nil)            // rm -f
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("a dead PID must be probed then removed, ran %d commands", len(calls))
+	}
+	if calls[1].Name != "rm" || argv(calls[1]) != "rm -f /run/zypp.pid" || !calls[1].Escalate {
+		t.Errorf("removal = %q (escalate=%v), want escalated \"rm -f /run/zypp.pid\"", argv(calls[1]), calls[1].Escalate)
+	}
+}
+
+func TestRemoveStaleZyppLock_EmptyFileRemoved(t *testing.T) {
+	stubStatFile(t, nil, "/run/zypp.pid")
+	stubReadFile(t, "  \n", nil) // empty/whitespace: no live holder to harm
+	f := newFake()
+	f.Push(pmexec.Result{}, nil) // rm -f
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 1 || calls[0].Name != "rm" {
+		t.Fatalf("an empty PID file must be removed without a kill probe, calls=%v", calls)
+	}
+}
+
+// A PID file whose content is not purely numeric — including a leading-dash
+// value that kill would treat as a flag / process group — must NEVER be spliced
+// into kill and must NOT trigger removal. Leave the lock; surface nothing.
+func TestRemoveStaleZyppLock_NonNumericRefused(t *testing.T) {
+	for _, content := range []string{"-1\n", "12 34", "abc", "0x10", "12;rm"} {
+		stubStatFile(t, nil, "/run/zypp.pid")
+		stubReadFile(t, content, nil)
+		f := newFake()
+		if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+			t.Fatalf("content %q: %v", content, err)
+		}
+		if n := len(f.Calls()); n != 0 {
+			t.Errorf("content %q: a non-numeric PID must run nothing (no kill, no rm), ran %d", content, n)
+		}
+	}
+}
+
+func TestRemoveStaleZyppLock_ReadErrorKeepsLock(t *testing.T) {
+	stubStatFile(t, nil, "/run/zypp.pid")
+	stubReadFile(t, "", errors.New("permission denied"))
+	f := newFake()
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatalf("a read failure is best-effort, got %v", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("a read error must leave the lock untouched, ran %d", n)
+	}
+}
+
+func TestRemoveStaleZyppLock_LivenessProbeExecErrorKeepsLock(t *testing.T) {
+	stubStatFile(t, nil, "/run/zypp.pid")
+	stubReadFile(t, "4242\n", nil)
+	f := newFake()
+	f.Push(pmexec.Result{}, errors.New("kill: not found")) // probe could not run
+	if err := removeStaleZyppLock(context.Background(), f, "/run/zypp.pid"); err != nil {
+		t.Fatalf("an inconclusive probe is best-effort, got %v", err)
+	}
+	if n := len(f.Calls()); n != 1 {
+		t.Errorf("a failed probe must NOT remove (1 call), ran %d", n)
+	}
+}
+
+func TestRemoveStaleZyppLock_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	f := newFake()
+	if err := removeStaleZyppLock(ctx, f, "/run/zypp.pid"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if n := len(f.Calls()); n != 0 {
+		t.Errorf("cancelled-at-entry must run nothing, ran %d", n)
+	}
+}

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -146,16 +146,35 @@ func (z *zypper) Autoremove(ctx context.Context) (pmexec.Result, error) {
 	return pmexec.Result{}, nil
 }
 
-// Repair clears a stale zypp lock and refreshes the repositories.
+// Repair recovers a wedged zypper/rpm state, mirroring dnf's best-effort
+// recovery (both are rpm-based). It clears a stale zypp PID lock, then runs
+// clean / refresh / verify and (only on rpmdb corruption) a rebuild. Every
+// package step is best-effort — a single wedged step is logged and the chain
+// continues, so e.g. a failed refresh does not skip the rpmdb rebuild — and only
+// a cancelled context aborts the chain (each step fails closed via runPriv). The
+// last step's Result is returned.
 func (z *zypper) Repair(ctx context.Context) (pmexec.Result, error) {
-	if err := removeStaleLock(ctx, z.r, "/run/zypp.pid"); err != nil {
+	if err := removeStaleZyppLock(ctx, z.r, "/run/zypp.pid"); err != nil {
 		return pmexec.Result{}, err
 	}
-	res, err := z.write(ctx, "--non-interactive", "refresh")
-	if err != nil {
-		return res, repairErr(ctx, "zypper refresh failed", err)
+	steps := []struct {
+		what string
+		run  func() (pmexec.Result, error)
+	}{
+		{"zypper clean --all", func() (pmexec.Result, error) { return z.write(ctx, "--non-interactive", "clean", "--all") }},
+		{"zypper refresh", func() (pmexec.Result, error) { return z.write(ctx, "--non-interactive", "refresh") }},
+		{"zypper verify", func() (pmexec.Result, error) { return z.write(ctx, "--non-interactive", "verify", "--recommends") }},
+		{"rpm --verifydb", func() (pmexec.Result, error) { return verifyOrRebuildRPMDB(ctx, z.r) }},
 	}
-	return res, nil
+	var last pmexec.Result
+	for _, s := range steps {
+		res, err := s.run()
+		last = res
+		if err := bestEffortStep(ctx, s.what, err); err != nil {
+			return res, err
+		}
+	}
+	return last, nil
 }
 
 // Search searches packages (exit 104 = no matches).

--- a/pkg/zypper_test.go
+++ b/pkg/zypper_test.go
@@ -194,28 +194,70 @@ func TestZypper_Autoremove(t *testing.T) {
 	}
 }
 
+// Repair mirrors dnf's best-effort recovery (both are rpm-based): clear a stale
+// zypp PID lock, then clean → refresh → verify → (rpmdb verify, rebuild only on
+// corruption). Every step is best-effort — a wedged step is logged, not fatal,
+// so e.g. a failed refresh does not skip the rpmdb rebuild — and only a
+// cancelled context aborts the chain.
 func TestZypper_Repair(t *testing.T) {
 	ctx := context.Background()
-	t.Run("happy", func(t *testing.T) {
-		stubStatFile(t, nil)
+	t.Run("runs the full best-effort sequence in order", func(t *testing.T) {
+		stubStatFile(t, nil) // no /run/zypp.pid → lock step is a no-op
 		m, f := zypperM(t)
-		ok(f, "")
+		ok(f, "") // zypper clean --all
+		ok(f, "") // zypper refresh
+		ok(f, "") // zypper verify --recommends
+		ok(f, "") // rpm --verifydb (clean)
 		if _, err := m.Repair(ctx); err != nil {
 			t.Fatal(err)
 		}
-		if argv(f.Calls()[0]) != "zypper --non-interactive refresh" {
-			t.Errorf("argv=%q", argv(f.Calls()[0]))
+		want := []string{
+			"zypper --non-interactive clean --all",
+			"zypper --non-interactive refresh",
+			"zypper --non-interactive verify --recommends",
+			"rpm --verifydb",
+		}
+		calls := f.Calls()
+		if len(calls) != len(want) {
+			t.Fatalf("ran %d steps, want %d: %v", len(calls), len(want), calls)
+		}
+		for i := range want {
+			if argv(calls[i]) != want[i] {
+				t.Errorf("step %d argv = %q, want %q", i, argv(calls[i]), want[i])
+			}
 		}
 	})
-	t.Run("refresh failure returned", func(t *testing.T) {
+	t.Run("a failed step is best-effort: the chain continues, no error", func(t *testing.T) {
 		stubStatFile(t, nil)
 		m, f := zypperM(t)
-		f.Push(pmexec.Result{ExitCode: 1, Stderr: "refresh failed"}, nil)
-		if _, err := m.Repair(ctx); err == nil || !strings.Contains(err.Error(), "zypper refresh failed") {
-			t.Fatalf("err=%v", err)
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "clean failed"}, nil) // clean fails
+		ok(f, "")                                                       // refresh
+		ok(f, "")                                                       // verify
+		ok(f, "")                                                       // verifydb clean
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatalf("a non-cancellation step failure must be swallowed, got %v", err)
+		}
+		if n := len(f.Calls()); n != 4 {
+			t.Errorf("the chain must continue past a failed step (4 calls), ran %d", n)
 		}
 	})
-	t.Run("cancellation", func(t *testing.T) {
+	t.Run("rpmdb corruption escalates to rpm --rebuilddb", func(t *testing.T) {
+		stubStatFile(t, nil)
+		m, f := zypperM(t)
+		ok(f, "")                                                        // clean
+		ok(f, "")                                                        // refresh
+		ok(f, "")                                                        // verify
+		f.Push(pmexec.Result{ExitCode: 1, Stderr: "rpmdb corrupt"}, nil) // verifydb: corruption
+		ok(f, "")                                                        // rebuilddb
+		if _, err := m.Repair(ctx); err != nil {
+			t.Fatal(err)
+		}
+		calls := f.Calls()
+		if len(calls) != 5 || argv(calls[4]) != "rpm --rebuilddb" {
+			t.Errorf("verifydb corruption must escalate to rpm --rebuilddb, calls=%v", calls)
+		}
+	})
+	t.Run("cancellation aborts", func(t *testing.T) {
 		stubStatFile(t, nil)
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()


### PR DESCRIPTION
`zypper.Repair` only cleared a stale lock + refreshed — missing the
clean/verify/rpmdb-rebuild recovery dnf already has. Worse, it removed
`/run/zypp.pid` via the **fuser** probe, which is wrong for a *PID file*: zypper
writes its PID and closes the descriptor, so fuser always reports "no holder"
and would green-light removal **while zypper is running**.

- **Repair** now mirrors dnf's best-effort recovery (both rpm-based): stale-lock
  → `clean --all` → `refresh` → `verify --recommends` → rpmdb verify+rebuild.
  Every step is best-effort (logged, not fatal), so a failed refresh no longer
  skips the rpmdb rebuild, and only a cancelled context aborts. Consistent with
  `dnf.Repair` rather than load-bearing on refresh.
- **`removeStaleZyppLock`** probes the named PID's liveness with an **escalated**
  `kill -0` (so a root-owned zypper's EPERM can't be misread as ESRCH): live PID
  → kept; dead/empty → removed; non-numeric content (incl. a leading-dash value
  `kill` would treat as a flag/process group) → refused, never spliced into kill.
- Extracts the shared **`verifyOrRebuildRPMDB`** used by both dnf and zypper (DRY).

Hermetic tests pin every branch (live/dead/empty/garbage/read-error/cancel +
the full Repair sequence/order/best-effort/rebuild-on-corruption). The container
test proves live-vs-dead discrimination against **real `kill -0`** (two-phase,
can't pass for the wrong reason).

Note: `TestZypper_Repair`'s old "refresh failure → error" contract is
intentionally replaced — repair is best-effort recovery (matches the agent's
`repairZypper` and `dnf.Repair`).