### PR TITLE
fix: derive container-test go.work version from go.mod

### DIFF
--- a/test/Dockerfile.almalinux
+++ b/test/Dockerfile.almalinux
@@ -27,7 +27,7 @@ RUN dnf -y install epel-release \
 
 WORKDIR /workspace
 COPY sdk/ ./sdk/
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 RUN cd sdk && go mod download
 
 # with-clamav: clamav from EPEL + the same static seed DB as the other images.

--- a/test/Dockerfile.arch
+++ b/test/Dockerfile.arch
@@ -24,7 +24,7 @@ RUN pacman -Sy --noconfirm \
 
 WORKDIR /workspace
 COPY sdk/ ./sdk/
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 RUN cd sdk && go mod download
 
 # with-clamav: clamav + the same static seed DB. Arch ships freshclam.conf at

--- a/test/Dockerfile.debian
+++ b/test/Dockerfile.debian
@@ -11,10 +11,11 @@
 # self-skips when its precondition is absent, so adding a state is a new stage +
 # a new test file — no CI wiring change.
 
-# The toolchain (1.26) is newer than the module's `go` directive (1.25.11, the
-# SDK's go.mod version mirrored into go.work below); a newer toolchain building
-# an older go-directive module is standard Go behaviour. Matches the pinning in
-# test/Dockerfile.integration so both images move together.
+# The toolchain (1.26) is newer than the module's `go` directive (the SDK's
+# go.mod version, derived into go.work below so the mirror can never go
+# stale); a newer toolchain building an older go-directive module is standard
+# Go behaviour. Matches the pinning in test/Dockerfile.integration so both
+# images move together.
 FROM golang:1.26-bookworm AS base
 
 # Tool surface for the container tests:
@@ -42,7 +43,7 @@ WORKDIR /workspace
 # Copy only the SDK module and pin it into a minimal workspace (standalone
 # resolution; mirrors test/Dockerfile.integration).
 COPY sdk/ ./sdk/
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 RUN cd sdk && go mod download
 
 # --- bad-state stages -------------------------------------------------------

--- a/test/Dockerfile.fedora
+++ b/test/Dockerfile.fedora
@@ -39,7 +39,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
 
 WORKDIR /workspace
 COPY sdk/ ./sdk/
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 RUN cd sdk && go mod download
 
 # --- bad-state stages -------------------------------------------------------

--- a/test/Dockerfile.integration
+++ b/test/Dockerfile.integration
@@ -44,7 +44,7 @@ WORKDIR /workspace
 COPY sdk/ ./sdk/
 
 # Create a minimal go.work for the SDK
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 
 # Pre-download dependencies
 RUN cd sdk && go mod download

--- a/test/Dockerfile.opensuse
+++ b/test/Dockerfile.opensuse
@@ -25,7 +25,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh \
 
 WORKDIR /workspace
 COPY sdk/ ./sdk/
-RUN printf 'go 1.25.11\n\nuse (\n\t./sdk\n)\n' > go.work
+RUN printf 'go %s\n\nuse (\n\t./sdk\n)\n' "$(sed -n 's/^go //p' sdk/go.mod)" > go.work
 RUN cd sdk && go mod download
 
 # with-clamav: clamav + the same static seed DB. openSUSE ships freshclam.conf at


### PR DESCRIPTION
Every container-test lane on main (and every PR) fails at `go mod download`:

```
go: module . listed in go.work file requires go >= 1.25.12, but go.work lists go 1.25.11
```

All six `test/Dockerfile.*` minted `go.work` with a hardcoded `go 1.25.11` — a manual mirror of go.mod's directive that went stale when #303 bumped go.mod to 1.25.12. Self-discovering fix: derive the version from `sdk/go.mod` at build time, so the mirror can never drift again.

Verified locally: the derived go.work + `go mod download` succeed, and `docker build -f sdk/test/Dockerfile.debian --target base` (the exact failing layer) builds clean.

Local CodeRabbit review: no findings.

Fixes manchtools/power-manage-sdk#305