### PR TITLE
feat(crypto): SealLpsPassword/OpenLpsPassword — single-source LPS seal context

### DIFF
--- a/crypto/lps.go
+++ b/crypto/lps.go
@@ -1,0 +1,64 @@
+package crypto
+
+import (
+	"crypto/ecdh"
+	"errors"
+)
+
+// ErrLpsContextIncomplete is returned when any of the (device, action,
+// username) context fields is empty. All three are required so the AAD
+// unambiguously binds the sealed password to exactly one record; a
+// non-empty-but-partial join (e.g. "device|action|") would bind loosely and
+// is refused.
+var ErrLpsContextIncomplete = errors.New("crypto: LPS seal context requires non-empty device, action, and username")
+
+// LPS password sealing: the agent seals each rotated local password to the
+// control server's X25519 public key so the relaying gateway (the least-
+// trusted server-side actor) can never read it. This is the ONE place the
+// domain-separation info and the context AAD are constructed — the agent
+// (SealLpsPassword) and the control server (OpenLpsPassword) both call
+// through here, so the two sides cannot drift on either value. Drift would
+// not be caught by any single-repo test (the seal happens on the agent, the
+// open on the server) and would silently break every unseal, so it is
+// deliberately impossible to construct them separately.
+
+// lpsSealInfo is the HKDF domain-separation string for LPS password sealing.
+// Versioned so a future construction change can coexist during rollout.
+const lpsSealInfo = "power-manage-lps-password:v1"
+
+// lpsSealAAD binds a sealed LPS password to its (device, action, username)
+// context so a valid blob cannot be relocated to another device/action/user
+// record. deviceID and actionID are ULIDs (Crockford base32 — never contain
+// '|') and username is a validated local username, so the join is
+// unambiguous. This mirrors SecretAAD's construction on the server's at-rest
+// path.
+func lpsSealAAD(deviceID, actionID, username string) []byte {
+	return []byte(deviceID + "|" + actionID + "|" + username)
+}
+
+// SealLpsPassword seals password to the control server's LPS public key,
+// binding the (deviceID, actionID, username) context. The output is the
+// opaque blob the agent puts on the wire; only the holder of the matching
+// private key (control) can open it. All three context fields are required —
+// an empty one makes the AAD ambiguous and is refused by the underlying AEAD.
+func SealLpsPassword(recipient *ecdh.PublicKey, password, deviceID, actionID, username string) ([]byte, error) {
+	if deviceID == "" || actionID == "" || username == "" {
+		return nil, ErrLpsContextIncomplete
+	}
+	return SealToPublicKey(recipient, []byte(password), lpsSealAAD(deviceID, actionID, username), lpsSealInfo)
+}
+
+// OpenLpsPassword reverses SealLpsPassword on the control server: it unseals
+// with the LPS private key under the SAME (deviceID, actionID, username)
+// context. A blob sealed for a different context, tampered, or sealed to a
+// different key fails authentication and returns an error and no plaintext.
+func OpenLpsPassword(priv *ecdh.PrivateKey, sealed []byte, deviceID, actionID, username string) (string, error) {
+	if deviceID == "" || actionID == "" || username == "" {
+		return "", ErrLpsContextIncomplete
+	}
+	pt, err := OpenWithPrivateKey(priv, sealed, lpsSealAAD(deviceID, actionID, username), lpsSealInfo)
+	if err != nil {
+		return "", err
+	}
+	return string(pt), nil
+}

--- a/crypto/lps_test.go
+++ b/crypto/lps_test.go
@@ -1,0 +1,58 @@
+package crypto
+
+import "testing"
+
+// SealLpsPassword → OpenLpsPassword round-trips under matching context, and
+// any context field mismatch (device, action, or username) fails to open.
+// This pins the exact agent↔server contract: the two sides derive AAD and
+// info only through these helpers, so this test IS the cross-repo agreement.
+func TestLpsPassword_RoundTripAndContextBinding(t *testing.T) {
+	priv := genRecipient(t)
+	const (
+		dev  = "01HKDEVICE0000000000000000"
+		act  = "01HKACTION0000000000000000"
+		user = "alice"
+		pw   = "R0tated-P@ssw0rd"
+	)
+
+	sealed, err := SealLpsPassword(priv.PublicKey(), pw, dev, act, user)
+	if err != nil {
+		t.Fatalf("SealLpsPassword: %v", err)
+	}
+
+	got, err := OpenLpsPassword(priv, sealed, dev, act, user)
+	if err != nil {
+		t.Fatalf("OpenLpsPassword: %v", err)
+	}
+	if got != pw {
+		t.Errorf("round-trip mismatch: got %q want %q", got, pw)
+	}
+
+	mismatches := []struct {
+		name           string
+		dev, act, user string
+	}{
+		{"wrong device", "01HKOTHER00000000000000000", act, user},
+		{"wrong action", dev, "01HKOTHER00000000000000000", user},
+		{"wrong username", dev, act, "bob"},
+	}
+	for _, m := range mismatches {
+		t.Run(m.name, func(t *testing.T) {
+			if pt, err := OpenLpsPassword(priv, sealed, m.dev, m.act, m.user); err == nil {
+				t.Errorf("opened under %s: got %q, want error", m.name, pt)
+			}
+		})
+	}
+}
+
+// An empty context field is refused (ambiguous AAD → no naked seal).
+func TestSealLpsPassword_RequiresContext(t *testing.T) {
+	priv := genRecipient(t)
+	for _, c := range []struct{ dev, act, user string }{
+		{"", "a", "u"}, {"d", "", "u"}, {"d", "a", ""},
+	} {
+		if _, err := SealLpsPassword(priv.PublicKey(), "pw", c.dev, c.act, c.user); err == nil {
+			t.Errorf("SealLpsPassword(%q,%q,%q) accepted an empty context field", c.dev, c.act, c.user)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #263 (refs #262). Server and agent both need to seal/open LPS passwords with an identical HKDF `info` and context AAD — and drift between them can't be caught by any single-repo test (seal on agent, open on server). These two helpers are the one place both are built.

- `SealLpsPassword(recipient, password, deviceID, actionID, username)` (agent)
- `OpenLpsPassword(priv, sealed, deviceID, actionID, username)` (control)

`info = "power-manage-lps-password:v1"`, `aad = device|action|username`. All three context fields required — a partial join (`device|action|`) binds loosely, so the helpers reject an empty field with `ErrLpsContextIncomplete` (a gap the round-trip test surfaced during red-check).

Round-trip + per-field context-mismatch rejection tests included; this test IS the cross-repo contract. Gates: gofmt, vet, staticcheck, race tests green. Local CodeRabbit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure password sealing and opening support tied to a device, action, and username context.

* **Bug Fixes**
  * Passwords now fail to open if the saved context does not match.
  * Empty context values are rejected to prevent incomplete or invalid protection data.

* **Tests**
  * Added coverage for successful round-trips and context mismatch/validation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->