### PR TITLE
refactor(sdk): dedup + dead-code sweep; fix S3 prefix-sync on path-prefixed endpoints

### DIFF
--- a/docs/03-capabilities/22-repositories.md
+++ b/docs/03-capabilities/22-repositories.md
@@ -60,12 +60,12 @@ same desired state is safe and produces no spurious change events.
 <!-- docref: end -->
 
 {% callout type="info" title="GPG keys are public material" %}
-<!-- docref: begin src=sys/repo/apt.go#updateAptKey:f3733dcc,sys/repo/dnf.go#manager.applyDnf:0bc9b98b -->
+<!-- docref: begin src=sys/repo/apt.go#updateAptKey:f3733dcc,sys/repo/dnf.go#manager.applyDnf:c628e81a,sys/repo/zypper.go#manager.applyZypper:159c1fe5 -->
 The signing keys here are *public* repository keys, not secrets. apt receives the
 key bytes (dearmored into `/etc/apt/keyrings`); dnf and zypper take a key
-reference (URL or path) the package manager imports — and dnf imports it only
-when `GPGCheck` is on, so a key is never trusted system-wide while the
-repository itself verifies nothing.
+reference (URL or path) the package manager imports — and both dnf and zypper
+import it only when `GPGCheck` is on, so a key is never trusted system-wide while
+the repository itself verifies nothing.
 <!-- docref: end -->
 {% /callout %}
 

--- a/pkg/dnf.go
+++ b/pkg/dnf.go
@@ -376,19 +376,19 @@ func (d *dnf) Show(ctx context.Context, name string) (*Package, error) {
 		line := scanner.Text()
 		switch {
 		case strings.HasPrefix(line, "Version"):
-			pkg.Version = parseValue(line)
+			pkg.Version = parseColonValue(line)
 		case strings.HasPrefix(line, "Release"):
 			if pkg.Version != "" {
-				pkg.Version += "-" + parseValue(line)
+				pkg.Version += "-" + parseColonValue(line)
 			}
 		case strings.HasPrefix(line, "Architecture"):
-			pkg.Architecture = parseValue(line)
+			pkg.Architecture = parseColonValue(line)
 		case strings.HasPrefix(line, "Size"):
-			pkg.Size = parseSize(parseValue(line))
+			pkg.Size = parseSize(parseColonValue(line))
 		case strings.HasPrefix(line, "Summary"):
-			pkg.Description = parseValue(line)
+			pkg.Description = parseColonValue(line)
 		case strings.HasPrefix(line, "Repository"):
-			pkg.Repository = parseValue(line)
+			pkg.Repository = parseColonValue(line)
 		}
 	}
 
@@ -585,28 +585,11 @@ func (d *dnf) getPinnedSet(ctx context.Context) (map[string]bool, error) {
 	return pinned, nil
 }
 
-func parseValue(line string) string {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(parts[1])
-}
-
 func parseSize(s string) int64 {
-	s = strings.TrimSpace(s)
-	multiplier := int64(1)
-	switch {
-	case strings.HasSuffix(s, " k"), strings.HasSuffix(s, " K"):
-		multiplier = 1024
-		s = strings.TrimSuffix(strings.TrimSuffix(s, " k"), " K")
-	case strings.HasSuffix(s, " M"):
-		multiplier = 1024 * 1024
-		s = strings.TrimSuffix(s, " M")
-	case strings.HasSuffix(s, " G"):
-		multiplier = 1024 * 1024 * 1024
-		s = strings.TrimSuffix(s, " G")
-	}
-	size, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return int64(size * float64(multiplier))
+	return parseSizeWithUnits(s, []sizeUnit{
+		{" k", 1024},
+		{" K", 1024},
+		{" M", 1024 * 1024},
+		{" G", 1024 * 1024 * 1024},
+	})
 }

