### PR TITLE
feat(ts): ApiClient.search sort_field + sort_direction (server#325)

### DIFF
--- a/ts/client.ts
+++ b/ts/client.ts
@@ -243,6 +243,8 @@ import {
 	DeviceStatus,
 	IdentityProviderType,
 	SearchScope,
+	SortField,
+	SortDirection,
 	RoleGrantScopeKind
 } from '../gen/ts/pm/v1/common_pb';
 import { timestampDate } from '@bufbuild/protobuf/wkt';
@@ -1790,10 +1792,12 @@ export class ApiClient {
 		pageSize: number = 50,
 		pageToken: string = '',
 		dateFilters?: Array<{ field: string; start: bigint; end: bigint }>,
-		tagFilters?: Record<string, string>
+		tagFilters?: Record<string, string>,
+		sortField: SortField = SortField.UNSPECIFIED,
+		sortDirection: SortDirection = SortDirection.UNSPECIFIED
 	) {
 		const client = this.getClient();
-		const req: Record<string, unknown> = { query, scope, pageSize, pageToken };
+		const req: Record<string, unknown> = { query, scope, pageSize, pageToken, sortField, sortDirection };
 		if (dateFilters && dateFilters.length > 0) {
 			req.dateFilters = dateFilters.map((df) =>
 				create(SearchDateFilterSchema, { field: df.field, start: df.start, end: df.end })


### PR DESCRIPTION
Surfaces the SearchRequest `sort_field` / `sort_direction` fields (added in #253) through the hand-written `ApiClient.search` TS facade, so the web list pages can drive server-side sort.

TS-only change to the hand-written facade; the generated client already carries the proto fields. Validated by the web `svelte-check` (0 errors) and standalone `tsc --noEmit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now be requested with sorting options.
  * Added support for choosing both the sort field and sort direction when searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->