### PR TITLE
fix(gateway-proto): require enroll hostname for control-authoritative DNS SAN (spec 31 D1)

### DIFF
--- a/gen/go/pm/v1/gateway_auth.pb.go
+++ b/gen/go/pm/v1/gateway_auth.pb.go
@@ -28,10 +28,15 @@ type EnrollGatewayRequest struct {
 	// PermissionDenied with no gateway_id allocated.
 	// @gotags: validate:"required,max=512"
 	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty" validate:"required,max=512"`
-	// Optional operator-facing hostname recorded on the GatewayEnrolled
-	// event for the admin view. Not trusted for any authorization decision.
-	// @gotags: validate:"omitempty,hostname_rfc1123,max=253"
-	Hostname string `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty" validate:"omitempty,hostname_rfc1123,max=253"`
+	// The gateway's public host — the name agents dial (GATEWAY_DOMAIN). The
+	// gateway MUST declare it; control cross-checks it against its own
+	// authoritative gateway host (from CONTROL_GATEWAY_URL) and refuses to
+	// enroll on any mismatch, then stamps ITS authoritative host — never this
+	// claimed value — as the issued cert's DNS SAN. Required so the operator
+	// configures one canonical name on both sides; an IP literal, an unlisted
+	// name, mixed case, or a trailing dot is rejected.
+	// @gotags: validate:"required,hostname_rfc1123,max=253"
+	Hostname string `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty" validate:"required,hostname_rfc1123,max=253"`
 	// Certificate Signing Request (PEM-encoded PKCS#10). The gateway
 	// generates its own keypair; the private key never leaves the process.
 	// The CA stamps the class SAN itself and rejects caller-supplied SANs.

--- a/gen/ts/pm/v1/gateway_auth_pb.ts
+++ b/gen/ts/pm/v1/gateway_auth_pb.ts
@@ -27,9 +27,14 @@ export type EnrollGatewayRequest = Message<"pm.v1.EnrollGatewayRequest"> & {
   token: string;
 
   /**
-   * Optional operator-facing hostname recorded on the GatewayEnrolled
-   * event for the admin view. Not trusted for any authorization decision.
-   * @gotags: validate:"omitempty,hostname_rfc1123,max=253"
+   * The gateway's public host — the name agents dial (GATEWAY_DOMAIN). The
+   * gateway MUST declare it; control cross-checks it against its own
+   * authoritative gateway host (from CONTROL_GATEWAY_URL) and refuses to
+   * enroll on any mismatch, then stamps ITS authoritative host — never this
+   * claimed value — as the issued cert's DNS SAN. Required so the operator
+   * configures one canonical name on both sides; an IP literal, an unlisted
+   * name, mixed case, or a trailing dot is rejected.
+   * @gotags: validate:"required,hostname_rfc1123,max=253"
    *
    * @generated from field: string hostname = 2;
    */

--- a/proto/pm/v1/gateway_auth.proto
+++ b/proto/pm/v1/gateway_auth.proto
@@ -30,9 +30,14 @@ message EnrollGatewayRequest {
   // PermissionDenied with no gateway_id allocated.
   // @gotags: validate:"required,max=512"
   string token = 1;
-  // Optional operator-facing hostname recorded on the GatewayEnrolled
-  // event for the admin view. Not trusted for any authorization decision.
-  // @gotags: validate:"omitempty,hostname_rfc1123,max=253"
+  // The gateway's public host — the name agents dial (GATEWAY_DOMAIN). The
+  // gateway MUST declare it; control cross-checks it against its own
+  // authoritative gateway host (from CONTROL_GATEWAY_URL) and refuses to
+  // enroll on any mismatch, then stamps ITS authoritative host — never this
+  // claimed value — as the issued cert's DNS SAN. Required so the operator
+  // configures one canonical name on both sides; an IP literal, an unlisted
+  // name, mixed case, or a trailing dot is rejected.
+  // @gotags: validate:"required,hostname_rfc1123,max=253"
   string hostname = 2;
   // Certificate Signing Request (PEM-encoded PKCS#10). The gateway
   // generates its own keypair; the private key never leaves the process.


### PR DESCRIPTION
## What

Flip `GatewayAuthService.EnrollGateway`'s `hostname` field from `omitempty` to **required** (keeping the `hostname_rfc1123,max=253` format constraint).

## Why

The enroll `hostname` was optional and — on the server side — stamped **verbatim** into the issued gateway certificate's DNS SAN. That DNS SAN is exactly what agents verify at the mTLS handshake, so a valid-token enrollee could mint a gateway cert bearing an arbitrary DNS name. ADR 0032 (gateway instance identity subordinate to the SPIFFE class gate) is only sound if the server name is control-authoritative.

The paired server change (spec 31 D1) stops trusting the claim: control derives the DNS SAN from its own `CONTROL_GATEWAY_URL` and refuses to enroll any gateway whose declared hostname does not exactly match that authoritative host (rejecting IP literals, mixed case, trailing dots, and unlisted names). Making the field required forces the operator to configure one canonical name (`GATEWAY_DOMAIN`) on both sides and lets control fail closed on a mismatch.

## Compatibility

Not a wire-breaking change — `buf breaking` passes (the constraint lives in an injected `validate` gotag, invisible to the wire format). The gateway client already always sends `GATEWAY_DOMAIN`, so no gateway behavior changes.

## Checks

- `buf lint` / `buf format` / `buf breaking` — green
- generated Go + TS regenerated via `make generate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Gateway enrollment now requires a valid public hostname.
  * Hostnames are checked against the gateway’s configured canonical host.
  * Enrollment rejects IP addresses, unrecognized names, mixed-case hostnames, trailing dots, and mismatched values.
  * Issued gateway certificates now use the verified authoritative hostname.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->