### PR TITLE
fix(pkg): resolve unattended-upgrade by absolute path before $PATH

### DIFF
--- a/pkg/apt.go
+++ b/pkg/apt.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -176,10 +177,37 @@ func (a *apt) UpgradeAll(ctx context.Context, opts UpgradeOptions) (pmexec.Resul
 // requires the unattended-upgrades package; if absent it fails closed with an
 // actionable error rather than silently performing a full upgrade.
 func (a *apt) securityUpgrade(ctx context.Context) (pmexec.Result, error) {
-	if _, err := lookPath("unattended-upgrade"); err != nil {
-		return pmexec.Result{}, fmt.Errorf("%w: unattended-upgrade not found — install the unattended-upgrades package for apt security-only upgrades", pmexec.ErrBackendUnavailable)
+	bin, err := resolveUnattendedUpgrade()
+	if err != nil {
+		return pmexec.Result{}, err
 	}
-	return a.write(ctx, "unattended-upgrade", "-v")
+	return a.write(ctx, bin, "-v")
+}
+
+// unattendedUpgradeBinPaths are the canonical absolute locations of the
+// unattended-upgrade binary, probed before a bare $PATH lookup. A hardened
+// systemd unit can run with a $PATH that omits /usr/sbin (or is empty), so the
+// bare command name may fail to resolve even when the package IS installed —
+// resolving an absolute path makes both the presence check and the exec robust.
+var unattendedUpgradeBinPaths = []string{
+	"/usr/bin/unattended-upgrade",
+	"/usr/sbin/unattended-upgrade",
+}
+
+// resolveUnattendedUpgrade returns an absolute path to the unattended-upgrade
+// binary, probing the known locations first and falling back to $PATH. It fails
+// closed with ErrBackendUnavailable when the unattended-upgrades package is not
+// installed.
+func resolveUnattendedUpgrade() (string, error) {
+	for _, p := range unattendedUpgradeBinPaths {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p, nil
+		}
+	}
+	if p, err := lookPath("unattended-upgrade"); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf("%w: unattended-upgrade not found — install the unattended-upgrades package for apt security-only upgrades", pmexec.ErrBackendUnavailable)
 }
 
 // Pin holds packages (apt-mark hold).

--- a/pkg/security_upgrade_test.go
+++ b/pkg/security_upgrade_test.go
@@ -3,10 +3,22 @@ package pkg
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	pmexec "github.com/manchtools/power-manage-sdk/sys/exec"
 )
+
+// stubUnattendedUpgradePaths overrides the known absolute-path probe list so the
+// apt security-upgrade tests don't depend on whether the test host actually has
+// /usr/bin/unattended-upgrade installed. Empty = no known path, fall to $PATH.
+func stubUnattendedUpgradePaths(t *testing.T, paths ...string) {
+	t.Helper()
+	orig := unattendedUpgradeBinPaths
+	unattendedUpgradeBinPaths = paths
+	t.Cleanup(func() { unattendedUpgradeBinPaths = orig })
+}
 
 // TestUpgradeAll_SecurityOnly pins the per-backend security-only upgrade contract
 // added so callers (the agent's UPDATE action) can apply ONLY security updates
@@ -38,7 +50,8 @@ func TestUpgradeAll_SecurityOnly(t *testing.T) {
 		}
 	})
 
