### PR TITLE
feat(service): Version() probe + ReadUnit() (spec 27)

### DIFF
--- a/sys/service/service.go
+++ b/sys/service/service.go
@@ -67,7 +67,18 @@ type Manager interface {
 	Unmask(ctx context.Context, unit string) error
 	DaemonReload(ctx context.Context) error
 	WriteUnit(ctx context.Context, unit, content string) error
+	// ReadUnit returns the on-disk content of a unit WriteUnit manages —
+	// the sibling read so the unit path is constructed in exactly one
+	// place. An absent unit surfaces sys/fs's wrapped fs.ErrNotExist
+	// (errors.Is-able), so callers can tell "not installed" from a read
+	// failure.
+	ReadUnit(ctx context.Context, unit string) (string, error)
 	RemoveUnit(ctx context.Context, unit string) error
+	// Version reports the service manager's major version (for systemd:
+	// the first integer token on the first line of `systemctl --version`).
+	// Unparseable or empty output is an ERROR, never a guessed value —
+	// version-conditional rendering decides its own fail-safe.
+	Version(ctx context.Context) (int, error)
 }
 
 // Option is the functional-option type for backend-specific knobs (none today).
@@ -114,9 +125,10 @@ func ensureCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, systemctlQueryTimeout)
 }
 
-// fsManager is the narrow slice of fs.Manager the systemd backend uses to write
-// and remove unit files; a small interface so tests inject a fake via newFS.
+// fsManager is the narrow slice of fs.Manager the systemd backend uses to read,
+// write, and remove unit files; a small interface so tests inject a fake via newFS.
 type fsManager interface {
+	ReadFile(ctx context.Context, path string) ([]byte, error)
 	WriteFile(ctx context.Context, path string, data []byte, opts fs.WriteOptions) error
 	Remove(ctx context.Context, path string) error
 }

--- a/sys/service/systemd.go
+++ b/sys/service/systemd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/manchtools/power-manage-sdk/sys/exec"
@@ -240,6 +241,20 @@ func (s *systemd) WriteUnit(ctx context.Context, unit, content string) error {
 	return s.fsm.WriteFile(ctx, "/etc/systemd/system/"+unit, []byte(content), fs.WriteOptions{Mode: 0o644, Owner: "root", Group: "root"})
 }
 
