### PR TITLE
fix(user): passwordless-aware Unlock + correct Locked semantics (* is not locked)

### DIFF
--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -76,7 +76,7 @@ written verbatim to a file, where newlines are legitimate payload, use
 `NewMultilineSecret`.)
 <!-- docref: end -->
 
-<!-- docref: begin src=sys/user/password.go#shadowUtils.SetPassword:acf8cd55 -->
+<!-- docref: begin src=sys/user/password.go#shadowUtils.SetPassword:33cb1ef7 -->
 `SetPassword` feeds `name:secret` to `chpasswd` on **stdin** — the password
 never appears in the process's argv, where any other process could read it from
 `/proc/<pid>/cmdline`. The `Reveal` call here is the single sanctioned sink for

--- a/sys/exec/exectest/fakerunner.go
+++ b/sys/exec/exectest/fakerunner.go
@@ -28,6 +28,7 @@ type FakeRunner struct {
 	mu      sync.Mutex
 	backend exec.PrivilegeBackend
 	calls   []exec.Command
+	ctxs    []context.Context
 	queue   []scripted
 }
 
@@ -58,11 +59,21 @@ func (f *FakeRunner) Calls() []exec.Command {
 	return append([]exec.Command(nil), f.calls...)
 }
 
-// record appends the attempted Command to the call log.
-func (f *FakeRunner) record(c exec.Command) {
+// CallContexts returns the context received with each recorded Command, in
+// order (1:1 with Calls). Lets a test assert the invariant that every escalated
+// call ran under a deadline-bounded context — see sys/user TestExecBoundsContext.
+func (f *FakeRunner) CallContexts() []context.Context {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]context.Context(nil), f.ctxs...)
+}
+
+// record appends the attempted Command and its context to the call log.
+func (f *FakeRunner) record(ctx context.Context, c exec.Command) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, c)
+	f.ctxs = append(f.ctxs, ctx)
 }
 
 // pop returns the next scripted outcome (FIFO), or a clean success if none.
@@ -89,7 +100,7 @@ func (f *FakeRunner) Run(ctx context.Context, c exec.Command) (exec.Result, erro
 	if err := exec.ValidateCommandEnv(c.Env); err != nil {
 		return exec.Result{}, err
 	}
-	f.record(c)
+	f.record(ctx, c)
 	if err := ctx.Err(); err != nil {
 		return exec.Result{}, err
 	}
@@ -104,7 +115,7 @@ func (f *FakeRunner) Stream(ctx context.Context, c exec.Command, onLine exec.Out
 	if err := exec.ValidateCommandEnv(c.Env); err != nil {
 		return exec.Result{}, err
 	}
-	f.record(c)
+	f.record(ctx, c)
 	if err := ctx.Err(); err != nil {
 		return exec.Result{}, err
 	}

--- a/sys/user/chokepoint_test.go
+++ b/sys/user/chokepoint_test.go
@@ -1,0 +1,92 @@
+package user
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These two guards together enforce — BY CONSTRUCTION, not by every method
+// remembering — that no user-package method can issue an unbounded escalated
+// command. That invariant was previously implemented per method (ensureCtx at the
+// top of each), so the methods that forgot (Lock, Unlock, SetPassword,
+// KillSessions, LastLogin) silently skipped it and no example-based test noticed.
+//
+//	1. exec applies ensureCtx (TestExecBoundsContext), and
+//	2. every Runner call goes through exec (TestAllRunnerCallsRouteThroughExec).
+//
+// Add a new method that calls the Runner directly and (2) fails the build.
+
+// TestExecBoundsContext: the single Runner chokepoint bounds a deadline-less ctx.
+func TestExecBoundsContext(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	su, ok := mgr(t, f).(*shadowUtils)
+	require.True(t, ok, "Manager is not *shadowUtils")
+
+	_, err := su.exec(context.Background(), exec.Command{Name: "true"})
+	require.NoError(t, err)
+
+	ctxs := f.CallContexts()
+	require.Len(t, ctxs, 1, "exec must run exactly one command")
+	_, hasDeadline := ctxs[0].Deadline()
+	assert.True(t, hasDeadline, "exec must bound a deadline-less context via ensureCtx")
+}
+
+// TestExecPassesThroughADeadline: a caller-supplied deadline is preserved, not
+// replaced — ensureCtx only ADDS a bound when one is missing.
+func TestExecPassesThroughADeadline(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	su := mgr(t, f).(*shadowUtils)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	deadlineCtx, dlCancel := context.WithTimeout(ctx, 42*time.Second)
+	defer dlCancel()
+	want, _ := deadlineCtx.Deadline()
+
+	_, err := su.exec(deadlineCtx, exec.Command{Name: "true"})
+	require.NoError(t, err)
+	got, ok := f.CallContexts()[0].Deadline()
+	require.True(t, ok)
+	assert.Equal(t, want, got, "an existing deadline must be preserved, not overwritten")
+}
+
+// TestAllRunnerCallsRouteThroughExec is the structural guard: every escalated /
+// Runner call MUST flow through (*shadowUtils).exec, which bounds the context. It
+// scans the package's NON-test source and asserts the raw Runner call `u.r.Run(`
+// appears exactly once — inside exec. A future method that calls the Runner
+// directly (and so could skip ensureCtx — exactly the Lock/Unlock regression)
+// makes the count != 1 and fails the build. Self-discovering: no method list to
+// keep in sync.
+func TestAllRunnerCallsRouteThroughExec(t *testing.T) {
+	src := nonTestPackageSource(t)
+	require.NotEmpty(t, src, "no non-test source read — the scan is broken")
+	n := strings.Count(src, "u.r.Run(")
+	assert.Equalf(t, 1, n,
+		"`u.r.Run(` must appear exactly once (inside exec); found %d. A direct Runner call bypasses the ctx-bounding chokepoint — route it through u.exec(...) instead.", n)
+}
+
+// nonTestPackageSource concatenates every non-_test .go file in the package dir.
+func nonTestPackageSource(t *testing.T) string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	var b strings.Builder
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		require.NoError(t, err)
+		b.Write(data)
+	}
+	return b.String()
+}

