### PR TITLE
feat(remote): bounded FetchBytes + URL normalization (Gaps 12 & 14)

### DIFF
--- a/docs/03-capabilities/21-remote.md
+++ b/docs/03-capabilities/21-remote.md
@@ -44,7 +44,7 @@ git, err  := remote.NewGit(remote.GitConfig{URL: "https://…", Ref: "v1.2.3"})
 s3, err   := remote.NewS3(remote.S3Config{Bucket: "artifacts", Key: "agent/latest"})
 ```
 
-<!-- docref: begin src=sys/remote/http.go#NewHTTP:ba137707,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:8a5701dc -->
+<!-- docref: begin src=sys/remote/http.go#NewHTTP:9089d62f,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:8a5701dc -->
 Each constructor validates its configuration up front and returns an error for a
 malformed one, so a bad URL, missing checksum, or unusable S3 config fails at
 construction rather than mid-download. The returned value is a `Source` — the

--- a/sys/remote/fetch_bytes.go
+++ b/sys/remote/fetch_bytes.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"fmt"
+	"io"
+)
+
+// defaultBytesMaxBytes bounds an in-memory FetchBytes when the caller leaves
+// MaxBytes unset. It is far smaller than the file-fetch default
+// (defaultHTTPMaxBytes, 2 GiB) because the whole body is buffered in RAM: 64 MiB
+// comfortably covers a GPG key or a SHA256SUMS manifest while refusing a
+// memory-exhaustion stream from a compromised origin.
+const defaultBytesMaxBytes int64 = 64 * 1024 * 1024
+
+// FetchBytes downloads the configured HTTP payload entirely into memory,
+// applying the SAME guards as Fetch — URL/scheme validation, the MaxBytes cap,
+// the optional sha256 pin, and the default-or-injected client — but bounded for
+// RAM. It is for SMALL payloads (a GPG key, a SHA256SUMS manifest), NOT large
+// artifacts: use Fetch (streamed, atomic, to a file) for those.
+//
+// When cfg.MaxBytes is unset it defaults to defaultBytesMaxBytes (64 MiB), NOT
+// the 2 GiB file default, so a runaway or compromised origin cannot exhaust
+// memory. A body exceeding the cap fails closed with ErrIntegrity and returns no
+// data, and a set ChecksumSHA256 is verified before the bytes are returned.
+// Extract/Prune are archive-to-directory concepts and are rejected here.
+func FetchBytes(ctx context.Context, cfg HTTPConfig) ([]byte, error) {
+	if cfg.Extract || cfg.Prune {
+		return nil, fmt.Errorf("%w: extract/prune are not valid for FetchBytes (single in-memory payload)", ErrInvalidConfig)
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = defaultBytesMaxBytes
+	}
+
+	h, err := newHTTPSource(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	body, _, err := h.openBody(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = body.Close() }()
+
+	// LimitReader caps at MaxBytes+1 so a one-byte over-read tells us the origin
+	// tried to deliver more than we allow — surfaced as ErrIntegrity, same bucket
+	// as a size-cap breach in the file path.
+	data, err := io.ReadAll(io.LimitReader(body, h.cfg.MaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body from %s: %w", h.cfg.URL, err)
+	}
+	if int64(len(data)) > h.cfg.MaxBytes {
+		return nil, fmt.Errorf("%w: payload exceeds %d bytes", ErrIntegrity, h.cfg.MaxBytes)
+	}
+
+	if h.checksum != nil {
+		sum := sha256.Sum256(data)
+		if subtle.ConstantTimeCompare(sum[:], h.checksum) != 1 {
+			return nil, fmt.Errorf("%w: sha256 mismatch for %s", ErrIntegrity, h.cfg.URL)
+		}
+	}
+
+	return data, nil
+}

--- a/sys/remote/fetch_bytes_test.go
+++ b/sys/remote/fetch_bytes_test.go
@@ -101,6 +101,9 @@ func TestFetchBytes_RejectsExtractAndBadScheme(t *testing.T) {
 	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: "https://example.com/y", Extract: true}); !errors.Is(err, ErrInvalidConfig) {
 		t.Errorf("Extract must be rejected for a memory fetch: %v", err)
 	}
+	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: "https://example.com/y", Prune: true}); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("Prune must be rejected for a memory fetch: %v", err)
+	}
 	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: "file:///etc/passwd"}); !errors.Is(err, ErrInvalidConfig) {
 		t.Errorf("a non-http(s) scheme must be rejected: %v", err)
 	}

--- a/sys/remote/fetch_bytes_test.go
+++ b/sys/remote/fetch_bytes_test.go
@@ -1,0 +1,92 @@
+package remote
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestFetchBytes_ReturnsBody — the value case: a small payload (a GPG key, a
+// checksum manifest) is returned in memory.
+func TestFetchBytes_ReturnsBody(t *testing.T) {
+	payload := []byte("gpg-key-or-sha256sums-manifest")
+	fix := newHTTPFixture(t, payload, `"v1"`)
+	data, err := FetchBytes(context.Background(), HTTPConfig{URL: fix.srv.URL + "/x"})
+	if err != nil {
+		t.Fatalf("FetchBytes: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Errorf("data = %q, want %q", data, payload)
+	}
+}
+
+// TestFetchBytes_EnforcesMaxBytes is the security test (Gap 12): a body that
+// exceeds the cap must fail closed with ErrIntegrity and return no data — this
+// is the bound the agent's uncapped bufio.Scanner manifest read lacked.
+func TestFetchBytes_EnforcesMaxBytes(t *testing.T) {
+	fix := newHTTPFixture(t, nil, `"v1"`)
+	fix.getDelay = func(w io.Writer) {
+		buf := make([]byte, 1024)
+		for i := 0; i < 10; i++ { // stream 10 KiB while the cap is 1 KiB
+			_, _ = w.Write(buf)
+		}
+	}
+	data, err := FetchBytes(context.Background(), HTTPConfig{URL: fix.srv.URL + "/x", MaxBytes: 1024})
+	if !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("err = %v, want ErrIntegrity for an over-cap body", err)
+	}
+	if data != nil {
+		t.Errorf("an over-cap fetch must return nil data, got %d bytes", len(data))
+	}
+}
+
+// TestFetchBytes_InMemoryDefaultIsSmall guards the OOM property: when MaxBytes is
+// unset, FetchBytes must default to a SMALL in-memory cap, never the 2 GiB
+// file-fetch default (buffering 2 GiB in RAM is the DoS this primitive closes).
+func TestFetchBytes_InMemoryDefaultIsSmall(t *testing.T) {
+	if defaultBytesMaxBytes >= defaultHTTPMaxBytes {
+		t.Fatalf("in-memory default cap %d must be far below the file default %d", defaultBytesMaxBytes, defaultHTTPMaxBytes)
+	}
+}
+
+func TestFetchBytes_ChecksumMatchAndMismatch(t *testing.T) {
+	payload := []byte("manifest-body")
+	sum := sha256.Sum256(payload)
+	fix := newHTTPFixture(t, payload, `"v1"`)
+
+	data, err := FetchBytes(context.Background(), HTTPConfig{URL: fix.srv.URL + "/x", ChecksumSHA256: hex.EncodeToString(sum[:])})
+	if err != nil || string(data) != string(payload) {
+		t.Fatalf("matching checksum: data=%q err=%v", data, err)
+	}
+
+	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: fix.srv.URL + "/x", ChecksumSHA256: strings.Repeat("0", 64)}); !errors.Is(err, ErrIntegrity) {
+		t.Fatalf("mismatched checksum err = %v, want ErrIntegrity", err)
+	}
+}
+
+func TestFetchBytes_RejectsExtractAndBadScheme(t *testing.T) {
+	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: "https://example.com/y", Extract: true}); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("Extract must be rejected for a memory fetch: %v", err)
+	}
+	if _, err := FetchBytes(context.Background(), HTTPConfig{URL: "file:///etc/passwd"}); !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("a non-http(s) scheme must be rejected: %v", err)
+	}
+}
+
+// TestFetchBytes_InjectedTLSClient: the same E1 transport seam works for the
+// in-memory path, so a consumer can test against an httptest TLS server.
+func TestFetchBytes_InjectedTLSClient(t *testing.T) {
+	payload := []byte("delivered-over-tls")
+	srv := newTLSFixture(t, payload)
+	data, err := FetchBytes(context.Background(), HTTPConfig{URL: srv.URL + "/x", Client: srv.Client()})
+	if err != nil {
+		t.Fatalf("FetchBytes over injected TLS client: %v", err)
+	}
+	if string(data) != string(payload) {
+		t.Errorf("data = %q, want %q", data, payload)
+	}
+}

--- a/sys/remote/fetch_bytes_test.go
+++ b/sys/remote/fetch_bytes_test.go
@@ -6,9 +6,38 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestRemote_NormalizesPaddedURL (Gap 14): a whitespace-padded but otherwise
+// valid URL — which sdk.ValidateHTTPSURL accepts, since it trims before parsing
+// — must be accepted by NewHTTP/Fetch and FetchBytes too. Otherwise "validation
+// passed" does not imply "the fetch accepts it", and a caller that validated up
+// front fails mysteriously at fetch time.
+func TestRemote_NormalizesPaddedURL(t *testing.T) {
+	fix := newHTTPFixture(t, []byte("ok"), `"v1"`)
+	padded := "  " + fix.srv.URL + "/x\n"
+
+	data, err := FetchBytes(context.Background(), HTTPConfig{URL: padded})
+	if err != nil {
+		t.Fatalf("FetchBytes rejected a padded URL the validator accepts: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Errorf("data = %q, want ok", data)
+	}
+
+	dest := filepath.Join(t.TempDir(), "f")
+	recordDestUnder(t, dest)
+	src, err := NewHTTP(HTTPConfig{URL: padded})
+	if err != nil {
+		t.Fatalf("NewHTTP rejected a padded URL: %v", err)
+	}
+	if _, err := src.Fetch(context.Background(), dest); err != nil {
+		t.Fatalf("Fetch with padded URL: %v", err)
+	}
+}
 
 // TestFetchBytes_ReturnsBody — the value case: a small payload (a GPG key, a
 // checksum manifest) is returned in memory.

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -108,6 +108,12 @@ func NewHTTP(cfg HTTPConfig) (Source, error) {
 // validates cfg, decodes the checksum, defaults MaxBytes/client, and returns the
 // concrete source.
 func newHTTPSource(cfg HTTPConfig) (*httpSource, error) {
+	// Normalize the URL the same way sdk.ValidateHTTPSURL does (it trims before
+	// parsing), so a whitespace-padded URL that passed validation also passes
+	// here and in the request itself — "validated" implies "fetchable". Trimming
+	// the surrounding whitespace before the control-character check leaves any
+	// INTERNAL control char still caught.
+	cfg.URL = strings.TrimSpace(cfg.URL)
 	if err := validateHTTPConfig(&cfg); err != nil {
 		return nil, err
 	}

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -95,6 +95,19 @@ type httpSource struct {
 // NewHTTP validates cfg and returns a Source. Returns ErrInvalidConfig
 // on any validation failure.
 func NewHTTP(cfg HTTPConfig) (Source, error) {
+	// Return an untyped nil on error — never a non-nil Source wrapping a nil
+	// *httpSource (the classic nil-interface trap for `src == nil` callers).
+	h, err := newHTTPSource(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// newHTTPSource is the shared constructor used by NewHTTP and FetchBytes: it
+// validates cfg, decodes the checksum, defaults MaxBytes/client, and returns the
+// concrete source.
+func newHTTPSource(cfg HTTPConfig) (*httpSource, error) {
 	if err := validateHTTPConfig(&cfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two related `sys/remote` correctness fixes from the post-adoption audit.

### Gap 12 (High/security) — bounded fetch-to-memory
`remote.Source` was `Fetch(ctx, dest)`-only, so a consumer needing
bytes-in-memory (a GPG key, a `SHA256SUMS` manifest) hand-rolled `net/http`. One
agent path — the checksum-manifest read — was **uncapped**: a compromised mirror
behind the operator's `checksum_url` could stream an unbounded body of short
lines past `bufio.Scanner`'s per-line bound → memory/CPU DoS.

- `FetchBytes(ctx, cfg)` carries the **same guards as `Fetch`** (URL/scheme
  validation, `MaxBytes` cap, optional sha256 pin, default-or-injected client)
  but bounded for RAM: unset `MaxBytes` → **64 MiB** (not the 2 GiB file
  default), over-cap → `ErrIntegrity` with no data, `Extract`/`Prune` rejected.
- Shared `httpSource` construction refactored out of `NewHTTP` (no behaviour
  change; `NewHTTP` still returns an untyped nil on error).

### Gap 14 (Low) — URL validate/fetch normalization
`sdk.ValidateHTTPSURL` trims before parsing; `parseHTTPURL` did not, so a
padded-but-valid URL passed validation then failed the fetch. `newHTTPSource`
now trims `cfg.URL` first (internal control chars still caught), so "validated"
implies "fetchable".

Tests: value path, the **security bound** (over-cap → `ErrIntegrity`, scoped
red-checked), checksum match/mismatch, scheme/extract rejection, the E1 TLS seam,
the in-memory-default guard, and a padded-URL acceptance test (red-first).

Supersedes the E5 WON'T-DO. Agent adopts `downloadAptKey` +
`downloadAndExtractChecksum` next.