### PR TITLE
docs: sync narrative docs with code, densify docref anchoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
+# docref: begin release-trigger
 on:
   push:
     tags:
       - 'v*'
+# docref: end release-trigger
 
 permissions:
   contents: write
@@ -41,6 +43,7 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # docref: begin ts-release-assets
       - name: Generate TypeScript SDK
         run: npx buf generate
 
@@ -55,6 +58,7 @@ jobs:
           tar czf release/ts-sdk.tar.gz -C gen/ts .
 
           cd release && sha256sum * > SHA256SUMS
+      # docref: end ts-release-assets
 
       - name: Generate changelog
         run: |

--- a/docs/01-getting-started/index.md
+++ b/docs/01-getting-started/index.md
@@ -10,6 +10,7 @@ icon: "🚀"
 The Power Manage SDK is the shared Go (and TypeScript) library the agent,
 control server, gateway, and web UI build on. It ships three things:
 
+<!-- docref: begin src=crypto/csr.go#GenerateCSR:4a9d84de,verify/verify.go#ActionVerifier.Verify:c3b3df3c,crypto/cert.go#CAFingerprintFromPEM:5a8bdd28 -->
 - **Protocol types** — the generated protobuf / Connect-RPC code for the
   Power Manage wire format.
 - **Crypto & signing helpers** — CSR generation, certificate utilities, and
@@ -17,6 +18,7 @@ control server, gateway, and web UI build on. It ships three things:
 - **A Linux system-management library** — package managers, users, services,
   filesystems, disk encryption, networking, antivirus, CA trust, and more,
   behind one consistent, dependency-injected API.
+<!-- docref: end -->
 
 These pages are the **narrative** docs — concepts, recipes, and the
 contributor workflow. The **API reference** is generated and lives on

--- a/docs/02-concepts/01-architecture.md
+++ b/docs/02-concepts/01-architecture.md
@@ -10,16 +10,20 @@ Every system-management capability follows the same three-part shape:
 
 {% steps %}
   {% step title="Build a Runner" %}
+  <!-- docref: begin src=sys/exec/runner.go#Runner:7679445f,sys/exec/runner.go#PrivilegeBackend:01258357 -->
   A `Runner` is how commands reach the host — directly (the process is
   already root), or escalated through `sudo` / `doas`. You construct it once
   and inject it everywhere.
+  <!-- docref: end -->
   {% /step %}
   {% step title="Choose a Backend" %}
+  <!-- docref: begin src=sys/service/service.go#Systemd:ff233171,sys/user/user.go#ShadowUtils:936a2cbe -->
   Capabilities that drive a *family* of tools (package managers, init systems,
   encryption tools) take an explicit `Backend` value — the caller always names
   it, even when only one backend is implemented today (`service.Systemd`,
   `user.ShadowUtils`), and the SDK never auto-detects. Single-tool capabilities
   (`smartctl`, `osqueryi`) take only a Runner.
+  <!-- docref: end -->
   {% /step %}
   {% step title="Get a Manager" %}
   `New` returns a handle whose methods do the work. The handle holds the

--- a/docs/02-concepts/02-backends.md
+++ b/docs/02-concepts/02-backends.md
@@ -6,12 +6,14 @@ description: How a capability's backend is chosen explicitly, how to discover wh
 
 # Backends & detection
 
+<!-- docref: begin src=sys/service/service.go#Backend:11393461,sys/user/user.go#ShadowUtils:936a2cbe -->
 A *backend* is one concrete way to do a job: `apt` vs `dnf` for packages,
 `systemd` for services, `ca-certificates` vs `p11-kit` for CA trust. A
 capability that drives such a family takes a `Backend` value at construction —
 and it takes one **even when only one backend is implemented today** (services
 has just `systemd`; users just shadow-utils), so the choice is always explicit
 and never auto-detected.
+<!-- docref: end -->
 
 <!-- docref: begin src=sys/smart/smart.go#New:b54f2658,sys/osquery/osquery.go#New:dda636e8 -->
 A capability that is a single tool by nature — `smartctl` for SMART, `osqueryi`
@@ -65,12 +67,14 @@ behind your back the way call-site auto-detection would.
 The `Backend`-enum shape fits "this host has exactly one right answer, fixed
 for the process" — package managers, init systems, encryption tools.
 
+<!-- docref: begin src=sys/remote/remote.go#Source:2cfeaa37,sys/remote/http.go#NewHTTP:9089d62f,sys/remote/git.go#NewGit:0a6c132d,sys/remote/s3.go#NewS3:78a4b3e6 -->
 `sys/remote` deliberately departs from it. An agent may fetch a tarball over
 HTTPS, clone a Git repo, and read an S3 prefix in the same cycle, driven by
 different actions — there is no single "active source" for the process. So
 `sys/remote` exposes a `Source` interface with one constructor per kind
 (`NewHTTP`, `NewGit`, `NewS3`), each validating its own config. The choice is
 **per call**, not per host.