--- a/sys/user/edge_test.go
+++ b/sys/user/edge_test.go
@@ -33,7 +33,13 @@ func TestGet_NonNumericGIDFailsClosed(t *testing.T) {
 
 // A '*'-prefixed shadow password (a common disabled-account marker) is detected
 // as locked, the same as '!'.
-func TestGet_StarLockedIsDetected(t *testing.T) {
+// TestGet_StarPasswordIsNotLocked pins the corrected lock semantics: a "*"
+// shadow password means "no password, password-login disabled" — it is NOT a
+// locked account (only a leading "!", from usermod -L, is). The account stays
+// reachable via SSH keys / su / a setuid opener, which is exactly how the
+// passwordless pm-tty-* terminal accounts work. Treating "*" as locked made the
+// agent refuse every terminal session ("tty user is disabled").
+func TestGet_StarPasswordIsNotLocked(t *testing.T) {
 	f := exectest.New(exec.Direct)
 	f.Push(exec.Result{Stdout: "deploy:x:1000:1000::/home/deploy:/bin/bash\n"}, nil)
 	f.Push(exec.Result{Stdout: "deploy:x:1000:\n"}, nil)
@@ -43,8 +49,8 @@ func TestGet_StarLockedIsDetected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !info.Locked {
-		t.Error("'*'-prefixed shadow entry not detected as locked")
+	if info.Locked {
+		t.Error("'*'-prefixed shadow entry wrongly detected as locked (only '!' means locked)")
 	}
 	if !info.LockedKnown {
 		t.Error("LockedKnown = false after a successful shadow read; Locked is authoritative here")

--- a/sys/user/group.go
+++ b/sys/user/group.go
@@ -42,7 +42,7 @@ func (u *shadowUtils) GroupExists(ctx context.Context, name string) (bool, error
 	}
 	ctx, cancel := ensureCtx(ctx)
 	defer cancel()
-	res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"group", name}})
+	res, err := u.exec(ctx, exec.Command{Name: "getent", Args: []string{"group", name}})
 	if err != nil {
 		return false, err
 	}

--- a/sys/user/password.go
+++ b/sys/user/password.go
@@ -72,7 +72,7 @@ func (u *shadowUtils) SetPassword(ctx context.Context, name string, password exe
 	// Reveal() here is the single sanctioned chpasswd sink (see the Secret
 	// redaction contract / the Reveal fitness function).
 	stdin := strings.NewReader(name + ":" + password.Reveal())
-	res, err := u.r.Run(ctx, exec.Command{Name: "chpasswd", Stdin: stdin, Escalate: true})
+	res, err := u.exec(ctx, exec.Command{Name: "chpasswd", Stdin: stdin, Escalate: true})
 	if err != nil {
 		return err
 	}

--- a/sys/user/sessions.go
+++ b/sys/user/sessions.go
@@ -19,10 +19,10 @@ func (u *shadowUtils) KillSessions(ctx context.Context, name string) error {
 	}
 	// loginctl first; the Runner resolves and runs it, reporting "not found" if
 	// systemd-logind is absent, in which case we fall through to pkill.
-	if res, err := u.r.Run(ctx, exec.Command{Name: "loginctl", Args: []string{"terminate-user", name}, Escalate: true}); err == nil && res.ExitCode == 0 {
+	if res, err := u.exec(ctx, exec.Command{Name: "loginctl", Args: []string{"terminate-user", name}, Escalate: true}); err == nil && res.ExitCode == 0 {
 		return nil
 	}
-	res, err := u.r.Run(ctx, exec.Command{Name: "pkill", Args: []string{"-KILL", "-u", name}, Escalate: true})
+	res, err := u.exec(ctx, exec.Command{Name: "pkill", Args: []string{"-KILL", "-u", name}, Escalate: true})
 	if err != nil {
 		return fmt.Errorf("kill sessions for %s: %w", name, err)
 	}
@@ -53,7 +53,7 @@ func (u *shadowUtils) LastLogin(ctx context.Context, name string) (time.Time, er
 	if err := validateUsername(name); err != nil {
 		return time.Time{}, err
 	}
-	res, err := u.r.Run(ctx, exec.Command{Name: "last", Args: []string{"-1", "-F", name}})
+	res, err := u.exec(ctx, exec.Command{Name: "last", Args: []string{"-1", "-F", name}})
 	if err != nil {
 		return time.Time{}, fmt.Errorf("last login for %s: %w", name, err)
 	}

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -168,11 +168,24 @@ func ensureCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, queryTimeout)
 }
 
+// exec is the SINGLE Runner chokepoint for this package. Every getent / usermod
+// / useradd / userdel / chpasswd / loginctl / pkill call flows through it, and it
+// bounds a deadline-less context (ensureCtx) so no method can issue an UNBOUNDED
+// escalated command — a hung privileged process can't block forever. The
+// invariant holds by construction here, not by each method remembering to call
+// ensureCtx (which is exactly how Lock/Unlock/SetPassword/KillSessions silently
+// skipped it). Enforced by TestExecBoundsContext.
+func (u *shadowUtils) exec(ctx context.Context, c exec.Command) (exec.Result, error) {
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	return u.r.Run(ctx, c)
+}
+
 // run executes an escalated mutating command and maps a non-zero exit to a
 // *exec.CommandError carrying stderr (the "user already exists" context callers
 // need).
 func (u *shadowUtils) run(ctx context.Context, name string, args ...string) error {
-	res, err := u.r.Run(ctx, exec.Command{Name: name, Args: args, Escalate: true})
+	res, err := u.exec(ctx, exec.Command{Name: name, Args: args, Escalate: true})
 	if err != nil {
 		return err
 	}
@@ -185,7 +198,7 @@ func (u *shadowUtils) run(ctx context.Context, name string, args ...string) erro
 // query executes an unescalated read command and returns trimmed stdout, mapping
 // a non-zero exit to a *exec.CommandError.
 func (u *shadowUtils) query(ctx context.Context, name string, args ...string) (string, error) {
-	res, err := u.r.Run(ctx, exec.Command{Name: name, Args: args})
+	res, err := u.exec(ctx, exec.Command{Name: name, Args: args})
 	if err != nil {
 		return "", err
 	}
@@ -421,7 +434,7 @@ func (u *shadowUtils) Unlock(ctx context.Context, name string) error {
 // /etc/shadow entry, read escalated (root-only). Returns an error when the
 // entry can't be read or is malformed.
 func (u *shadowUtils) shadowPassword(ctx context.Context, name string) (string, error) {
-	res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"shadow", name}, Escalate: true})
+	res, err := u.exec(ctx, exec.Command{Name: "getent", Args: []string{"shadow", name}, Escalate: true})
 	if err != nil {
 		return "", err
 	}
@@ -499,7 +512,7 @@ func (u *shadowUtils) Exists(ctx context.Context, name string) (bool, error) {
 	}
 	ctx, cancel := ensureCtx(ctx)
 	defer cancel()
-	res, err := u.r.Run(ctx, exec.Command{Name: "id", Args: []string{name}})
+	res, err := u.exec(ctx, exec.Command{Name: "id", Args: []string{name}})
 	if err != nil {
 		return false, err
 	}

--- a/sys/user/user.go
+++ b/sys/user/user.go
@@ -387,12 +387,52 @@ func (u *shadowUtils) Lock(ctx context.Context, name string) error {
 	return u.run(ctx, "usermod", "-L", name)
 }
 
-// Unlock unlocks an account (usermod -U).
+// Unlock unlocks an account so it can be used again.
+//
+// Plain `usermod -U` strips the leading "!" from the shadow password — but it
+// REFUSES when that would leave the account passwordless ("unlocking the user's
+// password would result in a passwordless account"). Accounts reached only via
+// setuid or SSH keys — the pm-tty-* terminal accounts — are passwordless by
+// design, so for a locked PASSWORDLESS account set the field to "*" (no
+// password, not locked) instead. An account with a real password hash still
+// round-trips through `usermod -U`, preserving the hash.
 func (u *shadowUtils) Unlock(ctx context.Context, name string) error {
 	if err := validateUsername(name); err != nil {
 		return err
 	}
+	field, err := u.shadowPassword(ctx, name)
+	if err != nil {
+		// Couldn't read the shadow (e.g. escalation not authorized): fall back
+		// to the plain unlock rather than guessing.
+		return u.run(ctx, "usermod", "-U", name)
+	}
+	if !strings.HasPrefix(field, "!") {
+		return nil // already unlocked
+	}
+	if rest := strings.TrimLeft(field, "!"); rest == "" || rest == "*" {
+		// Locked AND passwordless: usermod -U errors. "*" = no password, not
+		// locked — the unlocked state for a passwordless (pm-tty-*) account.
+		return u.run(ctx, "usermod", "-p", "*", name)
+	}
 	return u.run(ctx, "usermod", "-U", name)
+}
+
+// shadowPassword returns the password field (field 2) of the user's
+// /etc/shadow entry, read escalated (root-only). Returns an error when the
+// entry can't be read or is malformed.
+func (u *shadowUtils) shadowPassword(ctx context.Context, name string) (string, error) {
+	res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"shadow", name}, Escalate: true})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 || res.Stdout == "" {
+		return "", fmt.Errorf("read shadow entry for %q: exit %d", name, res.ExitCode)
+	}
+	sf := strings.Split(strings.TrimSpace(res.Stdout), ":")
+	if len(sf) < 2 {
+		return "", fmt.Errorf("malformed shadow entry for %q", name)
+	}
+	return sf[1], nil
 }
 
 // Get retrieves the current state of a user.
@@ -439,12 +479,15 @@ func (u *shadowUtils) Get(ctx context.Context, name string) (Info, error) {
 
 	// The shadow file is root-only: read it escalated. If escalation is not
 	// authorized, leave Locked=false rather than guessing.
-	if res, err := u.r.Run(ctx, exec.Command{Name: "getent", Args: []string{"shadow", name}, Escalate: true}); err == nil && res.ExitCode == 0 && res.Stdout != "" {
-		sf := strings.Split(strings.TrimSpace(res.Stdout), ":")
-		if len(sf) >= 2 {
-			info.Locked = strings.HasPrefix(sf[1], "!") || strings.HasPrefix(sf[1], "*")
-			info.LockedKnown = true // the shadow read succeeded; Locked is authoritative
-		}
+	//
+	// Only a leading "!" means LOCKED (that's what `usermod -L` prepends). A "*"
+	// is NOT locked — it means "no password, password login disabled," while the
+	// account stays reachable via SSH keys / su / a setuid opener. The pm-tty-*
+	// terminal accounts are passwordless ("*") on purpose; treating "*" as locked
+	// made the agent refuse every terminal session ("tty user is disabled").
+	if field, err := u.shadowPassword(ctx, name); err == nil {
+		info.Locked = strings.HasPrefix(field, "!")
+		info.LockedKnown = true // the shadow read succeeded; Locked is authoritative
 	}
 	return info, nil
 }

--- a/sys/user/user_test.go
+++ b/sys/user/user_test.go
@@ -201,11 +201,40 @@ func TestLockUnlock(t *testing.T) {
 	}
 	wantOneCmd(t, f, "usermod", []string{"-L", "deploy"}, true)
 
+	// Unlock of a PASSWORD-BEARING account: read the shadow, then `usermod -U`
+	// (strips the leading "!", preserving the hash).
 	f2 := exectest.New(exec.Direct)
+	f2.Push(exec.Result{Stdout: "deploy:!$6$abc$hash:19000:0:99999:7:::\n"}, nil) // getent shadow
+	f2.Push(exec.Result{}, nil)                                                   // usermod -U
 	if err := mgr(t, f2).Unlock(context.Background(), "deploy"); err != nil {
 		t.Fatal(err)
 	}
-	wantOneCmd(t, f2, "usermod", []string{"-U", "deploy"}, true)
+	calls := f2.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("want 2 commands (getent shadow + usermod -U), got %d: %+v", len(calls), calls)
+	}
+	if last := calls[1]; last.Name != "usermod" || last.Args[0] != "-U" {
+		t.Errorf("unlock of a password-bearing account must use usermod -U, got %+v", last)
+	}
+}
+
+// TestUnlock_Passwordless covers the pm-tty-* case: `usermod -U` REFUSES to
+// unlock a passwordless account ("would result in a passwordless account"), so
+// Unlock sets the field to "*" (no password, not locked) instead.
+func TestUnlock_Passwordless(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{Stdout: "pm-tty-paul:!:19000:0:99999:7:::\n"}, nil) // getent shadow: locked + passwordless
+	f.Push(exec.Result{}, nil)                                             // usermod -p '*'
+	if err := mgr(t, f).Unlock(context.Background(), "pm-tty-paul"); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("want 2 commands (getent shadow + usermod -p '*'), got %d: %+v", len(calls), calls)
+	}
+	if last := calls[1]; last.Name != "usermod" || len(last.Args) < 2 || last.Args[0] != "-p" || last.Args[1] != "*" {
+		t.Errorf("passwordless unlock must use usermod -p '*', got %+v", last)
+	}
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
## Two bugs that together broke remote terminals (pm-tty-* accounts)

