### PR TITLE
Document an installable operator CLI version

### DIFF
--- a/docs/01-getting-started/02-operator-cli.md
+++ b/docs/01-getting-started/02-operator-cli.md
@@ -8,7 +8,7 @@ description: Bootstrap OIDC, sign in locally, and operate Power Manage without t
 Build or install the `powermanage` command from this module:
 
 ```bash
-go install github.com/manchtools/power-manage-sdk/cmd/powermanage@main
+go install github.com/manchtools/power-manage-sdk/cmd/powermanage@v0.5.4-0.20260808183110-41889787d778
 ```
 
 The first release supports Unix-like operator workstations; Windows support is


### PR DESCRIPTION
Replace the moving `@main` install query with the immutable pseudo-version of merged SDK commit `41889787d7782c18d847686da409bd806ab03cdf`.

The exact documented `go install` command succeeds through the default Go module proxy, and `docref check` reports all 103 references current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation instructions to use a specific, stable `powermanage` version instead of the development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->