+func (s *systemd) ReadUnit(ctx context.Context, unit string) (string, error) {
+	if err := ValidateUnitName(unit); err != nil {
+		return "", err
+	}
+	// No extra wrapping on the error: sys/fs's ReadFile contract (wrapped
+	// fs.ErrNotExist on absence) must stay errors.Is-able for callers that
+	// treat "not installed" as a distinct state.
+	content, err := s.fsm.ReadFile(ctx, "/etc/systemd/system/"+unit)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
 func (s *systemd) RemoveUnit(ctx context.Context, unit string) error {
 	if err := ValidateUnitName(unit); err != nil {
 		return err
@@ -249,4 +264,25 @@ func (s *systemd) RemoveUnit(ctx context.Context, unit string) error {
 		return fmt.Errorf("remove systemd unit %s: %w", path, err)
 	}
 	return nil
+}
+
+// Version reports systemd's major version: the first integer token on the
+// first line of `systemctl --version` ("systemd 257 (257.7-1)" → 257),
+// mirroring the parse the agent install script used. Anything else — empty
+// output, no numeric token, an exec failure — is an error; the caller owns
+// its fail-safe.
+func (s *systemd) Version(ctx context.Context) (int, error) {
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	res, err := s.r.Run(ctx, exec.Command{Name: "systemctl", Args: []string{"--version"}})
+	if err != nil {
+		return 0, fmt.Errorf("systemctl --version: %w", err)
+	}
+	firstLine, _, _ := strings.Cut(res.Stdout, "\n")
+	for _, tok := range strings.Fields(firstLine) {
+		if v, convErr := strconv.Atoi(tok); convErr == nil {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("systemctl --version: no version token in %q", firstLine)
 }

--- a/sys/service/unitcontent.go
+++ b/sys/service/unitcontent.go
@@ -213,3 +213,12 @@ func validateEnvLine(value string) error {
 	}
 	return nil
 }
+
+// ValidateUnitContent applies the unit-file content policy to content
+// without writing anything — the same gate WriteUnit enforces. Exported
+// so a caller that RENDERS unit content (the agent's embedded unit,
+// spec 27) can pin at test time that its template never produces a
+// directive the write path would reject.
+func ValidateUnitContent(content string) error {
+	return validateUnitContent(content)
+}

--- a/sys/service/unitfile_test.go
+++ b/sys/service/unitfile_test.go
@@ -19,12 +19,22 @@ type fakeFS struct {
 	wrotePath, wroteContent string
 	wroteOpts               fs.WriteOptions
 	removedPath             string
+	readPath, readContent   string
 	writeErr, removeErr     error
+	readErr                 error
 }
 
 func (f *fakeFS) WriteFile(_ context.Context, path string, data []byte, opts fs.WriteOptions) error {
 	f.wrotePath, f.wroteContent, f.wroteOpts = path, string(data), opts
 	return f.writeErr
+}
+
+func (f *fakeFS) ReadFile(_ context.Context, path string) ([]byte, error) {
+	f.readPath = path
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	return []byte(f.readContent), nil
 }
 
 func (f *fakeFS) Remove(_ context.Context, path string) error {

--- a/sys/service/version_readunit_test.go
+++ b/sys/service/version_readunit_test.go
@@ -101,3 +101,15 @@ func TestReadUnit_RejectsInvalidUnitName(t *testing.T) {
 		t.Errorf("ReadUnit must not touch the filesystem for an invalid name, read %q", f.readPath)
 	}
 }
+
+// TestValidateUnitContent_ExportMatchesGate pins that the exported
+// wrapper IS the WriteUnit gate: a dropper unit is rejected, a plain
+// unit passes.
+func TestValidateUnitContent_ExportMatchesGate(t *testing.T) {
+	if err := ValidateUnitContent("[Service]\nExecStart=/bin/sh -c 'curl x | sh'\n"); !errors.Is(err, ErrUnsafeUnitContent) {
+		t.Errorf("shell dropper must be rejected, got %v", err)
+	}
+	if err := ValidateUnitContent("[Service]\nExecStart=/usr/bin/true\n"); err != nil {
+		t.Errorf("plain unit must pass, got %v", err)
+	}
+}

--- a/sys/service/version_readunit_test.go
+++ b/sys/service/version_readunit_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage-sdk/sys/exec"
+	"github.com/manchtools/power-manage-sdk/sys/exec/exectest"
+)
+
+// TestVersion_ParsesSystemctlOutput pins the probe's parse contract
+// (spec 27): the FIRST integer token of the FIRST line — mirroring the
+// install.sh awk this replaces — and an error (never a guessed value)
+// for anything else, so the caller's fail-safe (RestrictRealtime=false)
+// stays a conscious decision at the call site.
+func TestVersion_ParsesSystemctlOutput(t *testing.T) {
+	cases := []struct {
+		name    string
+		stdout  string
+		want    int
+		wantErr bool
+	}{
+		{"trixie", "systemd 257 (257.7-1)\n+PAM +AUDIT ...\n", 257, false},
+		{"bookworm", "systemd 252 (252.36-1~deb12u1)\n", 252, false},
+		{"fedora suffix build", "systemd 256 (256.11-1.fc41)\n", 256, false},
+		{"version only", "systemd 258\n", 258, false},
+		{"empty output", "", 0, true},
+		{"no numeric token", "systemd (unknown)\n", 0, true},
+		{"garbage", "command not found", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			f.Push(exec.Result{Stdout: tc.stdout}, nil)
+			got, err := mgr(t, f).Version(context.Background())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Version() = %d, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Version(): %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Version() = %d, want %d", got, tc.want)
+			}
+			wantOneCmd(t, f, []string{"--version"}, false)
+		})
+	}
+}
+
+func TestVersion_RunnerErrorSurfaces(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	f.Push(exec.Result{}, errors.New("no systemctl"))
+	if _, err := mgr(t, f).Version(context.Background()); err == nil {
+		t.Fatal("Version() must surface a runner error")
+	}
+}
+
+// TestReadUnit_RoundTripsWriteUnitPath pins that ReadUnit reads exactly
+// the path WriteUnit writes — the unit path is constructed in one place.
+func TestReadUnit_RoundTripsWriteUnitPath(t *testing.T) {
+	f := &fakeFS{readContent: "[Unit]\nDescription=demo\n"}
+	f.install(t)
+
+	got, err := mgr(t, exectest.New(exec.Sudo)).ReadUnit(context.Background(), "demo.service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "[Unit]\nDescription=demo\n" {
+		t.Errorf("ReadUnit content = %q", got)
+	}
+	if f.readPath != "/etc/systemd/system/demo.service" {
+		t.Errorf("ReadUnit path = %q, want /etc/systemd/system/demo.service", f.readPath)
+	}
+}
+
+func TestReadUnit_AbsentSurfacesErrNotExist(t *testing.T) {
+	f := &fakeFS{readErr: fs.ErrNotExist}
+	f.install(t)
+
+	_, err := mgr(t, exectest.New(exec.Sudo)).ReadUnit(context.Background(), "demo.service")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadUnit absent err = %v, want fs.ErrNotExist", err)
+	}
+}
+
+func TestReadUnit_RejectsInvalidUnitName(t *testing.T) {
+	f := &fakeFS{}
+	f.install(t)
+
+	_, err := mgr(t, exectest.New(exec.Sudo)).ReadUnit(context.Background(), "../../etc/shadow")
+	if err == nil || !strings.Contains(err.Error(), "invalid systemd unit name") {
+		t.Fatalf("ReadUnit(../../etc/shadow) err = %v, want unit-name rejection", err)
+	}
+	if f.readPath != "" {
+		t.Errorf("ReadUnit must not touch the filesystem for an invalid name, read %q", f.readPath)
+	}
+}


### PR DESCRIPTION
Closes #311. Consumer: the agent-managed systemd unit (spec 27, manchtools/power-manage-agent#187) — agent PR follows.

- `Manager.Version(ctx)` — systemd major version from `systemctl --version` (first integer token, first line — the exact parse the agent install script used). Unparseable/empty output is an **error**, never a guessed value: version-conditional rendering (RestrictRealtime) owns its own fail-safe at the call site.
- `Manager.ReadUnit(ctx, unit)` — sibling of `WriteUnit` so the unit path is constructed in exactly one place. Absent unit surfaces `sys/fs`'s `errors.Is`-able `fs.ErrNotExist` ("not installed" is a distinct state). Unit-name validation runs before any filesystem touch.

Tests: version parse table (trixie/bookworm/fedora-suffix/version-only/empty/no-token/garbage + runner error), ReadUnit path round-trip vs WriteUnit, absent → ErrNotExist, invalid-name rejection without fs touch.

Gate: GOWORK=off vet ✓ staticcheck ✓ full test suite ✓; local CodeRabbit re-review clean (a first run reported 2 minors whose detail was lost to output truncation on my side — flagging for the remote review to re-cover).