### PR TITLE
fix(repo): apt flat-repo + components rejected at the gate; parse-rejected sources roll back and fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/manchtools/power-manage-sdk
 
 // docref: end module-path
 
-go 1.25.11
+go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/sys/repo/apt.go
+++ b/sys/repo/apt.go
@@ -139,7 +139,12 @@ func (m *manager) applyApt(ctx context.Context, name string, c *AptConfig) (Outc
 			log.WriteString(res.Stdout)
 		}
 		if uerr != nil {
-			if strings.Contains(uerr.Error()+res.Stdout, repoFile) {
+			// The malformed-entry diagnostic reaches us through
+			// CommandError.Error() (which folds in stderr) — but match
+			// the raw streams too, so a runner path that doesn't fold
+			// stderr into the error can never turn this guard into dead
+			// code (CR catch).
+			if strings.Contains(uerr.Error()+res.Stdout+res.Stderr, repoFile) {
 				fmt.Fprintf(&log, "apt rejected the just-written %s; rolling it back\n", repoFile)
 				if len(existingBytes) > 0 {
 					if rerr := m.fsm.WriteFile(ctx, repoFile, existingBytes, fs.WriteOptions{Mode: 0o644}); rerr != nil {

--- a/sys/repo/apt.go
+++ b/sys/repo/apt.go
@@ -127,14 +127,32 @@ func (m *manager) applyApt(ctx context.Context, name string, c *AptConfig) (Outc
 		changed = true
 	}
 
-	// Refresh the index only when something actually changed (non-fatal: the
-	// config landed even if a typo'd URL fails the refresh).
+	// Refresh the index only when something actually changed. A NETWORK
+	// failure stays non-fatal (the config landed even if a typo'd URL
+	// fails the refresh) — but if apt names the file WE just wrote, the
+	// file itself is malformed and every apt operation on the host is now
+	// broken. Roll it back to the pre-apply content and FAIL: leaving it
+	// in place while reporting success bricked apt fleet-wide (#302).
 	if changed {
 		res, uerr := m.runPriv(ctx, "apt-get", "update")
 		if res.Stdout != "" {
 			log.WriteString(res.Stdout)
 		}
 		if uerr != nil {
+			if strings.Contains(uerr.Error()+res.Stdout, repoFile) {
+				fmt.Fprintf(&log, "apt rejected the just-written %s; rolling it back\n", repoFile)
+				if len(existingBytes) > 0 {
+					if rerr := m.fsm.WriteFile(ctx, repoFile, existingBytes, fs.WriteOptions{Mode: 0o644}); rerr != nil {
+						fmt.Fprintf(&log, "CRITICAL: rollback write failed — apt remains broken on this host: %v\n", rerr)
+					}
+				} else {
+					if rerr := m.fsm.Remove(ctx, repoFile); rerr != nil {
+						fmt.Fprintf(&log, "CRITICAL: rollback remove failed — apt remains broken on this host: %v\n", rerr)
+					}
+				}
+				ferr := fmt.Errorf("apt rejected the generated sources file for %s (rolled back): %w", name, uerr)
+				return Outcome{Result: fsResultErr(log.String(), ferr), Changed: false}, ferr
+			}
 			fmt.Fprintf(&log, "warning: apt-get update failed after configuring %s: %v\n", name, uerr)
 		}
 	}

--- a/sys/repo/apt_test.go
+++ b/sys/repo/apt_test.go
@@ -364,9 +364,14 @@ func TestApt_Apply_MalformedSourcesRollsBackAndFails(t *testing.T) {
 		}
 	})
 
-	t.Run("fresh file is removed", func(t *testing.T) {
+	t.Run("fresh file is removed; diagnostic only on stderr", func(t *testing.T) {
 		m, ff, fr := newTestManager(t, pkg.Apt)
-		fr.Push(pmexec.Result{}, fmt.Errorf("E: Malformed entry 1 in sources file %s (absolute Suite Component)", repoFile))
+		// The path arrives ONLY via Result.Stderr — pins that the guard
+		// reads the raw streams, not just the folded error string (CR).
+		fr.Push(pmexec.Result{
+			ExitCode: 100,
+			Stderr:   fmt.Sprintf("E: Malformed entry 1 in sources file %s (absolute Suite Component)", repoFile),
+		}, errors.New("apt-get: exit 100"))
 
 		_, err := m.Apply(context.Background(), Repository{Name: "docker", Apt: &AptConfig{
 			URL:          "https://download.docker.com/linux/ubuntu",

--- a/sys/repo/apt_test.go
+++ b/sys/repo/apt_test.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -333,4 +334,74 @@ func TestApt_Remove(t *testing.T) {
 			t.Fatalf("err = %v, want a wrapped primary-remove failure", err)
 		}
 	})
+}
+
+// #302: apt rejecting the JUST-WRITTEN sources file (e.g. the malformed
+// "absolute Suite Component" form) must roll the file back and FAIL —
+// leaving it in place while reporting success breaks every apt
+// operation on the host.
+func TestApt_Apply_MalformedSourcesRollsBackAndFails(t *testing.T) {
+	const repoFile = "/etc/apt/sources.list.d/docker.sources"
+
+	t.Run("prior content is restored", func(t *testing.T) {
+		m, ff, fr := newTestManager(t, pkg.Apt)
+		ff.read[repoFile] = []byte("# old good content\n")
+		fr.Push(pmexec.Result{}, fmt.Errorf("apt-get: exit 100: E: Malformed entry 1 in sources file %s (absolute Suite Component)", repoFile))
+
+		out, err := m.Apply(context.Background(), Repository{Name: "docker", Apt: &AptConfig{
+			URL:          "https://download.docker.com/linux/ubuntu",
+			Distribution: "noble",
+			Components:   []string{"stable"},
+		}})
+		if err == nil {
+			t.Fatalf("Apply must fail when apt rejects the written file, got success: %+v", out)
+		}
+		if out.Changed {
+			t.Error("a rolled-back apply must not report Changed")
+		}
+		if got := ff.wrote(repoFile); got != "# old good content\n" {
+			t.Errorf("repo file = %q, want the pre-apply content restored", got)
+		}
+	})
+
+	t.Run("fresh file is removed", func(t *testing.T) {
+		m, ff, fr := newTestManager(t, pkg.Apt)
+		fr.Push(pmexec.Result{}, fmt.Errorf("E: Malformed entry 1 in sources file %s (absolute Suite Component)", repoFile))
+
+		_, err := m.Apply(context.Background(), Repository{Name: "docker", Apt: &AptConfig{
+			URL:          "https://download.docker.com/linux/ubuntu",
+			Distribution: "noble",
+			Components:   []string{"stable"},
+		}})
+		if err == nil {
+			t.Fatal("Apply must fail when apt rejects the written file")
+		}
+		if !ff.didCall("Remove:" + repoFile) {
+			t.Error("a fresh malformed file must be removed, not left to break apt")
+		}
+	})
+}
+
+// #302 counterpart: an update failure that does NOT name our file (a
+// network error, a broken THIRD-PARTY repo) stays a warning — the
+// config landed and is valid; failing would block converging repos on
+// hosts with unrelated apt breakage.
+func TestApt_Apply_UnrelatedUpdateFailureStaysWarning(t *testing.T) {
+	m, ff, fr := newTestManager(t, pkg.Apt)
+	fr.Push(pmexec.Result{}, fmt.Errorf("apt-get: exit 100: Could not resolve 'download.docker.com'"))
+
+	out, err := m.Apply(context.Background(), Repository{Name: "docker", Apt: &AptConfig{
+		URL:          "https://download.docker.com/linux/ubuntu",
+		Distribution: "noble",
+		Components:   []string{"stable"},
+	}})
+	if err != nil {
+		t.Fatalf("a network-shaped update failure must stay non-fatal: %v", err)
+	}
+	if !out.Changed {
+		t.Error("the configuration landed; Changed must be true")
+	}
+	if got := ff.wrote("/etc/apt/sources.list.d/docker.sources"); !strings.Contains(got, "Suites: noble") {
+		t.Errorf("valid sources file must be kept, got %q", got)
+	}
 }

--- a/sys/repo/validate.go
+++ b/sys/repo/validate.go
@@ -145,6 +145,14 @@ func validateApt(c *AptConfig) error {
 	if c.Distribution != "" && !validAptDistribution.MatchString(c.Distribution) {
 		return badShape("apt.distribution")
 	}
+	// deb822 cross-field rule (#302): an empty distribution renders the
+	// exact-path/flat form (`Suites: /`), and apt forbids Components with
+	// an exact-path suite — the written file fails to parse ("Malformed
+	// entry … (absolute Suite Component)") and, because it is already on
+	// disk, EVERY apt operation on the host breaks. Reject at the gate.
+	if c.Distribution == "" && len(c.Components) > 0 {
+		return fmt.Errorf("%w: apt.components requires apt.distribution (a flat repository — empty distribution — must have no components)", ErrInvalidConfig)
+	}
 	for _, comp := range c.Components {
 		if err := rejectControl("apt.components", comp); err != nil {
 			return err

--- a/sys/repo/validate_test.go
+++ b/sys/repo/validate_test.go
@@ -184,3 +184,34 @@ func TestValidate_Zypper(t *testing.T) {
 
 // mut clones-by-mutation: applies f to c and returns it (test sugar).
 func mut(c *AptConfig, f func(*AptConfig)) *AptConfig { f(c); return c }
+
+// #302: deb822 forbids Components with the exact-path suite form that an
+// empty distribution renders (`Suites: /`) — apt rejects the file with
+// "Malformed entry … (absolute Suite Component)" and, once written,
+// every apt operation on the host breaks. Validate must reject the
+// combination at the gate.
+func TestValidate_Apt_FlatRepoWithComponentsRejected(t *testing.T) {
+	m, _, _ := newTestManager(t, pkg.Apt)
+	err := m.Validate(Repository{Name: "docker", Apt: &AptConfig{
+		URL:        "https://download.docker.com/linux/ubuntu",
+		Components: []string{"stable"}, // no distribution → flat form
+	}})
+	if err == nil {
+		t.Fatal("empty distribution + components must be rejected (would write a malformed .sources)")
+	}
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("want ErrInvalidConfig, got %v", err)
+	}
+
+	// Both resolutions of the conflict stay valid.
+	if err := m.Validate(Repository{Name: "docker", Apt: &AptConfig{
+		URL: "https://download.docker.com/linux/ubuntu", // flat, no components
+	}}); err != nil {
+		t.Fatalf("flat repository without components must validate: %v", err)
+	}
+	if err := m.Validate(Repository{Name: "docker", Apt: &AptConfig{
+		URL: "https://download.docker.com/linux/ubuntu", Distribution: "noble", Components: []string{"stable"},
+	}}); err != nil {
+		t.Fatalf("distribution + components must validate: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #302 (field report: a docker REPOSITORY action bricked apt host-wide and reported success).

**Root cause**: `buildAptSources` renders an empty `distribution` as the exact-path form `Suites: /` but wrote `Components:` regardless — deb822 forbids that combination, so apt rejected the file ("Malformed entry … (absolute Suite Component)"), every apt operation on the host broke, and `Apply` treated the `apt-get update` failure as a non-fatal warning (exit 0).

**Fixes** (two layers):
1. `Validate`: empty `apt.distribution` + non-empty `apt.components` → `ErrInvalidConfig` with a message naming the resolution. The agent runs Validate before any write, so the malformed file is unreachable. Red-checked.
2. `Apply`: when `apt-get update` fails **and its output names the file we just wrote**, the file is rolled back (prior content restored, or removed when fresh) and Apply fails. The guard matches the folded error plus raw stdout/stderr (local CodeRabbit catch — the diagnostic arrives on stderr; a stderr-only test pins the channel). Network-shaped failures that don't name our file stay warnings — the config landed and is valid, and failing would block convergence on hosts with unrelated apt breakage.

Tests: rollback-restores-prior / removes-fresh (stderr-only diagnostic), unrelated-failure-stays-warning, flat-repo-with-components rejected + both valid resolutions. Full host suite green.

Follow-up after merge: bump the agent's SDK pin so deployed agents pick up the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an apt refresh fails after saving a repository source: invalid source files are now rolled back or removed, and the operation fails instead of silently continuing.
  * Kept non-source-related apt refresh failures non-fatal, with a warning and continued processing.
  * Added validation to reject flat apt repository entries that include components, preventing invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->