+<!-- docref: end -->
 
 {% callout type="info" title="Rule of thumb" %}
 If the answer to "which backend?" is *"whichever this machine has"* (one per

--- a/docs/02-concepts/03-errors.md
+++ b/docs/02-concepts/03-errors.md
@@ -21,7 +21,10 @@ if errors.Is(err, svc.ErrUnknownBackend) {
 }
 ```
 
-Each multi-backend package exports `ErrUnknownBackend`.
+<!-- docref: begin src=pkg/pkg.go#ErrUnknownBackend:fed789a4,sys/service/service.go#ErrUnknownBackend:1b9dc3c6 -->
+Each multi-backend package exports `ErrUnknownBackend`, returned by its `New`
+for the zero value and any unimplemented backend.
+<!-- docref: end -->
 
 <!-- docref: begin src=sys/exec/command_error.go#@escalation-sentinels:89446e95 -->
 The `exec` package adds sentinels for the escalation path —
@@ -32,11 +35,15 @@ that can't escalate fails fast instead of hanging.
 
 ## Command failures — inspect with errors.As
 
+<!-- docref: begin src=sys/exec/runner.go#Runner:7679445f -->
 A non-zero exit code is **not** automatically an error. The Runner reports the
 exit code in its result and leaves the judgement to the capability layer,
 because some non-zero codes are meaningful answers (a `cryptsetup` probe
-returning "not a LUKS device", for example). When a capability does decide a
+returning "not a LUKS device", for example). A non-nil error from `Run` means
+the command *could not be executed* — binary not found, blocked env var,
+cancelled context — or escalation failed. When a capability does decide a
 command failed, it wraps the details in a typed error:
+<!-- docref: end -->
 
 <!-- docref: begin src=sys/exec/command_error.go#CommandError:c48644e3 -->
 `CommandError` is the typed error the capability layer wraps a failed command

--- a/docs/02-concepts/04-crypto.md
+++ b/docs/02-concepts/04-crypto.md
@@ -1,0 +1,108 @@
+---
+title: Crypto helpers
+label: Crypto
+description: The crypto package's guarantees — mandatory domain separation on every AEAD and seal, one-way X25519 sealing past a low-trust relay, and CSR / CA-continuity rules.
+---
+
+# Crypto helpers
+
+The top-level `crypto` package holds the primitives the Power Manage trust
+story is built from: authenticated encryption, asymmetric sealing, LPS
+password sealing, and the certificate utilities used at agent enrollment and
+renewal. The design rule across all of them: **misuse is rejected by
+construction**, not left to caller discipline.
+
+## No naked AEAD calls
+
+<!-- docref: begin src=crypto/aead.go#SealWithAAD:462ff1c8,crypto/aead.go#ErrAADRequired:c7997fd7 -->
+`SealWithAAD` encrypts with AES-256-GCM and **requires a non-empty AAD** —
+an empty one is refused with `ErrAADRequired`. That makes domain separation
+mandatory: two different ciphertext domains can never be confused or
+cross-decrypted, and "forgot the AAD" is impossible to do silently. The
+96-bit nonce is generated per call from `crypto/rand` and prepended to the
+output; it is never taken from the caller, so nonce reuse under one key —
+catastrophic for GCM — cannot be introduced by a caller mistake, and an RNG
+failure fails closed rather than emitting a predictable nonce.
+<!-- docref: end -->
+
+<!-- docref: begin src=crypto/aead.go#OpenWithAAD:9ba6d7a3 -->
+`OpenWithAAD` reverses it under the *same* key and AAD. Any authentication
+failure — a wrong key, a wrong-domain AAD, a tampered ciphertext — returns an
+error and **no plaintext**; a blob too short to carry its nonce and tag is
+rejected up front with a precise `ErrMalformedCiphertext` rather than a
+generic authentication failure.
+<!-- docref: end -->
+
+## Sealing to a public key
+
+Some secrets must cross a relay that is not allowed to read them. The
+sealing construction is ECIES-style: an ephemeral X25519 key agreement,
+HKDF-SHA256, then the same AEAD.
+
+<!-- docref: begin src=crypto/seal.go#SealToPublicKey:6b2352e6,crypto/seal.go#OpenWithPrivateKey:f52d2fda,crypto/seal.go#ErrInfoRequired:53c99fd6 -->
+`SealToPublicKey` encrypts so that only the holder of the recipient's X25519
+private key can open, and requires **both** a non-empty AAD and a non-empty
+HKDF `info` string (`ErrInfoRequired`) — the info domain-separates every
+sealing surface, so a blob sealed for one purpose can never open under
+another even if the recipient key were reused. Both public keys are bound
+into the HKDF salt, tying the derived key to this exact (ephemeral,
+recipient) pair. `OpenWithPrivateKey` re-derives under the *same* info and
+AAD; any mismatch — a tampered byte, a different context, the wrong key —
+returns an error and no plaintext.
+<!-- docref: end -->
+
+## LPS password sealing
+
+The concrete consumer is Local Password Solution rotation: the agent seals
+each rotated local password to the control server's key, so the relaying
+gateway — the least-trusted server-side actor — can never read it.
+
+<!-- docref: begin src=crypto/lps.go#SealLpsPassword:94af0f03,crypto/lps.go#OpenLpsPassword:c17da04f,crypto/lps.go#ErrLpsContextIncomplete:6fc490b5 -->
+`SealLpsPassword` (agent side) and `OpenLpsPassword` (control side) are the
+**single construction site** for the LPS domain-separation info and the
+context AAD — both sides call through the same functions, so they cannot
+drift on either value (a drift would not be caught by any single-repo test
+and would silently break every unseal). The AAD binds the sealed password to
+its exact (device, action, username) record; all three fields are required,
+and a partial context is refused with `ErrLpsContextIncomplete` — a valid
+blob cannot be relocated to another device, action, or user record.
+<!-- docref: end -->
+
+## Certificates: CSRs, pins, and CA continuity
+
+<!-- docref: begin src=crypto/csr.go#GenerateCSR:4a9d84de,crypto/csr.go#GenerateCSRFromKey:698f4840 -->
+`GenerateCSR` creates the agent's ECDSA P-256 key pair and a CSR that
+deliberately carries **no SANs**: agent certificates are client certs,
+identified by the device ID the control server writes into the issued cert —
+the CA rejects any CSR that requests subject alternative names, so including
+one fails registration immediately. The hostname goes in the CN only for
+operator debuggability (the CA discards it). `GenerateCSRFromKey` builds the
+same SAN-free shape for renewal, reusing the existing key pair.
+<!-- docref: end -->
+
+<!-- docref: begin src=crypto/cert.go#VerifyCAContinuity:30b656cc,crypto/cert.go#CAFingerprintFromPEM:5a8bdd28 -->
+At renewal the agent guards its trust anchor with `VerifyCAContinuity`: a
+returned CA must be byte-identical to the enrolled one, or cross-signed by
+it. An unrelated CA is refused — that is exactly the trust-anchor swap a
+compromised or MITM'd control origin would attempt — and a hard CA swap
+requires re-enrollment, never silent adoption over the renewal channel.
+`CAFingerprintFromPEM` computes the lowercase-hex SHA-256 of the CA's DER
+bytes, matching what an operator derives out-of-band (`openssl x509 -outform
+DER | sha256sum`), which is what the optional enrollment CA-pin compares
+against.
+<!-- docref: end -->
+
+{% callout type="info" title="Reference" %}
+Signatures over server-originated *commands* (actions, queries, LUKS
+revocations) live in the `verify` package — see
+[Agent client & signed commands](/concepts/client).
+{% /callout %}
+
+## Related
+
+- [Agent client & signed commands](/concepts/client) — where these
+  primitives are used on the wire.
+<!-- docref: begin src=crypto/aead.go#ErrAADRequired:c7997fd7 -->
+- [Errors](/concepts/errors) — sentinel errors like `ErrAADRequired` are
+  matched with `errors.Is`.
+<!-- docref: end -->

--- a/docs/02-concepts/05-client.md
+++ b/docs/02-concepts/05-client.md
@@ -1,0 +1,127 @@
+---
+title: Agent client & signed commands
+label: Client & signing
+description: The long-lived bidirectional stream between agent and gateway — dispatch robustness against a hostile relay, fail-closed action-signature verification, and maintenance-window evaluation.
+---
+
+# Agent client & signed commands
+
+Three pieces of the SDK carry the agent's server-facing behaviour: the
+`Client` (a long-lived bidirectional stream to the gateway), the `verify`
+package (signatures over every server-originated command), and the
+`maintenance` package (when scheduled work is allowed to run). The common
+thread: the gateway is the *least-trusted* server-side actor, so the client
+treats every inbound frame as potentially hostile and every command as
+unauthenticated until a CA signature says otherwise.
+
+## The stream
+
+The agent connects over mTLS and keeps one bidirectional stream open;
+heartbeats, action results, inventory, and terminal I/O all multiplex over
+it.
+
+<!-- docref: begin src=client.go#WithMTLSFromPEM:7e7dc2c3,client.go#WithMTLSFromPEMAndSystemRoots:0388329a -->
+Gateway trust is strict: the mTLS options verify the server **only** against
+the enrolled internal CA — system roots are deliberately not consulted, so a
+certificate signed by any public CA cannot impersonate the gateway even with
+a matching SNI. The `...AndSystemRoots` variant exists solely for
+control-server endpoints fronted by a public CA (a reverse proxy with Let's
+Encrypt); using it for the gateway connection would broaden the gateway's
+trust and is explicitly warned against.
+<!-- docref: end -->
+
+<!-- docref: begin src=client.go#MinHeartbeatInterval:2278f3a7,client.go#Client.applyWelcomeHeartbeat:64ed1259 -->
+The server can retune the heartbeat cadence via its Welcome message, but the
+SDK clamps the value into a safe band (5 seconds to 5 minutes) before
+applying it — a misconfigured or malicious server can never push the cadence
+into stream spam or make the agent look dead to liveness tracking. A
+zero/unset interval keeps the caller-supplied one.
+<!-- docref: end -->
+
+<!-- docref: begin src=client.go#Client.send:881c9f04 -->
+All writes to the stream are serialized through a context-aware send lock:
+concurrent writers (heartbeat, results, terminal output) can never interleave
+bytes on the wire, and a sender stalled behind a peer that stops draining
+abandons its claim on its own deadline instead of wedging every other sender
+behind it. At most one send is ever in flight, so the on-wire serialization
+guarantee survives even an abandoned send.
+<!-- docref: end -->
+
+## Dispatch robustness
+
+Inbound frames get no benefit of the doubt — a compromised gateway is in the
+threat model.
+
+<!-- docref: begin src=client.go#maxInboundMessageBytes:794c84c6,client.go#Client.validateInbound:e0ff57f2,client.go#Client.dispatchServerMessage:afa7bd96 -->
+A single inbound message is size-capped (16 MiB — far above any legitimate
+control frame), so a multi-gigabyte frame cannot force an allocation; the
+connection that receives one is torn down with a resource-exhausted error.
+Every concrete command payload is then re-validated against the shared
+`validate` tags at the SDK boundary — a malformed-but-non-nil frame
+(out-of-range PTY dimensions, a non-ULID session id, an empty envelope) is
+dropped before it reaches a handler. Nil oneof payloads are dropped
+non-fatally, unknown payload variants from a newer server are logged and
+dropped rather than tearing the connection down, and a **panic inside any
+handler is recovered and turned into a dropped frame** — one hostile or buggy
+invocation cannot crash-loop the agent.
+<!-- docref: end -->
+
+<!-- docref: begin src=client.go#actionQueueDepth:794c84c6,client.go#Client.runDispatchedAction:528ff624 -->
+Server-dispatched actions execute on a single worker goroutine off the
+receive loop — one at a time, in order — so a long-running action can never
+head-of-line-block terminal input or a stop request. The queue is bounded; a
+flood beyond it is dropped with a loud warning (the server re-dispatches
+unacked actions on reconnect) rather than allowed to grow without bound or to
+block the receive loop.
+<!-- docref: end -->
+
+## Every server command is signed
+
+The stream being authenticated is not enough: the gateway relays commands, it
+does not originate them. Authority comes from a control-server CA signature
+on the command itself.
+
+<!-- docref: begin src=client.go#StreamHandler:0163986d,verify/verify.go#ActionVerifier.Verify:c3b3df3c,verify/envelope.go#MarshalEnvelope:eeb40f10 -->
+An action arrives as opaque **envelope bytes plus a signature**. The handler
+contract is verify-then-execute-the-same-bytes: verify the signature over
+exactly the bytes received, then unmarshal *those same bytes* to execute —
+never a re-marshalled copy — so the executed action is byte-for-byte the
+verified action. The envelope covers the whole command (id, type, params,
+desired state, timeout, schedule, target device), which means a compromised
+relay cannot flip a field, swap params, or retarget the device under a
+still-valid signature.
+<!-- docref: end -->
+
+<!-- docref: begin src=verify/verify.go#ActionSignatureDomain:fe438abc,verify/verify.go#canonicalDigest:8e724a35 -->
+Every signing surface that shares the CA key — actions, osquery dispatches,
+log queries, LUKS revocations, inventory requests, the LPS public key — has
+its own domain string, and the digest mixes in the domain with a length
+prefix, so a signature minted for one surface can never be replayed against
+another.
+<!-- docref: end -->
+
+<!-- docref: begin src=verify/verify.go#ActionVerifier.verifyDigest:5f7ba25f -->
+Verification is fail-closed: an empty signature or payload is rejected, and
+only ECDSA and RSA keys are accepted — any other key type (including
+Ed25519) is an explicit error, so a key-type drift between server and agent
+surfaces loudly instead of as a silent mismatch.
+<!-- docref: end -->
+
+## Maintenance windows
+
+<!-- docref: begin src=maintenance/window.go#IsAllowed:8a918a14,maintenance/window.go#Union:be10448d,maintenance/window.go#Validate:eb666b47 -->
+The `maintenance` package is the **shared** parser, validator, union resolver
+and evaluator for maintenance windows, so server and agent agree bit-for-bit
+on what counts as an allowed dispatch moment. An empty window means "always
+allowed" (the feature is opt-in); entries within a window OR together, and
+the union across a device's groups ORs again — if any reaching group has no
+window, the union collapses to unconstrained. Evaluation runs against the
+device's **local** wall-clock on the agent; the server never computes
+allowedness, because the device is the only authority on its own clock.
+<!-- docref: end -->
+
+## Related
+
+- [Crypto helpers](/concepts/crypto) — the AEAD, sealing, and certificate
+  primitives underneath.
+- [Errors](/concepts/errors) — how failures surface across the SDK.

--- a/docs/02-concepts/index.md
+++ b/docs/02-concepts/index.md
@@ -8,7 +8,9 @@ icon: "🧩"
 
 The system-management packages (`sys/*`, `pkg`) all share one shape, so once
 you understand a single capability you understand them all. These pages cover
-that shape and the conventions that hold across every package.
+that shape, the conventions that hold across every package, and the two
+cross-cutting surfaces the agent and servers build on: the crypto helpers and
+the streaming client with its signed-command model.
 
 {% cards %}
   {% card title="Architecture" href="/concepts/architecture" icon="🏗️" %}
@@ -22,5 +24,13 @@ that shape and the conventions that hold across every package.
   {% card title="Errors" href="/concepts/errors" icon="⚠️" %}
   Sentinel errors you match with errors.Is, the typed command error, and the
   fail-closed default.
+  {% /card %}
+  {% card title="Crypto helpers" href="/concepts/crypto" icon="🔑" %}
+  Mandatory domain separation on every AEAD and seal, X25519 sealing past a
+  low-trust relay, and the CSR / CA-continuity rules.
+  {% /card %}
+  {% card title="Client & signing" href="/concepts/client" icon="📡" %}
+  The agent's bidirectional stream, dispatch robustness against a hostile
+  relay, fail-closed command signatures, and maintenance windows.
   {% /card %}
 {% /cards %}

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -62,7 +62,8 @@ if err != nil {
 fmt.Println(res.Stdout)
 
 _, err = m.Remove(ctx, pkg.RemoveOptions{}, "telnet")
-// Refresh the index and upgrade everything:
+// Refresh the index, then upgrade everything:
+_, err = m.Update(ctx)
 _, err = m.UpgradeAll(ctx, pkg.UpgradeOptions{})
 // Or upgrade specific packages:
 _, err = m.Upgrade(ctx, "openssl")
@@ -78,7 +79,10 @@ the package manager's `exec.Result`.
 
 ## Query installed state
 
-Reads do not need escalation — a `Direct` Runner is enough:
+<!-- docref: begin src=sys/exec/runner.go#Direct:ed029c0e,pkg/exec.go#runRead:cc3d492f -->
+Reads never escalate — the query path runs each command without the privilege
+wrapper, so a `Direct` Runner is enough:
+<!-- docref: end -->
 
 ```go
 ok, err := m.IsInstalled(ctx, "curl")
@@ -103,12 +107,23 @@ nothing.
 
 Behavioural differences the Manager smooths over but you should know about:
 
-- **apt / dnf / zypper** refresh their index as part of an upgrade; **pacman**
-  uses `-Sy` to sync the database first.
+<!-- docref: begin src=pkg/pkg.go#Manager:48758d2d,pkg/pacman.go#pacman.UpgradeAll:ac396816 -->
+- `Update` is the explicit index refresh; `UpgradeAll` maps to the backend's
+  full upgrade (`apt dist-upgrade` / `dnf upgrade` / `zypper dist-upgrade` /
+  `flatpak update`) and does **not** re-sync the index first — except
+  **pacman**, whose `-Syu` syncs the database and upgrades in one transaction
+  (Arch does not support partial upgrades).
+- `UpgradeOptions.SecurityOnly` narrows the upgrade to security updates where
+  the backend supports it (apt / dnf / zypper); **pacman** and **flatpak** have
+  no security-only concept and fail closed with `ErrSecurityOnlyUnsupported`
+  rather than silently running a full upgrade.
 - **flatpak** installs are per-remote application IDs, not distro package names;
   use it for desktop apps, the distro backends for system packages.
-- **dnf / zypper / apt** resolve dependencies automatically; `Autoremove`
-  prunes what's no longer needed.
+- `Upgrade` with an empty package list is a **no-op**, never a full upgrade —
+  an accidentally-empty list must not upgrade the whole system; `UpgradeAll` is
+  the explicit way to do that. `Autoremove` prunes no-longer-needed
+  dependencies, and is a no-op on backends with no native equivalent.
+<!-- docref: end -->
 
 {% callout type="info" title="Reference" %}
 The full method set and option fields are generated API docs on

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -65,8 +65,9 @@ if _, err := m.Remove(ctx, pkg.RemoveOptions{}, "telnet"); err != nil {
     return err
 }
 
-// Refresh the index, then upgrade everything. A failed refresh must not
-// fall through to the upgrade:
+// Refresh the index first on backends that need it (pacman's UpgradeAll
+// already syncs in-transaction), then upgrade everything. A failed
+// refresh must not fall through to the upgrade:
 if _, err := m.Update(ctx); err != nil {
     return err
 }

--- a/docs/03-capabilities/01-packages.md
+++ b/docs/03-capabilities/01-packages.md
@@ -61,14 +61,28 @@ if err != nil {
 }
 fmt.Println(res.Stdout)
 
-_, err = m.Remove(ctx, pkg.RemoveOptions{}, "telnet")
-// Refresh the index, then upgrade everything:
-_, err = m.Update(ctx)
-_, err = m.UpgradeAll(ctx, pkg.UpgradeOptions{})
+if _, err := m.Remove(ctx, pkg.RemoveOptions{}, "telnet"); err != nil {
+    return err
+}
+
+// Refresh the index, then upgrade everything. A failed refresh must not
+// fall through to the upgrade:
+if _, err := m.Update(ctx); err != nil {
+    return err
+}
+if _, err := m.UpgradeAll(ctx, pkg.UpgradeOptions{}); err != nil {
+    return err
+}
+
 // Or upgrade specific packages:
-_, err = m.Upgrade(ctx, "openssl")
+if _, err := m.Upgrade(ctx, "openssl"); err != nil {
+    return err
+}
+
 // Drop orphaned dependencies:
-_, err = m.Autoremove(ctx)
+if _, err := m.Autoremove(ctx); err != nil {
+    return err
+}
 ```
 
 <!-- docref: begin src=pkg/dnf.go#dnf.Install:24ff67e3 -->

--- a/docs/03-capabilities/02-identity.md
+++ b/docs/03-capabilities/02-identity.md
@@ -58,7 +58,9 @@ logged into by accident.
 
 ## Passwords are secrets, not arguments
 
+<!-- docref: begin src=sys/user/password.go#shadowUtils.SetPassword:33cb1ef7 -->
 `SetPassword` takes an `exec.Secret`, not a string:
+<!-- docref: end -->
 
 ```go
 pw, err := exec.NewSecret("correct horse battery staple")

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -44,7 +44,10 @@ unimplemented backend is an explicit error, not a silent no-op.
 
 ## Query unit state
 
-Reads are unprivileged:
+<!-- docref: begin src=sys/service/systemd.go#systemd.query:f8774d53,sys/service/systemd.go#systemd.mutate:985e7091 -->
+Reads are unprivileged — the query verbs run `systemctl` without escalation,
+while every mutation goes through the escalated path:
+<!-- docref: end -->
 
 ```go
 st, err := m.Status(ctx, "sshd.service") // active state, sub-state, …
@@ -82,6 +85,16 @@ err := m.WriteUnit(ctx, "pm-agent.service", unit)
 err = m.DaemonReload(ctx)            // re-read unit files
 err = m.EnableNow(ctx, "pm-agent.service")
 ```
+
+<!-- docref: begin src=sys/service/systemd.go#systemd.WriteUnit:cbdc6014,sys/service/unitcontent.go#ErrUnsafeUnitContent:ee7dfadb -->
+`WriteUnit` validates the unit name *and* the unit body before the root-owned
+file is created under `/etc/systemd/system/`. A unit runs as root under PID 1,
+so content that would turn it into a dropper is refused with
+`ErrUnsafeUnitContent`: an `Exec*` directive that shells out via `sh -c`, runs
+a binary from a world-writable directory (`/tmp`, `/var/tmp`, `/dev/shm`), or
+an `Environment=` that injects a dynamic-linker override (`LD_PRELOAD` and
+friends).
+<!-- docref: end -->
 
 ## Mask a unit
 

--- a/docs/03-capabilities/03-services.md
+++ b/docs/03-capabilities/03-services.md
@@ -88,8 +88,9 @@ err = m.EnableNow(ctx, "pm-agent.service")
 
 <!-- docref: begin src=sys/service/systemd.go#systemd.WriteUnit:cbdc6014,sys/service/unitcontent.go#ErrUnsafeUnitContent:ee7dfadb -->
 `WriteUnit` validates the unit name *and* the unit body before the root-owned
-file is created under `/etc/systemd/system/`. A unit runs as root under PID 1,
-so content that would turn it into a dropper is refused with
+file is created under `/etc/systemd/system/`. The unit file is parsed and
+executed by PID 1 with whatever privileges it declares, so content that would
+turn it into a dropper is refused with
 `ErrUnsafeUnitContent`: an `Exec*` directive that shells out via `sh -c`, runs
 a binary from a world-writable directory (`/tmp`, `/var/tmp`, `/dev/shm`), or
 an `Environment=` that injects a dynamic-linker override (`LD_PRELOAD` and

--- a/docs/03-capabilities/04-reboot.md
+++ b/docs/03-capabilities/04-reboot.md
@@ -25,7 +25,9 @@ if err != nil {
 
 ## Is a reboot required?
 
+<!-- docref: begin src=sys/reboot/reboot.go#rebooter.IsRequired:acb46152,sys/exec/runner.go#Direct:ed029c0e -->
 The probe is unprivileged, so a `Direct` Runner is enough to *read*:
+<!-- docref: end -->
 
 ```go
 need, err := rb.IsRequired(ctx)
@@ -65,8 +67,11 @@ can't transpose the delay and the wall message.
 <!-- docref: end -->
 
 {% callout type="warning" title="Schedule really reboots" %}
-`Schedule` calls the host's real `shutdown -r`. It is not a dry run — the host
-will reboot at the requested time unless you `Cancel` first.
+<!-- docref: begin src=sys/reboot/reboot.go#rebooter.Schedule:2028bda5,sys/reboot/reboot.go#rebooter.Cancel:ab133980 -->
+`Schedule` calls the host's real `shutdown -r` (escalated). It is not a dry
+run — the host will reboot at the requested time unless you `Cancel` (a
+`shutdown -c`) first.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/06-filesystem.md
+++ b/docs/03-capabilities/06-filesystem.md
@@ -59,17 +59,22 @@ err = m.Remove(ctx, "/var/lib/power-manage/state/stale.tmp")
 rejected.
 <!-- docref: end -->
 
-The operations are privilege-backend-keyed: as root they take a TOCTOU-safe,
-fd-anchored path — each step operates on an open directory handle, so a symlink
-swapped in mid-operation can't redirect a write or delete out of bounds; when
-escalation is via sudo, the same operations are driven through the escalated
-tool.
+<!-- docref: begin src=sys/fs/fs.go#manager.direct:9e4adeb0 -->
+The operations are privilege-backend-keyed: as root (a `Direct` Runner) they
+take a TOCTOU-safe, fd-anchored path — each step operates on an open directory
+handle, so a symlink swapped in mid-operation can't redirect a write or delete
+out of bounds; when escalation is via sudo, the same operations are driven
+through the escalated tool.
+<!-- docref: end -->
 
 {% callout type="info" title="Read-only roots" %}
-`IsReadOnly` and `RemountRW` handle the immutable-root case (ostree, a
-read-only `/usr`): check, remount read-write for the change, and the caller can
-remount back. Mutations refuse to write into protected system subtrees they
-don't own.
+<!-- docref: begin src=sys/fs/mount.go#manager.IsReadOnly:1edb9acd,sys/fs/mount.go#manager.RemountRW:3eadcb2c,sys/fs/protected.go#IsUnderProtectedPrefix:4231d9a0 -->
+`IsReadOnly` (an unprivileged `findmnt` probe) and `RemountRW` (an escalated
+`mount -o remount,rw`) handle the immutable-root case (ostree, a read-only
+`/usr`): check, remount read-write for the change. There is no remount-ro
+helper — restoring the read-only state afterwards is the caller's job.
+Mutations refuse to write into protected system subtrees they don't own.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/07-encryption.md
+++ b/docs/03-capabilities/07-encryption.md
@@ -63,9 +63,12 @@ authenticating passphrase — before `cryptsetup` is ever run.
 <!-- docref: end -->
 
 {% callout type="warning" title="Key-slot operations are destructive" %}
-`KillSlot` erases a key slot; `RemoveKey` removes the slot matching a passphrase.
+<!-- docref: begin src=sys/encryption/luks.go#luks.KillSlot:8e6852ce,sys/encryption/luks.go#luks.RemoveKey:b9040d71 -->
+`KillSlot` erases a specific key slot, authenticating with an existing
+passphrase; `RemoveKey` removes the slot matching a passphrase.
 Removing the last usable key makes the volume unopenable — the SDK validates
 inputs, but the *policy* of which slot is safe to remove is the caller's.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/09-network.md
+++ b/docs/03-capabilities/09-network.md
@@ -78,9 +78,12 @@ client key. An invalid profile is rejected with no side effect.
 <!-- docref: end -->
 
 {% callout type="info" title="EAP-TLS" %}
+<!-- docref: begin src=sys/network/certs.go#writeCerts:361f715b -->
 For enterprise networks, set `AuthType: network.AuthEAPTLS` and provide the
-client certificate and key; the key is written to a cert file under the
-connection's directory, again never on the command line.
+client certificate and key; the private key is written `0600` into the
+profile's cert directory, and only the file *paths* go on the `nmcli` command
+line — the key contents never do.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/10-dns.md
+++ b/docs/03-capabilities/10-dns.md
@@ -66,10 +66,12 @@ per-link runtime settings.
 <!-- docref: end -->
 
 {% callout type="info" title="Backend scope" %}
+<!-- docref: begin src=sys/dns/dns.go#Config.Interface:acca040e,sys/dns/networkmanager.go#nmManager.Apply:88f225c8 -->
 The **Resolved** backend supports host-global config (empty `Interface`).
 **NetworkManager** is connection-scoped — it configures DNS on a specific
 interface's active connection, so `Interface` is required there. For host-wide
 DNS, use Resolved.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/11-netconfig.md
+++ b/docs/03-capabilities/11-netconfig.md
@@ -65,9 +65,11 @@ change is made.
 <!-- docref: end -->
 
 {% callout type="info" title="DNS lives in two places" %}
-`InterfaceConfig.DNS` sets resolvers on the interface as a convenience.
-Host-wide DNS policy — global nameservers, search domains — is the proper job of
-[`sys/dns`](/capabilities/dns).
+<!-- docref: begin src=sys/netconfig/netconfig.go#InterfaceConfig.DNS:9c1f3793 -->
+`InterfaceConfig.DNS` sets resolvers on the interface as a convenience (in both
+addressing modes). Host-wide DNS policy — global nameservers, search domains —
+is the proper job of [`sys/dns`](/capabilities/dns).
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -8,8 +8,9 @@ icon: "🧱"
 # Firewall
 
 <!-- docref: begin src=sys/firewall/nftables.go#nftables:1d3ee6dd,sys/firewall/firewalld.go#firewalldServiceName:19892a3a -->
-`sys/firewall` manages a small set of allow/deny rules — by protocol, port, and
-source/destination — through nftables or firewalld. It owns a dedicated
+`sys/firewall` manages a small set of firewall rules: full allow/deny rules —
+by protocol, port, and source/destination — through nftables, and a narrower
+allow-only subset through firewalld. It owns a dedicated
 namespace (a dedicated `inet <namespace>_filter` nftables table, or
 `<namespace>-` prefixed firewalld service definitions in the default zone) so
 it never clobbers rules it didn't create.

--- a/docs/03-capabilities/12-firewall.md
+++ b/docs/03-capabilities/12-firewall.md
@@ -7,10 +7,13 @@ icon: "🧱"
 
 # Firewall
 
+<!-- docref: begin src=sys/firewall/nftables.go#nftables:1d3ee6dd,sys/firewall/firewalld.go#firewalldServiceName:19892a3a -->
 `sys/firewall` manages a small set of allow/deny rules — by protocol, port, and
 source/destination — through nftables or firewalld. It owns a dedicated
-namespace (an nftables table / a firewalld zone) so it never clobbers rules it
-didn't create.
+namespace (a dedicated `inet <namespace>_filter` nftables table, or
+`<namespace>-` prefixed firewalld service definitions in the default zone) so
+it never clobbers rules it didn't create.
+<!-- docref: end -->
 
 ## Construct a manager
 
@@ -62,6 +65,15 @@ what it matches; an empty `Source`/`Dest` or a zero `Port` means "any". Rules
 are scoped to the manager's own namespace, so listing and removal never touch
 the host's other firewall state.
 <!-- docref: end -->
+
+{% callout type="info" title="Backend scope" %}
+<!-- docref: begin src=sys/firewall/firewalld.go#firewalldValidateRule:398b9411 -->
+The **firewalld** backend is deliberately narrow in v1: allow rules with a
+concrete protocol and port only. A deny rule or source/destination scoping is
+rejected with `ErrInvalidRule` and a hint naming the unsupported field — use
+the **nftables** backend for those.
+<!-- docref: end -->
+{% /callout %}
 
 ## Related
 

--- a/docs/03-capabilities/13-catrust.md
+++ b/docs/03-capabilities/13-catrust.md
@@ -7,10 +7,13 @@ icon: "📜"
 
 # CA trust
 
+<!-- docref: begin src=sys/catrust/catrust.go#CaCertificates:350dcebc,sys/catrust/catrust.go#P11Kit:350dcebc,sys/catrust/catrust.go#SuseCaCertificates:350dcebc -->
 `sys/catrust` manages the system's CA trust store — the anchors every TLS client
 on the host validates against. Install a corporate root, remove one, list what's
-trusted, across the Debian (`update-ca-certificates`) and Red Hat / SUSE
-(`p11-kit`) flows.
+trusted, across three flows: Debian/Ubuntu (`update-ca-certificates`),
+Fedora/RHEL/Arch (p11-kit's `update-ca-trust`), and openSUSE/SLES (its own
+`update-ca-certificates` layout).
+<!-- docref: end -->
 
 ## Construct a manager
 

--- a/docs/03-capabilities/14-antivirus.md
+++ b/docs/03-capabilities/14-antivirus.md
@@ -61,9 +61,12 @@ exit surfaces as an error rather than being swallowed.
 <!-- docref: end -->
 
 {% callout type="info" title="Version needs a signature DB" %}
-`Version` reports the engine *and* signature-database version, so it expects a
-real ClamAV signature DB to be present. A freshly-installed ClamAV that has never
-run `freshclam` has no signature version to report.
+<!-- docref: begin src=sys/antivirus/clamav.go#clamavManager.Version:5f37c067,sys/antivirus/clamav.go#parseClamscanVersion:e124e2f8 -->
+`Version` parses `clamscan --version` into the engine *and* signature-database
+version, so it expects a real ClamAV signature DB to be present. A
+freshly-installed ClamAV that has never run `freshclam` reports no signature
+version — `Version` returns an error rather than a half-filled result.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/17-log.md
+++ b/docs/03-capabilities/17-log.md
@@ -56,9 +56,13 @@ so a caller can tell "no logs matched" from "journalctl broke".
 <!-- docref: end -->
 
 {% callout type="info" title="Backend differences" %}
-`Unit`, `Since`, `Until`, `Priority`, and `Kernel` are journald-only (ignored by the Syslog backend). The
-Syslog backend tails the log file and applies `Grep`/`Lines` in-process. For
-unit- or priority-scoped queries, use Journald.
+<!-- docref: begin src=sys/log/syslog.go#syslogSource:e33f14f6 -->
+`Unit`, `Since`, `Until`, `Priority`, and `Kernel` are journald-only — the
+Syslog backend still validates them (a bad value errors) but does not apply
+them. The Syslog backend tails the log file and applies `Grep`/`Lines`
+in-process, filtering within the tail window. For unit- or priority-scoped
+queries, use Journald.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/19-desktop.md
+++ b/docs/03-capabilities/19-desktop.md
@@ -63,9 +63,11 @@ user-scoped command.
 <!-- docref: end -->
 
 {% callout type="info" title="It's a Runner, not a one-shot" %}
+<!-- docref: begin src=sys/desktop/runas_runner.go#RunAsRunner:f70588a4 -->
 `RunAsRunner` returns an `exec.Runner` you compose with any capability (a per-user
 Flatpak manager, a script exec), so the privilege drop and environment are wired
 in once and reused — no separate streaming pipeline to build.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/03-capabilities/21-remote.md
+++ b/docs/03-capabilities/21-remote.md
@@ -53,10 +53,12 @@ caller holds the interface, not the concrete client.
 
 ## Following redirects
 
+<!-- docref: begin src=sys/remote/http.go#RedirectSameOrigin:9f1477bb,sys/remote/http.go#RedirectCrossOrigin:9f1477bb -->
 By default an HTTP fetch follows only same-origin redirects: a hop that changes
 host or scheme is refused. A source behind a CDN that bounces to another host —
 GitHub release downloads redirect `github.com` to
 `release-assets.githubusercontent.com` — needs `RedirectCrossOrigin`:
+<!-- docref: end -->
 
 ```go
 src, err := remote.NewHTTP(remote.HTTPConfig{
@@ -78,9 +80,11 @@ governs the default client only; a caller-supplied `Client` owns its own.
 
 ## Fetch into memory
 
+<!-- docref: begin src=sys/remote/fetch_bytes.go#FetchBytes:c8e91045 -->
 When the payload is small and you want the bytes in hand rather than a file on
 disk — a `SHA256SUMS` manifest, a GPG key, a short JSON descriptor — `FetchBytes`
 fetches an HTTPS source into memory and returns the bytes:
+<!-- docref: end -->
 
 ```go
 data, err := remote.FetchBytes(ctx, remote.HTTPConfig{

--- a/docs/03-capabilities/22-repositories.md
+++ b/docs/03-capabilities/22-repositories.md
@@ -25,6 +25,13 @@ if err != nil {
 }
 ```
 
+<!-- docref: begin src=sys/repo/repo.go#New:73121dda -->
+`New` reuses the `pkg.Backend` enum and is fail-closed: a nil Runner or a
+backend without native repository support (flatpak, the zero value) is
+rejected. It is pure — it does not probe the host; use `pkg.Detect` to learn
+which backends are installed.
+<!-- docref: end -->
+
 ## Apply and remove
 
 ```go
@@ -53,9 +60,13 @@ same desired state is safe and produces no spurious change events.
 <!-- docref: end -->
 
 {% callout type="info" title="GPG keys are public material" %}
+<!-- docref: begin src=sys/repo/apt.go#updateAptKey:f3733dcc,sys/repo/dnf.go#manager.applyDnf:0bc9b98b -->
 The signing keys here are *public* repository keys, not secrets. apt receives the
 key bytes (dearmored into `/etc/apt/keyrings`); dnf and zypper take a key
-reference (URL or path) the package manager imports.
+reference (URL or path) the package manager imports — and dnf imports it only
+when `GPGCheck` is on, so a key is never trusted system-wide while the
+repository itself verifies nothing.
+<!-- docref: end -->
 {% /callout %}
 
 ## Related

--- a/docs/04-contributing/01-release-coordination.md
+++ b/docs/04-contributing/01-release-coordination.md
@@ -39,12 +39,15 @@ require (
 )
 ```
 
-The module path now equals the repo URL, so `go get` resolves it
+<!-- docref: begin src=go.mod#@module-path:3320c783 -->
+The module path now equals the repo URL
+(`github.com/manchtools/power-manage-sdk`), so `go get` resolves it
 directly — no `replace` directive needed. The version is a Go-compatible
 semver tag (`v0.x.x` / `v1.x.x`); pseudo-versions
 (`v0.0.0-TIMESTAMP-SHORTSHA`) are accepted for pinning an untagged
 commit, but prefer a tagged release when one exists — `go.mod` stays
 readable.
+<!-- docref: end -->
 
 `go build` fetches the pinned version from GitHub. Nothing looks at
 SDK main unless someone explicitly bumps the pin.
@@ -137,10 +140,13 @@ The SDK uses two kinds of tags side-by-side:
 | Go module tag | `v0.x.x` semver | agent/server `go.mod` |
 | Human-readable release label | `vYYYY.MM.XX` calendar date (e.g. `v2026.04.03`) | GitHub Releases UI, operator-facing docs |
 
+<!-- docref: begin src=.github/workflows/release.yml#@release-trigger:6d9c7468,.github/workflows/release.yml#@ts-release-assets:b589cafd -->
 Both can live at the same commit — the release workflow
 (`.github/workflows/release.yml`) fires on any tag matching `v*` and
-builds TypeScript SDK assets for the GitHub Release page regardless of
-the format. They're just two ways to reference the same release.
+builds TypeScript SDK assets (`ts-sdk.tar.gz`, plus the proto sources
+as `proto.tar.gz`) for the GitHub Release page regardless of the
+format. They're just two ways to reference the same release.
+<!-- docref: end -->
 
 ### Why two conventions
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,7 @@
+// docref: begin module-path
 module github.com/manchtools/power-manage-sdk
+
+// docref: end module-path
 
 go 1.25.11
 


### PR DESCRIPTION
Closes #266

## What

- **Drift fixes** (all doc-side; code verified correct): packages page taught that `UpgradeAll` refreshes indexes — only pacman syncs in-transaction, the example now calls `Update` first and `SecurityOnly`'s fail-closed contract is documented; catrust SUSE vs Fedora/RHEL/Arch backend mapping was swapped; firewalld backend materialises `<ns>-`-prefixed service definitions in the default zone, not a dedicated zone; filesystem docs no longer imply an SDK remount-ro helper; antivirus `Version` errors on a missing `/sig` part; log page: journald-only fields are validated but not applied; network EAP-TLS key written 0600 into the profile CertDir, only paths on argv.
- **Anchoring**: `docref suggest` driven to empty (was 20 hits); every behavioral assertion now carries a claim — **66 → 114 refs**, `docref check` fully green (0 broken / 0 stale / 0 unused).
- **New pages**: `02-concepts/04-crypto.md` (mandatory AAD/info domain separation, X25519 sealing, LPS single construction site, CSR/CA-continuity rules) and `02-concepts/05-client.md` (strict internal-CA gateway trust, stream robustness caps, verify-then-execute-the-same-bytes signing contract, maintenance-window semantics).
- **Comment-only code edits**: docref region markers in `go.mod` and `.github/workflows/release.yml` backing the release-coordination anchors. `GOWORK=off go build ./...` green; release.yml parses.

## Verification

- `docref check` → 114 up-to-date, 0/0/0/0 (exit 0)
- `docref suggest` → empty
- `GOWORK=off go build ./...` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new and expanded documentation covering crypto helpers, client signing, backend behavior, filesystem safety, networking, firewall rules, repositories, and release coordination.
  * Improved the getting-started and concept guides with clearer navigation and more cross-links.

* **Documentation**
  * Refined several existing docs for clearer guidance on privilege use, error handling, package management, identity secrets, reboot behavior, encryption, DNS, logs, desktop actions, remote fetching, and CA trust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->