### PR TITLE
feat(ts): export ErrCannotModifySystemAction error code (server#477)

### DIFF
--- a/ts/errors.ts
+++ b/ts/errors.ts
@@ -42,6 +42,7 @@ export const ErrGroupNotDynamic = 'group_not_dynamic';
 export const ErrDynamicGroupManualModify = 'dynamic_group_manual_modify';
 export const ErrCannotDeleteSystemRole = 'cannot_delete_system_role';
 export const ErrCannotRenameSystemRole = 'cannot_rename_system_role';
+export const ErrCannotModifySystemAction = 'cannot_modify_system_action';
 export const ErrCannotRemoveLastAdmin = 'cannot_remove_last_admin';
 export const ErrRoleInUse = 'role_in_use';
 export const ErrScimAlreadyEnabled = 'scim_already_enabled';


### PR DESCRIPTION
Adds `ErrCannotModifySystemAction = 'cannot_modify_system_action'` to `ts/errors.ts`.

The server now rejects user mutation/assignment of system-managed actions with this code (server#477). Exporting the const keeps the TS SDK in lockstep with the server's error set (the server↔SDK error-code parity guard) and lets the web client map it to a localized message instead of showing the raw code.