### PR TITLE
feat(crypto): AES-256-GCM seal/open with mandatory domain-separation AAD

### DIFF
--- a/crypto/aead.go
+++ b/crypto/aead.go
@@ -1,0 +1,96 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+)
+
+// keyLen is the required symmetric key length: AES-256.
+const keyLen = 32
+
+var (
+	// ErrInvalidKey is returned when the key is not exactly 32 bytes (AES-256).
+	ErrInvalidKey = errors.New("crypto: key must be 32 bytes (AES-256)")
+
+	// ErrAADRequired is returned when the AAD is empty. Domain-separation AAD is
+	// MANDATORY: a naked AEAD call (nil/empty AAD) is refused by construction, so
+	// two different ciphertext domains can never be confused or cross-decrypted,
+	// and "forgot the AAD" is impossible to do silently.
+	ErrAADRequired = errors.New("crypto: AAD is required (domain separation; no naked AEAD calls)")
+
+	// ErrMalformedCiphertext is returned when a ciphertext is too short to carry
+	// its prepended nonce.
+	ErrMalformedCiphertext = errors.New("crypto: ciphertext too short")
+)
+
+// SealWithAAD encrypts plaintext with AES-256-GCM under key, binding aad as
+// additional authenticated data, and returns nonce||ciphertext||tag.
+//
+// A fresh random 96-bit nonce is generated PER CALL and prepended to the output.
+// The nonce is generated here, never taken from the caller, so nonce reuse under
+// the same key (catastrophic for GCM) cannot be introduced by a caller mistake;
+// a crypto/rand failure fails closed rather than emitting a predictable nonce.
+//
+// Both a 32-byte key and a NON-EMPTY aad are required: an empty aad is rejected
+// (ErrAADRequired) so every ciphertext is domain-separated. The AEAD tag covers
+// the plaintext AND the aad, so a wrong key, a wrong-domain aad, or any tamper
+// fails authentication in OpenWithAAD.
+func SealWithAAD(key, plaintext, aad []byte) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(aad) == 0 {
+		return nil, ErrAADRequired
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("crypto: generate nonce: %w", err)
+	}
+	// Seal appends the ciphertext+tag to its first argument, so passing nonce as
+	// the destination yields nonce||ciphertext||tag.
+	return gcm.Seal(nonce, nonce, plaintext, aad), nil
+}
+
+// OpenWithAAD reverses SealWithAAD: it splits the prepended nonce, then
+// authenticates and decrypts under key with the SAME aad. Any authentication
+// failure — a wrong key, a wrong-domain aad, or a tampered ciphertext — returns
+// an error and NO plaintext. A 32-byte key and a non-empty aad are required.
+func OpenWithAAD(key, ciphertext, aad []byte) ([]byte, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(aad) == 0 {
+		return nil, ErrAADRequired
+	}
+	ns := gcm.NonceSize()
+	if len(ciphertext) < ns {
+		return nil, ErrMalformedCiphertext
+	}
+	nonce, ct := ciphertext[:ns], ciphertext[ns:]
+	pt, err := gcm.Open(nil, nonce, ct, aad)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: open: %w", err)
+	}
+	return pt, nil
+}
+
+// newGCM builds an AES-256-GCM AEAD, rejecting a key that is not 32 bytes.
+func newGCM(key []byte) (cipher.AEAD, error) {
+	if len(key) != keyLen {
+		return nil, ErrInvalidKey
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: new cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: new gcm: %w", err)
+	}
+	return gcm, nil
+}

--- a/crypto/aead.go
+++ b/crypto/aead.go
@@ -68,7 +68,10 @@ func OpenWithAAD(key, ciphertext, aad []byte) ([]byte, error) {
 		return nil, ErrAADRequired
 	}
 	ns := gcm.NonceSize()