-	t.Run("apt via unattended-upgrade (escalated)", func(t *testing.T) {
+	t.Run("apt via unattended-upgrade (escalated, absolute path)", func(t *testing.T) {
+		stubUnattendedUpgradePaths(t) // no known absolute paths -> resolve via $PATH
 		stubLookPath(t, "apt", "apt-get", "unattended-upgrade")
 		m, f := mustNew(t, Apt)
 		ok(f, "")
@@ -46,13 +59,16 @@ func TestUpgradeAll_SecurityOnly(t *testing.T) {
 			t.Fatal(err)
 		}
 		c := f.Calls()[0]
-		if argv(c) != "unattended-upgrade -v" || !c.Escalate {
-			t.Errorf("argv = %q (escalate=%v), want escalated `unattended-upgrade -v`", argv(c), c.Escalate)
+		// The binary is run by absolute path (stubLookPath resolves to /usr/bin/<name>),
+		// so a hardened systemd $PATH can't break the exec.
+		if argv(c) != "/usr/bin/unattended-upgrade -v" || !c.Escalate {
+			t.Errorf("argv = %q (escalate=%v), want escalated `/usr/bin/unattended-upgrade -v`", argv(c), c.Escalate)
 		}
 	})
 
 	t.Run("apt without unattended-upgrade fails closed (ErrBackendUnavailable, no command run)", func(t *testing.T) {
-		m, f := aptM(t) // stub resolves apt/apt-get only — unattended-upgrade absent
+		stubUnattendedUpgradePaths(t) // no known absolute paths, and $PATH won't resolve it either
+		m, f := aptM(t)               // stub resolves apt/apt-get only — unattended-upgrade absent
 		_, err := m.UpgradeAll(ctx, UpgradeOptions{SecurityOnly: true})
 		if !errors.Is(err, pmexec.ErrBackendUnavailable) {
 			t.Fatalf("err = %v, want ErrBackendUnavailable", err)
@@ -75,4 +91,42 @@ func TestUpgradeAll_SecurityOnly(t *testing.T) {
 			t.Errorf("err = %v, want ErrSecurityOnlyUnsupported", err)
 		}
 	})
+}
+
+// TestResolveUnattendedUpgrade_PrefersAbsolutePath pins the carry-forward fix: a
+// known absolute path is used even when $PATH cannot resolve the bare name — the
+// exact case that broke under a hardened systemd unit whose $PATH omits /usr/sbin.
+func TestResolveUnattendedUpgrade_PrefersAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "unattended-upgrade")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// First known path is missing, second exists — and $PATH resolves nothing.
+	stubUnattendedUpgradePaths(t, filepath.Join(dir, "missing"), bin)
+	stubLookPath(t)
+
+	got, err := resolveUnattendedUpgrade()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != bin {
+		t.Fatalf("got %q, want the known absolute path %q (must not depend on $PATH)", got, bin)
+	}
+}
+
+// TestResolveUnattendedUpgrade_FallsBackToPath covers the no-known-path case:
+// resolution defers to $PATH, and is absent → ErrBackendUnavailable.
+func TestResolveUnattendedUpgrade_FallsBackToPath(t *testing.T) {
+	stubUnattendedUpgradePaths(t, filepath.Join(t.TempDir(), "missing"))
+
+	stubLookPath(t, "unattended-upgrade")
+	if got, err := resolveUnattendedUpgrade(); err != nil || got != "/usr/bin/unattended-upgrade" {
+		t.Fatalf("got (%q, %v), want (/usr/bin/unattended-upgrade, nil)", got, err)
+	}
+
+	stubLookPath(t) // resolves nothing
+	if _, err := resolveUnattendedUpgrade(); !errors.Is(err, pmexec.ErrBackendUnavailable) {
+		t.Fatalf("err = %v, want ErrBackendUnavailable", err)
+	}
 }


### PR DESCRIPTION
## What

apt security-only upgrade resolved the `unattended-upgrade` binary by **bare command name** (`lookPath("unattended-upgrade")`). A hardened systemd unit can run with a `$PATH` that omits `/usr/sbin` (or is empty), so the lookup fails even when the `unattended-upgrades` package **is** installed — the upgrade then wrongly reports the backend unavailable and refuses to run.

## Change

`securityUpgrade` now calls a new `resolveUnattendedUpgrade()` that:

1. probes the canonical absolute locations (`/usr/bin/unattended-upgrade`, `/usr/sbin/unattended-upgrade`) first, then
2. falls back to `$PATH`, and
3. still fails **closed** with `ErrBackendUnavailable` (same actionable message) when the package is genuinely absent.

The binary is then executed by absolute path, so a stripped `$PATH` can't break the exec either.

## Tests

- `unattendedUpgradeBinPaths` is a package var with a `stubUnattendedUpgradePaths` test seam so the apt subtests stay hermetic (don't depend on whether the host has the binary).
- `TestResolveUnattendedUpgrade_PrefersAbsolutePath` — known absolute path is used even when `$PATH` resolves nothing (the exact hardened-systemd case).
- `TestResolveUnattendedUpgrade_FallsBackToPath` — no known path → defers to `$PATH`; absent → `ErrBackendUnavailable`.
- Existing `TestUpgradeAll_SecurityOnly` apt subtests updated to assert the absolute-path exec.

## Context

Carry-forward item (c) from the 2026.07 release tracker (server#320). Pure SDK fix; no proto/API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security upgrade execution so the required binary is found reliably, even when the system PATH is limited or unavailable.
  * Added broader handling for common system locations, reducing failures in hardened environments.
  * Continued to fail safely when the upgrade tool cannot be located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->