### PR TITLE
feat: cap repeated batch ID fields at max=256 (spec 29 S7)

### DIFF
--- a/gen/go/pm/v1/control.pb.go
+++ b/gen/go/pm/v1/control.pb.go
@@ -1962,8 +1962,8 @@ type CreateUserRequest struct {
 	// @gotags: validate:"required,min=8"
 	Password string `protobuf:"bytes,2,opt,name=password,proto3" json:"password,omitempty" validate:"required,min=8"`
 	// Role IDs to assign to the new user. If empty, the default "User" role is assigned.
-	// @gotags: validate:"omitempty,dive,ulid"
-	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	// Optional profile fields
 	// @gotags: validate:"omitempty,max=255"
 	DisplayName string `protobuf:"bytes,4,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty" validate:"omitempty,max=255"`
@@ -3695,10 +3695,10 @@ type AssignDeviceRequest struct {
 	UserId string `protobuf:"bytes,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" validate:"omitempty,ulid"`
 	// @gotags: validate:"omitempty,ulid"
 	GroupId string `protobuf:"bytes,3,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty" validate:"omitempty,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	UserIds []string `protobuf:"bytes,4,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty" validate:"omitempty,dive,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	GroupIds      []string `protobuf:"bytes,5,rep,name=group_ids,json=groupIds,proto3" json:"group_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	UserIds []string `protobuf:"bytes,4,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	GroupIds      []string `protobuf:"bytes,5,rep,name=group_ids,json=groupIds,proto3" json:"group_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9657,8 +9657,8 @@ type AddDeviceToGroupRequest struct {
 	GroupId string `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"omitempty,ulid"
 	DeviceId string `protobuf:"bytes,2,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty" validate:"omitempty,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	DeviceIds     []string `protobuf:"bytes,3,rep,name=device_ids,json=deviceIds,proto3" json:"device_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	DeviceIds     []string `protobuf:"bytes,3,rep,name=device_ids,json=deviceIds,proto3" json:"device_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -11779,8 +11779,8 @@ func (x *DispatchActionResponse) GetExecution() *ActionExecution {
 
 type DispatchToMultipleRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// @gotags: validate:"required,min=1,dive,ulid"
-	DeviceIds []string `protobuf:"bytes,1,rep,name=device_ids,json=deviceIds,proto3" json:"device_ids,omitempty" validate:"required,min=1,dive,ulid"`
+	// @gotags: validate:"required,min=1,max=256,dive,ulid"
+	DeviceIds []string `protobuf:"bytes,1,rep,name=device_ids,json=deviceIds,proto3" json:"device_ids,omitempty" validate:"required,min=1,max=256,dive,ulid"`
 	// Types that are valid to be assigned to ActionSource:
 	//
 	//	*DispatchToMultipleRequest_ActionId
@@ -15161,8 +15161,8 @@ type AssignRoleToUserRequest struct {
 	UserId string `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"omitempty,ulid"
 	RoleId string `protobuf:"bytes,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty" validate:"omitempty,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	// Optional grant scope. Paired-or-neither: both scope_kind and
 	// scope_id MUST be set together, or both absent. Absent =
 	// unscoped/global grant (backward-compatible with pre-#7 grants).
@@ -16188,8 +16188,8 @@ type AddUserToGroupRequest struct {
 	GroupId string `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"omitempty,ulid"
 	UserId string `protobuf:"bytes,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty" validate:"omitempty,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	UserIds       []string `protobuf:"bytes,3,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	UserIds       []string `protobuf:"bytes,3,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16377,8 +16377,8 @@ type AssignRoleToUserGroupRequest struct {
 	GroupId string `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty" validate:"required,ulid"`
 	// @gotags: validate:"omitempty,ulid"
 	RoleId string `protobuf:"bytes,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty" validate:"omitempty,ulid"`
-	// @gotags: validate:"omitempty,dive,ulid"
-	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,dive,ulid"`
+	// @gotags: validate:"omitempty,max=256,dive,ulid"
+	RoleIds []string `protobuf:"bytes,3,rep,name=role_ids,json=roleIds,proto3" json:"role_ids,omitempty" validate:"omitempty,max=256,dive,ulid"`
 	// Optional grant scope. Same paired-or-neither semantics as
 	// AssignRoleToUserRequest.scope_*. Every member of the target
 	// user group inherits this scope through the grant. server #7.

--- a/gen/ts/pm/v1/control_pb.ts
+++ b/gen/ts/pm/v1/control_pb.ts
@@ -979,7 +979,7 @@ export type CreateUserRequest = Message<"pm.v1.CreateUserRequest"> & {
 
   /**
    * Role IDs to assign to the new user. If empty, the default "User" role is assigned.
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string role_ids = 3;
    */
@@ -1854,14 +1854,14 @@ export type AssignDeviceRequest = Message<"pm.v1.AssignDeviceRequest"> & {
   groupId: string;
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string user_ids = 4;
    */
   userIds: string[];
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string group_ids = 5;
    */
@@ -4657,7 +4657,7 @@ export type AddDeviceToGroupRequest = Message<"pm.v1.AddDeviceToGroupRequest"> &
   deviceId: string;
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string device_ids = 3;
    */
@@ -5724,7 +5724,7 @@ export const DispatchActionResponseSchema: GenMessage<DispatchActionResponse> = 
  */
 export type DispatchToMultipleRequest = Message<"pm.v1.DispatchToMultipleRequest"> & {
   /**
-   * @gotags: validate:"required,min=1,dive,ulid"
+   * @gotags: validate:"required,min=1,max=256,dive,ulid"
    *
    * @generated from field: repeated string device_ids = 1;
    */
@@ -7379,7 +7379,7 @@ export type AssignRoleToUserRequest = Message<"pm.v1.AssignRoleToUserRequest"> &
   roleId: string;
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string role_ids = 3;
    */
@@ -7873,7 +7873,7 @@ export type AddUserToGroupRequest = Message<"pm.v1.AddUserToGroupRequest"> & {
   userId: string;
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string user_ids = 3;
    */
@@ -7958,7 +7958,7 @@ export type AssignRoleToUserGroupRequest = Message<"pm.v1.AssignRoleToUserGroupR
   roleId: string;
 
   /**
-   * @gotags: validate:"omitempty,dive,ulid"
+   * @gotags: validate:"omitempty,max=256,dive,ulid"
    *
    * @generated from field: repeated string role_ids = 3;
    */

--- a/proto/pm/v1/control.proto
+++ b/proto/pm/v1/control.proto
@@ -276,7 +276,7 @@ message CreateUserRequest {
   // @gotags: validate:"required,min=8"
   string password = 2;
   // Role IDs to assign to the new user. If empty, the default "User" role is assigned.
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string role_ids = 3;
   // Optional profile fields
   // @gotags: validate:"omitempty,max=255"
@@ -507,9 +507,9 @@ message AssignDeviceRequest {
   string user_id = 2;
   // @gotags: validate:"omitempty,ulid"
   string group_id = 3;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string user_ids = 4;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string group_ids = 5;
 }
 
@@ -1240,7 +1240,7 @@ message AddDeviceToGroupRequest {
   string group_id = 1;
   // @gotags: validate:"omitempty,ulid"
   string device_id = 2;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string device_ids = 3;
 }
 
@@ -1527,7 +1527,7 @@ message DispatchActionResponse {
 }
 
 message DispatchToMultipleRequest {
-  // @gotags: validate:"required,min=1,dive,ulid"
+  // @gotags: validate:"required,min=1,max=256,dive,ulid"
   repeated string device_ids = 1;
   oneof action_source {
     // @gotags: validate:"omitempty,ulid"
@@ -1999,7 +1999,7 @@ message AssignRoleToUserRequest {
   string user_id = 1;
   // @gotags: validate:"omitempty,ulid"
   string role_id = 2;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string role_ids = 3;
   // Optional grant scope. Paired-or-neither: both scope_kind and
   // scope_id MUST be set together, or both absent. Absent =
@@ -2138,7 +2138,7 @@ message AddUserToGroupRequest {
   string group_id = 1;
   // @gotags: validate:"omitempty,ulid"
   string user_id = 2;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string user_ids = 3;
 }
 
@@ -2158,7 +2158,7 @@ message AssignRoleToUserGroupRequest {
   string group_id = 1;
   // @gotags: validate:"omitempty,ulid"
   string role_id = 2;
-  // @gotags: validate:"omitempty,dive,ulid"
+  // @gotags: validate:"omitempty,max=256,dive,ulid"
   repeated string role_ids = 3;
   // Optional grant scope. Same paired-or-neither semantics as
   // AssignRoleToUserRequest.scope_*. Every member of the target


### PR DESCRIPTION
Closes #315.

Repeated ID request fields carried `dive,ulid` (per-element format) but no `max=` count cap, so one request could drive O(N) synchronous DB round-trips / CA-signings / enqueues — an asymmetric-work DoS inconsistent with the codebase's own `max=32`/`max=64` bounds elsewhere.

Adds `max=256` to the **8 request-side** repeated ID fields:
- `CreateUserRequest.role_ids`
- `AssignDeviceRequest.user_ids`, `.group_ids`
- `AddDeviceToGroupRequest.device_ids`
- `DispatchToMultipleRequest.device_ids` (required,min=1 → required,min=1,max=256)
- `AssignRoleToUserRequest.role_ids`
- `AddUserToGroupRequest.user_ids`
- `AssignRoleToUserGroupRequest.role_ids`

`GetDeviceGroupResponse.device_ids` (a response field) is intentionally left uncapped. Regenerated Go + TS. **Wire-compatible** — validate-tag-only change, `buf lint` + `buf breaking` pass. The server enforces it at the proto-validation boundary; server-side handler count-guards land in a companion server PR (defense in depth).

No SDK release tag in this PR — tagging is left to the maintainer.