### PR TITLE
feat(service): NeedsReload — pending daemon-reload probe (spec 27)

### DIFF
--- a/sys/service/service.go
+++ b/sys/service/service.go
@@ -79,6 +79,13 @@ type Manager interface {
 	// Unparseable or empty output is an ERROR, never a guessed value —
 	// version-conditional rendering decides its own fail-safe.
 	Version(ctx context.Context) (int, error)
+	// NeedsReload reports whether the manager's LOADED configuration for
+	// unit is stale relative to the on-disk unit file (systemd's
+	// NeedDaemonReload property) — i.e. a daemon-reload is pending. Lets
+	// a caller that once failed a reload retry it later without tracking
+	// state of its own. Unexpected output is an ERROR, never a guessed
+	// false.
+	NeedsReload(ctx context.Context, unit string) (bool, error)
 }
 
 // Option is the functional-option type for backend-specific knobs (none today).

--- a/sys/service/systemd.go
+++ b/sys/service/systemd.go
@@ -266,6 +266,30 @@ func (s *systemd) RemoveUnit(ctx context.Context, unit string) error {
 	return nil
 }
 
+// NeedsReload reports whether systemd's loaded configuration for unit is
+// stale relative to the on-disk unit file, via the NeedDaemonReload unit
+// property. `systemctl show` is lenient (exit 0 even for unknown units), so
+// correctness rides on the strict yes/no output parse: anything else is an
+// error, never a guessed false.
+func (s *systemd) NeedsReload(ctx context.Context, unit string) (bool, error) {
+	if err := ValidateUnitName(unit); err != nil {
+		return false, err
+	}
+	ctx, cancel := ensureCtx(ctx)
+	defer cancel()
+	res, err := s.r.Run(ctx, exec.Command{Name: "systemctl", Args: []string{"show", "--property=NeedDaemonReload", "--", unit}})
+	if err != nil {
+		return false, fmt.Errorf("systemctl show %s: %w", unit, err)
+	}
+	switch strings.TrimSpace(res.Stdout) {
+	case "NeedDaemonReload=yes":
+		return true, nil
+	case "NeedDaemonReload=no":
+		return false, nil
+	}
+	return false, fmt.Errorf("systemctl show %s: unexpected NeedDaemonReload output %q", unit, strings.TrimSpace(res.Stdout))
+}
+
 // Version reports systemd's major version: the first integer token on the
 // first line of `systemctl --version` ("systemd 257 (257.7-1)" → 257),
 // mirroring the parse the agent install script used. Anything else — empty

--- a/sys/service/systemd.go
+++ b/sys/service/systemd.go
@@ -281,13 +281,14 @@ func (s *systemd) NeedsReload(ctx context.Context, unit string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("systemctl show %s: %w", unit, err)
 	}
-	switch strings.TrimSpace(res.Stdout) {
+	out := strings.TrimSpace(res.Stdout)
+	switch out {
 	case "NeedDaemonReload=yes":
 		return true, nil
 	case "NeedDaemonReload=no":
 		return false, nil
 	}
-	return false, fmt.Errorf("systemctl show %s: unexpected NeedDaemonReload output %q", unit, strings.TrimSpace(res.Stdout))
+	return false, fmt.Errorf("systemctl show %s: unexpected NeedDaemonReload output %q", unit, out)
 }
 
 // Version reports systemd's major version: the first integer token on the

--- a/sys/service/version_readunit_test.go
+++ b/sys/service/version_readunit_test.go
@@ -135,6 +135,7 @@ func TestNeedsReload_ParsesShowOutput(t *testing.T) {
 			f := exectest.New(exec.Direct)
 			f.Push(exec.Result{Stdout: tc.stdout}, nil)
 			got, err := mgr(t, f).NeedsReload(context.Background(), "demo.service")
+			wantOneCmd(t, f, []string{"show", "--property=NeedDaemonReload", "--", "demo.service"}, false)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("NeedsReload() = %v, want error", got)
@@ -147,7 +148,6 @@ func TestNeedsReload_ParsesShowOutput(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("NeedsReload() = %v, want %v", got, tc.want)
 			}
-			wantOneCmd(t, f, []string{"show", "--property=NeedDaemonReload", "--", "demo.service"}, false)
 		})
 	}
 }

--- a/sys/service/version_readunit_test.go
+++ b/sys/service/version_readunit_test.go
@@ -113,3 +113,51 @@ func TestValidateUnitContent_ExportMatchesGate(t *testing.T) {
 		t.Errorf("plain unit must pass, got %v", err)
 	}
 }
+
+// TestNeedsReload_ParsesShowOutput pins the NeedDaemonReload probe
+// (spec 27 reload-retry): yes/no parse strictly, anything else — an
+// empty reply, an error line, a D-Bus stall — is an ERROR, never a
+// guessed false (fail-closed, matching the package's query posture).
+func TestNeedsReload_ParsesShowOutput(t *testing.T) {
+	cases := []struct {
+		name    string
+		stdout  string
+		want    bool
+		wantErr bool
+	}{
+		{"pending", "NeedDaemonReload=yes\n", true, false},
+		{"clean", "NeedDaemonReload=no\n", false, false},
+		{"empty", "", false, true},
+		{"garbage", "Failed to get properties", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := exectest.New(exec.Direct)
+			f.Push(exec.Result{Stdout: tc.stdout}, nil)
+			got, err := mgr(t, f).NeedsReload(context.Background(), "demo.service")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NeedsReload() = %v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NeedsReload(): %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("NeedsReload() = %v, want %v", got, tc.want)
+			}
+			wantOneCmd(t, f, []string{"show", "--property=NeedDaemonReload", "--", "demo.service"}, false)
+		})
+	}
+}
+
+func TestNeedsReload_RejectsInvalidUnitName(t *testing.T) {
+	f := exectest.New(exec.Direct)
+	if _, err := mgr(t, f).NeedsReload(context.Background(), "../evil"); err == nil {
+		t.Fatal("invalid unit name must be rejected")
+	}
+	if len(f.Calls()) != 0 {
+		t.Fatal("no systemctl call may run for an invalid unit name")
+	}
+}


### PR DESCRIPTION
Closes #313. Follow-up mechanism for spec 27 (found by local review on the agent PR).

**The gap:** `WriteUnit` succeeds, `DaemonReload` fails → the unit is updated on disk but systemd keeps the stale loaded config, and a byte-comparing caller (the agent's startup reconcile) sees identical bytes forever after and never retries — drift persists silently until a reboot.

**The mechanism:** systemd's `NeedDaemonReload` unit property is the exact stateless signal. `Manager.NeedsReload(ctx, unit)` wraps `systemctl show --property=NeedDaemonReload -- <unit>`; since `systemctl show` is lenient (exit 0 for nearly anything), correctness rides on the strict `yes`/`no` parse — unexpected output is an **error**, never a guessed `false`.

Tests: yes/no/empty/garbage parse table with argv assertion, invalid-unit-name rejection with zero systemctl calls.

Gate: GOWORK=off vet ✓ staticcheck ✓ full sys/service suite ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service status detection to indicate when a daemon reload is required after unit file changes.
  * Invalid service names are rejected before any system command is run.

* **Bug Fixes**
  * Unexpected or malformed status responses now return an error instead of being interpreted incorrectly.

* **Tests**
  * Added coverage for reload-needed, up-to-date, malformed-response, and invalid-name scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->