### PR TITLE
feat(ts): ApiClient wrappers for listGateways + revokeGatewayCertificate (spec 31)

### DIFF
--- a/ts/client.ts
+++ b/ts/client.ts
@@ -42,6 +42,9 @@ import {
 	RenameTokenRequestSchema,
 	SetTokenDisabledRequestSchema,
 	DeleteTokenRequestSchema,
+	// Gateways (spec 31)
+	ListGatewaysRequestSchema,
+	RevokeGatewayCertificateRequestSchema,
 	// Actions (renamed from definitions)
 	CreateActionRequestSchema,
 	GetActionRequestSchema,
@@ -734,6 +737,22 @@ export class ApiClient {
 	async deleteToken(id: string) {
 		const client = this.getClient();
 		await client.deleteToken(create(DeleteTokenRequestSchema, { id }));
+	}
+
+	// Gateways (spec 31): list enrolled gateways and revoke an individual
+	// gateway's certificate by gateway_id. Permission-gated server-side
+	// (ListGateways / RevokeGatewayCertificate).
+	async listGateways() {
+		const client = this.getClient();
+		const response = await client.listGateways(create(ListGatewaysRequestSchema, {}));
+		return response.gateways;
+	}
+
+	async revokeGatewayCertificate(gatewayId: string) {
+		const client = this.getClient();
+		await client.revokeGatewayCertificate(
+			create(RevokeGatewayCertificateRequestSchema, { gatewayId })
+		);
 	}
 
 	// ============================================================================


### PR DESCRIPTION
Adds `ApiClient.listGateways()` and `ApiClient.revokeGatewayCertificate(gatewayId)` — the hand-written wrappers the web Gateways view (spec 31 PR6) calls. Mirrors the existing token/role wrapper pattern; `tsc --noEmit` clean.

Closes https://github.com/manchtools/power-manage-sdk/issues/321