**1. `Get()` reported `*` as locked.** A `*` shadow password means "no password, password-login disabled" — the account is **not** locked (only a leading `!`, from `usermod -L`, is). `pm-tty-*` terminal accounts are passwordless by design, so they read as `Locked=true` and the agent refused every terminal session ("tty user is disabled"). `Info.Locked` now keys off a leading `!` only.

**2. `Unlock` couldn't unlock a passwordless account.** A bare `usermod -U` **refuses** a passwordless account ("unlocking would result in a passwordless account"). `Unlock` now reads the shadow and, for a *locked passwordless* account, sets `*` (no password, not locked) — never stripping `!` into an **empty, login-able** password (the #94 hole). An account with a real hash still round-trips through `usermod -U`, preserving the hash.

## Why

These power the agent's "lock = user-is-disabled" terminal model: an enabled `pm-tty-*` account rests at `*` (unlocked-passwordless), a disabled one at `!` (locked), and the agent unlocks/locks via this `Manager` interface — no shelling out. See the companion agent PR.

## Tests

- `TestGet_StarPasswordIsNotLocked` — `*` is not locked (was the inverted `TestGet_StarLockedIsDetected`); `!`-locked detection unchanged.
- `TestUnlock_Passwordless` — a locked passwordless account unlocks via `usermod -p '*'`.
- `TestLockUnlock` — a password-bearing account still unlocks via `usermod -U`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account lock detection so only truly locked accounts are marked as locked.
  * Passwordless accounts are now handled correctly and won’t be mistakenly treated as locked.
  * Unlocking an account now preserves passwordless access instead of disabling login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->