-	if len(ciphertext) < ns {
+	// A valid ciphertext carries the prepended nonce AND the GCM tag; reject
+	// anything too short to hold both up front with a precise error, rather than
+	// letting it fail later as a generic authentication failure in gcm.Open.
+	if len(ciphertext) < ns+gcm.Overhead() {
 		return nil, ErrMalformedCiphertext
 	}
 	nonce, ct := ciphertext[:ns], ciphertext[ns:]

--- a/crypto/aead_test.go
+++ b/crypto/aead_test.go
@@ -105,9 +105,15 @@ func TestSealOpen_RejectsEmptyAAD(t *testing.T) {
 
 func TestOpen_RejectsMalformedCiphertext(t *testing.T) {
 	key := key32(t)
-	// Shorter than a 96-bit nonce → can't even split off the nonce.
-	if _, err := OpenWithAAD(key, []byte("tiny"), []byte("d")); !errors.Is(err, ErrMalformedCiphertext) {
-		t.Fatalf("Open(short ciphertext): err = %v, want ErrMalformedCiphertext", err)
+	aad := []byte("d")
+	// A valid AES-256-GCM ciphertext is at least nonce(12) + tag(16) = 28 bytes.
+	// Anything shorter cannot carry BOTH a nonce and a tag, so it is malformed and
+	// must be rejected up front with the precise ErrMalformedCiphertext — not pass
+	// the length check and fail later inside gcm.Open with a generic auth error.
+	for _, n := range []int{0, 4, 12, 27} { // 12 = nonce-only, 27 = one short of nonce+tag
+		if _, err := OpenWithAAD(key, make([]byte, n), aad); !errors.Is(err, ErrMalformedCiphertext) {
+			t.Errorf("Open(%d-byte ciphertext): err = %v, want ErrMalformedCiphertext", n, err)
+		}
 	}
 }
 

--- a/crypto/aead_test.go
+++ b/crypto/aead_test.go
@@ -1,0 +1,123 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"testing"
+)
+
+func key32(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+func TestSealOpen_RoundTrip(t *testing.T) {
+	key := key32(t)
+	pt := []byte("super secret credential")
+	aad := []byte("pm-agent:credentials:v1")
+	ct, err := SealWithAAD(key, pt, aad)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if bytes.Contains(ct, pt) {
+		t.Fatal("ciphertext contains the plaintext verbatim")
+	}
+	got, err := OpenWithAAD(key, ct, aad)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Errorf("round-trip = %q, want %q", got, pt)
+	}
+}
+
+func TestSealOpen_EmptyPlaintextRoundTrips(t *testing.T) {
+	key := key32(t)
+	aad := []byte("domain")
+	ct, err := SealWithAAD(key, nil, aad)
+	if err != nil {
+		t.Fatalf("Seal(nil): %v", err)
+	}
+	got, err := OpenWithAAD(key, ct, aad)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty plaintext must round-trip to empty, got %q", got)
+	}
+}
+
+func TestOpen_WrongAADFails(t *testing.T) {
+	key := key32(t)
+	ct, _ := SealWithAAD(key, []byte("x"), []byte("domain-A"))
+	if _, err := OpenWithAAD(key, ct, []byte("domain-B")); err == nil {
+		t.Fatal("Open with a DIFFERENT AAD must fail authentication (domain separation)")
+	}
+}
+
+func TestOpen_WrongKeyFails(t *testing.T) {
+	ct, _ := SealWithAAD(key32(t), []byte("x"), []byte("d"))
+	if _, err := OpenWithAAD(key32(t), ct, []byte("d")); err == nil {
+		t.Fatal("Open with a different key must fail")
+	}
+}
+
+func TestOpen_TamperedCiphertextFails(t *testing.T) {
+	key := key32(t)
+	aad := []byte("d")
+	ct, _ := SealWithAAD(key, []byte("hello world"), aad)
+	ct[len(ct)-1] ^= 0xff // flip a tag byte
+	if _, err := OpenWithAAD(key, ct, aad); err == nil {
+		t.Fatal("a tampered ciphertext must fail authentication")
+	}
+}
+
+func TestSealOpen_RejectsBadKeyLength(t *testing.T) {
+	for _, n := range []int{0, 16, 31, 33, 64} {
+		k := make([]byte, n)
+		if _, err := SealWithAAD(k, []byte("x"), []byte("d")); !errors.Is(err, ErrInvalidKey) {
+			t.Errorf("Seal with a %d-byte key: err = %v, want ErrInvalidKey", n, err)
+		}
+		if _, err := OpenWithAAD(k, make([]byte, 64), []byte("d")); !errors.Is(err, ErrInvalidKey) {
+			t.Errorf("Open with a %d-byte key: err = %v, want ErrInvalidKey", n, err)
+		}
+	}
+}
+
+// Domain-separation AAD is MANDATORY: a naked AEAD call (nil/empty AAD) must be
+// refused by both Seal and Open, so the nil-AAD class is impossible to use.
+func TestSealOpen_RejectsEmptyAAD(t *testing.T) {
+	key := key32(t)
+	for _, aad := range [][]byte{nil, {}} {
+		if _, err := SealWithAAD(key, []byte("x"), aad); !errors.Is(err, ErrAADRequired) {
+			t.Errorf("Seal with empty AAD: err = %v, want ErrAADRequired", err)
+		}
+		if _, err := OpenWithAAD(key, make([]byte, 64), aad); !errors.Is(err, ErrAADRequired) {
+			t.Errorf("Open with empty AAD: err = %v, want ErrAADRequired", err)
+		}
+	}
+}
+
+func TestOpen_RejectsMalformedCiphertext(t *testing.T) {
+	key := key32(t)
+	// Shorter than a 96-bit nonce → can't even split off the nonce.
+	if _, err := OpenWithAAD(key, []byte("tiny"), []byte("d")); !errors.Is(err, ErrMalformedCiphertext) {
+		t.Fatalf("Open(short ciphertext): err = %v, want ErrMalformedCiphertext", err)
+	}
+}
+
+func TestSeal_NonceIsRandomPerCall(t *testing.T) {
+	key := key32(t)
+	pt := []byte("identical plaintext")
+	aad := []byte("identical aad")
+	a, _ := SealWithAAD(key, pt, aad)
+	b, _ := SealWithAAD(key, pt, aad)
+	if bytes.Equal(a, b) {
+		t.Fatal("two seals of identical input produced identical output — the nonce is not random (catastrophic nonce reuse for GCM)")
+	}
+}


### PR DESCRIPTION
**Gap 13 (Medium/security+DRY).** The agent (at-rest credentials) and the server
(`internal/crypto`) each hand-roll AES-256-GCM — two divergent impls of one
primitive — and the agent's call passed a **nil AAD**, a naked AEAD call the
project's crypto rule forbids. There was no shared SDK symmetric primitive to
delegate to.

- `SealWithAAD(key, plaintext, aad)` / `OpenWithAAD(key, ciphertext, aad)` —
  nonce-prepended AES-256-GCM, with the **AAD required by construction**: an
  empty/nil AAD is rejected (`ErrAADRequired`), making the naked-call class
  impossible and every ciphertext domain-separated.
- The 96-bit nonce is generated **per call** from `crypto/rand` (never
  caller-supplied; fail-closed on a rand error), so caller mistakes can't
  introduce nonce reuse.

Tests: round-trip (incl. empty plaintext), wrong-AAD / wrong-key / tamper all
fail authentication, 32-byte key enforced, **mandatory-AAD enforced (scoped
red-checked)**, short-ciphertext rejected, per-call nonce randomness.

The agent's `credentials.go` AES-GCM and the server's `enc:v2` are expressible
through this; both adopt it next (a storage-format migration, best done with the
primitive rather than before it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure encryption capability with integrated message authentication and domain separation support
  * Implemented automatic per-call random nonce generation ensuring unique ciphertexts even for identical inputs

* **Tests**
  * Added extensive test coverage validating encryption round-trips and authentication properties
  * Includes error condition testing and security verification such as nonce randomness and tampering detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->