### PR TITLE
fix(agent-proto): require target_device_id as ULID on stream-RPC payloads (PMSEC-001)

### DIFF
--- a/client_dispatch_robust_test.go
+++ b/client_dispatch_robust_test.go
@@ -149,7 +149,7 @@ func TestDispatch_HandlerPanic_Recovered_LoopSurvives(t *testing.T) {
 		msg := &pm.ServerMessage{
 			Id: NewULID(),
 			Payload: &pm.ServerMessage_RequestInventory{
-				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000"},
+				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000", TargetDeviceId: "01HQ0000000000000000000000"},
 			},
 		}
 		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
@@ -172,7 +172,7 @@ func TestDispatch_HandlerPanic_Recovered_LoopSurvives(t *testing.T) {
 		msg := &pm.ServerMessage{
 			Id: NewULID(),
 			Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
-				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000"},
+				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000", TargetDeviceId: "01HQ0000000000000000000000"},
 			},
 		}
 		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {

--- a/client_dispatch_test.go
+++ b/client_dispatch_test.go
@@ -87,7 +87,7 @@ func TestDispatchServerMessage_InventoryConcurrencyBounded(t *testing.T) {
 		msg := &pm.ServerMessage{
 			Id: "m",
 			Payload: &pm.ServerMessage_RequestInventory{
-				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000"},
+				RequestInventory: &pm.RequestInventory{QueryId: "01HQ0000000000000000000000", TargetDeviceId: "01HQ0000000000000000000000"},
 			},
 		}
 		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {
@@ -125,7 +125,7 @@ func TestDispatchServerMessage_LuksRevokeConcurrencyBounded(t *testing.T) {
 		msg := &pm.ServerMessage{
 			Id: "m",
 			Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
-				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000"},
+				RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: "01HQ0000000000000000000000", TargetDeviceId: "01HQ0000000000000000000000"},
 			},
 		}
 		if err := c.dispatchServerMessage(context.Background(), msg, h); err != nil {

--- a/client_inbound_validation_test.go
+++ b/client_inbound_validation_test.go
@@ -22,6 +22,7 @@ import (
 // dropped by validateInbound BEFORE it reaches the handler, and — as a
 // guard against a vacuous pass — that a well-formed one still gets through.
 type recordingHandler struct {
+	osqueryCalls   int32
 	inventoryCalls int32
 	logQueryCalls  int32
 	luksCalls      int32
@@ -32,6 +33,7 @@ func (h *recordingHandler) OnAction(context.Context, []byte, []byte) (*pm.Action
 	return nil, nil
 }
 func (h *recordingHandler) OnQuery(context.Context, *pm.OSQuery) (*pm.OSQueryResult, error) {
+	atomic.AddInt32(&h.osqueryCalls, 1)
 	return nil, nil
 }
 func (h *recordingHandler) OnError(context.Context, *pm.Error) error { return nil }
@@ -52,8 +54,9 @@ func (h *recordingHandler) OnRevokeLuksDeviceKey(context.Context, *pm.RevokeLuks
 }
 
 // validULID is a syntactically valid ULID; badULID fails the
-// `validate:"required,ulid"` rule the three command payloads carry on their
-// query_id / action_id field.
+// `validate:"required,ulid"` rule the command payloads carry on their
+// query_id / action_id field — and, since PMSEC-001, on their
+// target_device_id field too.
 const (
 	validULID = "01HQ0000000000000000000000"
 	badULID   = "not-a-ulid"
@@ -70,17 +73,20 @@ const (
 // (the rejection — the point of the test), and a valid ULID DOES (so the test
 // can't pass vacuously because the handler interface went unsatisfied).
 func TestDispatch_RejectsInvalidInboundCommands(t *testing.T) {
+	// Each builder sets a VALID target_device_id (also `required,ulid` since
+	// PMSEC-001) so `id` — the query_id / action_id — stays the only field
+	// under test here. target_device_id gets its own rejection test below.
 	mkInventory := func(id string) *pm.ServerMessage {
 		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RequestInventory{
-			RequestInventory: &pm.RequestInventory{QueryId: id}}}
+			RequestInventory: &pm.RequestInventory{QueryId: id, TargetDeviceId: validULID}}}
 	}
 	mkLogQuery := func(id string) *pm.ServerMessage {
 		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_LogQuery{
-			LogQuery: &pm.LogQuery{QueryId: id}}}
+			LogQuery: &pm.LogQuery{QueryId: id, TargetDeviceId: validULID}}}
 	}
 	mkLuks := func(id string) *pm.ServerMessage {
 		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
-			RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: id}}}
+			RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: id, TargetDeviceId: validULID}}}
 	}
 
 	cases := []struct {
@@ -124,6 +130,81 @@ func TestDispatch_RejectsInvalidInboundCommands(t *testing.T) {
 // settle waits a short, fixed period for a dispatch-spawned goroutine to have
 // run, so a "handler must NOT be called" assertion is not racing the spawn.
 func settle() { time.Sleep(150 * time.Millisecond) }
+
+// TestDispatch_RejectsMissingOrInvalidTargetDeviceId pins the PMSEC-001 hardening:
+// all four non-action stream-RPC payloads (OSQuery, RequestInventory, LogQuery,
+// RevokeLuksDeviceKey) now carry `validate:"required,ulid"` on target_device_id,
+// so validateInbound drops a command that names no target device (or a malformed
+// one) at the SDK boundary — before it reaches a privileged handler. A missing
+// target is exactly the shape a target-stripped or pre-binding relay frame has;
+// dropping it is defence-in-depth beneath the agent's own target==self check.
+//
+// Each surface asserts BOTH a missing and a non-ULID target are dropped, and — as
+// a guard against a vacuous pass — that a valid target still reaches the handler.
+func TestDispatch_RejectsMissingOrInvalidTargetDeviceId(t *testing.T) {
+	// build(target) sets a VALID query/action id and the given target_device_id,
+	// so target_device_id is the only field under test.
+	mkOSQuery := func(target string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_Query{
+			Query: &pm.OSQuery{QueryId: validULID, Table: "processes", TargetDeviceId: target}}}
+	}
+	mkInventory := func(target string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RequestInventory{
+			RequestInventory: &pm.RequestInventory{QueryId: validULID, TargetDeviceId: target}}}
+	}
+	mkLogQuery := func(target string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_LogQuery{
+			LogQuery: &pm.LogQuery{QueryId: validULID, TargetDeviceId: target}}}
+	}
+	mkLuks := func(target string) *pm.ServerMessage {
+		return &pm.ServerMessage{Id: "m", Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
+			RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{ActionId: validULID, TargetDeviceId: target}}}
+	}
+
+	cases := []struct {
+		name  string
+		build func(target string) *pm.ServerMessage
+		count func(*recordingHandler) int32
+	}{
+		{"OSQuery", mkOSQuery, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.osqueryCalls) }},
+		{"RequestInventory", mkInventory, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.inventoryCalls) }},
+		{"LogQuery", mkLogQuery, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.logQueryCalls) }},
+		{"RevokeLuksDeviceKey", mkLuks, func(h *recordingHandler) int32 { return atomic.LoadInt32(&h.luksCalls) }},
+	}
+
+	bad := []struct{ label, target string }{
+		{"missing_target", ""},
+		{"nonulid_target", badULID},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		for _, b := range bad {
+			b := b
+			t.Run(tc.name+"/"+b.label+"_never_reaches_handler", func(t *testing.T) {
+				c := NewClient("https://gw.invalid", WithAuth(validULID, ""))
+				h := &recordingHandler{}
+				if err := c.dispatchServerMessage(context.Background(), tc.build(b.target), h); err != nil {
+					t.Fatalf("dispatch: %v", err)
+				}
+				// The async surfaces run the handler on a spawned goroutine;
+				// settle so an unguarded dispatch would have reached it.
+				settle()
+				if got := tc.count(h); got != 0 {
+					t.Fatalf("%s: a command with a %s reached the handler %d time(s); validateInbound must drop it at the boundary (PMSEC-001)", tc.name, b.label, got)
+				}
+			})
+		}
+		t.Run(tc.name+"/valid_target_reaches_handler", func(t *testing.T) {
+			c := NewClient("https://gw.invalid", WithAuth(validULID, ""))
+			h := &recordingHandler{}
+			if err := c.dispatchServerMessage(context.Background(), tc.build(validULID), h); err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			waitForCond(t, func() bool { return tc.count(h) == 1 })
+		})
+	}
+}
 
 // TestDispatchValidatesEveryInboundCommand is the self-discovering regression
 // guard for P0.3: it walks EVERY ServerMessage oneof arm whose payload carries

