### PR TITLE
feat: WithMTLSFromPEMAndRevocationCheck for agent gateway-CRL enforcement (spec 31 Part D)

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,8 +4,10 @@ package sdk
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -306,6 +308,56 @@ func WithMTLSFromPEMAndSystemRoots(certPEM, keyPEM, caPEM []byte) (ClientOption,
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caPool,
 		MinVersion:   tls.VersionTLS13,
+	}
+
+	return &funcOption{func(c *Client, httpClient **http.Client) {
+		*httpClient = newHTTPClientWithTLS(tlsConfig)
+	}}, nil
+}
+
+// WithMTLSFromPEMAndRevocationCheck is WithMTLSFromPEM plus the agent-facing
+// gateway revocation gate (spec 31 Part D, AC 11): trust is still the strict
+// internal CA only, and AFTER normal chain verification the connection's leaf
+// certificate is fingerprinted (hex SHA-256 of its DER — the exact value the
+// control server stores in gateways_projection.fingerprint and serves in the
+// CRL) and passed to check. A non-nil return from check FAILS the handshake, so
+// a revoked gateway — or, when check reports a stale/unavailable CRL, an
+// unverifiable one — is refused fail-closed rather than trusted.
+//
+// check MUST be non-nil: a nil check would silently disable the gate, so it is
+// a construction error, not a no-op. The caller (the agent's CRL cache) owns the
+// policy — which fingerprints are revoked and when a stale list fails closed
+// (AC 12); this option only supplies the mechanism.
+func WithMTLSFromPEMAndRevocationCheck(certPEM, keyPEM, caPEM []byte, check func(fingerprintHex string) error) (ClientOption, error) {
+	if check == nil {
+		return nil, errors.New("revocation check is required (fail-closed); pass a non-nil check")
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse client certificate: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("failed to parse CA certificate")
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS13,
+		// VerifyConnection runs AFTER the standard chain/RootCAs/ServerName
+		// verification (InsecureSkipVerify stays false), so this narrows trust
+		// further — it never widens it. A revoked (or unverifiable) gateway
+		// leaf is rejected even though it chains to the pinned CA.
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("gateway presented no certificate")
+			}
+			sum := sha256.Sum256(cs.PeerCertificates[0].Raw)
+			return check(hex.EncodeToString(sum[:]))
+		},
 	}
 
 	return &funcOption{func(c *Client, httpClient **http.Client) {

--- a/client_loopback_test.go
+++ b/client_loopback_test.go
@@ -2,8 +2,11 @@ package sdk
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -695,6 +698,96 @@ func TestWithMTLSFromPEM_RejectsServerSignedByForeignCA(t *testing.T) {
 		"tok", "host", "v0", []byte("csr"), opt)
 	if err == nil {
 		t.Fatal("strict mTLS must reject a server signed by a CA other than the pinned internal CA")
+	}
+}
+
+// certFingerprintHex returns the hex SHA-256 of a PEM cert's DER — the same
+// value the control server stores in gateways_projection.fingerprint and hands
+// out in the CRL, so the agent-side check compares like-for-like.
+func certFingerprintHex(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("pem.Decode(cert)")
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestWithMTLSFromPEMAndRevocationCheck_RejectsRevokedGateway pins spec 31 Part D
+// AC 11: the revocation-gated variant fingerprints the gateway's presented leaf
+// cert and refuses the connection when the caller's check reports it revoked —
+// even though that cert chains to the pinned internal CA and would otherwise be
+// accepted. This is the agent-facing enforcement of RevokeGatewayCertificate.
+func TestWithMTLSFromPEMAndRevocationCheck_RejectsRevokedGateway(t *testing.T) {
+	caPEM, caKey, caCert := cryptotest.GenCA(t, "internal-ca")
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "127.0.0.1", true)
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "device-client", false)
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("AppendCertsFromPEM(ca)")
+	}
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, clientCAPool)
+
+	revokedFP := certFingerprintHex(t, serverCertPEM)
+	check := func(fp string) error {
+		if fp == revokedFP {
+			return fmt.Errorf("gateway cert %s is revoked", fp)
+		}
+		return nil
+	}
+
+	opt, err := WithMTLSFromPEMAndRevocationCheck(clientCertPEM, clientKeyPEM, caPEM, check)
+	if err != nil {
+		t.Fatalf("WithMTLSFromPEMAndRevocationCheck: %v", err)
+	}
+	if _, err := RegisterAgent(context.Background(), srvURL,
+		"tok", "host", "v0", []byte("csr"), opt); err == nil {
+		t.Fatal("revocation check must refuse a revoked gateway cert even though it chains to the pinned CA")
+	}
+}
+
+// TestWithMTLSFromPEMAndRevocationCheck_AllowsUnrevokedGateway pins the happy
+// path: a non-revoked gateway still connects, and the check is actually invoked
+// (guards against the VerifyConnection hook being silently dropped).
+func TestWithMTLSFromPEMAndRevocationCheck_AllowsUnrevokedGateway(t *testing.T) {
+	caPEM, caKey, caCert := cryptotest.GenCA(t, "internal-ca")
+	serverCertPEM, serverKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "127.0.0.1", true)
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "device-client", false)
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("AppendCertsFromPEM(ca)")
+	}
+	srvURL := startMTLSTestServer(t, serverCertPEM, serverKeyPEM, clientCAPool)
+
+	var checked atomic.Bool
+	check := func(fp string) error { checked.Store(true); return nil } // nothing revoked
+
+	opt, err := WithMTLSFromPEMAndRevocationCheck(clientCertPEM, clientKeyPEM, caPEM, check)
+	if err != nil {
+		t.Fatalf("WithMTLSFromPEMAndRevocationCheck: %v", err)
+	}
+	got, err := RegisterAgent(context.Background(), srvURL,
+		"tok", "host", "v0", []byte("csr"), opt)
+	if err != nil {
+		t.Fatalf("unrevoked gateway must connect: %v", err)
+	}
+	if !checked.Load() {
+		t.Error("revocation check was never invoked — VerifyConnection not wired into the TLS config")
+	}
+	if got.DeviceID != "ok" {
+		t.Errorf("DeviceID = %q", got.DeviceID)
+	}
+}
+
+// TestWithMTLSFromPEMAndRevocationCheck_NilCheckRejected pins that the variant
+// refuses a nil check at construction — a nil check would silently disable the
+// fail-closed gate, so it must be a wiring error, not a no-op.
+func TestWithMTLSFromPEMAndRevocationCheck_NilCheckRejected(t *testing.T) {
+	caPEM, caKey, caCert := cryptotest.GenCA(t, "internal-ca")
+	clientCertPEM, clientKeyPEM := cryptotest.GenLeaf(t, caCert, caKey, "device-client", false)
+	if _, err := WithMTLSFromPEMAndRevocationCheck(clientCertPEM, clientKeyPEM, caPEM, nil); err == nil {
+		t.Fatal("a nil revocation check must be rejected (fail-closed), not accepted as a no-op")
 	}
 }
 


### PR DESCRIPTION
Adds the agent-facing SDK mechanism for spec 31 Part D gateway revocation (AC 11).

`WithMTLSFromPEMAndRevocationCheck(cert,key,ca, check)` = `WithMTLSFromPEM` + a `tls.Config.VerifyConnection` that hex-SHA-256-fingerprints the gateway's leaf cert (matching `gateways_projection.fingerprint` / the CRL) and calls `check`. Non-nil return → handshake fails (fail-closed). Trust only narrows (runs after chain verification). Nil check rejected at construction.

Policy (revoked set, stale-CRL fail-closed per AC 12) lives in the agent's CRL cache — this is mechanism only.

Tests: revoked fp → refused; unrevoked → connects (+ check invoked); nil check → construction error.

Pairs with the agent CRL cache (PR5) and server-side `GetCertificateRevocationList` (already merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict mutual TLS configuration with gateway certificate revocation checking.
  * Connections now validate the gateway’s SHA-256 certificate fingerprint and fail closed when revoked or when no validation callback is provided.

* **Bug Fixes**
  * Prevented connections to gateways with revoked certificates.

* **Tests**
  * Added coverage for revoked, valid, and missing revocation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->