### PR TITLE
feat: FetchGatewayCRL helper for the agent gateway-CRL client (spec 31 Part D)

### DIFF
--- a/client.go
+++ b/client.go
@@ -482,6 +482,45 @@ type RenewCertificateResult struct {
 	CACert      []byte // Active CA certificate (non-empty when CA has been rotated)
 }
 
+// GatewayCRL is a snapshot of the gateway certificate revocation list fetched
+// from control (spec 31 Part D). RevokedFingerprints are hex SHA-256 leaf-cert
+// fingerprints — compare against the value produced by
+// WithMTLSFromPEMAndRevocationCheck. NotAfter bounds how long the agent may
+// trust this snapshot before it must fail closed (AC 12); RefreshedAt is when
+// control assembled it, for staleness reasoning.
+type GatewayCRL struct {
+	RevokedFingerprints []string
+	NotAfter            time.Time
+	RefreshedAt         time.Time
+}
+
+// FetchGatewayCRL retrieves the current gateway CRL from control over the given
+// transport (the agent uses WithMTLSFromPEMAndSystemRoots, as control sits
+// behind a public-CA proxy). Like RenewCertificate, control is reached
+// directly — no gateway relay (spec 31 AC 13), which is what lets an agent
+// learn its gateway is revoked even while still connected to it.
+func FetchGatewayCRL(ctx context.Context, controlURL string, opts ...ClientOption) (*GatewayCRL, error) {
+	c := &Client{}
+	httpClient := bootstrapHTTPClient()
+	for _, opt := range opts {
+		opt.apply(c, &httpClient)
+	}
+
+	controlClient := pmv1connect.NewControlServiceClient(httpClient, controlURL)
+
+	resp, err := controlClient.GetCertificateRevocationList(ctx,
+		connect.NewRequest(&pm.GetCertificateRevocationListRequest{}))
+	if err != nil {
+		return nil, fmt.Errorf("get gateway CRL: %w", err)
+	}
+
+	return &GatewayCRL{
+		RevokedFingerprints: resp.Msg.RevokedFingerprints,
+		NotAfter:            resp.Msg.NotAfter.AsTime(),
+		RefreshedAt:         resp.Msg.RefreshedAt.AsTime(),
+	}, nil
+}
+
 // RenewCertificate renews a device certificate via the control server.
 // The agent presents its current certificate for identity verification.
 func RenewCertificate(ctx context.Context, controlURL string, csr, currentCert []byte, opts ...ClientOption) (*RenewCertificateResult, error) {

--- a/client_loopback_test.go
+++ b/client_loopback_test.go
@@ -141,6 +141,14 @@ type recordingControlHandler struct {
 
 	registerFn         func(*connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error)
 	renewCertificateFn func(*connect.Request[pm.RenewCertificateRequest]) (*connect.Response[pm.RenewCertificateResponse], error)
+	getCRLFn           func(*connect.Request[pm.GetCertificateRevocationListRequest]) (*connect.Response[pm.GetCertificateRevocationListResponse], error)
+}
+
+func (h *recordingControlHandler) GetCertificateRevocationList(ctx context.Context, req *connect.Request[pm.GetCertificateRevocationListRequest]) (*connect.Response[pm.GetCertificateRevocationListResponse], error) {
+	if h.getCRLFn != nil {
+		return h.getCRLFn(req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("GetCertificateRevocationList not stubbed"))
 }
 
 func (h *recordingControlHandler) Register(ctx context.Context, req *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
@@ -266,6 +274,45 @@ func TestRenewCertificate_HappyPath(t *testing.T) {
 	}
 	if observed == nil || string(observed.Csr) != "new-csr" || string(observed.CurrentCertificate) != "old-cert" {
 		t.Errorf("request lost fields: %+v", observed)
+	}
+}
+
+func TestFetchGatewayCRL_HappyPath(t *testing.T) {
+	cl := newControlLoopback(t)
+
+	notAfter := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	refreshedAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	cl.handler.getCRLFn = func(_ *connect.Request[pm.GetCertificateRevocationListRequest]) (*connect.Response[pm.GetCertificateRevocationListResponse], error) {
+		return connect.NewResponse(&pm.GetCertificateRevocationListResponse{
+			RevokedFingerprints: []string{"aa11", "bb22"},
+			NotAfter:            timestamppb.New(notAfter),
+			RefreshedAt:         timestamppb.New(refreshedAt),
+		}), nil
+	}
+
+	got, err := FetchGatewayCRL(context.Background(), cl.serverURL)
+	if err != nil {
+		t.Fatalf("FetchGatewayCRL: %v", err)
+	}
+	if len(got.RevokedFingerprints) != 2 || got.RevokedFingerprints[0] != "aa11" || got.RevokedFingerprints[1] != "bb22" {
+		t.Errorf("RevokedFingerprints = %v", got.RevokedFingerprints)
+	}
+	if !got.NotAfter.Equal(notAfter) {
+		t.Errorf("NotAfter = %v want %v", got.NotAfter, notAfter)
+	}
+	if !got.RefreshedAt.Equal(refreshedAt) {
+		t.Errorf("RefreshedAt = %v want %v", got.RefreshedAt, refreshedAt)
+	}
+}
+
+func TestFetchGatewayCRL_ServerErrorPropagates(t *testing.T) {
+	cl := newControlLoopback(t)
+	cl.handler.getCRLFn = func(_ *connect.Request[pm.GetCertificateRevocationListRequest]) (*connect.Response[pm.GetCertificateRevocationListResponse], error) {
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("control down"))
+	}
+
+	if _, err := FetchGatewayCRL(context.Background(), cl.serverURL); err == nil {
+		t.Fatal("FetchGatewayCRL must propagate a control error (so the cache retains its last-good snapshot and eventually fails closed)")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #323. Adds `FetchGatewayCRL(ctx, controlURL, opts...) (*GatewayCRL, error)` — a package helper mirroring `RenewCertificate` that calls `GetCertificateRevocationList` on control and maps the response to `GatewayCRL{RevokedFingerprints, NotAfter, RefreshedAt}`.

The agent's `crl.Cache` consumes it behind an injected fetch seam (fail-closed policy lives there). Reached directly against control, no gateway relay (AC 13).

Tests: happy-path field mapping + server-error propagation.