--- a/gen/go/pm/v1/agent.pb.go
+++ b/gen/go/pm/v1/agent.pb.go
@@ -1368,7 +1368,8 @@ type OSQuery struct {
 	// onto another device that trusts the same CA (PMSEC-001, sibling of
 	// SignedActionEnvelope.target_device_id). The agent verifies target ==
 	// itself after the signature and refuses otherwise.
-	TargetDeviceId string `protobuf:"bytes,8,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty"`
+	// @gotags: validate:"required,ulid"
+	TargetDeviceId string `protobuf:"bytes,8,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty" validate:"required,ulid"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1758,7 +1759,8 @@ type RequestInventory struct {
 	// device's validly-signed request onto another (PMSEC-001, sibling of
 	// SignedActionEnvelope.target_device_id). The agent verifies target == itself
 	// after the signature and refuses otherwise.
-	TargetDeviceId string `protobuf:"bytes,3,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty"`
+	// @gotags: validate:"required,ulid"
+	TargetDeviceId string `protobuf:"bytes,3,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty" validate:"required,ulid"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2060,7 +2062,8 @@ type RevokeLuksDeviceKey struct {
 	// replay one device's validly-signed revocation onto another that trusts the
 	// same CA (PMSEC-001, sibling of SignedActionEnvelope.target_device_id). The
 	// agent verifies target == itself after the signature and refuses otherwise.
-	TargetDeviceId string `protobuf:"bytes,3,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty"`
+	// @gotags: validate:"required,ulid"
+	TargetDeviceId string `protobuf:"bytes,3,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty" validate:"required,ulid"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2624,7 +2627,8 @@ type LogQuery struct {
 	// validly-signed log query onto another that trusts the same CA (PMSEC-001,
 	// sibling of SignedActionEnvelope.target_device_id). The agent verifies
 	// target == itself after the signature and refuses otherwise.
-	TargetDeviceId string `protobuf:"bytes,11,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty"`
+	// @gotags: validate:"required,ulid"
+	TargetDeviceId string `protobuf:"bytes,11,opt,name=target_device_id,json=targetDeviceId,proto3" json:"target_device_id,omitempty" validate:"required,ulid"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }

--- a/gen/ts/pm/v1/agent_pb.ts
+++ b/gen/ts/pm/v1/agent_pb.ts
@@ -604,6 +604,7 @@ export type OSQuery = Message<"pm.v1.OSQuery"> & {
    * onto another device that trusts the same CA (PMSEC-001, sibling of
    * SignedActionEnvelope.target_device_id). The agent verifies target ==
    * itself after the signature and refuses otherwise.
+   * @gotags: validate:"required,ulid"
    *
    * @generated from field: string target_device_id = 8;
    */
@@ -787,6 +788,7 @@ export type RequestInventory = Message<"pm.v1.RequestInventory"> & {
    * device's validly-signed request onto another (PMSEC-001, sibling of
    * SignedActionEnvelope.target_device_id). The agent verifies target == itself
    * after the signature and refuses otherwise.
+   * @gotags: validate:"required,ulid"
    *
    * @generated from field: string target_device_id = 3;
    */
@@ -951,6 +953,7 @@ export type RevokeLuksDeviceKey = Message<"pm.v1.RevokeLuksDeviceKey"> & {
    * replay one device's validly-signed revocation onto another that trusts the
    * same CA (PMSEC-001, sibling of SignedActionEnvelope.target_device_id). The
    * agent verifies target == itself after the signature and refuses otherwise.
+   * @gotags: validate:"required,ulid"
    *
    * @generated from field: string target_device_id = 3;
    */
@@ -1318,6 +1321,7 @@ export type LogQuery = Message<"pm.v1.LogQuery"> & {
    * validly-signed log query onto another that trusts the same CA (PMSEC-001,
    * sibling of SignedActionEnvelope.target_device_id). The agent verifies
    * target == itself after the signature and refuses otherwise.
+   * @gotags: validate:"required,ulid"
    *
    * @generated from field: string target_device_id = 11;
    */

--- a/proto/pm/v1/agent.proto
+++ b/proto/pm/v1/agent.proto
@@ -246,6 +246,7 @@ message OSQuery {
   // onto another device that trusts the same CA (PMSEC-001, sibling of
   // SignedActionEnvelope.target_device_id). The agent verifies target ==
   // itself after the signature and refuses otherwise.
+  // @gotags: validate:"required,ulid"
   string target_device_id = 8;
 }
 
@@ -321,6 +322,7 @@ message RequestInventory {
   // device's validly-signed request onto another (PMSEC-001, sibling of
   // SignedActionEnvelope.target_device_id). The agent verifies target == itself
   // after the signature and refuses otherwise.
+  // @gotags: validate:"required,ulid"
   string target_device_id = 3;
 }
 
@@ -410,6 +412,7 @@ message RevokeLuksDeviceKey {
   // replay one device's validly-signed revocation onto another that trusts the
   // same CA (PMSEC-001, sibling of SignedActionEnvelope.target_device_id). The
   // agent verifies target == itself after the signature and refuses otherwise.
+  // @gotags: validate:"required,ulid"
   string target_device_id = 3;
 }
 
@@ -585,6 +588,7 @@ message LogQuery {
   // validly-signed log query onto another that trusts the same CA (PMSEC-001,
   // sibling of SignedActionEnvelope.target_device_id). The agent verifies
   // target == itself after the signature and refuses otherwise.
+  // @gotags: validate:"required,ulid"
   string target_device_id = 11;
 }
 


### PR DESCRIPTION
## Summary

The four non-action stream-RPC payloads — `OSQuery`, `RequestInventory`, `LogQuery`, `RevokeLuksDeviceKey` — carry `target_device_id` inside their CA-signed canonical bytes (PMSEC-001, #325), but the field had **no `@gotags validate` tag**. The SDK's inbound `validateInbound` boundary (`client.go`) therefore accepted a command that names **no target device** at all — contrary to the project rule that every field crossing a trust boundary carries a validate tag.

This adds `validate:"required,ulid"` to all four fields (mirroring the sibling `query_id`/`action_id` on the same messages). The SDK now drops a target-less or malformed-target command at the boundary, **beneath** the agent's own `target == self` enforcement — defence in depth, not a replacement.

A missing `target_device_id` is exactly the shape a pre-binding or target-stripped relay frame has.

## Changes

- `proto/pm/v1/agent.proto`: `@gotags validate:"required,ulid"` on the four `target_device_id` fields; regenerated Go + TS.
- `client_inbound_validation_test.go`: new `TestDispatch_RejectsMissingOrInvalidTargetDeviceId` — for all four surfaces, a missing and a non-ULID target are dropped before the handler; a valid target reaches it (guards against a vacuous pass). Existing `TestDispatch_RejectsInvalidInboundCommands` builders now set a valid target so `id` stays the field under test.
- `client_dispatch_test.go`, `client_dispatch_robust_test.go`: existing dispatch fixtures set a valid `target_device_id` to model the new required-target contract.

## Verification

- `buf lint` / `buf breaking` (additive, non-wire-breaking) / `go vet` / `docref check` — all green.
- Full SDK suite green (33 packages). Red-before-green confirmed: weakening one field to `omitempty` makes the `missing_target` subtest fail for the right reason.

Closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure commands include a valid device identifier.
  * Invalid or missing device identifiers are now rejected before reaching command handlers.

* **Tests**
  * Expanded coverage for device identifier validation.
  * Updated dispatch and concurrency scenarios to use complete command payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->