### PR TITLE
feat(client): expose LpsPublicKey on SyncActionsResult

### DIFF
--- a/client.go
+++ b/client.go
@@ -1588,6 +1588,11 @@ type SyncActionsResult struct {
 	// firing scheduler-driven dispatches; pushed actions (REBOOT,
 	// SYNC, ad-hoc) bypass the gate. See manchtools/power-manage-server#58.
 	MaintenanceWindow *pm.MaintenanceWindow
+	// LpsPublicKey is the control server's CA-signed X25519 key the agent
+	// seals LPS passwords to (spec 18). nil when the control instance has no
+	// keypair configured; the agent MUST verify the signature against its
+	// enrollment CA and refuse the key on mismatch before sealing to it.
+	LpsPublicKey *pm.LpsPublicKey
 }
 
 // SyncActions fetches all actions currently assigned to this device from the server.
@@ -1617,5 +1622,6 @@ func (c *Client) SyncActions(ctx context.Context) (*SyncActionsResult, error) {
 		GroupedActions:      resp.Msg.GroupedActions,
 		SyncIntervalMinutes: resp.Msg.SyncIntervalMinutes,
 		MaintenanceWindow:   resp.Msg.MaintenanceWindow,
+		LpsPublicKey:        resp.Msg.LpsPublicKey,
 	}, nil
 }

--- a/client_loopback_test.go
+++ b/client_loopback_test.go
@@ -44,6 +44,8 @@ type recordingAgentHandler struct {
 	received []*pm.AgentMessage
 
 	onStream func(ctx context.Context, stream *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) error
+	// syncResp, when set, is returned verbatim by SyncActions (else empty).
+	syncResp *pm.SyncActionsResponse
 }
 
 func (h *recordingAgentHandler) Stream(ctx context.Context, s *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) error {
@@ -73,6 +75,9 @@ func (h *recordingAgentHandler) snapshot() []*pm.AgentMessage {
 }
 
 func (h *recordingAgentHandler) SyncActions(ctx context.Context, req *connect.Request[pm.SyncActionsRequest]) (*connect.Response[pm.SyncActionsResponse], error) {
+	if h.syncResp != nil {
+		return connect.NewResponse(h.syncResp), nil
+	}
 	return connect.NewResponse(&pm.SyncActionsResponse{}), nil
 }
 
@@ -297,6 +302,32 @@ func TestConnect_DoubleConnectErrors(t *testing.T) {
 
 	if err := c.Connect(ctx); err == nil {
 		t.Fatal("second Connect should error")
+	}
+}
+
+// TestSyncActions_MapsLpsPublicKey guards the hand-written SyncActionsResult
+// facade against drift: a proto regen that adds a field but forgets the facade
+// mapping would silently drop it (the recurring facade-lag bug). Pins that the
+// LPS public key the server puts on SyncActionsResponse reaches the caller.
+func TestSyncActions_MapsLpsPublicKey(t *testing.T) {
+	l := newAgentLoopback(t)
+	l.handler.syncResp = &pm.SyncActionsResponse{
+		LpsPublicKey: &pm.LpsPublicKey{
+			PublicKey: make([]byte, 32),
+			Signature: []byte("sig"),
+		},
+	}
+	c := l.newClient(WithAuth("01HKDEVICE0000000000000000", "tok"))
+
+	res, err := c.SyncActions(context.Background())
+	if err != nil {
+		t.Fatalf("SyncActions: %v", err)
+	}
+	if res.LpsPublicKey == nil {
+		t.Fatal("LpsPublicKey dropped by the SyncActionsResult facade")
+	}
+	if len(res.LpsPublicKey.PublicKey) != 32 || string(res.LpsPublicKey.Signature) != "sig" {
+		t.Errorf("LpsPublicKey mismatch: %+v", res.LpsPublicKey)
 	}
 }
 


### PR DESCRIPTION
Third and final SDK piece for sealed LPS transport (refs #262; follows #263 primitive + #264 helpers). The agent reads SyncActions through this hand-written `SyncActionsResult` facade, so the CA-signed LPS public key the control server attaches to `SyncActionsResponse` (spec 18) must be surfaced here — proto regen alone doesn't touch the facade (the recurring facade-lag bug, cf. WS5 TS facade).

One field + its mapping + a loopback test that pins the mapping so a future regen can't silently drop it.

Gate: gofmt, vet, staticcheck, test green. Local CodeRabbit rate-limited; remote CR + CI cover it.