--- a/pkg/dnf_test.go
+++ b/pkg/dnf_test.go
@@ -848,11 +848,11 @@ func TestDnf_NEVRAParsing(t *testing.T) {
 }
 
 func TestDnf_ParseValue(t *testing.T) {
-	if v := parseValue("Version      : 8.2"); v != "8.2" {
-		t.Errorf("parseValue keyed line = %q, want 8.2", v)
+	if v := parseColonValue("Version      : 8.2"); v != "8.2" {
+		t.Errorf("parseColonValue keyed line = %q, want 8.2", v)
 	}
-	if v := parseValue("a line with no colon"); v != "" {
-		t.Errorf("parseValue no-colon = %q, want empty", v)
+	if v := parseColonValue("a line with no colon"); v != "" {
+		t.Errorf("parseColonValue no-colon = %q, want empty", v)
 	}
 }
 

--- a/pkg/exec.go
+++ b/pkg/exec.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
@@ -125,6 +126,49 @@ func rpmLocalPackageInfo(ctx context.Context, r pmexec.Runner, path string) (*Lo
 		info.Arch = fields[2]
 	}
 	return info, nil
+}
+
+// parseColonValue returns the trimmed value after the first colon in a
+// "Key: value" info line, or "" when the line has no colon. Shared by every
+// rpm/pacman/flatpak info parser so the "split on first colon" rule cannot drift
+// between backends.
+func parseColonValue(line string) string {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+// sizeUnit pairs a trailing size suffix (with its leading space, e.g. " KiB")
+// with the byte multiplier it denotes.
+type sizeUnit struct {
+	suffix string
+	mult   int64
+}
+
+// parseSizeWithUnits parses a human-readable size string ("3.0 MiB", "512 k",
+// "900 B") into bytes using the supplied ordered unit table. Units are tried in
+// order, so a caller must list more specific suffixes before any that are a
+// suffix of them. A matched suffix is stripped and its multiplier applied; a
+// unit with mult == 1 is a no-op-multiplier suffix that is merely trimmed. The
+// remaining text is parsed with strconv.ParseFloat: an empty string, an
+// unrecognised suffix, or unparseable digits all yield 0 (ParseFloat's error is
+// intentionally ignored, mirroring the per-backend originals). The input is
+// space-trimmed before matching; callers needing other preprocessing (e.g.
+// flatpak's comma stripping) do it before calling.
+func parseSizeWithUnits(s string, units []sizeUnit) int64 {
+	s = strings.TrimSpace(s)
+	multiplier := int64(1)
+	for _, u := range units {
+		if strings.HasSuffix(s, u.suffix) {
+			multiplier = u.mult
+			s = strings.TrimSuffix(s, u.suffix)
+			break
+		}
+	}
+	size, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return int64(size * float64(multiplier))
 }
 
 // splitPositionalFields splits VALUE-ONLY one-field-per-line command output (rpm

--- a/pkg/flatpak.go
+++ b/pkg/flatpak.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
@@ -591,30 +590,17 @@ func parseFlatpakValue(line string) string {
 }
 
 func parseFlatpakSize(s string) int64 {
-	s = strings.ReplaceAll(strings.TrimSpace(s), ",", "")
-	multiplier := int64(1)
-	switch {
-	case strings.HasSuffix(s, " kB"), strings.HasSuffix(s, " KB"):
-		multiplier = 1000
-		s = strings.TrimSuffix(strings.TrimSuffix(s, " kB"), " KB")
-	case strings.HasSuffix(s, " KiB"):
-		multiplier = 1024
-		s = strings.TrimSuffix(s, " KiB")
-	case strings.HasSuffix(s, " MB"):
-		multiplier = 1000 * 1000
-		s = strings.TrimSuffix(s, " MB")
-	case strings.HasSuffix(s, " MiB"):
-		multiplier = 1024 * 1024
-		s = strings.TrimSuffix(s, " MiB")
-	case strings.HasSuffix(s, " GB"):
-		multiplier = 1000 * 1000 * 1000
-		s = strings.TrimSuffix(s, " GB")
-	case strings.HasSuffix(s, " GiB"):
-		multiplier = 1024 * 1024 * 1024
-		s = strings.TrimSuffix(s, " GiB")
-	case strings.HasSuffix(s, " bytes"):
-		s = strings.TrimSuffix(s, " bytes")
-	}
-	size, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return int64(size * float64(multiplier))
+	// flatpak's human sizes can carry thousands separators ("1,536 MB"); strip
+	// them before the shared unit parser, which only space-trims.
+	s = strings.ReplaceAll(s, ",", "")
+	return parseSizeWithUnits(s, []sizeUnit{
+		{" kB", 1000},
+		{" KB", 1000},
+		{" KiB", 1024},
+		{" MB", 1000 * 1000},
+		{" MiB", 1024 * 1024},
+		{" GB", 1000 * 1000 * 1000},
+		{" GiB", 1024 * 1024 * 1024},
+		{" bytes", 1},
+	})
 }

--- a/pkg/pacman.go
+++ b/pkg/pacman.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strconv"
+	"slices"
 	"strings"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
@@ -348,15 +348,15 @@ func (p *pacman) Show(ctx context.Context, name string) (*Package, error) {
 		line := scanner.Text()
 		switch {
 		case strings.HasPrefix(line, "Version"):
-			pkg.Version = parsePacmanValue(line)
+			pkg.Version = parseColonValue(line)
 		case strings.HasPrefix(line, "Architecture"):
-			pkg.Architecture = parsePacmanValue(line)
+			pkg.Architecture = parseColonValue(line)
 		case strings.HasPrefix(line, "Description"):
-			pkg.Description = parsePacmanValue(line)
+			pkg.Description = parseColonValue(line)
 		case strings.HasPrefix(line, "Installed Size"):
-			pkg.Size = parsePacmanSize(parsePacmanValue(line))
+			pkg.Size = parsePacmanSize(parseColonValue(line))
 		case strings.HasPrefix(line, "Repository"):
-			pkg.Repository = parsePacmanValue(line)
+			pkg.Repository = parseColonValue(line)
 		}
 	}
 
@@ -396,9 +396,9 @@ func (p *pacman) ListVersions(ctx context.Context, name string) (*VersionInfo, e
 		line := scanner.Text()
 		switch {
 		case strings.HasPrefix(line, "Version"):
-			version = parsePacmanValue(line)
+			version = parseColonValue(line)
 		case strings.HasPrefix(line, "Repository"):
-			repo = parsePacmanValue(line)
+			repo = parseColonValue(line)
 		}
 	}
 	if version != "" {
@@ -522,7 +522,7 @@ func (p *pacman) Pin(ctx context.Context, packages ...string) (pmexec.Result, er
 	}
 	ignored := getIgnoredPackages(conf)
 	for _, name := range packages {
-		if !contains(ignored, name) {
+		if !slices.Contains(ignored, name) {
 			ignored = append(ignored, name)
 		}
 	}
@@ -544,7 +544,7 @@ func (p *pacman) Unpin(ctx context.Context, packages ...string) (pmexec.Result, 
 	}
 	var kept []string
 	for _, name := range getIgnoredPackages(conf) {
-		if !contains(packages, name) {
+		if !slices.Contains(packages, name) {
 			kept = append(kept, name)
 		}
 	}
@@ -582,7 +582,7 @@ func (p *pacman) IsPinned(ctx context.Context, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return contains(getIgnoredPackages(conf), name), nil
+	return slices.Contains(getIgnoredPackages(conf), name), nil
 }
 
 func (p *pacman) getPinnedSet(ctx context.Context) (map[string]bool, error) {
@@ -670,39 +670,11 @@ func buildIgnorePkgConf(conf string, ignored []string) string {
 	return b.String()
 }
 
-func parsePacmanValue(line string) string {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(parts[1])
-}
-
 func parsePacmanSize(s string) int64 {
-	s = strings.TrimSpace(s)
-	multiplier := int64(1)
-	switch {
-	case strings.HasSuffix(s, " KiB"):
-		multiplier = 1024
-		s = strings.TrimSuffix(s, " KiB")
-	case strings.HasSuffix(s, " MiB"):
-		multiplier = 1024 * 1024
-		s = strings.TrimSuffix(s, " MiB")
-	case strings.HasSuffix(s, " GiB"):
-		multiplier = 1024 * 1024 * 1024
-		s = strings.TrimSuffix(s, " GiB")
-	case strings.HasSuffix(s, " B"):
-		s = strings.TrimSuffix(s, " B")
-	}
-	size, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return int64(size * float64(multiplier))
-}
-
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
+	return parseSizeWithUnits(s, []sizeUnit{
+		{" KiB", 1024},
+		{" MiB", 1024 * 1024},
+		{" GiB", 1024 * 1024 * 1024},
+		{" B", 1},
+	})
 }

--- a/pkg/pacman_test.go
+++ b/pkg/pacman_test.go
@@ -910,18 +910,12 @@ func TestPacman_GetIgnoredPackages(t *testing.T) {
 	}
 }
 
-func TestPacman_Contains(t *testing.T) {
-	if !contains([]string{"a", "b"}, "b") || contains([]string{"a"}, "z") || contains(nil, "x") {
-		t.Error("contains is wrong")
-	}
-}
-
 func TestPacman_ParseValueAndSize(t *testing.T) {
-	if v := parsePacmanValue("Version : 9.0"); v != "9.0" {
-		t.Errorf("parsePacmanValue=%q", v)
+	if v := parseColonValue("Version : 9.0"); v != "9.0" {
+		t.Errorf("parseColonValue=%q", v)
 	}
-	if v := parsePacmanValue("no colon"); v != "" {
-		t.Errorf("parsePacmanValue no-colon=%q", v)
+	if v := parseColonValue("no colon"); v != "" {
+		t.Errorf("parseColonValue no-colon=%q", v)
 	}
 	cases := map[string]int64{
 		"3.00 MiB": 3 * 1024 * 1024,

--- a/pkg/zypper.go
+++ b/pkg/zypper.go
@@ -323,17 +323,17 @@ func (z *zypper) Show(ctx context.Context, name string) (*Package, error) {
 		line := scanner.Text()
 		switch {
 		case strings.HasPrefix(line, "Version"):
-			pkg.Version = parseZypperValue(line)
+			pkg.Version = parseColonValue(line)
 		case strings.HasPrefix(line, "Arch"):
-			pkg.Architecture = parseZypperValue(line)
+			pkg.Architecture = parseColonValue(line)
 		case strings.HasPrefix(line, "Summary"):
-			pkg.Description = parseZypperValue(line)
+			pkg.Description = parseColonValue(line)
 		case strings.HasPrefix(line, "Installed Size"):
-			pkg.Size = parseZypperSize(parseZypperValue(line))
+			pkg.Size = parseZypperSize(parseColonValue(line))
 		case strings.HasPrefix(line, "Repository"):
-			pkg.Repository = parseZypperValue(line)
+			pkg.Repository = parseColonValue(line)
 		case strings.HasPrefix(line, "Status"):
-			if strings.Contains(strings.ToLower(parseZypperValue(line)), "installed") {
+			if strings.Contains(strings.ToLower(parseColonValue(line)), "installed") {
 				pkg.Status = "installed"
 			}
 		}
@@ -587,30 +587,11 @@ func (z *zypper) getPinnedSet(ctx context.Context) (map[string]bool, error) {
 	return pinned, nil
 }
 
-func parseZypperValue(line string) string {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(parts[1])
-}
-
 func parseZypperSize(s string) int64 {
-	s = strings.TrimSpace(s)
-	multiplier := int64(1)
-	switch {
-	case strings.HasSuffix(s, " KiB"):
-		multiplier = 1024
-		s = strings.TrimSuffix(s, " KiB")
-	case strings.HasSuffix(s, " MiB"):
-		multiplier = 1024 * 1024
-		s = strings.TrimSuffix(s, " MiB")
-	case strings.HasSuffix(s, " GiB"):
-		multiplier = 1024 * 1024 * 1024
-		s = strings.TrimSuffix(s, " GiB")
-	case strings.HasSuffix(s, " B"):
-		s = strings.TrimSuffix(s, " B")
-	}
-	size, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return int64(size * float64(multiplier))
+	return parseSizeWithUnits(s, []sizeUnit{
+		{" KiB", 1024},
+		{" MiB", 1024 * 1024},
+		{" GiB", 1024 * 1024 * 1024},
+		{" B", 1},
+	})
 }

--- a/pkg/zypper_test.go
+++ b/pkg/zypper_test.go
@@ -708,11 +708,11 @@ func TestZypper_ListPinnedAndIsPinned(t *testing.T) {
 }
 
 func TestZypper_ParseValueAndSize(t *testing.T) {
-	if v := parseZypperValue("Version : 9.0"); v != "9.0" {
-		t.Errorf("parseZypperValue=%q", v)
+	if v := parseColonValue("Version : 9.0"); v != "9.0" {
+		t.Errorf("parseColonValue=%q", v)
 	}
-	if v := parseZypperValue("no colon"); v != "" {
-		t.Errorf("parseZypperValue no-colon=%q", v)
+	if v := parseColonValue("no colon"); v != "" {
+		t.Errorf("parseColonValue no-colon=%q", v)
 	}
 	cases := map[string]int64{
 		"3.0 MiB": 3 * 1024 * 1024,

--- a/sys/exec/capped_buffer.go
+++ b/sys/exec/capped_buffer.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"io"
+	"slices"
 	"sync"
 )
 
@@ -90,9 +91,7 @@ func (b *CappedBuffer) Bytes() []byte {
 		out = append(out, truncationMarker...)
 		return out
 	}
-	out := make([]byte, len(b.buf))
-	copy(out, b.buf)
-	return out
+	return slices.Clone(b.buf)
 }
 
 // compile-time guard: CappedBuffer satisfies io.Writer.

--- a/sys/exec/env.go
+++ b/sys/exec/env.go
@@ -40,13 +40,13 @@ var ValidEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 // BlockedEnvVars are environment variable names that must never be overridden
 // because they can hijack process execution (library injection, path manipulation).
+//
+// The whole LD_*, BASH_FUNC_*, and DYLD_* families are blocked unconditionally by
+// the prefix check in IsAllowedEnvVar, so individual LD_* keys (LD_PRELOAD,
+// LD_LIBRARY_PATH, LD_AUDIT, LD_DEBUG, LD_PROFILE) and the BASH_FUNC_ prefix are
+// not enumerated here — listing them would only duplicate the prefix rule. This
+// map carries the names that have no covering prefix.
 var BlockedEnvVars = map[string]bool{
-	// Linux dynamic linker injection
-	"LD_PRELOAD":      true,
-	"LD_LIBRARY_PATH": true,
-	"LD_AUDIT":        true,
-	"LD_DEBUG":        true,
-	"LD_PROFILE":      true,
 	// glibc iconv module loading (CVE-2021-4034 vector)
 	"GCONV_PATH": true,
 	// DNS/resolver manipulation
@@ -67,7 +67,6 @@ var BlockedEnvVars = map[string]bool{
 	"BASH_ENV":   true,
 	"CDPATH":     true,
 	"GLOBIGNORE": true,
-	"BASH_FUNC_": true,
 }
 
 // IsAllowedEnvVar returns true if the environment variable name is safe to set.

--- a/sys/exec/env_test.go
+++ b/sys/exec/env_test.go
@@ -106,21 +106,28 @@ func TestIsAllowedEnvVar_InvalidNames(t *testing.T) {
 }
 
 func TestBlockedEnvVars_Completeness(t *testing.T) {
-	// Verify the critical security-sensitive env vars are in the blocklist
+	// Verify the critical security-sensitive env vars are rejected. The check is
+	// against IsAllowedEnvVar — the real security boundary — not the map alone,
+	// because the LD_* / BASH_FUNC_ families are blocked by an unconditional
+	// prefix rule rather than enumerated as map keys.
 	critical := []string{
 		"LD_PRELOAD",
 		"LD_LIBRARY_PATH",
+		"LD_AUDIT",
+		"LD_DEBUG",
+		"LD_PROFILE",
 		"PATH",
 		"IFS",
 		"BASH_ENV",
+		"BASH_FUNC_foo",
 		"GCONV_PATH",
 		"NODE_OPTIONS",
 		"HOSTALIASES",
 	}
 
 	for _, name := range critical {
-		if !BlockedEnvVars[name] {
-			t.Errorf("BlockedEnvVars missing critical entry %q", name)
+		if IsAllowedEnvVar(name) {
+			t.Errorf("IsAllowedEnvVar(%q) = true, want false (critical blocked entry)", name)
 		}
 	}
 }

--- a/sys/firewall/nftables.go
+++ b/sys/firewall/nftables.go
@@ -145,14 +145,6 @@ func (n *nftables) nftDeleteManagedTable(ctx context.Context) error {
 	return err // missing table on the second teardown surfaces as a (harmless) error
 }
 
-// nftBuildApplyScript builds the batch script for an ApplyRule call,
-// no validation beyond the dispatch layer's ID check. Used by the
-// idempotency-test cases that exercise the builder's output shape.
-func nftBuildApplyScript(namespace string, rule Rule, replaceHandle int64) string {
-	script, _ := nftBuildApplyScriptStrict(namespace, rule, replaceHandle)
-	return script
-}
-
 // nftBuildApplyScriptStrict errors on nft-untranslatable Rule combos —
 // currently just "Port set without Protocol", which can't be expressed
 // in one nft rule.

--- a/sys/firewall/nftables_test.go
+++ b/sys/firewall/nftables_test.go
@@ -38,31 +38,37 @@ func skipIfNotNftablesUsable(t *testing.T) {
 // exact nft batch grammar so future refactors of the builder don't
 // silently change what we send to the kernel.
 func TestNftBuildScript_AcceptTCP(t *testing.T) {
-	got := nftBuildApplyScript(nftTestNamespace, Rule{
+	got, err := nftBuildApplyScriptStrict(nftTestNamespace, Rule{
 		ID:       "ssh-in",
 		Allow:    true,
 		Protocol: ProtocolTCP,
 		Port:     22,
 	}, 0)
+	if err != nil {
+		t.Fatalf("nftBuildApplyScriptStrict(accept tcp): %v", err)
+	}
 	want := strings.Join([]string{
 		`add table inet fwtest_filter`,
 		`add chain inet fwtest_filter input { type filter hook input priority 0; policy accept; }`,
 		`add rule inet fwtest_filter input tcp dport 22 accept comment "ssh-in"`,
 	}, "\n") + "\n"
 	if got != want {
-		t.Fatalf("nftBuildApplyScript:\n--- got  ---\n%s\n--- want ---\n%s", got, want)
+		t.Fatalf("nftBuildApplyScriptStrict:\n--- got  ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
 
 // TestNftBuildScript_DropUDP — Deny side + UDP, verifies the
 // allow→accept/drop and protocol→tcp/udp toggles independently.
 func TestNftBuildScript_DropUDP(t *testing.T) {
-	got := nftBuildApplyScript(nftTestNamespace, Rule{
+	got, err := nftBuildApplyScriptStrict(nftTestNamespace, Rule{
 		ID:       "block-dns",
 		Allow:    false,
 		Protocol: ProtocolUDP,
 		Port:     53,
 	}, 0)
+	if err != nil {
+		t.Fatalf("nftBuildApplyScriptStrict(drop udp): %v", err)
+	}
 	if !strings.Contains(got, `add rule inet fwtest_filter input udp dport 53 drop comment "block-dns"`) {
 		t.Fatalf("missing expected rule line:\n%s", got)
 	}
@@ -72,7 +78,7 @@ func TestNftBuildScript_DropUDP(t *testing.T) {
 // source / dest fields. Source comes BEFORE protocol match, dest comes
 // AFTER (mirrors nft's own statement order from manpage examples).
 func TestNftBuildScript_WithSourceAndDest(t *testing.T) {
-	got := nftBuildApplyScript(nftTestNamespace, Rule{
+	got, err := nftBuildApplyScriptStrict(nftTestNamespace, Rule{
 		ID:       "from-vpn",
 		Allow:    true,
 		Protocol: ProtocolTCP,
@@ -80,6 +86,9 @@ func TestNftBuildScript_WithSourceAndDest(t *testing.T) {
 		Source:   "10.0.0.0/8",
 		Dest:     "192.168.1.10",
 	}, 0)
+	if err != nil {
+		t.Fatalf("nftBuildApplyScriptStrict(source and dest): %v", err)
+	}
 	want := `add rule inet fwtest_filter input ip saddr 10.0.0.0/8 ip daddr 192.168.1.10 tcp dport 443 accept comment "from-vpn"`
 	if !strings.Contains(got, want) {
 		t.Fatalf("missing expected rule line:\n%s", got)
@@ -90,11 +99,14 @@ func TestNftBuildScript_WithSourceAndDest(t *testing.T) {
 // Port is 0 we still produce a valid rule (just accept from a source).
 // This is the "allow this network full access" case.
 func TestNftBuildScript_AnyProtocolNoPort(t *testing.T) {
-	got := nftBuildApplyScript(nftTestNamespace, Rule{
+	got, err := nftBuildApplyScriptStrict(nftTestNamespace, Rule{
 		ID:     "trusted-net",
 		Allow:  true,
 		Source: "172.16.0.0/12",
 	}, 0)
+	if err != nil {
+		t.Fatalf("nftBuildApplyScriptStrict(any protocol no port): %v", err)
+	}
 	want := `add rule inet fwtest_filter input ip saddr 172.16.0.0/12 accept comment "trusted-net"`
 	if !strings.Contains(got, want) {
 		t.Fatalf("missing expected rule line:\n%s", got)
@@ -106,12 +118,15 @@ func TestNftBuildScript_AnyProtocolNoPort(t *testing.T) {
 // the same transaction as the new ADD. Atomic; if either fails the
 // kernel rolls back both.
 func TestNftBuildScript_ReplacesExistingHandle(t *testing.T) {
-	got := nftBuildApplyScript(nftTestNamespace, Rule{
+	got, err := nftBuildApplyScriptStrict(nftTestNamespace, Rule{
 		ID:       "ssh-in",
 		Allow:    true,
 		Protocol: ProtocolTCP,
 		Port:     22,
 	}, 17)
+	if err != nil {
+		t.Fatalf("nftBuildApplyScriptStrict(replace handle): %v", err)
+	}
 	if !strings.Contains(got, `delete rule inet fwtest_filter input handle 17`) {
 		t.Fatalf("missing delete-of-old-handle line:\n%s", got)
 	}

--- a/sys/fs/protected.go
+++ b/sys/fs/protected.go
@@ -6,30 +6,41 @@ import (
 )
 
 // dangerousPaths are top-level system directories that must never be removed.
-// IsProtectedPath matches these (plus extraProtectedPaths); the deny-by-default
-// subtree check RemoveDir uses lives in IsUnderProtectedPrefix below.
+// IsProtectedPath matches this set; the deny-by-default subtree check RemoveDir
+// uses lives in IsUnderProtectedPrefix below.
+//
+// The first block is the critical OS tree (also guarded as subtrees by
+// protectedPrefixRoots); the second block are additional top-level directories
+// IsProtectedPath guards by exact match but that RemoveDir's subtree check does
+// not need (less critical or already covered).
 var dangerousPaths = map[string]bool{
-	"/":      true,
-	"/boot":  true,
-	"/dev":   true,
-	"/etc":   true,
-	"/proc":  true,
-	"/run":   true,
-	"/sys":   true,
-	"/usr":   true,
-	"/var":   true,
-	"/bin":   true,
-	"/sbin":  true,
-	"/lib":   true,
-	"/lib64": true,
-	"/home":  true,
-	"/root":  true,
+	"/":       true,
+	"/boot":   true,
+	"/dev":    true,
+	"/etc":    true,
+	"/proc":   true,
+	"/run":    true,
+	"/sys":    true,
+	"/usr":    true,
+	"/var":    true,
+	"/bin":    true,
+	"/sbin":   true,
+	"/lib":    true,
+	"/lib64":  true,
+	"/home":   true,
+	"/root":   true,
+	"/lib32":  true,
+	"/libx32": true,
+	"/media":  true,
+	"/mnt":    true,
+	"/opt":    true,
+	"/srv":    true,
+	"/tmp":    true,
+	"/snap":   true, // snap-based distributions (Ubuntu)
 }
 
 // IsProtectedPath returns true if path is a system directory that should
 // never be deleted. The path is cleaned and resolved to absolute before checking.
-// This uses the same set as dangerousPaths plus additional top-level
-// directories.
 func IsProtectedPath(path string) bool {
 	clean := filepath.Clean(path)
 	if !filepath.IsAbs(clean) {
@@ -39,21 +50,7 @@ func IsProtectedPath(path string) bool {
 		}
 		clean = abs
 	}
-	return dangerousPaths[clean] || extraProtectedPaths[clean]
-}
-
-// extraProtectedPaths extends dangerousPaths with additional top-level
-// directories that IsProtectedPath should guard but RemoveDir does not
-// need to check (since they are less critical or already covered).
-var extraProtectedPaths = map[string]bool{
-	"/lib32":  true,
-	"/libx32": true,
-	"/media":  true,
-	"/mnt":    true,
-	"/opt":    true,
-	"/srv":    true,
-	"/tmp":    true,
-	"/snap":   true, // snap-based distributions (Ubuntu)
+	return dangerousPaths[clean]
 }
 
 // protectedPrefixRoots are directory subtrees that a managed directory

--- a/sys/netconfig/networkmanager.go
+++ b/sys/netconfig/networkmanager.go
@@ -64,7 +64,15 @@ func nmModifyArgs(cfg InterfaceConfig) []string {
 		)
 	} else {
 		v4addr, v6addr := partitionAddrsByFamily(cfg.Addresses)
-		gwV4, gwV6 := splitGatewayByFamily(cfg.Gateway)
+		// cfg.Gateway is a validated IP literal (or empty); bucket it by family.
+		var gwV4, gwV6 string
+		if cfg.Gateway != "" {
+			if net.ParseIP(cfg.Gateway).To4() != nil {
+				gwV4 = cfg.Gateway
+			} else {
+				gwV6 = cfg.Gateway
+			}
+		}
 		if len(v4addr) > 0 {
 			a = append(a, "ipv4.method", "manual", "ipv4.addresses", strings.Join(v4addr, ","))
 			if gwV4 != "" {
@@ -98,18 +106,6 @@ func nmModifyArgs(cfg InterfaceConfig) []string {
 		}
 	}
 	return a
-}
-
-// splitGatewayByFamily returns the gateway as (v4, v6) — exactly one is set (or
-// neither when gw is empty). gw is a validated IP literal.
-func splitGatewayByFamily(gw string) (v4, v6 string) {
-	if gw == "" {
-		return "", ""
-	}
-	if net.ParseIP(gw).To4() != nil {
-		return gw, ""
-	}
-	return "", gw
 }
 
 // nmRoutesByFamily renders each route as nmcli's "<dest> <gateway> [metric]"

--- a/sys/remote/http.go
+++ b/sys/remote/http.go
@@ -199,10 +199,7 @@ func newHTTPSource(cfg HTTPConfig) (*httpSource, error) {
 //     lives outside the project-managed prefixes.
 func (h *httpSource) Fetch(ctx context.Context, dest string) (Result, error) {
 	if h.cfg.Extract {
-		if httpArchiveDispatch == nil {
-			return Result{}, errFetchArchiveUnimplemented
-		}
-		return httpArchiveDispatch(ctx, h, dest)
+		return h.fetchArchive(ctx, dest)
 	}
 	if err := validateDestination(dest); err != nil {
 		return Result{}, err

--- a/sys/remote/http_archive.go
+++ b/sys/remote/http_archive.go
@@ -5,7 +5,6 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -113,11 +112,12 @@ func (h *httpSource) fetchArchive(ctx context.Context, dest string) (Result, err
 	}
 	defer func() { _ = os.Remove(tmp) }()
 
-	// Mine the random suffix tmpPathFor stamped into tmp so the staging
-	// dir gets a matching tail — keeps the two sibling artefacts visible
-	// as a pair when an extract is interrupted mid-flight.
-	stagingSuffix := stagingSuffixFromTmp(tmp)
-	staging := dest + ".staging." + stagingSuffix
+	// Build an unpredictable sibling staging dir via the same fail-closed
+	// crypto/rand suffix tmpPathFor stamps onto the tmp file.
+	staging, err := tmpPathFor(dest + ".staging")
+	if err != nil {
+		return Result{}, err
+	}
 	if err := os.MkdirAll(staging, 0o755); err != nil {
 		return Result{}, fmt.Errorf("mkdir staging %s: %w", staging, err)
 	}
@@ -429,34 +429,3 @@ func safeJoinDest(staging, entry string) (string, error) {
 	}
 	return full, nil
 }
-
-// http.go's Fetch dispatches here when cfg.Extract is set; wired up in
-// the same commit so the test suite sees a green archive branch.
-func init() {
-	httpArchiveDispatch = func(ctx context.Context, h *httpSource, dest string) (Result, error) {
-		return h.fetchArchive(ctx, dest)
-	}
-}
-
-// httpArchiveDispatch is the seam Fetch calls into for the archive
-// branch. Initialised in this file's init so the single-file branch in
-// http.go can remain ignorant of archive types.
-var httpArchiveDispatch func(ctx context.Context, h *httpSource, dest string) (Result, error)
-
-// stagingSuffixFromTmp pulls the random hex tail tmpPathFor stamped
-// after ".tmp." out of a tmp path, so the staging dir can carry the
-// same suffix. Returns the basename verbatim when no ".tmp." marker is
-// present (defensive — keeps the malformation visible if streamToTmp's
-// naming convention ever changes).
-func stagingSuffixFromTmp(tmp string) string {
-	base := filepath.Base(tmp)
-	if idx := strings.LastIndex(base, ".tmp."); idx >= 0 {
-		return base[idx+len(".tmp."):]
-	}
-	return base
-}
-
-// errFetchArchiveUnimplemented is the sentinel http.go returns when
-// httpArchiveDispatch hasn't been wired up yet (a build-tag scenario
-// no production caller hits, but worth a clear message).
-var errFetchArchiveUnimplemented = errors.New("remote: http archive Fetch dispatcher not registered")

--- a/sys/remote/prune.go
+++ b/sys/remote/prune.go
@@ -41,15 +41,15 @@ func pruneTo(dest string, keep map[string]struct{}) error {
 		return fmt.Errorf("stat dest %s: %w", dest, err)
 	}
 
-	// Two-pass walk: collect, then act. WalkDir's mid-walk Remove is
-	// allowed by the stdlib but the rules around dir-vs-file ordering
-	// are easy to get wrong; collecting first keeps the deletion order
-	// deterministic.
-	type victim struct {
-		path string
-		dir  bool
-	}
-	var victims []victim
+	// Single collect-then-act walk. WalkDir's mid-walk Remove is allowed
+	// by the stdlib but the rules around dir-vs-file ordering are easy to
+	// get wrong; collecting first keeps the deletion order deterministic.
+	// One pass gathers both the files to delete and every directory; the
+	// dirs are removed afterwards in path-length DESC order (children
+	// before parents), and os.Remove on a non-empty dir is a no-op via
+	// the ENOTEMPTY tolerance below.
+	var victims []string
+	var dirs []string
 
 	walkErr := filepath.WalkDir(dest, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -58,17 +58,18 @@ func pruneTo(dest string, keep map[string]struct{}) error {
 		if path == dest {
 			return nil
 		}
+		if d.IsDir() {
+			// Decide later — only an empty dir gets removed.
+			dirs = append(dirs, path)
+			return nil
+		}
 		rel, rerr := filepath.Rel(dest, path)
 		if rerr != nil {
 			return rerr
 		}
 		rel = filepath.ToSlash(rel)
-		if d.IsDir() {
-			// Decide later — only an empty dir gets removed.
-			return nil
-		}
 		if _, ok := keep[rel]; !ok {
-			victims = append(victims, victim{path: path, dir: false})
+			victims = append(victims, path)
 		}
 		return nil
 	})
@@ -78,27 +79,13 @@ func pruneTo(dest string, keep map[string]struct{}) error {
 
 	// Remove regular files first.
 	for _, v := range victims {
-		if err := os.Remove(v.path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove %s: %w", v.path, err)
+		if err := os.Remove(v); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove %s: %w", v, err)
 		}
 	}
 
-	// Now collect directories that ended up empty, in path-length DESC
-	// order so children are removed before their parents.
-	var dirs []string
-	dirsWalkErr := filepath.WalkDir(dest, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if path == dest || !d.IsDir() {
-			return nil
-		}
-		dirs = append(dirs, path)
-		return nil
-	})
-	if dirsWalkErr != nil {
-		return fmt.Errorf("walk %s: %w", dest, dirsWalkErr)
-	}
+	// Remove directories that ended up empty, in path-length DESC order
+	// so children are removed before their parents.
 	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
 	for _, d := range dirs {
 		// os.Remove only succeeds when the dir is empty; that's exactly

--- a/sys/remote/s3.go
+++ b/sys/remote/s3.go
@@ -82,10 +82,7 @@ func NewS3(cfg S3Config) (Source, error) {
 // sync lands in Slice 12.
 func (s *s3Source) Fetch(ctx context.Context, dest string) (Result, error) {
 	if strings.HasSuffix(s.cfg.Key, "/") {
-		if s3PrefixDispatch == nil {
-			return Result{}, errPrefixSyncUnimplemented
-		}
-		return s3PrefixDispatch(ctx, s, dest)
+		return s.fetchPrefix(ctx, dest)
 	}
 	if err := validateDestination(dest); err != nil {
 		return Result{}, err

--- a/sys/remote/s3_prefix.go
+++ b/sys/remote/s3_prefix.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -119,7 +118,6 @@ func (s *s3Source) fetchPrefix(ctx context.Context, dest string) (Result, error)
 type s3Object struct {
 	Key  string
 	ETag string
-	Size int64
 }
 
 // maxPrefixObjects caps the total objects a single prefix-sync will
@@ -138,14 +136,13 @@ const maxPrefixObjects = 10000
 // ContinuationToken query of the next. Exceeding maxPrefixObjects
 // surfaces as ErrInvalidConfig so the operator can narrow the prefix.
 func (s *s3Source) listObjects(ctx context.Context) ([]s3Object, error) {
-	endpoint, _ := url.Parse(s.objectURL) // already validated in NewS3
-	bucketURL := *endpoint
-	// Listing happens at the bucket root, NOT the prefix path.
-	parts := strings.SplitN(strings.TrimPrefix(endpoint.Path, "/"), "/", 2)
-	if len(parts) == 0 {
-		return nil, fmt.Errorf("%w: cannot derive bucket from %s", ErrInvalidConfig, s.objectURL)
+	// Listing happens at the bucket root, NOT the prefix path. Derive it
+	// from cfg the same way NewS3 builds objectURL so a path-prefixed
+	// endpoint (e.g. a proxy fronting S3 under /v1) is honored.
+	bucketURL, err := s.bucketRootURL()
+	if err != nil {
+		return nil, err
 	}
-	bucketURL.Path = "/" + parts[0]
 
 	var all []s3Object
 	var token string
@@ -182,9 +179,9 @@ func (s *s3Source) listObjects(ctx context.Context) ([]s3Object, error) {
 		}
 		_ = resp.Body.Close()
 		for _, e := range parsed.Contents {
-			all = append(all, s3Object{Key: e.Key, ETag: e.ETag, Size: e.Size})
+			all = append(all, s3Object{Key: e.Key, ETag: e.ETag})
 			if len(all) > maxPrefixObjects {
-				return nil, fmt.Errorf("%w: prefix %q under %s/%s contains more than %d objects; narrow the prefix or paginate the source", ErrInvalidConfig, s.cfg.Key, s.cfg.Endpoint, parts[0], maxPrefixObjects)
+				return nil, fmt.Errorf("%w: prefix %q under %s/%s contains more than %d objects; narrow the prefix or paginate the source", ErrInvalidConfig, s.cfg.Key, s.cfg.Endpoint, s.cfg.Bucket, maxPrefixObjects)
 			}
 		}
 		if !parsed.IsTruncated || parsed.NextContinuationToken == "" {
@@ -202,7 +199,6 @@ type listV2Response struct {
 	Contents              []struct {
 		Key  string `xml:"Key"`
 		ETag string `xml:"ETag"`
-		Size int64  `xml:"Size"`
 	} `xml:"Contents"`
 }
 
@@ -223,15 +219,31 @@ func hashListing(objs []s3Object) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// bucketRootURL returns the bucket-root URL (endpoint path + bucket),
+// the base for both ListObjectsV2 and per-object GETs. It mirrors how
+// NewS3 builds objectURL, so a path-prefixed endpoint is addressed
+// consistently across single-key and prefix-sync modes. The bucket is
+// taken from cfg (already validated) rather than re-derived from the
+// pre-joined objectURL, which cannot distinguish an endpoint path prefix
+// from the bucket segment.
+func (s *s3Source) bucketRootURL() (*url.URL, error) {
+	endpoint, err := parseS3Endpoint(s.cfg.Endpoint)
+	if err != nil {
+		return nil, err // already wraps ErrInvalidConfig
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/" + s.cfg.Bucket
+	return endpoint, nil
+}
+
 // openSingleObject is openObject restricted to the v1 anonymous-GET
 // surface, parameterised by the full key (rather than the cfg.Key the
 // prefix-sync path can't use).
 func (s *s3Source) openSingleObject(ctx context.Context, key string) (io.ReadCloser, string, error) {
-	endpoint, _ := url.Parse(s.objectURL)
-	bucketAndKey := *endpoint
-	parts := strings.SplitN(strings.TrimPrefix(endpoint.Path, "/"), "/", 2)
-	bucket := parts[0]
-	bucketAndKey.Path = "/" + bucket + "/" + key
+	bucketAndKey, err := s.bucketRootURL()
+	if err != nil {
+		return nil, "", err
+	}
+	bucketAndKey.Path = bucketAndKey.Path + "/" + key
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bucketAndKey.String(), nil)
 	if err != nil {
@@ -311,20 +323,3 @@ func assertWithinDest(dest, full string) error {
 	}
 	return nil
 }
-
-// init wires the prefix-sync dispatcher into s3Source.Fetch.
-func init() {
-	s3PrefixDispatch = func(ctx context.Context, s *s3Source, dest string) (Result, error) {
-		return s.fetchPrefix(ctx, dest)
-	}
-}
-
-// s3PrefixDispatch is the seam s3.go's Fetch calls into for the
-// prefix-sync branch.
-var s3PrefixDispatch func(ctx context.Context, s *s3Source, dest string) (Result, error)
-
-// errPrefixSyncUnimplemented — sentinel returned when the prefix
-// dispatcher hasn't been wired up yet (a build-tag scenario nothing
-// in production triggers; keeps the error message clear if it
-// somehow does).
-var errPrefixSyncUnimplemented = errors.New("remote: S3 prefix sync dispatcher not registered")

--- a/sys/remote/s3_prefix_test.go
+++ b/sys/remote/s3_prefix_test.go
@@ -214,7 +214,8 @@ func TestS3Fetch_PrefixSync_PathPrefixedEndpoint(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/"+bucket && r.URL.Query().Get("list-type") == "2":
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/"+bucket &&
+			r.URL.Query().Get("list-type") == "2" && r.URL.Query().Get("prefix") == "data/":
 			writeListResponse(w, bucket, "data/", objs)
 		case r.Method == http.MethodHead && r.URL.Path == "/v1/"+bucket+"/data/a.txt":
 			w.Header().Set("ETag", `"a1"`)

--- a/sys/remote/s3_prefix_test.go
+++ b/sys/remote/s3_prefix_test.go
@@ -214,17 +214,16 @@ func TestS3Fetch_PrefixSync_PathPrefixedEndpoint(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/v1/"+bucket && r.URL.Query().Get("list-type") == "2":
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/"+bucket && r.URL.Query().Get("list-type") == "2":
 			writeListResponse(w, bucket, "data/", objs)
-		case r.URL.Path == "/v1/"+bucket+"/data/a.txt":
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/"+bucket+"/data/a.txt":
 			w.Header().Set("ETag", `"a1"`)
-			if r.Method == http.MethodHead {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/"+bucket+"/data/a.txt":
+			w.Header().Set("ETag", `"a1"`)
 			_, _ = w.Write([]byte("alpha"))
 		default:
-			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)
 		}
 	}))
 	t.Cleanup(srv.Close)

--- a/sys/remote/s3_prefix_test.go
+++ b/sys/remote/s3_prefix_test.go
@@ -202,6 +202,54 @@ func TestS3Fetch_PrefixSync_PruneRemovesLocalExtras(t *testing.T) {
 	}
 }
 
+// TestS3Fetch_PrefixSync_PathPrefixedEndpoint is a regression test:
+// when the endpoint carries a path prefix (e.g. a reverse proxy fronting
+// S3 under /v1), prefix-sync must address the bucket at
+// <endpoint-path>/<bucket> — the same way NewS3 and single-key mode do.
+// The buggy version split objectURL and mistook the path prefix for the
+// bucket, listing at /v1 and GETting /v1/<key> with the bucket dropped.
+func TestS3Fetch_PrefixSync_PathPrefixedEndpoint(t *testing.T) {
+	const bucket = "mybucket"
+	objs := []s3TestObject{{key: "data/a.txt", body: []byte("alpha"), etag: `"a1"`}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/"+bucket && r.URL.Query().Get("list-type") == "2":
+			writeListResponse(w, bucket, "data/", objs)
+		case r.URL.Path == "/v1/"+bucket+"/data/a.txt":
+			w.Header().Set("ETag", `"a1"`)
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			_, _ = w.Write([]byte("alpha"))
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	dest := filepath.Join(t.TempDir(), "tree")
+	recordDestUnder(t, dest)
+
+	src, err := NewS3(S3Config{
+		Endpoint: srv.URL + "/v1",
+		Bucket:   bucket,
+		Key:      "data/",
+	})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	res, err := src.Fetch(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !res.Changed || res.FilesTouched != 1 {
+		t.Fatalf("Result = %+v; want Changed=true FilesTouched=1", res)
+	}
+	assertFile(t, filepath.Join(dest, "a.txt"), "alpha")
+}
+
 // TestS3Fetch_PrefixSync_403OnList_SurfacesClearError — anonymous
 // listing forbidden by bucket policy must surface as ErrInvalidConfig
 // so the operator knows what to fix.

--- a/sys/remote/vc_gogit.go
+++ b/sys/remote/vc_gogit.go
@@ -10,7 +10,6 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
@@ -341,5 +340,3 @@ func restoreUntracked(dest string, snap []untrackedFile) error {
 	}
 	return nil
 }
-
-var _ = storer.ErrStop // anchor the storer import for future use (HEAD walk in v2)

--- a/sys/repo/dnf.go
+++ b/sys/repo/dnf.go
@@ -67,22 +67,10 @@ func (m *manager) applyDnf(ctx context.Context, name string, c *DnfConfig) (Outc
 	// trust it system-wide while the repository itself verifies nothing — a trust
 	// downgrade. Honor gpgcheck as the single switch and never import behind it.
 	if c.GPGCheck && c.GPGKey != "" {
-		res, kerr := m.runPriv(ctx, "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
-		if res.Stdout != "" {
-			log.WriteString(res.Stdout)
-		}
-		if kerr != nil {
-			fmt.Fprintf(&log, "warning: failed to import GPG key: %v\n", kerr)
-		}
+		m.runNonFatal(ctx, &log, "warning: failed to import GPG key", "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
 	}
 
-	res, rerr := m.runPriv(ctx, "dnf", "-y", "makecache", "--repo", name)
-	if res.Stdout != "" {
-		log.WriteString(res.Stdout)
-	}
-	if rerr != nil {
-		fmt.Fprintf(&log, "warning: failed to refresh repo metadata: %v\n", rerr)
-	}
+	m.runNonFatal(ctx, &log, "warning: failed to refresh repo metadata", "dnf", "-y", "makecache", "--repo", name)
 
 	return out(log.String(), true), nil
 }

--- a/sys/repo/pacman.go
+++ b/sys/repo/pacman.go
@@ -73,13 +73,7 @@ func (m *manager) applyPacman(ctx context.Context, name string, c *PacmanConfig)
 	}
 	fmt.Fprintf(&log, "configured repository: %s\n", name)
 
-	res, serr := m.runPriv(ctx, "pacman", "-Sy", "--noconfirm")
-	if res.Stdout != "" {
-		log.WriteString(res.Stdout)
-	}
-	if serr != nil {
-		fmt.Fprintf(&log, "warning: failed to sync repository database: %v\n", serr)
-	}
+	m.runNonFatal(ctx, &log, "warning: failed to sync repository database", "pacman", "-Sy", "--noconfirm")
 	return out(log.String(), true), nil
 }
 

--- a/sys/repo/repo.go
+++ b/sys/repo/repo.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/manchtools/power-manage-sdk/pkg"
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
@@ -302,6 +303,23 @@ func (m *manager) runPriv(ctx context.Context, name string, args ...string) (pme
 		return res, &pmexec.CommandError{Name: name, ExitCode: res.ExitCode, Stderr: res.Stderr}
 	}
 	return res, nil
+}
+
+// runNonFatal runs an escalated package-manager command whose failure is
+// non-fatal: its stdout is appended to log when non-empty, and on error a
+// warning (warnMsg followed by the error) is written to log and execution
+// continues. warnMsg is the per-site message WITHOUT the trailing ": <err>"
+// (e.g. "warning: failed to refresh repo metadata"). This folds the
+// run-append-stdout-warn-on-error idiom repeated across the backends; paths
+// where a command failure is fatal must NOT use it.
+func (m *manager) runNonFatal(ctx context.Context, log *strings.Builder, warnMsg, name string, args ...string) {
+	res, err := m.runPriv(ctx, name, args...)
+	if res.Stdout != "" {
+		log.WriteString(res.Stdout)
+	}
+	if err != nil {
+		fmt.Fprintf(log, "%s: %v\n", warnMsg, err)
+	}
 }
 
 // runStdin runs an UNPRIVILEGED command with stdin (the gpg --dearmor path: it

--- a/sys/repo/zypper.go
+++ b/sys/repo/zypper.go
@@ -73,21 +73,9 @@ func (m *manager) applyZypper(ctx context.Context, name string, c *ZypperConfig)
 	}
 	// Key import + refresh are non-fatal (the repo is configured).
 	if c.GPGKey != "" {
-		res, kerr := m.runPriv(ctx, "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
-		if res.Stdout != "" {
-			log.WriteString(res.Stdout)
-		}
-		if kerr != nil {
-			fmt.Fprintf(&log, "warning: failed to import GPG key: %v\n", kerr)
-		}
+		m.runNonFatal(ctx, &log, "warning: failed to import GPG key", "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
 	}
-	res2, rerr := m.runPriv(ctx, "zypper", "--non-interactive", "refresh", name)
-	if res2.Stdout != "" {
-		log.WriteString(res2.Stdout)
-	}
-	if rerr != nil {
-		fmt.Fprintf(&log, "warning: failed to refresh repo: %v\n", rerr)
-	}
+	m.runNonFatal(ctx, &log, "warning: failed to refresh repo", "zypper", "--non-interactive", "refresh", name)
 
 	return out(log.String(), true), nil
 }

--- a/sys/repo/zypper.go
+++ b/sys/repo/zypper.go
@@ -71,8 +71,13 @@ func (m *manager) applyZypper(ctx context.Context, name string, c *ZypperConfig)
 			return Outcome{}, fmt.Errorf("disable repo: %w", err)
 		}
 	}
-	// Key import + refresh are non-fatal (the repo is configured).
-	if c.GPGKey != "" {
+	// Key import + refresh are non-fatal (the repo is configured). Import
+	// the key ONLY when signature checking is on: with GPGCheck=false the
+	// repo is added --no-gpgcheck (above), so importing the key would
+	// silently trust it system-wide in the rpm keyring while the repo
+	// verifies nothing — a trust downgrade. Same single-switch rule as
+	// applyDnf.
+	if c.GPGCheck && c.GPGKey != "" {
 		m.runNonFatal(ctx, &log, "warning: failed to import GPG key", "rpm", pmexec.SeparatePositionals([]string{"--import"}, c.GPGKey)...)
 	}
 	m.runNonFatal(ctx, &log, "warning: failed to refresh repo", "zypper", "--non-interactive", "refresh", name)

--- a/sys/repo/zypper_test.go
+++ b/sys/repo/zypper_test.go
@@ -181,3 +181,22 @@ func TestZypper_Remove(t *testing.T) {
 		}
 	})
 }
+
+// TestZypper_Apply_GPGCheckFalseIgnoresKey guards the trust-downgrade fix
+// (parity with TestDnf_Apply_GPGCheckFalseIgnoresKey): with GPGCheck=false
+// the repo is added --no-gpgcheck, so importing the GPGKey would trust it
+// system-wide in the rpm keyring while the repo verifies nothing. The key
+// import must be gated on GPGCheck.
+func TestZypper_Apply_GPGCheckFalseIgnoresKey(t *testing.T) {
+	m, _, fr := newTestManager(t, pkg.Zypper)
+	if _, err := m.Apply(context.Background(), Repository{Name: "r", Zypper: &ZypperConfig{
+		URL: "https://h/r", Enabled: true, GPGCheck: false, GPGKey: "https://h/KEY",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range argvs(fr) {
+		if strings.Contains(cmd, "rpm --import") {
+			t.Fatalf("rpm --import ran despite GPGCheck=false — trust downgrade:\n%v", argvs(fr))
+		}
+	}
+}

--- a/verify/canonical.go
+++ b/verify/canonical.go
@@ -26,17 +26,33 @@ import (
 // agree. The gateway relays the proto message verbatim; it never re-derives or
 // originates a signature.
 
+// domainCanonical is the shared body behind every *Canonical encoder: it
+// guards against a nil message, deterministically clones it, clears the
+// `signature` field via protoreflect (so the signature can never cover
+// itself), and returns the deterministic wire bytes. Clearing by field name
+// keeps the four call sites identical and auto-binds every other field —
+// including any added later — without a hand-maintained list. typeName names
+// the message in the nil-guard error so each wrapper keeps its exact message.
+func domainCanonical[T proto.Message](m T, typeName string) ([]byte, error) {
+	// A typed-nil pointer reflects to an invalid message; treat it (and a nil
+	// interface) as "no message" so each wrapper keeps its nil-guard contract.
+	if !m.ProtoReflect().IsValid() {
+		return nil, fmt.Errorf("verify: nil %s", typeName)
+	}
+	c := proto.Clone(m)
+	r := c.ProtoReflect()
+	if fd := r.Descriptor().Fields().ByName("signature"); fd != nil {
+		r.Clear(fd)
+	}
+	return proto.MarshalOptions{Deterministic: true}.Marshal(c)
+}
+
 // OSQueryCanonical returns the signing pre-image bytes for an OSQuery. It
 // binds query_id, table, columns, where, limit and raw_sql — so a compromised
 // gateway cannot swap the table, inject raw_sql, or retarget the query under a
 // valid signature.
 func OSQueryCanonical(q *pmv1.OSQuery) ([]byte, error) {
-	if q == nil {
-		return nil, fmt.Errorf("verify: nil OSQuery")
-	}
-	c := proto.Clone(q).(*pmv1.OSQuery)
-	c.Signature = nil
-	return proto.MarshalOptions{Deterministic: true}.Marshal(c)
+	return domainCanonical(q, "OSQuery")
 }
 
 // LogQueryCanonical returns the signing pre-image bytes for a LogQuery. It
@@ -44,36 +60,21 @@ func OSQueryCanonical(q *pmv1.OSQuery) ([]byte, error) {
 // source — so a compromised gateway cannot retarget the unit or widen the
 // query under a valid signature.
 func LogQueryCanonical(q *pmv1.LogQuery) ([]byte, error) {
-	if q == nil {
-		return nil, fmt.Errorf("verify: nil LogQuery")
-	}
-	c := proto.Clone(q).(*pmv1.LogQuery)
-	c.Signature = nil
-	return proto.MarshalOptions{Deterministic: true}.Marshal(c)
+	return domainCanonical(q, "LogQuery")
 }
 
 // RevokeLuksDeviceKeyCanonical returns the signing pre-image bytes for a
 // RevokeLuksDeviceKey. It binds action_id, so a compromised gateway cannot
 // forge or replay a slot-7 wipe onto any known action_id.
 func RevokeLuksDeviceKeyCanonical(m *pmv1.RevokeLuksDeviceKey) ([]byte, error) {
-	if m == nil {
-		return nil, fmt.Errorf("verify: nil RevokeLuksDeviceKey")
-	}
-	c := proto.Clone(m).(*pmv1.RevokeLuksDeviceKey)
-	c.Signature = nil
-	return proto.MarshalOptions{Deterministic: true}.Marshal(c)
+	return domainCanonical(m, "RevokeLuksDeviceKey")
 }
 
 // RequestInventoryCanonical returns the signing pre-image bytes for a
 // server-originated RequestInventory. It binds query_id so a compromised
 // gateway cannot forge an inventory-collection command.
 func RequestInventoryCanonical(m *pmv1.RequestInventory) ([]byte, error) {
-	if m == nil {
-		return nil, fmt.Errorf("verify: nil RequestInventory")
-	}
-	c := proto.Clone(m).(*pmv1.RequestInventory)
-	c.Signature = nil
-	return proto.MarshalOptions{Deterministic: true}.Marshal(c)
+	return domainCanonical(m, "RequestInventory")
 }
 
 // LpsPublicKeyCanonical returns the signing pre-image bytes for the control


### PR DESCRIPTION
Two logically separate changes, one per commit so they review independently.

## 1. `refactor:` — dedup + dead-code (behavior-preserving)

Surfaced by an over-engineering audit. No exported signatures changed; security allow/deny sets verified byte-identical before/after.

- **pkg** — one `parseColonValue` + one `parseSizeWithUnits` shared by the apt/dnf/pacman/zypper/flatpak backends (were 3 identical + 4 near-identical helpers); `contains` → `slices.Contains`.
- **sys/repo** — shared `(*manager).runNonFatal` for the repeated "run / append stdout / warn on error" blocks across the four backends. Fatal-error and `note:`-prefixed sites left alone.
- **verify** — `domainCanonical[T proto.Message]` generic backs the four exported `*Canonical` funcs; public signatures unchanged.
- **sys/exec** — drop env-var entries already covered by the `LD_`/`BASH_FUNC_` prefix checks; `CappedBuffer.Bytes` → `slices.Clone`.
- **sys/fs** — fold `extraProtectedPaths` into `dangerousPaths` (protected set unchanged).
- **sys/firewall** — drop the `nftBuildApplyScript` non-strict wrapper (tests repoint to the strict variant).
- **sys/netconfig** — inline single-caller `splitGatewayByFamily`.

## 2. `fix(remote):` — S3 prefix-sync on path-prefixed endpoints

**Bug:** prefix-sync (Key ending in `/`) re-derived the bucket by splitting the pre-joined `objectURL` and taking the first path segment. For a path-prefixed endpoint (e.g. a proxy fronting S3 under `/v1`) that segment is the path prefix, **not** the bucket:
- `listObjects` queried `/v1` instead of `/v1/<bucket>`;
- `openSingleObject` dropped the bucket entirely → 404.

Single-key mode already honored such endpoints via the URL `NewS3` builds, so the two modes disagreed. **Fix:** derive the bucket root from `cfg` (`bucketRootURL`, mirroring `NewS3`) for both list and per-object GET. Includes a regression test with a path-prefixed endpoint that fails on the old split.

Also clears co-located dead code in this subsystem: the `httpArchiveDispatch`/`s3PrefixDispatch` init-seam indirection + unreachable `*Unimplemented` sentinels (now direct calls), the never-read `s3Object.Size`, the `storer.ErrStop` "future use" import anchor, and `pruneTo`'s redundant second `WalkDir` pass.

## Verification
`GOWORK=off go build ./... && go vet ./... && go test ./... -count=1` — all green. Each commit builds independently.

## Deliberately NOT changed
Two audit candidates were skipped because they'd change behavior: the S3 bucket simplification turned out to *be* the bug above (fixed properly with a test), and `isHex` (old impl accepts odd-length, rejects empty — opposite of `hex.DecodeString`). Exported-but-unused SDK surface (`WithMTLS`/`WithH2C`/etc., the VC backend registry) was left intact — it's the published API for external consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package information and size parsing across DNF, Pacman, Flatpak, and Zypper.
  - Fixed S3 prefix synchronization when endpoints include an additional URL path.
  - Repository refreshes and key imports now continue gracefully with clear warnings when non-critical failures occur.
  - Zypper no longer imports repository keys when GPG checking is disabled.
  - Strengthened protection for sensitive environment variables and system paths.

- **Documentation**
  - Improved formatting of repository signing-key guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->