### PR TITLE
feat(ts): exportAuditEvents client wrapper (spec 26)

### DIFF
--- a/ts/client.ts
+++ b/ts/client.ts
@@ -5,7 +5,7 @@
 import { createClient, Code, ConnectError } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { create } from '@bufbuild/protobuf';
-import { timestampFromDate } from '@bufbuild/protobuf/wkt';
+import { timestampFromDate, type Timestamp } from '@bufbuild/protobuf/wkt';
 
 import {
 	ControlService,
@@ -111,6 +111,7 @@ import {
 	ListExecutionsRequestSchema,
 	// Audit Log
 	ListAuditEventsRequestSchema,
+	ExportAuditEventsRequestSchema,
 	// LPS
 	GetDeviceLpsPasswordsRequestSchema,
 	// LUKS
@@ -1475,6 +1476,25 @@ export class ApiClient {
 		return client.listAuditEvents(
 			create(ListAuditEventsRequestSchema, { pageSize, pageToken, actorId, streamType, eventType })
 		);
+	}
+
+	/**
+	 * One chunk of the audit-log export (spec 26). The export is unary
+	 * and chunked: pass the returned nextPageToken back until it comes
+	 * back empty, concatenating the chunks into one valid CSV file or
+	 * JSON array.
+	 */
+	async exportAuditEvents(options: {
+		format: 'csv' | 'json';
+		actorId?: string;
+		streamTypes?: string[];
+		eventType?: string;
+		occurredFrom?: Timestamp;
+		occurredTo?: Timestamp;
+		pageToken?: string;
+	}) {
+		const client = this.getClient();
+		return client.exportAuditEvents(create(ExportAuditEventsRequestSchema, options));
 	}
 
 	// ============================================================================


### PR DESCRIPTION
Closes #308 (together with the already-merged #309).

TS `ApiClient` wrapper for the `ExportAuditEvents` RPC: single options object mirroring the request message; callers loop `nextPageToken` and concatenate `chunk`s into one CSV file / JSON array. Used by the web audit page's export button.

`npm run typecheck` + `npm test` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting audit-log data in CSV or JSON format.
  * Exports can be filtered by actor, stream type, event type, time range, and page token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->